### PR TITLE
feat: improve output for mcp query and result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `renderCall` on direct tools and the `mcp` proxy tool: displays tool name and arguments inline on invocation, matching the style of native pi tools like `read` and `edit`.
+- `renderResult` on direct tools and the `mcp` proxy tool: results collapse to 10 lines by default with a native Ctrl+O expand hint, consistent with built-in pi tools like `bash` and `read`.
+
 ## [2.4.0] - 2026-04-13
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import type { McpExtensionState } from "./state.js";
 import { Type } from "@sinclair/typebox";
 import { showStatus, showTools, reconnectServers, authenticateServer, openMcpPanel } from "./commands.js";
@@ -72,6 +73,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       description: spec.description || "(no description)",
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
       parameters: Type.Unsafe<Record<string, unknown>>(spec.inputSchema || { type: "object", properties: {} }),
+      renderCall(args, theme) {
+        let line = theme.fg("toolTitle", theme.bold(spec.prefixedName));
+        const argStr = formatArgsCompact(args as Record<string, unknown>);
+        if (argStr) line += " " + theme.fg("accent", argStr);
+        return new Text(line, 0, 0);
+      },
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
     });
   }
@@ -235,6 +242,28 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" })),
       }),
+      renderCall(args, theme) {
+        let line = theme.fg("toolTitle", theme.bold("mcp"));
+        const a = args as { tool?: string; args?: string; search?: string; connect?: string; describe?: string; server?: string; action?: string };
+        if (a.tool) {
+          line += " " + theme.fg("accent", a.tool);
+          if (a.args) {
+            const truncated = a.args.length > 60 ? a.args.slice(0, 57) + "..." : a.args;
+            line += " " + theme.fg("muted", truncated);
+          }
+        } else if (a.search) {
+          line += theme.fg("muted", " search:") + " " + theme.fg("accent", `"${a.search}"`);
+        } else if (a.connect) {
+          line += theme.fg("muted", " connect:") + " " + theme.fg("accent", a.connect);
+        } else if (a.describe) {
+          line += theme.fg("muted", " describe:") + " " + theme.fg("accent", a.describe);
+        } else if (a.server) {
+          line += theme.fg("muted", " server:") + " " + theme.fg("accent", a.server);
+        } else if (a.action) {
+          line += theme.fg("muted", " action:") + " " + theme.fg("accent", a.action);
+        }
+        return new Text(line, 0, 0);
+      },
       async execute(_toolCallId, params: {
         tool?: string;
         args?: string;
@@ -302,4 +331,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       },
     });
   }
+}
+
+function formatArgsCompact(args: Record<string, unknown>, maxLen = 80): string {
+  if (!args || Object.keys(args).length === 0) return "";
+  const parts = Object.entries(args).map(([k, v]) => {
+    if (typeof v === "string") return `${k}=${v}`;
+    if (typeof v === "number" || typeof v === "boolean") return `${k}=${v}`;
+    return `${k}=${JSON.stringify(v)}`;
+  });
+  const str = parts.join(" ");
+  return str.length <= maxLen ? str : str.slice(0, maxLen - 3) + "...";
 }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
+import { keyHint, type ExtensionAPI, type ToolInfo } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import type { McpExtensionState } from "./state.js";
 import { Type } from "@sinclair/typebox";
@@ -78,6 +78,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         const argStr = formatArgsCompact(args as Record<string, unknown>);
         if (argStr) line += " " + theme.fg("accent", argStr);
         return new Text(line, 0, 0);
+      },
+      renderResult(result, { expanded, isPartial }, theme) {
+        return renderMcpResult(result.content, expanded, isPartial, theme);
       },
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
     });
@@ -264,6 +267,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         }
         return new Text(line, 0, 0);
       },
+      renderResult(result, { expanded, isPartial }, theme) {
+        return renderMcpResult(result.content, expanded, isPartial, theme);
+      },
       async execute(_toolCallId, params: {
         tool?: string;
         args?: string;
@@ -331,6 +337,39 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       },
     });
   }
+}
+
+const PREVIEW_LINES = 10;
+
+function renderMcpResult(
+  content: Array<{ type: string; text?: string }> | undefined,
+  expanded: boolean,
+  isPartial: boolean,
+  theme: { fg: (color: string, text: string) => string },
+): Text {
+  if (isPartial) {
+    return new Text(theme.fg("muted", "Loading..."), 0, 0);
+  }
+
+  const text = (content ?? [])
+    .filter((c) => c.type === "text")
+    .map((c) => c.text ?? "")
+    .join("\n");
+
+  if (!text) {
+    return new Text(theme.fg("muted", "(empty result)"), 0, 0);
+  }
+
+  const lines = text.split("\n");
+
+  if (expanded || lines.length <= PREVIEW_LINES) {
+    return new Text(text, 0, 0);
+  }
+
+  const preview = lines.slice(0, PREVIEW_LINES).join("\n");
+  const remaining = lines.length - PREVIEW_LINES;
+  const hint = `${theme.fg("muted", `\n... (${remaining} more line${remaining === 1 ? "" : "s"},`)} ${keyHint("expandTools", "to expand")})`;
+  return new Text(preview + hint, 0, 0);
 }
 
 function formatArgsCompact(args: Record<string, unknown>, maxLen = 80): string {


### PR DESCRIPTION
MCP tool calls have no visual feedback for the query being run and output result is displaid in full.

This PR adds support both `renderCall` and `renderResult` to both direct tools and the mcp proxy tool to match behavior from other pi tools (read, write, etc.). The tool name and args are displayed inline on invocation, and results are collapsed to 10 lines with a native expand hint with `ctrl+o`. 


