### PR TITLE
Add configurable `requestTimeout` for tool/resource requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Two calls instead of 26 tools cluttering the context.
 | `bearerToken` / `bearerTokenEnv` | Token or env var name |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
+| `requestTimeout` | Milliseconds before tool/resource requests timeout (default: 60000) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `debug` | Show server stderr (default: false) |
@@ -104,7 +105,8 @@ Two calls instead of 26 tools cluttering the context.
 {
   "settings": {
     "toolPrefix": "server",
-    "idleTimeout": 10
+    "idleTimeout": 10,
+    "requestTimeout": 120000
   },
   "mcpServers": { }
 }
@@ -114,9 +116,10 @@ Two calls instead of 26 tools cluttering the context.
 |---------|-------------|
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
+| `requestTimeout` | Global request timeout in milliseconds (default: 60000) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 
-Per-server `idleTimeout` overrides the global setting.
+Per-server `idleTimeout` and `requestTimeout` override the global settings.
 
 ### Direct Tools
 

--- a/types.ts
+++ b/types.ts
@@ -68,6 +68,7 @@ export interface ServerEntry {
   bearerTokenEnv?: string;
   lifecycle?: "keep-alive" | "lazy" | "eager";
   idleTimeout?: number; // minutes, overrides global setting
+  requestTimeout?: number; // milliseconds, timeout for tool/resource requests
   // Resource handling
   exposeResources?: boolean;
   // Direct tool registration
@@ -80,6 +81,7 @@ export interface ServerEntry {
 export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
   idleTimeout?: number; // minutes, default 10, 0 to disable
+  requestTimeout?: number; // milliseconds, default 60000 (MCP SDK default)
   directTools?: boolean;
 }
 


### PR DESCRIPTION
I was hitting the following error when the harness made MCP calls that took a long time:

`MCP error -32001: Request timed out`

https://buildwithpi.ai/session/#81a14cbbe1205515368b5d745b7abfe8