### PR TITLE
feat: implement automatic OAuth flow with dynamic client registration

### DIFF
--- a/commands.ts
+++ b/commands.ts
@@ -13,6 +13,7 @@ import {
   writeStarterProjectConfig,
 } from "./config.js";
 import { lazyConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds } from "./init.js";
+import { executePause, executeResume } from "./proxy-modes.js";
 import { loadMetadataCache } from "./metadata-cache.js";
 import { buildToolMetadata } from "./tool-metadata.js";
 import { supportsOAuth, authenticate } from "./mcp-auth-flow.js";
@@ -315,6 +316,18 @@ export async function openMcpPanel(
       const freshCache = loadMetadataCache();
       return freshCache?.servers?.[serverName] ?? null;
     },
+    isPaused: (serverName: string) => state.pausedServers.has(serverName),
+    pause: async (serverName: string) => {
+      await executePause(state, serverName);
+    },
+    // Panel resume only unpauses — no eager reconnect. Connection happens
+    // lazily on the next tool call. (executeResume is used by the AI tool
+    // and does reconnect eagerly, which is the right behaviour there.)
+    resume: async (serverName: string) => {
+      state.pausedServers.delete(serverName);
+      state.failureTracker.delete(serverName);
+      updateStatusBar(state);
+    },
   };
 
   const { createMcpPanel } = await import("./mcp-panel.js");
