### PR TITLE
fix(status): remove empty footer line when no MCP servers configured

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -262,7 +262,7 @@ export function updateStatusBar(state: McpExtensionState): void {
   if (!ui) return;
   const total = Object.keys(state.config.mcpServers).length;
   if (total === 0) {
-    ui.setStatus("mcp", "");
+    ui.setStatus("mcp", undefined);
     return;
   }
   const connectedCount = state.manager.getAllConnections().size;


### PR DESCRIPTION
## Problem

When no MCP servers are configured (`mcpServers: {}`), the Pi TUI renders an empty/blank line at the very bottom of the screen — below the normal footer stats line.

## Root Cause

In `updateStatusBar()`, when `total === 0`, the extension calls:

```typescript
ui.setStatus("mcp", "");
```

Pi's `FooterDataProvider.setExtensionStatus()` only **deletes** a status entry when the value is `undefined`. An empty string `""` is stored as a valid entry in the `extensionStatuses` map.

The footer component checks `if (extensionStatuses.size > 0)` and renders a dedicated status line for extensions. Since the empty string entry keeps `size` at 1, the footer renders a blank third line.

## Fix

Pass `undefined` instead of `""` so the entry is properly removed from the map:

```typescript
ui.setStatus("mcp", undefined);
```

This matches the `setStatus` type signature (`text: string | undefined`) and ensures the footer doesn't render an empty extension status line when there are no MCP servers.