### PR TITLE
Route MCP lifecycle messages through Pi UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `settings.lifecycleLogs` to disable non-error MCP lifecycle logs in the Pi input area
 
 ## [2.1.2] - 2026-02-03
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Two calls instead of 26 tools cluttering the context.
   "settings": {
     "toolPrefix": "server",
     "idleTimeout": 10,
-    "lifecycleLogs": true
   },
   "mcpServers": { }
 }
@@ -116,9 +115,7 @@ Two calls instead of 26 tools cluttering the context.
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
-| `lifecycleLogs` | Log non-error MCP lifecycle messages to stdout, including npx resolution, keep-alive reconnects, and idle disconnects (default: true) |
-
-Per-server `idleTimeout` overrides the global setting. Set `lifecycleLogs: false` to suppress those informational log lines.
+Per-server `idleTimeout` overrides the global setting.
 
 ### Direct Tools
 

--- a/index.ts
+++ b/index.ts
@@ -363,7 +363,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       initPromise = null;
       updateStatusBar(s);
     }).catch(err => {
-      console.error("MCP initialization failed:", err);
+      if (ctx.hasUI) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.ui.notify(`MCP initialization failed: ${message}`, "error");
+      }
       initPromise = null;
     });
   });
@@ -1156,9 +1159,6 @@ async function initializeMcp(
   
   const manager = new McpServerManager();
   const lifecycle = new McpLifecycleManager(manager);
-  const lifecycleLogsEnabled = config.settings?.lifecycleLogs !== false;
-  manager.setLifecycleLogsEnabled(lifecycleLogsEnabled);
-  lifecycle.setLifecycleLogsEnabled(lifecycleLogsEnabled);
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const failureTracker = new Map<string, number>();
   const ui = ctx.hasUI ? ctx.ui : undefined;
@@ -1234,7 +1234,6 @@ async function initializeMcp(
       if (ctx.hasUI) {
         ctx.ui.notify(`MCP: Failed to connect to ${name}: ${error}`, "error");
       }
-      console.error(`MCP: Failed to connect to ${name}: ${error}`);
       continue;
     }
 
@@ -1300,18 +1299,30 @@ async function initializeMcp(
     }
   }
 
+  manager.setNpxResolvedCallback(() => {
+    // Intentionally silent: npx resolution is internal adapter detail.
+  });
+
   lifecycle.setReconnectCallback((serverName) => {
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
     state.failureTracker.delete(serverName);
+    if (state.ui) {
+      state.ui.setStatus("mcp", `MCP: reconnected to ${serverName}`);
+    }
     updateStatusBar(state);
   });
 
-  lifecycle.setIdleShutdownCallback((serverName) => {
-    const idleMinutes = getEffectiveIdleTimeoutMinutes(state, serverName);
-    if (state.config.settings?.lifecycleLogs !== false) {
-      console.log(`MCP: ${serverName} shut down (idle ${idleMinutes}m)`);
+  lifecycle.setReconnectErrorCallback((serverName, error) => {
+    state.failureTracker.set(serverName, Date.now());
+    const message = error instanceof Error ? error.message : String(error);
+    if (state.ui) {
+      state.ui.notify(`MCP: Failed to reconnect to ${serverName}: ${message}`, "error");
     }
+    updateStatusBar(state);
+  });
+
+  lifecycle.setIdleShutdownCallback((_serverName) => {
     updateStatusBar(state);
   });
 

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -12,15 +12,11 @@ export class McpLifecycleManager {
   private globalIdleTimeout: number = 10 * 60 * 1000;
   private healthCheckInterval?: NodeJS.Timeout;
   private onReconnect?: ReconnectCallback;
+  private onReconnectError?: (serverName: string, error: unknown) => void;
   private onIdleShutdown?: (serverName: string) => void;
-  private lifecycleLogsEnabled = true;
   
   constructor(manager: McpServerManager) {
     this.manager = manager;
-  }
-
-  setLifecycleLogsEnabled(enabled: boolean): void {
-    this.lifecycleLogsEnabled = enabled;
   }
   
   /**
@@ -29,6 +25,10 @@ export class McpLifecycleManager {
    */
   setReconnectCallback(callback: ReconnectCallback): void {
     this.onReconnect = callback;
+  }
+
+  setReconnectErrorCallback(callback: (serverName: string, error: unknown) => void): void {
+    this.onReconnectError = callback;
   }
   
   markKeepAlive(name: string, definition: ServerDefinition): void {
@@ -64,13 +64,10 @@ export class McpLifecycleManager {
       if (!connection || connection.status !== "connected") {
         try {
           await this.manager.connect(name, definition);
-          if (this.lifecycleLogsEnabled) {
-            console.log(`MCP: Reconnected to ${name}`);
-          }
           // Notify extension to update metadata
           this.onReconnect?.(name);
         } catch (error) {
-          console.error(`MCP: Failed to reconnect to ${name}:`, error);
+          this.onReconnectError?.(name, error);
         }
       }
     }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -21,10 +21,10 @@ interface ServerConnection {
 export class McpServerManager {
   private connections = new Map<string, ServerConnection>();
   private connectPromises = new Map<string, Promise<ServerConnection>>();
-  private lifecycleLogsEnabled = true;
+  private onNpxResolved?: (serverName: string, binPath: string) => void;
 
-  setLifecycleLogsEnabled(enabled: boolean): void {
-    this.lifecycleLogsEnabled = enabled;
+  setNpxResolvedCallback(callback: (serverName: string, binPath: string) => void): void {
+    this.onNpxResolved = callback;
   }
   
   async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
@@ -69,9 +69,7 @@ export class McpServerManager {
         if (resolved) {
           command = resolved.isJs ? "node" : resolved.binPath;
           args = resolved.isJs ? [resolved.binPath, ...resolved.extraArgs] : resolved.extraArgs;
-          if (this.lifecycleLogsEnabled) {
-            console.log(`MCP: ${name} resolved to ${resolved.binPath} (skipping npm parent)`);
-          }
+          this.onNpxResolved?.(name, resolved.binPath);
         }
       }
 

--- a/types.ts
+++ b/types.ts
@@ -81,7 +81,6 @@ export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
   idleTimeout?: number; // minutes, default 10, 0 to disable
   directTools?: boolean;
-  lifecycleLogs?: boolean; // log non-error MCP lifecycle events to stdout (default: true)
 }
 
 // Root config


### PR DESCRIPTION
## Summary
- remove the proposed `settings.lifecycleLogs` config flag
- stop emitting MCP lifecycle info via `console.log` / `console.error` in the extension runtime
- route reconnect failures through Pi UI notifications instead
- keep non-actionable lifecycle events silent

## What changed
This PR takes a different approach than the original config-based proposal.

Instead of adding a setting to suppress lifecycle logs, it removes the lifecycle console output path entirely for normal adapter operation:

- npx resolution messages are now silent
- keep-alive reconnect success updates extension state without writing to stdout
- idle shutdown messages are silent
- reconnect failures are surfaced through Pi's UI notification channel

This avoids noisy stdout/stderr messages appearing in Pi's input area while still keeping actual problems visible to the user.

## Motivation
Pi does not expose a dedicated extension logger API, but it does provide UI mechanisms like `ctx.ui.notify()` and `ctx.ui.setStatus()`.

Using those UI channels is a better fit than introducing a new adapter config flag just to suppress stdout lifecycle chatter.

Closes #4
Closes #16