@@ -322,8 +335,8 @@ export async function openMcpPanel(
 
   await new Promise<void>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, _keybindings, done) => {
-        return createMcpPanel(config, cache, provenanceMap, callbacks, tui, (result: McpPanelResult) => {
+      (tui, _theme, keybindings, done) => {
+        return createMcpPanel(config, cache, provenanceMap, callbacks, tui, keybindings, (result: McpPanelResult) => {
           if (!result.cancelled && result.changes.size > 0) {
             writeDirectToolsConfig(result.changes, provenanceMap, config);
             configChanged = true;

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { loadMcpConfig } from "./config.js";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.js";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js";
 import { loadMetadataCache } from "./metadata-cache.js";
-import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
+import { executeCall, executeConnect, executeDescribe, executeList, executePause, executeResume, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
 
@@ -175,6 +175,24 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         case "reconnect":
           await reconnectServers(state, ctx, targetServer);
           break;
+        case "pause": {
+          if (!targetServer) {
+            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp pause <server-name>", "error");
+            break;
+          }
+          const pauseResult = await executePause(state, targetServer);
+          if (ctx.hasUI) ctx.ui.notify(pauseResult.content[0].text, "info");
+          break;
+        }
+        case "resume": {
+          if (!targetServer) {
+            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp resume <server-name>", "error");
+            break;
+          }
+          const resumeResult = await executeResume(state, targetServer);
+          if (ctx.hasUI) ctx.ui.notify(resumeResult.content[0].text, "info");
+          break;
+        }
         case "tools":
           await showTools(state, ctx);
           break;
@@ -238,7 +256,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
       parameters: Type.Object({
         tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
-        args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),
+        args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{"key": "value"}')" })),
         connect: Type.Optional(Type.String({ description: "Server name to connect (lazy connect + metadata refresh)" })),
         describe: Type.Optional(Type.String({ description: "Tool name to describe (shows parameters)" })),
         search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
@@ -246,6 +264,8 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" })),
+        pause: Type.Optional(Type.String({ description: "Server name to pause — hides its tools and closes the connection" })),
+        resume: Type.Optional(Type.String({ description: "Server name to resume after pausing — reconnects and makes tools available again" })),
       }),
       async execute(_toolCallId, params: {
         tool?: string;
@@ -257,6 +277,8 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         includeSchemas?: boolean;
         server?: string;
         action?: string;
+        pause?: string;
+        resume?: string;
       }, _signal, _onUpdate, _ctx) {
         let parsedArgs: Record<string, unknown> | undefined;
         if (params.args) {
@@ -294,6 +316,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
         if (params.action === "ui-messages") {
           return executeUiMessages(state);
+        }
+        if (params.pause) {
+          return executePause(state, params.pause);
+        }
+        if (params.resume) {
+          return executeResume(state, params.resume);
         }
         if (params.tool) {
           return executeCall(state, params.tool, parsedArgs, params.server);

--- a/init.ts
+++ b/init.ts
@@ -36,6 +36,7 @@ export async function initializeMcp(
   const lifecycle = new McpLifecycleManager(manager);
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const failureTracker = new Map<string, number>();
+  const pausedServers = new Set<string>();
   const uiResourceHandler = new UiResourceHandler(manager);
   const consentManager = new ConsentManager("once-per-server");
   const ui = ctx.hasUI ? ctx.ui : undefined;
@@ -45,6 +46,7 @@ export async function initializeMcp(
     toolMetadata,
     config,
     failureTracker,
+    pausedServers,
     uiResourceHandler,
     consentManager,
     uiServer: null,
@@ -265,7 +267,11 @@ export function updateStatusBar(state: McpExtensionState): void {
     return;
   }
   const connectedCount = state.manager.getAllConnections().size;
-  ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`));
+  const pausedCount = state.pausedServers.size;
+  const label = pausedCount > 0
+    ? `MCP: ${connectedCount}/${total} servers (${pausedCount} paused)`
+    : `MCP: ${connectedCount}/${total} servers`;
+  ui.setStatus("mcp", ui.theme.fg("accent", label));
 }
 
 export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,8 +1,124 @@
-import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { KeybindingsManager, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { KeybindingDefinitions } from "@mariozechner/pi-tui";
 import { isToolExcluded } from "./types.js";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
 import type { MetadataCache, ServerCacheEntry, CachedTool } from "./metadata-cache.js";
+
+
+// All panel action IDs — every keybinding is configurable via
+// ~/.pi/agent/keybindings.json using the "mcp.panel.*" keys.
+// Declaration merging into the global Keybindings interface is not done here because
+// @mariozechner/pi-tui is a peer dep not in the project's own node_modules.
+// We use a local union type and a one-shot `as any` at the call site instead.
+type PanelAction =
+  | "mcp.panel.navigateUp"
+  | "mcp.panel.navigateDown"
+  | "mcp.panel.confirm"
+  | "mcp.panel.toggle"
+  | "mcp.panel.cancel"
+  | "mcp.panel.save"
+  | "mcp.panel.quit"
+  | "mcp.panel.reconnect"
+  | "mcp.panel.pause"
+  | "mcp.panel.descSearch"
+  | "mcp.panel.deleteBack"
+  | "mcp.panel.discardConfirm"
+  | "mcp.panel.discardCancel"
+  | "mcp.panel.discardSwitch";
+
+const MCP_PANEL_KB_DEFS: KeybindingDefinitions = {
+  "mcp.panel.navigateUp":     { defaultKeys: "up",                        description: "Navigate up" },
+  "mcp.panel.navigateDown":   { defaultKeys: "down",                      description: "Navigate down" },
+  "mcp.panel.confirm":        { defaultKeys: "return",                    description: "Expand server / toggle tool" },
+  "mcp.panel.toggle":         { defaultKeys: "space",                     description: "Toggle direct tool on/off" },
+  "mcp.panel.cancel":         { defaultKeys: "escape",                    description: "Clear search / close panel" },
+  "mcp.panel.save":           { defaultKeys: "ctrl+s",                    description: "Save changes" },
+  "mcp.panel.quit":           { defaultKeys: "ctrl+c",                    description: "Quit without saving" },
+  "mcp.panel.reconnect":      { defaultKeys: "ctrl+r",                    description: "Reconnect server" },
+  "mcp.panel.pause":          { defaultKeys: "ctrl+x",                    description: "Pause / resume server" },
+  "mcp.panel.descSearch":     { defaultKeys: "?",                         description: "Open description search" },
+  "mcp.panel.deleteBack":     { defaultKeys: "backspace",                 description: "Delete character from search" },
+  "mcp.panel.discardConfirm": { defaultKeys: ["y", "shift+y"],            description: "Confirm discard changes" },
+  "mcp.panel.discardCancel":  { defaultKeys: ["n", "shift+n"],            description: "Cancel discard (keep changes)" },
+  "mcp.panel.discardSwitch":  { defaultKeys: ["left", "right", "tab"],    description: "Switch between Discard/Keep buttons" },
+};
+
+// Single cast point — avoids scattering "as any" throughout the class
+function panelMatches(kb: KeybindingsManager, data: string, action: PanelAction): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return kb.matches(data, action as any);
+}
+function panelKeys(kb: KeybindingsManager, action: PanelAction): string[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return kb.getKeys(action as any);
+}
+
+/** Format a raw key id into a readable symbol/label for the hint bar. */
+function fmtKey(key: string): string {
+  const map: Record<string, string> = {
+    up: "↑", down: "↓", left: "←", right: "→",
+    enter: "⏎", return: "⏎", escape: "esc", space: "␣", backspace: "⌫",
+  };
+  return map[key.toLowerCase()] ?? key;
+}
+
+// All panel action IDs — every keybinding is configurable via
+// ~/.pi/agent/keybindings.json using the "mcp.panel.*" keys.
+// Declaration merging into the global Keybindings interface is not done here because
+// @mariozechner/pi-tui is a peer dep not in the project's own node_modules.
+// We use a local union type and a one-shot `as any` at the call site instead.
+type PanelAction =
+  | "mcp.panel.navigateUp"
+  | "mcp.panel.navigateDown"
+  | "mcp.panel.confirm"
+  | "mcp.panel.toggle"
+  | "mcp.panel.cancel"
+  | "mcp.panel.save"
+  | "mcp.panel.quit"
+  | "mcp.panel.reconnect"
+  | "mcp.panel.pause"
+  | "mcp.panel.descSearch"
+  | "mcp.panel.deleteBack"
+  | "mcp.panel.discardConfirm"
+  | "mcp.panel.discardCancel"
+  | "mcp.panel.discardSwitch";
+
+const MCP_PANEL_KB_DEFS: KeybindingDefinitions = {
+  "mcp.panel.navigateUp":     { defaultKeys: "up",                        description: "Navigate up" },
+  "mcp.panel.navigateDown":   { defaultKeys: "down",                      description: "Navigate down" },
+  "mcp.panel.confirm":        { defaultKeys: "return",                    description: "Expand server / toggle tool" },
+  "mcp.panel.toggle":         { defaultKeys: "space",                     description: "Toggle direct tool on/off" },
+  "mcp.panel.cancel":         { defaultKeys: "escape",                    description: "Clear search / close panel" },
+  "mcp.panel.save":           { defaultKeys: "ctrl+s",                    description: "Save changes" },
+  "mcp.panel.quit":           { defaultKeys: "ctrl+c",                    description: "Quit without saving" },
+  "mcp.panel.reconnect":      { defaultKeys: "ctrl+r",                    description: "Reconnect server" },
+  "mcp.panel.pause":          { defaultKeys: "ctrl+x",                    description: "Pause / resume server" },
+  "mcp.panel.descSearch":     { defaultKeys: "?",                         description: "Open description search" },
+  "mcp.panel.deleteBack":     { defaultKeys: "backspace",                 description: "Delete character from search" },
+  "mcp.panel.discardConfirm": { defaultKeys: ["y", "shift+y"],            description: "Confirm discard changes" },
+  "mcp.panel.discardCancel":  { defaultKeys: ["n", "shift+n"],            description: "Cancel discard (keep changes)" },
+  "mcp.panel.discardSwitch":  { defaultKeys: ["left", "right", "tab"],    description: "Switch between Discard/Keep buttons" },
+};
+
+// Single cast point — avoids scattering "as any" throughout the class
+function panelMatches(kb: KeybindingsManager, data: string, action: PanelAction): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return kb.matches(data, action as any);
+}
+function panelKeys(kb: KeybindingsManager, action: PanelAction): string[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return kb.getKeys(action as any);
+}
+
+/** Format a raw key id into a readable symbol/label for the hint bar. */
+function fmtKey(key: string): string {
+  const map: Record<string, string> = {
+    up: "↑", down: "↓", left: "←", right: "→",
+    enter: "⏎", return: "⏎", escape: "esc", space: "␣", backspace: "⌫",
+  };
+  return map[key.toLowerCase()] ?? key;
+}
 
 interface PanelTheme {
   border: string;
@@ -99,6 +215,7 @@ interface ServerState {
   connectionStatus: ConnectionStatus;
   tools: ToolState[];
   hasCachedData: boolean;
+  paused: boolean;
 }
 
 interface VisibleItem {
@@ -124,6 +241,7 @@ class McpPanel {
   private visibleItems: VisibleItem[] = [];
   private tui: { requestRender(): void };
   private t = DEFAULT_THEME;
+  private kb: KeybindingsManager;
 
   private static readonly MAX_VISIBLE = 12;
   private static readonly INACTIVITY_MS = 60_000;
@@ -134,12 +252,16 @@ class McpPanel {
     provenance: Map<string, ServerProvenance>,
     private callbacks: McpPanelCallbacks,
     tui: { requestRender(): void },
+    piKeybindings: KeybindingsManager,
     private done: (result: McpPanelResult) => void,
     noticeLines: string[] = [],
   ) {
     this.tui = tui;
     this.noticeLines = noticeLines;
     this.prefix = config.settings?.toolPrefix ?? "server";
+    // Build a panel-local manager so users can override these actions via
+    // ~/.pi/agent/keybindings.json using the "mcp.panel.*" action IDs.
+    this.kb = new KeybindingsManager(MCP_PANEL_KB_DEFS, piKeybindings.getUserBindings());
 
     for (const [serverName, definition] of Object.entries(config.mcpServers)) {
       const prov = provenance.get(serverName);
@@ -201,6 +323,7 @@ class McpPanel {
         connectionStatus: status,
         tools,
         hasCachedData: !!serverCache,
+        paused: callbacks.isPaused(serverName),
       });
     }
 
@@ -292,13 +415,13 @@ class McpPanel {
     }
 
     // Global shortcuts — always work, even during desc search
-    if (matchesKey(data, "ctrl+c")) {
+    if (panelMatches(this.kb, data, "mcp.panel.quit")) {
       this.cleanup();
       this.done({ cancelled: true, changes: new Map() });
       return;
     }
 
-    if (matchesKey(data, "ctrl+s")) {
+    if (panelMatches(this.kb, data, "mcp.panel.save")) {
       this.cleanup();
       this.done(this.buildResult());
       return;
@@ -306,14 +429,14 @@ class McpPanel {
 
     // Modal description search mode
     if (this.descSearchActive) {
-      if (matchesKey(data, "escape") || matchesKey(data, "return")) {
+      if (panelMatches(this.kb, data, "mcp.panel.cancel") || panelMatches(this.kb, data, "mcp.panel.confirm")) {
         this.descSearchActive = false;
         this.descQuery = "";
         this.rebuildVisibleItems();
         this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1));
         return;
       }
-      if (matchesKey(data, "backspace")) {
+      if (panelMatches(this.kb, data, "mcp.panel.deleteBack")) {
         if (this.descQuery.length > 0) {
           this.descQuery = this.descQuery.slice(0, -1);
           this.rebuildVisibleItems();
@@ -321,9 +444,9 @@ class McpPanel {
         }
         return;
       }
-      if (matchesKey(data, "up")) { this.moveCursor(-1); return; }
-      if (matchesKey(data, "down")) { this.moveCursor(1); return; }
-      if (matchesKey(data, "space")) {
+      if (panelMatches(this.kb, data, "mcp.panel.navigateUp")) { this.moveCursor(-1); return; }
+      if (panelMatches(this.kb, data, "mcp.panel.navigateDown")) { this.moveCursor(1); return; }
+      if (panelMatches(this.kb, data, "mcp.panel.toggle")) {
         // Toggle even while in desc search
         const item = this.visibleItems[this.cursorIndex];
         if (item) this.toggleItem(item);
@@ -338,7 +461,7 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "escape")) {
+    if (panelMatches(this.kb, data, "mcp.panel.cancel")) {
       if (this.nameQuery) {
         this.nameQuery = "";
         this.rebuildVisibleItems();
@@ -355,16 +478,16 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "up")) { this.moveCursor(-1); return; }
-    if (matchesKey(data, "down")) { this.moveCursor(1); return; }
+    if (panelMatches(this.kb, data, "mcp.panel.navigateUp")) { this.moveCursor(-1); return; }
+    if (panelMatches(this.kb, data, "mcp.panel.navigateDown")) { this.moveCursor(1); return; }
 
-    if (matchesKey(data, "space")) {
+    if (panelMatches(this.kb, data, "mcp.panel.toggle")) {
       const item = this.visibleItems[this.cursorIndex];
       if (item) this.toggleItem(item);
       return;
     }
 
-    if (matchesKey(data, "return")) {
+    if (panelMatches(this.kb, data, "mcp.panel.confirm")) {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
       const server = this.servers[item.serverIndex];
@@ -387,11 +510,19 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "ctrl+r")) {
+    if (panelMatches(this.kb, data, "mcp.panel.pause")) {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
       const server = this.servers[item.serverIndex];
-      if (server.connectionStatus === "connecting") return;
+      this.toggleServerPause(server);
+      return;
+    }
+
+    if (panelMatches(this.kb, data, "mcp.panel.reconnect")) {
+      const item = this.visibleItems[this.cursorIndex];
+      if (!item) return;
+      const server = this.servers[item.serverIndex];
+      if (server.paused || server.connectionStatus === "connecting") return;
       server.connectionStatus = "connecting";
       this.callbacks.reconnect(server.name).then(() => {
         server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
@@ -412,7 +543,7 @@ class McpPanel {
       return;
     }
 
-    if (data === "?") {
+    if (panelMatches(this.kb, data, "mcp.panel.descSearch")) {
       this.descSearchActive = true;
       this.descQuery = "";
       this.rebuildVisibleItems();
@@ -421,7 +552,7 @@ class McpPanel {
     }
 
     // Backspace removes from name query
-    if (matchesKey(data, "backspace")) {
+    if (panelMatches(this.kb, data, "mcp.panel.deleteBack")) {
       if (this.nameQuery.length > 0) {
         this.nameQuery = this.nameQuery.slice(0, -1);
         this.rebuildVisibleItems();
@@ -457,17 +588,45 @@ class McpPanel {
     this.updateDirty();
   }
 
+
+  private toggleServerPause(server: ServerState): void {
+    // Don't allow while a reconnect/previous pause is in progress
+    if (server.connectionStatus === "connecting") return;
+
+    const wasPaused = server.paused;
+    server.paused = !wasPaused;
+    if (!wasPaused) {
+      // Collapsing tools immediately gives snappy feedback
+      server.expanded = false;
+      this.rebuildVisibleItems();
+    }
+    this.tui.requestRender();
+
+    const action = wasPaused ? this.callbacks.resume.bind(this.callbacks) : this.callbacks.pause.bind(this.callbacks);
+    action(server.name).then(() => {
+      server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      this.tui.requestRender();
+    }).catch(() => {
+      // Revert optimistic update on error
+      server.paused = wasPaused;
+      if (wasPaused) server.expanded = false;
+      server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      this.rebuildVisibleItems();
+      this.tui.requestRender();
+    });
+  }
+
   private handleDiscardInput(data: string): void {
-    if (matchesKey(data, "ctrl+c")) {
+    if (panelMatches(this.kb, data, "mcp.panel.quit")) {
       this.cleanup();
       this.done({ cancelled: true, changes: new Map() });
       return;
     }
-    if (matchesKey(data, "escape") || data === "n" || data === "N") {
+    if (panelMatches(this.kb, data, "mcp.panel.cancel") || panelMatches(this.kb, data, "mcp.panel.discardCancel")) {
       this.confirmingDiscard = false;
       return;
     }
-    if (matchesKey(data, "return")) {
+    if (panelMatches(this.kb, data, "mcp.panel.confirm")) {
       if (this.discardSelected === 0) {
         this.cleanup();
         this.done({ cancelled: true, changes: new Map() });
@@ -476,12 +635,12 @@ class McpPanel {
       }
       return;
     }
-    if (data === "y" || data === "Y") {
+    if (panelMatches(this.kb, data, "mcp.panel.discardConfirm")) {
       this.cleanup();
       this.done({ cancelled: true, changes: new Map() });
       return;
     }
-    if (matchesKey(data, "left") || matchesKey(data, "right") || matchesKey(data, "tab")) {
+    if (panelMatches(this.kb, data, "mcp.panel.discardSwitch")) {
       this.discardSelected = this.discardSelected === 0 ? 1 : 0;
     }
   }
@@ -535,6 +694,33 @@ class McpPanel {
     server.tools = newTools;
     this.rebuildVisibleItems();
     this.updateDirty();
+  }
+
+  private toggleServerPause(server: ServerState): void {
+    // Don't allow while a reconnect/previous pause is in progress
+    if (server.connectionStatus === "connecting") return;
+
+    const wasPaused = server.paused;
+    server.paused = !wasPaused;
+    if (!wasPaused) {
+      // Collapsing tools immediately gives snappy feedback
+      server.expanded = false;
+      this.rebuildVisibleItems();
+    }
+    this.tui.requestRender();
+
+    const action = wasPaused ? this.callbacks.resume.bind(this.callbacks) : this.callbacks.pause.bind(this.callbacks);
+    action(server.name).then(() => {
+      server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      this.tui.requestRender();
+    }).catch(() => {
+      // Revert optimistic update on error
+      server.paused = wasPaused;
+      if (wasPaused) server.expanded = false;
+      server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      this.rebuildVisibleItems();
+      this.tui.requestRender();
+    });
   }
 
   render(width: number): string[] {
@@ -642,15 +828,27 @@ class McpPanel {
     }
 
     lines.push(emptyRow());
+    const upKey       = fmtKey(panelKeys(this.kb, "mcp.panel.navigateUp")[0]   ?? "up");
+    const dnKey       = fmtKey(panelKeys(this.kb, "mcp.panel.navigateDown")[0] ?? "down");
+    const toggleKey   = fmtKey(panelKeys(this.kb, "mcp.panel.toggle")[0]       ?? "space");
+    const confirmKey  = fmtKey(panelKeys(this.kb, "mcp.panel.confirm")[0]      ?? "return");
+    const reconnKey   = fmtKey(panelKeys(this.kb, "mcp.panel.reconnect")[0]    ?? "ctrl+r");
+    const pauseKey    = fmtKey(panelKeys(this.kb, "mcp.panel.pause")[0]        ?? "ctrl+x");
+    const dsearchKey  = fmtKey(panelKeys(this.kb, "mcp.panel.descSearch")[0]   ?? "?");
+    const saveKey     = fmtKey(panelKeys(this.kb, "mcp.panel.save")[0]         ?? "ctrl+s");
+    const cancelKey   = fmtKey(panelKeys(this.kb, "mcp.panel.cancel")[0]       ?? "escape");
+    const quitKey     = fmtKey(panelKeys(this.kb, "mcp.panel.quit")[0]         ?? "ctrl+c");
+    const navStr      = upKey === "↑" && dnKey === "↓" ? "↑↓" : `${upKey}/${dnKey}`;
     const hints = [
-      italic("↑↓") + " navigate",
-      italic("space") + " toggle",
-      italic("⏎") + " expand",
-      italic("ctrl+r") + " reconnect",
-      italic("?") + " desc search",
-      italic("ctrl+s") + " save",
-      italic("esc") + " clear/close",
-      italic("ctrl+c") + " quit",
+      italic(navStr)       + " navigate",
+      italic(toggleKey)    + " toggle",
+      italic(confirmKey)   + " expand",
+      italic(reconnKey)    + " reconnect",
+      italic(pauseKey)     + " pause/resume",
+      italic(dsearchKey)   + " desc search",
+      italic(saveKey)      + " save",
+      italic(cancelKey)    + " clear/close",
+      italic(quitKey)      + " quit",
     ];
     const gap = "  ";
     const gapW = 2;
@@ -680,11 +878,21 @@ class McpPanel {
     const t = this.t;
     const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
 
+    const importLabel = server.source === "import" ? fg(t.description, ` (${server.importKind ?? "import"})`) : "";
+
+    if (server.paused) {
+      const pauseIcon = fg(t.hint, "⏸");
+      const dot = fg(t.hint, "·");
+      const nameStr = isCursor ? bold(fg(t.selected, server.name)) : fg(t.hint, server.name);
+      const toolCount = server.tools.length;
+      const label = fg(t.hint, `(paused, ${toolCount} tool${toolCount === 1 ? "" : "s"} hidden)`);
+      return `${pauseIcon} ${dot} ${nameStr}${importLabel}  ${label}`;
+    }
+
     const expandIcon = server.expanded ? "▾" : "▸";
     const prefix = isCursor ? fg(t.selected, expandIcon) : fg(t.border, server.expanded ? expandIcon : "·");
 
     const nameStr = isCursor ? bold(fg(t.selected, server.name)) : server.name;
-    const importLabel = server.source === "import" ? fg(t.description, ` (${server.importKind ?? "import"})`) : "";
 
     if (!server.hasCachedData) {
       return `${prefix}   ${nameStr}${importLabel}  ${fg(t.description, "(not cached)")}`;
@@ -743,8 +951,9 @@ export function createMcpPanel(
   provenance: Map<string, ServerProvenance>,
   callbacks: McpPanelCallbacks,
   tui: { requestRender(): void },
+  piKeybindings: KeybindingsManager,
   done: (result: McpPanelResult) => void,
   options?: { noticeLines?: string[] },
 ): McpPanel & { dispose(): void } {
-  return new McpPanel(config, cache, provenance, callbacks, tui, done, options?.noticeLines ?? []);
+  return new McpPanel(config, cache, provenance, callbacks, tui, piKeybindings, done, options?.noticeLines ?? []);
 }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -9,6 +9,69 @@ import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.js";
 import { truncateAtWord } from "./utils.js";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js";
 
+export async function executePause(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+  if (!state.config.mcpServers[serverName]) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "pause", error: "not_found", server: serverName },
+    };
+  }
+
+  if (state.pausedServers.has(serverName)) {
+    const toolCount = state.toolMetadata.get(serverName)?.length ?? 0;
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" is already paused (${toolCount} tools hidden). Use mcp({ resume: "${serverName}" }) to resume.` }],
+      details: { mode: "pause", server: serverName, toolCount, alreadyPaused: true },
+    };
+  }
+
+  // Close the connection to free resources (kills the subprocess)
+  await state.manager.close(serverName);
+
+  // Mark as paused (metadata is kept so status can still show tool count)
+  state.pausedServers.add(serverName);
+  updateStatusBar(state);
+
+  const toolCount = state.toolMetadata.get(serverName)?.length ?? 0;
+  return {
+    content: [{ type: "text" as const, text: `Server "${serverName}" paused — ${toolCount} tool${toolCount === 1 ? "" : "s"} hidden. Use mcp({ resume: "${serverName}" }) to resume.` }],
+    details: { mode: "pause", server: serverName, toolCount },
+  };
+}
+
+export async function executeResume(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+  if (!state.config.mcpServers[serverName]) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "resume", error: "not_found", server: serverName },
+    };
+  }
+
+  if (!state.pausedServers.has(serverName)) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" is not paused.` }],
+      details: { mode: "resume", server: serverName, notPaused: true },
+    };
+  }
+
+  state.pausedServers.delete(serverName);
+  // Clear any stale failure so lazyConnect will actually try
+  state.failureTracker.delete(serverName);
+
+  const connected = await lazyConnect(state, serverName);
+  if (connected) {
+    // Show available tools via executeList
+    return executeList(state, serverName);
+  }
+
+  // Reconnect failed — still resumed (tools visible again on next successful connect)
+  const toolCount = state.toolMetadata.get(serverName)?.length ?? 0;
+  return {
+    content: [{ type: "text" as const, text: `Server "${serverName}" resumed but could not reconnect right now. ${toolCount} cached tool${toolCount === 1 ? "" : "s"} available when it connects.` }],
+    details: { mode: "resume", server: serverName, connected: false, toolCount },
+  };
+}
+
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
 type AutoAuthResult =
@@ -135,12 +198,15 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
   const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null }> = [];
 
   for (const name of Object.keys(state.config.mcpServers)) {
+    const isPaused = state.pausedServers.has(name);
     const connection = state.manager.getConnection(name);
     const metadata = state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
     const failedAgo = getFailureAgeSeconds(state, name);
     let status = "not connected";
-    if (connection?.status === "connected") {
+    if (isPaused) {
+      status = "paused";
+    } else if (connection?.status === "connected") {
       status = "connected";
     } else if (connection?.status === "needs-auth") {
       status = "needs-auth";
@@ -153,11 +219,21 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
     servers.push({ name, status, toolCount, failedAgo });
   }
 
-  const totalTools = servers.reduce((sum, s) => sum + s.toolCount, 0);
+  const totalTools = servers.filter(s => s.status !== "paused").reduce((sum, s) => sum + s.toolCount, 0);
   const connectedCount = servers.filter(s => s.status === "connected").length;
+  const pausedCount = servers.filter(s => s.status === "paused").length;
 
-  let text = `MCP: ${connectedCount}/${servers.length} servers, ${totalTools} tools\n\n`;
+  let text = `MCP: ${connectedCount}/${servers.length} servers, ${totalTools} tools`;
+  if (pausedCount > 0) {
+    text += ` (${pausedCount} paused)`;
+  }
+  text += "\n\n";
+
   for (const server of servers) {
+    if (server.status === "paused") {
+      text += `⏸ ${server.name} (paused, ${server.toolCount} tools hidden)\n`;
+      continue;
+    }
     if (server.status === "connected") {
       text += `✓ ${server.name} (${server.toolCount} tools)\n`;
       continue;
@@ -179,11 +255,14 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
   if (servers.length > 0) {
     text += `\nmcp({ server: "name" }) to list tools, mcp({ search: "..." }) to search`;
+    if (pausedCount > 0) {
+      text += `, mcp({ resume: "name" }) to unpause`;
+    }
   }
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "status", servers, totalTools, connectedCount },
+    details: { mode: "status", servers, totalTools, connectedCount, pausedCount },
   };
 }
 
@@ -279,6 +358,7 @@ export function executeSearch(
 
   for (const [serverName, metadata] of state.toolMetadata.entries()) {
     if (server && serverName !== server) continue;
+    if (state.pausedServers.has(serverName)) continue; // tools invisible while paused
     for (const tool of metadata) {
       if (pattern.test(tool.name) || pattern.test(tool.description)) {
         matches.push({
@@ -356,6 +436,14 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
     return {
       content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "list", server, tools: [], count: 0, error: "not_found" },
+    };
+  }
+
+  if (state.pausedServers.has(server)) {
+    const toolCount = state.toolMetadata.get(server)?.length ?? 0;
+    return {
+      content: [{ type: "text" as const, text: `Server "${server}" is paused (${toolCount} tools hidden). Use mcp({ resume: "${server}" }) to resume.` }],
+      details: { mode: "list", server, tools: [], count: 0, paused: true },
     };
   }
 
@@ -477,9 +565,16 @@ export async function executeCall(
   }
 
   if (serverName) {
+    if (state.pausedServers.has(serverName)) {
+      return {
+        content: [{ type: "text" as const, text: `Server "${serverName}" is paused. Use mcp({ resume: "${serverName}" }) to resume it first.` }],
+        details: { mode: "call", error: "server_paused", server: serverName },
+      };
+    }
     toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
   } else {
     for (const [server, metadata] of state.toolMetadata.entries()) {
+      if (state.pausedServers.has(server)) continue; // tools invisible while paused
       const found = findToolByName(metadata, toolName);
       if (found) {
         serverName = server;
@@ -546,6 +641,7 @@ export async function executeCall(
 
   if (!serverName && !toolMeta && prefixMode !== "none") {
     const candidates = Object.keys(state.config.mcpServers)
+      .filter(name => !state.pausedServers.has(name)) // skip paused servers
       .map(name => ({ name, prefix: getServerPrefix(name, prefixMode) }))
       .filter(c => c.prefix && toolName.startsWith(c.prefix + "_"))
       .sort((a, b) => b.prefix.length - a.prefix.length);

--- a/state.ts
+++ b/state.ts
@@ -31,6 +31,8 @@ export interface McpExtensionState {
   toolMetadata: Map<string, ToolMetadata[]>;
   config: McpConfig;
   failureTracker: Map<string, number>;
+  /** Servers explicitly paused by the user this session. Their tools are hidden from the AI. */
+  pausedServers: Set<string>;
   uiResourceHandler: UiResourceHandler;
   consentManager: ConsentManager;
   uiServer: UiServerHandle | null;

--- a/types.ts
+++ b/types.ts
@@ -361,6 +361,9 @@ export interface McpPanelCallbacks {
   reconnect: (serverName: string) => Promise<boolean>;
   getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth";
   refreshCacheAfterReconnect: (serverName: string) => import("./metadata-cache.js").ServerCacheEntry | null;
+  isPaused: (serverName: string) => boolean;
+  pause: (serverName: string) => Promise<void>;
+  resume: (serverName: string) => Promise<void>;
 }
 
 export interface McpPanelResult {


### PR DESCRIPTION
Disclaimer:  This was fully vibed with `pi` and `kimi-k2.5`.  I don't have yet the time to devote a full revision.  I have successfully registered Notion's and Sentry's MCPs with this.  In particular Sentry provide tokens with refresh of 15 minutes, which makes this auto-refresh a nice addition.

---

Add full OAuth 2.0 authorization code flow with PKCE:

- New oauth-flow.ts: Complete OAuth implementation
  - Discovery via .well-known/oauth-authorization-server
  - Dynamic client registration at /register endpoint
  - PKCE code verifier/challenge generation
  - Local HTTP callback server with random port
  - Automatic browser opening for authorization
  - Token exchange and storage

- Enhanced oauth-handler.ts:
  - Automatic token refresh when expired
  - Uses refresh_token to get new access_token
  - Stores authorization metadata (server, clientId)

- Updated types.ts:
  - Added scopes, clientId, authorizationServer fields

- Updated commands.ts:
  - /mcp-auth now runs full OAuth flow instead of showing instructions
  - Step-by-step progress notifications

- Updated server-manager.ts:
  - Async token loading with automatic refresh

Fixes: OAuth servers like Notion that require dynamic client registration now work automatically without manual setup.