### PR TITLE
feat(config): support repeated --mcp-config flags

### DIFF
--- a/__tests__/config-provenance.test.ts
+++ b/__tests__/config-provenance.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn<(path: string) => boolean>(),
+  readFileSync: vi.fn<(path: string, encoding: string) => string>(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: fsMock.existsSync,
+  readFileSync: fsMock.readFileSync,
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+import { getServerProvenance } from "../config.js";
+
+describe("getServerProvenance multi-file provenance", () => {
+  const originalWarn = console.warn;
+  let files: Record<string, string>;
+
+  beforeEach(() => {
+    files = {};
+    fsMock.existsSync.mockImplementation((path: string) => path in files);
+    fsMock.readFileSync.mockImplementation((path: string) => {
+      if (!(path in files)) {
+        throw new Error(`ENOENT: ${path}`);
+      }
+      return files[path];
+    });
+    console.warn = vi.fn();
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    vi.restoreAllMocks();
+  });
+
+  it("tracks the source file for each server across multiple override files", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: { alpha: { command: "a" } },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: { beta: { command: "b" } },
+    });
+
+    const provenance = getServerProvenance(["/a.json", "/b.json"]);
+
+    expect(provenance.get("alpha")).toEqual({ path: "/a.json", kind: "user" });
+    expect(provenance.get("beta")).toEqual({ path: "/b.json", kind: "user" });
+  });
+
+  it("uses the later file as provenance when the same server is overridden", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "old" } },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "new" } },
+    });
+
+    const provenance = getServerProvenance(["/a.json", "/b.json"]);
+
+    expect(provenance.get("playwright")).toEqual({ path: "/b.json", kind: "user" });
+  });
+});

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn<(path: string) => boolean>(),
+  readFileSync: vi.fn<(path: string, encoding: string) => string>(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: fsMock.existsSync,
+  readFileSync: fsMock.readFileSync,
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+import os from "node:os";
+import { loadMcpConfig } from "../config.js";
+
+const cwd = process.cwd();
+const defaultConfigPath = `${os.homedir()}/.pi/agent/mcp.json`;
+const projectConfigPath = `${cwd}/.pi/mcp.json`;
+
+describe("loadMcpConfig multi-file merge", () => {
+  const originalArgv = process.argv;
+  const originalWarn = console.warn;
+  let files: Record<string, string>;
+  let warnSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.argv = [...originalArgv];
+    files = {};
+    fsMock.existsSync.mockImplementation((path: string) => path in files);
+    fsMock.readFileSync.mockImplementation((path: string) => {
+      if (!(path in files)) {
+        throw new Error(`ENOENT: ${path}`);
+      }
+      return files[path];
+    });
+    warnSpy = vi.fn();
+    console.warn = warnSpy;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    console.warn = originalWarn;
+    vi.restoreAllMocks();
+  });
+
+  it("loads a single file from an array override", () => {
+    files["/one.json"] = JSON.stringify({
+      mcpServers: { one: { command: "node" } },
+    });
+
+    expect(loadMcpConfig(["/one.json"])).toEqual({
+      mcpServers: { one: { command: "node" } },
+    });
+  });
+
+  it("loads multiple files and merges servers", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: { alpha: { command: "a" } },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: { beta: { command: "b" } },
+    });
+
+    expect(loadMcpConfig(["/a.json", "/b.json"]).mcpServers).toEqual({
+      alpha: { command: "a" },
+      beta: { command: "b" },
+    });
+  });
+
+  it("lets later files override the same server", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "old", args: ["--stdio"] } },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "new", args: ["serve"] } },
+    });
+
+    expect(loadMcpConfig(["/a.json", "/b.json"]).mcpServers.playwright).toEqual({
+      command: "new",
+      args: ["serve"],
+    });
+  });
+
+  it("merges settings shallowly across files", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: {},
+      settings: { toolPrefix: "short" },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: {},
+      settings: { idleTimeout: 30 },
+    });
+
+    expect(loadMcpConfig(["/a.json", "/b.json"]).settings).toEqual({
+      toolPrefix: "short",
+      idleTimeout: 30,
+    });
+  });
+
+  it("merges imports as a deduplicated union", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: {},
+      imports: ["cursor"],
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: {},
+      imports: ["claude-code", "cursor"],
+    });
+
+    expect(loadMcpConfig(["/a.json", "/b.json"]).imports).toEqual(["cursor", "claude-code"]);
+  });
+
+  it("skips missing files gracefully and loads existing ones", () => {
+    files["/exists.json"] = JSON.stringify({
+      mcpServers: { only: { command: "node" } },
+    });
+
+    expect(loadMcpConfig(["/missing.json", "/exists.json"]).mcpServers).toEqual({
+      only: { command: "node" },
+    });
+  });
+
+  it("falls back to the default config when given an empty array", () => {
+    files[defaultConfigPath] = JSON.stringify({
+      mcpServers: { defaulted: { command: "node" } },
+    });
+
+    expect(loadMcpConfig([])).toEqual(loadMcpConfig(undefined));
+  });
+
+  it("still accepts a string override path", () => {
+    files["/single.json"] = JSON.stringify({
+      mcpServers: { single: { command: "node" } },
+    });
+
+    expect(loadMcpConfig("/single.json").mcpServers).toEqual({
+      single: { command: "node" },
+    });
+  });
+
+  it("skips invalid JSON files, warns, and still loads valid files", () => {
+    files["/bad.json"] = "{";
+    files["/good.json"] = JSON.stringify({
+      mcpServers: { good: { command: "node" } },
+    });
+
+    expect(loadMcpConfig(["/bad.json", "/good.json"]).mcpServers).toEqual({
+      good: { command: "node" },
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("lets project config override merged multi-file config", () => {
+    files["/a.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "a" }, alpha: { command: "alpha" } },
+    });
+    files["/b.json"] = JSON.stringify({
+      mcpServers: { playwright: { command: "b" }, beta: { command: "beta" } },
+    });
+    files[projectConfigPath] = JSON.stringify({
+      mcpServers: { playwright: { command: "project" } },
+    });
+
+    expect(loadMcpConfig(["/a.json", "/b.json"]).mcpServers).toEqual({
+      alpha: { command: "alpha" },
+      beta: { command: "beta" },
+      playwright: { command: "project" },
+    });
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,79 @@
+import os from "node:os";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getConfigPathFromArgv, getConfigPathsFromArgv, parseConfigFlag } from "../utils.js";
+
+describe("config path parsing", () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    process.argv = [...originalArgv];
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  describe("getConfigPathsFromArgv", () => {
+    it("returns undefined when no --mcp-config flag is present", () => {
+      process.argv = ["node", "pi"];
+
+      expect(getConfigPathsFromArgv()).toBeUndefined();
+    });
+
+    it("returns a single path after one --mcp-config flag", () => {
+      process.argv = ["node", "pi", "--mcp-config", "a.json"];
+
+      expect(getConfigPathsFromArgv()).toEqual(["a.json"]);
+    });
+
+    it("returns multiple paths after one --mcp-config flag", () => {
+      process.argv = ["node", "pi", "--mcp-config", "a.json", "b.json"];
+
+      expect(getConfigPathsFromArgv()).toEqual(["a.json", "b.json"]);
+    });
+
+    it("collects paths from repeated --mcp-config flags", () => {
+      process.argv = ["node", "pi", "--mcp-config", "a.json", "--mcp-config", "b.json"];
+
+      expect(getConfigPathsFromArgv()).toEqual(["a.json", "b.json"]);
+    });
+
+    it("expands ~ to the current home directory", () => {
+      process.argv = ["node", "pi", "--mcp-config", "~/a.json"];
+
+      expect(getConfigPathsFromArgv()).toEqual([`${os.homedir()}/a.json`]);
+    });
+
+    it("stops collecting paths at the next flag", () => {
+      process.argv = ["node", "pi", "--mcp-config", "a.json", "--other"];
+
+      expect(getConfigPathsFromArgv()).toEqual(["a.json"]);
+    });
+  });
+
+  describe("getConfigPathFromArgv", () => {
+    it("returns the first parsed config path for legacy compatibility", () => {
+      process.argv = ["node", "pi", "--mcp-config", "~/a.json", "b.json"];
+
+      expect(getConfigPathFromArgv()).toBe(`${os.homedir()}/a.json`);
+    });
+  });
+
+  describe("parseConfigFlag", () => {
+    it("preserves a string flag as a single config path", () => {
+      expect(parseConfigFlag("a.json")).toEqual(["a.json"]);
+    });
+
+    it("preserves spaces inside a single config path", () => {
+      expect(parseConfigFlag("~/Library/Application Support/mcp.json")).toEqual([
+        `${os.homedir()}/Library/Application Support/mcp.json`,
+      ]);
+    });
+
+    it("returns undefined when the flag is undefined", () => {
+      expect(parseConfigFlag(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/wiring.test.ts
+++ b/__tests__/wiring.test.ts
@@ -10,7 +10,7 @@ describe("multi-config call-site wiring", () => {
   it("index.ts imports getConfigPathsFromArgv instead of getConfigPathFromArgv", () => {
     const source = readSource("index.ts");
 
-    expect(source).toContain('import { getConfigPathsFromArgv } from "./utils.js";');
+    expect(source).toMatch(/import\s+\{[^}]*getConfigPathsFromArgv[^}]*\}\s+from\s+"\.\/utils\.js";/);
     expect(source).not.toContain('import { getConfigPathFromArgv } from "./utils.js";');
   });
 
@@ -42,8 +42,9 @@ describe("multi-config call-site wiring", () => {
     const source = readSource("commands.ts");
 
     expect(source).toMatch(/import\s+\{[^}]*getConfigPathsFromArgv[^}]*\}\s+from\s+"\.\/utils\.js";/);
-    expect(source).toContain('const configPaths = getConfigPathsFromArgv() ?? (configOverridePath ? [configOverridePath] : undefined);');
+    expect(source).toContain('const configPaths = getConfigPathsFromArgv();');
     expect(source).toContain('const provenanceMap = getServerProvenance(configPaths);');
     expect(source).not.toContain('parseConfigFlag(pi.getFlag("mcp-config"))');
+    expect(source).not.toContain('configOverridePath');
   });
 });

--- a/__tests__/wiring.test.ts
+++ b/__tests__/wiring.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+function readSource(file: string): string {
+  return readFileSync(resolve(import.meta.dirname, "..", file), "utf-8");
+}
+
+describe("multi-config call-site wiring", () => {
+  it("index.ts imports getConfigPathsFromArgv instead of getConfigPathFromArgv", () => {
+    const source = readSource("index.ts");
+
+    expect(source).toContain('import { getConfigPathsFromArgv } from "./utils.js";');
+    expect(source).not.toContain('import { getConfigPathFromArgv } from "./utils.js";');
+  });
+
+  it("index.ts passes earlyConfigPaths into loadMcpConfig", () => {
+    const source = readSource("index.ts");
+
+    expect(source).toContain("const earlyConfigPaths = getConfigPathsFromArgv();");
+    expect(source).toContain("const earlyConfig = loadMcpConfig(earlyConfigPaths);");
+    expect(source).not.toContain("const earlyConfigPath = getConfigPathFromArgv();");
+    expect(source).not.toContain("const earlyConfig = loadMcpConfig(earlyConfigPath);");
+  });
+
+  it("index.ts describes the mcp-config flag as supporting repeated paths", () => {
+    const source = readSource("index.ts");
+
+    expect(source).toMatch(/description:\s*"[^"]*(Path\(s\)|can be repeated)[^"]*"/);
+  });
+
+  it("init.ts uses getConfigPathsFromArgv so repeated mcp-config flags are preserved", () => {
+    const source = readSource("init.ts");
+
+    expect(source).toContain('import { getConfigPathsFromArgv, openUrl, parallelLimit } from "./utils.js";');
+    expect(source).toContain('const configPaths = getConfigPathsFromArgv();');
+    expect(source).toContain('const config = loadMcpConfig(configPaths);');
+    expect(source).not.toContain('parseConfigFlag(pi.getFlag("mcp-config"))');
+  });
+
+  it("commands.ts uses getConfigPathsFromArgv-derived config paths for provenance so repeated flags survive end-to-end", () => {
+    const source = readSource("commands.ts");
+
+    expect(source).toMatch(/import\s+\{[^}]*getConfigPathsFromArgv[^}]*\}\s+from\s+"\.\/utils\.js";/);
+    expect(source).toContain('const configPaths = getConfigPathsFromArgv() ?? (configOverridePath ? [configOverridePath] : undefined);');
+    expect(source).toContain('const provenanceMap = getServerProvenance(configPaths);');
+    expect(source).not.toContain('parseConfigFlag(pi.getFlag("mcp-config"))');
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -6,6 +6,7 @@ import { lazyConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds
 import { loadMetadataCache } from "./metadata-cache.js";
 import { getStoredTokens } from "./oauth-handler.js";
 import { buildToolMetadata } from "./tool-metadata.js";
+import { getConfigPathsFromArgv } from "./utils.js";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -168,7 +169,8 @@ export async function openMcpPanel(
 ): Promise<void> {
   const config = state.config;
   const cache = loadMetadataCache();
-  const provenanceMap = getServerProvenance(pi.getFlag("mcp-config") as string | undefined ?? configOverridePath);
+  const configPaths = getConfigPathsFromArgv() ?? (configOverridePath ? [configOverridePath] : undefined);
+  const provenanceMap = getServerProvenance(configPaths);
 
   const callbacks: McpPanelCallbacks = {
     reconnect: async (serverName: string) => {

--- a/commands.ts
+++ b/commands.ts
@@ -165,11 +165,10 @@ export async function openMcpPanel(
   state: McpExtensionState,
   pi: ExtensionAPI,
   ctx: ExtensionContext,
-  configOverridePath?: string,
 ): Promise<void> {
   const config = state.config;
   const cache = loadMetadataCache();
-  const configPaths = getConfigPathsFromArgv() ?? (configOverridePath ? [configOverridePath] : undefined);
+  const configPaths = getConfigPathsFromArgv();
   const provenanceMap = getServerProvenance(configPaths);
 
   const callbacks: McpPanelCallbacks = {

--- a/config.ts
+++ b/config.ts
@@ -17,37 +17,57 @@ const IMPORT_PATHS: Record<ImportKind, string> = {
   "vscode": ".vscode/mcp.json", // Relative to project
 };
 
-export function loadMcpConfig(overridePath?: string): McpConfig {
-  const configPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH;
-  
-  // Load base config
+export function loadMcpConfig(overridePaths?: string | string[]): McpConfig {
+  const configPaths = Array.isArray(overridePaths)
+    ? (overridePaths.length > 0 ? overridePaths.map(path => resolve(path)) : [DEFAULT_CONFIG_PATH])
+    : [overridePaths ? resolve(overridePaths) : DEFAULT_CONFIG_PATH];
+
   let config: McpConfig = { mcpServers: {} };
-  
-  if (existsSync(configPath)) {
+  const importKinds: ImportKind[] = [];
+
+  for (const configPath of configPaths) {
+    if (!existsSync(configPath)) continue;
+
     try {
       const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      config = validateConfig(raw);
+      const validated = validateConfig(raw);
+
+      config.mcpServers = { ...config.mcpServers, ...validated.mcpServers };
+      if (validated.settings) {
+        config.settings = { ...config.settings, ...validated.settings };
+      }
+      if (validated.imports?.length) {
+        for (const importKind of validated.imports) {
+          if (!importKinds.includes(importKind)) {
+            importKinds.push(importKind);
+          }
+        }
+      }
     } catch (error) {
       console.warn(`Failed to load MCP config from ${configPath}:`, error);
     }
   }
-  
+
+  if (importKinds.length > 0) {
+    config.imports = importKinds;
+  }
+
   // Process imports from other tools
   if (config.imports?.length) {
     for (const importKind of config.imports) {
       const importPath = IMPORT_PATHS[importKind];
       if (!importPath) continue;
-      
-      const fullPath = importPath.startsWith(".") 
-        ? resolve(process.cwd(), importPath) 
+
+      const fullPath = importPath.startsWith(".")
+        ? resolve(process.cwd(), importPath)
         : importPath;
-      
+
       if (!existsSync(fullPath)) continue;
-      
+
       try {
         const imported = JSON.parse(readFileSync(fullPath, "utf-8"));
         const servers = extractServers(imported, importKind);
-        
+
         // Merge - local config takes precedence over imports
         for (const [name, def] of Object.entries(servers)) {
           if (!config.mcpServers[name]) {
@@ -59,14 +79,14 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
       }
     }
   }
-  
-  // Check for project-local config (skip if it's the same as the main config)
+
+  // Check for project-local config (skip if it's the same as one of the main config paths)
   const projectPath = resolve(process.cwd(), PROJECT_CONFIG_NAME);
-  if (existsSync(projectPath) && projectPath !== configPath) {
+  if (existsSync(projectPath) && !configPaths.includes(projectPath)) {
     try {
       const projectConfig = JSON.parse(readFileSync(projectPath, "utf-8"));
       const validated = validateConfig(projectConfig);
-      
+
       // Project config overrides everything
       config.mcpServers = { ...config.mcpServers, ...validated.mcpServers };
       if (validated.settings) {
@@ -76,7 +96,7 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
       console.warn(`Failed to load project MCP config:`, error);
     }
   }
-  
+
   return config;
 }
 
@@ -128,42 +148,52 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
   return servers as Record<string, ServerEntry>;
 }
 
-export function getServerProvenance(overridePath?: string): Map<string, ServerProvenance> {
+export function getServerProvenance(overridePaths?: string | string[]): Map<string, ServerProvenance> {
   const provenance = new Map<string, ServerProvenance>();
-  const userPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH;
+  const userPaths = Array.isArray(overridePaths)
+    ? (overridePaths.length > 0 ? overridePaths.map(path => resolve(path)) : [DEFAULT_CONFIG_PATH])
+    : [overridePaths ? resolve(overridePaths) : DEFAULT_CONFIG_PATH];
+  const importKinds: { path: string; kind: ImportKind }[] = [];
 
-  let userConfig: McpConfig = { mcpServers: {} };
-  if (existsSync(userPath)) {
-    try {
-      userConfig = validateConfig(JSON.parse(readFileSync(userPath, "utf-8")));
-    } catch {}
-  }
-  for (const name of Object.keys(userConfig.mcpServers)) {
-    provenance.set(name, { path: userPath, kind: "user" });
-  }
-
-  if (userConfig.imports?.length) {
-    for (const importKind of userConfig.imports) {
-      const importPath = IMPORT_PATHS[importKind];
-      if (!importPath) continue;
-      const fullPath = importPath.startsWith(".")
-        ? resolve(process.cwd(), importPath)
-        : importPath;
-      if (!existsSync(fullPath)) continue;
+  for (const userPath of userPaths) {
+    let userConfig: McpConfig = { mcpServers: {} };
+    if (existsSync(userPath)) {
       try {
-        const imported = JSON.parse(readFileSync(fullPath, "utf-8"));
-        const servers = extractServers(imported, importKind);
-        for (const name of Object.keys(servers)) {
-          if (!provenance.has(name)) {
-            provenance.set(name, { path: userPath, kind: "import", importKind });
-          }
-        }
+        userConfig = validateConfig(JSON.parse(readFileSync(userPath, "utf-8")));
       } catch {}
+    }
+
+    for (const name of Object.keys(userConfig.mcpServers)) {
+      provenance.set(name, { path: userPath, kind: "user" });
+    }
+
+    if (userConfig.imports?.length) {
+      for (const importKind of userConfig.imports) {
+        importKinds.push({ path: userPath, kind: importKind });
+      }
     }
   }
 
+  for (const { path: userPath, kind: importKind } of importKinds) {
+    const importPath = IMPORT_PATHS[importKind];
+    if (!importPath) continue;
+    const fullPath = importPath.startsWith(".")
+      ? resolve(process.cwd(), importPath)
+      : importPath;
+    if (!existsSync(fullPath)) continue;
+    try {
+      const imported = JSON.parse(readFileSync(fullPath, "utf-8"));
+      const servers = extractServers(imported, importKind);
+      for (const name of Object.keys(servers)) {
+        if (!provenance.has(name)) {
+          provenance.set(name, { path: userPath, kind: "import", importKind });
+        }
+      }
+    } catch {}
+  }
+
   const projectPath = resolve(process.cwd(), PROJECT_CONFIG_NAME);
-  if (existsSync(projectPath) && projectPath !== userPath) {
+  if (existsSync(projectPath) && !userPaths.includes(projectPath)) {
     try {
       const projectConfig = validateConfig(JSON.parse(readFileSync(projectPath, "utf-8")));
       for (const name of Object.keys(projectConfig.mcpServers)) {

--- a/index.ts
+++ b/index.ts
@@ -7,14 +7,15 @@ import { buildProxyDescription, createDirectToolExecutor, resolveDirectTools } f
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js";
 import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
-import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
+import { getConfigPathsFromArgv, truncateAtWord } from "./utils.js";
+import { getConfigPathsFromArgv } from "./utils.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
 
-  const earlyConfigPath = getConfigPathFromArgv();
-  const earlyConfig = loadMcpConfig(earlyConfigPath);
+  const earlyConfigPaths = getConfigPathsFromArgv();
+  const earlyConfig = loadMcpConfig(earlyConfigPaths);
   const earlyCache = loadMetadataCache();
   const prefix = earlyConfig.settings?.toolPrefix ?? "server";
 
@@ -42,7 +43,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
 
   pi.registerFlag("mcp-config", {
-    description: "Path to MCP config file",
+    description: "Path(s) to MCP config file; can be repeated",
     type: "string",
   });
 
@@ -110,7 +111,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         case "":
         default:
           if (ctx.hasUI) {
-            await openMcpPanel(state, pi, ctx, earlyConfigPath);
+            await openMcpPanel(state, pi, ctx);
           } else {
             await showStatus(state, ctx);
           }

--- a/init.ts
+++ b/init.ts
@@ -19,7 +19,7 @@ import {
 import { McpServerManager } from "./server-manager.js";
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.js";
 import { UiResourceHandler } from "./ui-resource-handler.js";
-import { openUrl, parallelLimit } from "./utils.js";
+import { getConfigPathsFromArgv, openUrl, parallelLimit } from "./utils.js";
 import { logger } from "./logger.js";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
@@ -28,8 +28,8 @@ export async function initializeMcp(
   pi: ExtensionAPI,
   ctx: ExtensionContext
 ): Promise<McpExtensionState> {
-  const configPath = pi.getFlag("mcp-config") as string | undefined;
-  const config = loadMcpConfig(configPath);
+  const configPaths = getConfigPathsFromArgv();
+  const config = loadMcpConfig(configPaths);
 
   const manager = new McpServerManager();
   const lifecycle = new McpLifecycleManager(manager);

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 
 export async function openUrl(pi: ExtensionAPI, url: string, browser?: string): Promise<void> {
   const os = platform();
@@ -40,12 +40,43 @@ export async function parallelLimit<T, R>(
   return results;
 }
 
-export function getConfigPathFromArgv(): string | undefined {
-  const idx = process.argv.indexOf("--mcp-config");
-  if (idx >= 0 && idx + 1 < process.argv.length) {
-    return process.argv[idx + 1];
+function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return `${homedir()}${path.slice(1)}`;
+  return path;
+}
+
+export function parseConfigFlag(flag: unknown): string[] | undefined {
+  if (typeof flag !== "string") return undefined;
+
+  const path = flag.trim();
+  if (!path) return undefined;
+
+  return [expandHome(path)];
+}
+
+export function getConfigPathsFromArgv(): string[] | undefined {
+  const paths: string[] = [];
+
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] !== "--mcp-config") continue;
+
+    for (let j = i + 1; j < process.argv.length; j++) {
+      const value = process.argv[j];
+      if (value.startsWith("--")) {
+        i = j - 1;
+        break;
+      }
+      paths.push(expandHome(value));
+      i = j;
+    }
   }
-  return undefined;
+
+  return paths.length > 0 ? paths : undefined;
+}
+
+export function getConfigPathFromArgv(): string | undefined {
+  return getConfigPathsFromArgv()?.[0];
 }
 
 export function truncateAtWord(text: string, target: number): string {


### PR DESCRIPTION
## Problem
The adapter only preserved a single `--mcp-config` value end-to-end even though layered MCP configuration is useful for combining shared and project-specific definitions.

## Root Cause
The config loading path still treated `--mcp-config` as a single string in key wiring points:
- argv parsing only exposed one path
- config loading and provenance tracking expected one override path
- `/mcp` panel wiring still relied on the stale single-path flow

## Fix
- parse repeated `--mcp-config` flags from argv in order
- let `loadMcpConfig()` merge multiple config files in order before project-local overrides
- let `getServerProvenance()` track multiple user config sources
- update initialization and `/mcp` panel wiring to use `getConfigPathsFromArgv()` directly so repeated flags survive end-to-end
- keep the existing single-path behavior intact when only one config path is provided

## Summary
- add `getConfigPathsFromArgv()` in `utils.ts`
- extend `config.ts` to accept multiple override paths for config loading and provenance
- update `index.ts`, `init.ts`, and `commands.ts` to use the repeated-flag path flow
- add tests for config merging, provenance, argv parsing, and call-site wiring

## Testing
### Targeted tests for this change
```bash
npx vitest run __tests__/config.test.ts __tests__/config-provenance.test.ts __tests__/utils.test.ts __tests__/wiring.test.ts
```

```text
 RUN  v3.2.4 /tmp/pi-mcp-adapter-pr1

 ✓ __tests__/wiring.test.ts (5 tests) 2ms
 ✓ __tests__/utils.test.ts (10 tests) 3ms
 ✓ __tests__/config-provenance.test.ts (2 tests) 3ms
 ✓ __tests__/config.test.ts (10 tests) 5ms

 Test Files  4 passed (4)
      Tests  27 passed (27)
   Duration  217ms
```

### Maintainer note
`upstream/main` currently does not track `examples/interactive-visualizer/dist/app.html` or `dist/server.js`, so the unrelated `__tests__/interactive-visualizer-server.test.ts` fails on a full-suite run before this PR's changes are involved.
