### PR TITLE
feat: Add compact rendering and improved UX for MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added argument completions for `/mcp` subcommands and reconnect/logout server names. Thanks @sting8k for PR #8.
 - Surfaced MCP connection failure reasons from bounded stdio diagnostics in status output and the `/mcp` panel, with a shortcut to copy the selected failure. Thanks @parkuman for PR #197.
 - Added Codex MCP imports from `.codex/config.toml`, with fallback to the existing JSON config. Thanks @npo-mmenke for PR #31.
 - Added environment-variable interpolation for HTTP MCP server URLs, with missing URL variables failing closed before requests are sent. Thanks @ozeias for PR #206.

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -473,6 +473,49 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.shutdownOAuth).toHaveBeenCalledTimes(1);
   });
 
+  it("completes current `/mcp` subcommands and server arguments", async () => {
+    const state = createState();
+    state.config.mcpServers = {
+      github: { command: "github-mcp" },
+      gitlab: { command: "gitlab-mcp" },
+      notion: { command: "notion-mcp" },
+    };
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp")?.[1];
+    expect(commandDef.getArgumentCompletions("reconnect ")).toBeNull();
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(commandDef.getArgumentCompletions("").map(({ value }: { value: string }) => value)).toEqual([
+      "reconnect",
+      "tools",
+      "setup",
+      "logout",
+      "status",
+    ]);
+    expect(commandDef.getArgumentCompletions("st")).toEqual([
+      { value: "status", label: "status — Show server status" },
+    ]);
+    expect(commandDef.getArgumentCompletions("reconnect ")).toEqual([
+      { value: "reconnect github", label: "github" },
+      { value: "reconnect gitlab", label: "gitlab" },
+      { value: "reconnect notion", label: "notion" },
+    ]);
+    expect(commandDef.getArgumentCompletions("  logout git")).toEqual([
+      { value: "logout github", label: "github" },
+      { value: "logout gitlab", label: "gitlab" },
+    ]);
+    expect(commandDef.getArgumentCompletions("tools anything")).toBeNull();
+    expect(api.registerCommand.mock.calls.some((call: any[]) => call[0] === "mcp-reconnect")).toBe(false);
+  });
+
   it("routes `/mcp setup` to the onboarding flow", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);

--- a/index.ts
+++ b/index.ts
@@ -168,6 +168,28 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
   pi.registerCommand("mcp", {
     description: "Show MCP server status",
+    getArgumentCompletions: (prefix: string) => {
+      const normalized = prefix.trimStart();
+      const argumentMatch = normalized.match(/^(\S+)\s+(.*)$/);
+      if (!argumentMatch) {
+        const subcommands = [
+          { value: "reconnect", label: "reconnect — Reconnect servers" },
+          { value: "tools", label: "tools — List all tools" },
+          { value: "setup", label: "setup — Configure MCP servers" },
+          { value: "logout", label: "logout — Clear server credentials" },
+          { value: "status", label: "status — Show server status" },
+        ].filter(({ value }) => value.startsWith(normalized));
+        return subcommands.length > 0 ? subcommands : null;
+      }
+
+      const [, subcommand, argumentPrefix] = argumentMatch;
+      if ((subcommand !== "reconnect" && subcommand !== "logout") || !state) return null;
+
+      const servers = Object.keys(state.config.mcpServers)
+        .filter((serverName) => serverName.startsWith(argumentPrefix.trimStart()))
+        .map((serverName) => ({ value: `${subcommand} ${serverName}`, label: serverName }));
+      return servers.length > 0 ? servers : null;
+    },
     handler: async (args, ctx) => {
       if (!state && initPromise) {
         try {


### PR DESCRIPTION
- Add custom renderCall/renderResult for cleaner CLI output
  - Collapsed view: show first 5 lines instead of raw dump
  - Expanded view: cap at 50 lines with overflow indicator
  - Running state: show ⏳ indicator
  - Error state: show ✗ prefix with truncated error
- Add getArgumentCompletions to /mcp command for subcommands
- Add /mcp-reconnect command with server name autocomplete

Improves readability and UX when using MCP tools from Pi CLI.