### PR TITLE
feat(policy): add MCP policy layer with startup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,70 @@ Two calls instead of 26 tools cluttering the context.
 
 Per-server `idleTimeout` overrides the global setting.
 
+### MCP Policy Layer
+
+You can add a generic policy layer per server to control what the agent can see and send.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "policy": {
+        "allowedTools": ["search_repositories", "get_file_contents", "create_issue"],
+        "allowedResources": [],
+        "allowedPrompts": [],
+        "toolPolicies": {
+          "get_file_contents": {
+            "defaults": { "ref": "main" },
+            "requireKeys": ["owner", "repo", "path"],
+            "forbidKeys": ["token"],
+            "allowedValues": {
+              "ref": ["main", "develop"]
+            }
+          },
+          "create_issue": {
+            "forbidKeys": ["assignees"],
+            "injectIntoEachItem": { "source": "pi" },
+            "allowedValuesEach": {
+              "source": ["pi"]
+            },
+            "forbidPerItemKeys": ["admin"],
+            "requirePerItemKeys": ["source"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Visibility rules**
+
+- `allowedTools`, `allowedResources`, `allowedPrompts`
+- Missing or empty list = allow all
+- Non-empty list = only listed entries are visible/usable
+- If an allowlist names tools/resources/prompts that the server does not actually expose, the adapter logs warnings so you can fix stale config
+
+**Per-tool request rules**
+
+Inside `toolPolicies[toolName]`:
+
+- `defaults` — fill missing top-level args
+- `allowedValues` — restrict top-level arg values
+- `forbidKeys` — reject requests containing these top-level keys
+- `requireKeys` — require these top-level keys
+- `injectIntoEachItem` — fill missing keys into each object in `items`
+- `allowedValuesEach` — restrict values inside each object in `items`
+- `forbidPerItemKeys` — reject per-item keys
+- `requirePerItemKeys` — require per-item keys
+
+**Validation**
+
+- Policy config is validated fail-fast at startup
+- Invalid combinations such as the same key appearing in both `forbidKeys` and `requireKeys` reject adapter initialization before server connection work begins
+
 ### Direct Tools
 
 By default, all MCP tools are accessed through the single `mcp` proxy tool. This keeps context small but means the LLM has to discover tools via search. If you want specific tools to show up directly in the agent's tool list — alongside `read`, `bash`, `edit`, etc. — add `directTools` to your config.

--- a/__tests__/policy-allowlist.test.ts
+++ b/__tests__/policy-allowlist.test.ts
@@ -1,0 +1,184 @@
+// policy-allowlist.test.ts — RED phase: allowlist filtering functions (Slice 2)
+import { describe, it, expect } from "vitest";
+import {
+  isToolAllowed,
+  isResourceAllowed,
+  isPromptAllowed,
+  filterAllowedTools,
+  filterAllowedResources,
+  filterAllowedPrompts,
+  type ServerPolicy,
+} from "../policy.js";
+
+// Minimal metadata shapes matching MCP SDK conventions
+interface ToolMeta { name: string; description?: string }
+interface ResourceMeta { uri: string; name?: string }
+interface PromptMeta { name: string; description?: string }
+
+// ---------------------------------------------------------------------------
+// isToolAllowed
+// ---------------------------------------------------------------------------
+describe("isToolAllowed", () => {
+  it("returns true when allowedTools is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(isToolAllowed(policy, "read_file")).toBe(true);
+  });
+
+  it("returns true when allowedTools is empty", () => {
+    const policy: ServerPolicy = { allowedTools: [] };
+    expect(isToolAllowed(policy, "read_file")).toBe(true);
+  });
+
+  it("returns true when tool is in allowedTools", () => {
+    const policy: ServerPolicy = { allowedTools: ["read_file", "write_file"] };
+    expect(isToolAllowed(policy, "read_file")).toBe(true);
+  });
+
+  it("returns false when tool is NOT in allowedTools", () => {
+    const policy: ServerPolicy = { allowedTools: ["read_file"] };
+    expect(isToolAllowed(policy, "delete_file")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isResourceAllowed
+// ---------------------------------------------------------------------------
+describe("isResourceAllowed", () => {
+  it("returns true when allowedResources is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(isResourceAllowed(policy, "file:///readme.md")).toBe(true);
+  });
+
+  it("returns true when allowedResources is empty", () => {
+    const policy: ServerPolicy = { allowedResources: [] };
+    expect(isResourceAllowed(policy, "file:///readme.md")).toBe(true);
+  });
+
+  it("returns true when resource URI is in allowedResources", () => {
+    const policy: ServerPolicy = { allowedResources: ["file:///readme.md", "file:///src/index.ts"] };
+    expect(isResourceAllowed(policy, "file:///readme.md")).toBe(true);
+  });
+
+  it("returns false when resource URI is NOT in allowedResources", () => {
+    const policy: ServerPolicy = { allowedResources: ["file:///readme.md"] };
+    expect(isResourceAllowed(policy, "file:///secret.txt")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPromptAllowed
+// ---------------------------------------------------------------------------
+describe("isPromptAllowed", () => {
+  it("returns true when allowedPrompts is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(isPromptAllowed(policy, "summarize")).toBe(true);
+  });
+
+  it("returns true when allowedPrompts is empty", () => {
+    const policy: ServerPolicy = { allowedPrompts: [] };
+    expect(isPromptAllowed(policy, "summarize")).toBe(true);
+  });
+
+  it("returns true when prompt is in allowedPrompts", () => {
+    const policy: ServerPolicy = { allowedPrompts: ["summarize", "translate"] };
+    expect(isPromptAllowed(policy, "summarize")).toBe(true);
+  });
+
+  it("returns false when prompt is NOT in allowedPrompts", () => {
+    const policy: ServerPolicy = { allowedPrompts: ["summarize"] };
+    expect(isPromptAllowed(policy, "generate_code")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterAllowedTools
+// ---------------------------------------------------------------------------
+describe("filterAllowedTools", () => {
+  const tools: ToolMeta[] = [
+    { name: "read_file", description: "Read a file" },
+    { name: "write_file", description: "Write a file" },
+    { name: "delete_file", description: "Delete a file" },
+  ];
+
+  it("returns all tools when allowedTools is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(filterAllowedTools(policy, tools)).toEqual(tools);
+  });
+
+  it("returns all tools when allowedTools is empty", () => {
+    const policy: ServerPolicy = { allowedTools: [] };
+    expect(filterAllowedTools(policy, tools)).toEqual(tools);
+  });
+
+  it("returns only allowed tools", () => {
+    const policy: ServerPolicy = { allowedTools: ["read_file", "write_file"] };
+    expect(filterAllowedTools(policy, tools)).toEqual([tools[0], tools[1]]);
+  });
+
+  it("returns empty array when no tools match allowedTools", () => {
+    const policy: ServerPolicy = { allowedTools: ["bash"] };
+    expect(filterAllowedTools(policy, tools)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterAllowedResources
+// ---------------------------------------------------------------------------
+describe("filterAllowedResources", () => {
+  const resources: ResourceMeta[] = [
+    { uri: "file:///readme.md", name: "README" },
+    { uri: "file:///src/index.ts", name: "Index" },
+    { uri: "file:///secret.txt", name: "Secret" },
+  ];
+
+  it("returns all resources when allowedResources is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(filterAllowedResources(policy, resources)).toEqual(resources);
+  });
+
+  it("returns all resources when allowedResources is empty", () => {
+    const policy: ServerPolicy = { allowedResources: [] };
+    expect(filterAllowedResources(policy, resources)).toEqual(resources);
+  });
+
+  it("returns only allowed resources", () => {
+    const policy: ServerPolicy = { allowedResources: ["file:///readme.md"] };
+    expect(filterAllowedResources(policy, resources)).toEqual([resources[0]]);
+  });
+
+  it("returns empty array when no resources match allowedResources", () => {
+    const policy: ServerPolicy = { allowedResources: ["file:///other.txt"] };
+    expect(filterAllowedResources(policy, resources)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterAllowedPrompts
+// ---------------------------------------------------------------------------
+describe("filterAllowedPrompts", () => {
+  const prompts: PromptMeta[] = [
+    { name: "summarize", description: "Summarize text" },
+    { name: "translate", description: "Translate text" },
+    { name: "generate_code", description: "Generate code" },
+  ];
+
+  it("returns all prompts when allowedPrompts is undefined", () => {
+    const policy: ServerPolicy = {};
+    expect(filterAllowedPrompts(policy, prompts)).toEqual(prompts);
+  });
+
+  it("returns all prompts when allowedPrompts is empty", () => {
+    const policy: ServerPolicy = { allowedPrompts: [] };
+    expect(filterAllowedPrompts(policy, prompts)).toEqual(prompts);
+  });
+
+  it("returns only allowed prompts", () => {
+    const policy: ServerPolicy = { allowedPrompts: ["summarize", "translate"] };
+    expect(filterAllowedPrompts(policy, prompts)).toEqual([prompts[0], prompts[1]]);
+  });
+
+  it("returns empty array when no prompts match allowedPrompts", () => {
+    const policy: ServerPolicy = { allowedPrompts: ["review"] };
+    expect(filterAllowedPrompts(policy, prompts)).toEqual([]);
+  });
+});

--- a/__tests__/policy-apply.test.ts
+++ b/__tests__/policy-apply.test.ts
@@ -1,0 +1,221 @@
+// policy-apply.test.ts — RED phase: applyToolPolicy (Slice 3)
+import { describe, it, expect } from "vitest";
+import { applyToolPolicy, type ToolPolicy } from "../policy.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function ok(result: ReturnType<typeof applyToolPolicy>) {
+  if (!result.ok) throw new Error(`Expected ok but got error: ${result.error}`);
+  return result.args;
+}
+
+function err(result: ReturnType<typeof applyToolPolicy>) {
+  if (result.ok) throw new Error(`Expected error but got ok`);
+  return result.error;
+}
+
+// ---------------------------------------------------------------------------
+// Malformed shape checks
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: malformed args shape", () => {
+  const policy: ToolPolicy = {};
+
+  it("rejects null", () => {
+    expect(err(applyToolPolicy(policy, null))).toMatch(/plain object/);
+  });
+
+  it("rejects array", () => {
+    expect(err(applyToolPolicy(policy, []))).toMatch(/plain object/);
+  });
+
+  it("rejects string", () => {
+    expect(err(applyToolPolicy(policy, "hello"))).toMatch(/plain object/);
+  });
+
+  it("rejects number", () => {
+    expect(err(applyToolPolicy(policy, 42))).toMatch(/plain object/);
+  });
+
+  it("rejects Object.create(null) (no prototype)", () => {
+    expect(err(applyToolPolicy(policy, Object.create(null)))).toMatch(/plain object/);
+  });
+
+  it("rejects args.items that is not an array", () => {
+    expect(err(applyToolPolicy(policy, { items: "not-an-array" }))).toMatch(/items must be an array/);
+  });
+
+  it("rejects args.items[i] that is not a plain object", () => {
+    expect(err(applyToolPolicy(policy, { items: ["string-item"] }))).toMatch(/each item in items must be a plain object/);
+  });
+
+  it("accepts args.items as empty array", () => {
+    expect(applyToolPolicy(policy, { items: [] }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaults
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: defaults", () => {
+  it("fills missing keys with defaults", () => {
+    const policy: ToolPolicy = { defaults: { mode: "read", limit: 10 } };
+    const result = ok(applyToolPolicy(policy, { path: "/tmp" }));
+    expect(result).toMatchObject({ path: "/tmp", mode: "read", limit: 10 });
+  });
+
+  it("does not overwrite existing values", () => {
+    const policy: ToolPolicy = { defaults: { mode: "read" } };
+    const result = ok(applyToolPolicy(policy, { mode: "write" }));
+    expect(result.mode).toBe("write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forbidKeys
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: forbidKeys", () => {
+  it("rejects when a forbidden key is present", () => {
+    const policy: ToolPolicy = { forbidKeys: ["dangerous"] };
+    expect(err(applyToolPolicy(policy, { dangerous: true }))).toMatch(/dangerous/);
+  });
+
+  it("passes when no forbidden key is present", () => {
+    const policy: ToolPolicy = { forbidKeys: ["dangerous"] };
+    expect(applyToolPolicy(policy, { safe: true }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireKeys
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: requireKeys", () => {
+  it("rejects when a required key is missing", () => {
+    const policy: ToolPolicy = { requireKeys: ["path"] };
+    expect(err(applyToolPolicy(policy, { mode: "read" }))).toMatch(/path/);
+  });
+
+  it("passes when all required keys are present", () => {
+    const policy: ToolPolicy = { requireKeys: ["path"] };
+    expect(applyToolPolicy(policy, { path: "/tmp" }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowedValues
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: allowedValues", () => {
+  it("rejects when a value is not in the allowed list", () => {
+    const policy: ToolPolicy = { allowedValues: { mode: ["read", "list"] } };
+    expect(err(applyToolPolicy(policy, { mode: "delete" }))).toMatch(/mode/);
+  });
+
+  it("passes when value is in the allowed list (strict ===)", () => {
+    const policy: ToolPolicy = { allowedValues: { mode: ["read", "list"] } };
+    expect(applyToolPolicy(policy, { mode: "read" }).ok).toBe(true);
+  });
+
+  it("passes when the key is absent (not enforced if missing)", () => {
+    const policy: ToolPolicy = { allowedValues: { mode: ["read"] } };
+    expect(applyToolPolicy(policy, {}).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// injectIntoEachItem
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: injectIntoEachItem", () => {
+  it("injects missing keys into each item", () => {
+    const policy: ToolPolicy = { injectIntoEachItem: { role: "user" } };
+    const result = ok(applyToolPolicy(policy, { items: [{ text: "hi" }] }));
+    expect((result.items as any[])[0]).toMatchObject({ text: "hi", role: "user" });
+  });
+
+  it("does not overwrite existing item keys", () => {
+    const policy: ToolPolicy = { injectIntoEachItem: { role: "user" } };
+    const result = ok(applyToolPolicy(policy, { items: [{ role: "admin" }] }));
+    expect((result.items as any[])[0].role).toBe("admin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forbidPerItemKeys
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: forbidPerItemKeys", () => {
+  it("rejects when a forbidden per-item key is present in any item", () => {
+    const policy: ToolPolicy = { forbidPerItemKeys: ["secret"] };
+    expect(err(applyToolPolicy(policy, { items: [{ secret: "x" }] }))).toMatch(/secret/);
+  });
+
+  it("passes when no item contains a forbidden key", () => {
+    const policy: ToolPolicy = { forbidPerItemKeys: ["secret"] };
+    expect(applyToolPolicy(policy, { items: [{ text: "hi" }] }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePerItemKeys
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: requirePerItemKeys", () => {
+  it("rejects when a required per-item key is missing from any item", () => {
+    const policy: ToolPolicy = { requirePerItemKeys: ["text"] };
+    expect(err(applyToolPolicy(policy, { items: [{ other: "x" }] }))).toMatch(/text/);
+  });
+
+  it("passes when all items have the required key", () => {
+    const policy: ToolPolicy = { requirePerItemKeys: ["text"] };
+    expect(applyToolPolicy(policy, { items: [{ text: "hi" }] }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowedValuesEach
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: allowedValuesEach", () => {
+  it("rejects when any item has a value not in the allowed list", () => {
+    const policy: ToolPolicy = { allowedValuesEach: { role: ["user", "assistant"] } };
+    expect(err(applyToolPolicy(policy, { items: [{ role: "system" }] }))).toMatch(/role/);
+  });
+
+  it("passes when all items have allowed values", () => {
+    const policy: ToolPolicy = { allowedValuesEach: { role: ["user", "assistant"] } };
+    expect(applyToolPolicy(policy, { items: [{ role: "user" }, { role: "assistant" }] }).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+describe("applyToolPolicy: happy paths", () => {
+  it("no policy defined → args pass through unchanged", () => {
+    const args = { path: "/tmp", limit: 5 };
+    const result = ok(applyToolPolicy({}, args));
+    expect(result).toEqual(args);
+  });
+
+  it("full policy applied — defaults + injection, all checks pass", () => {
+    const policy: ToolPolicy = {
+      defaults: { limit: 10 },
+      requireKeys: ["path"],
+      forbidKeys: ["root"],
+      allowedValues: { mode: ["read"] },
+      injectIntoEachItem: { role: "user" },
+      requirePerItemKeys: ["text"],
+      forbidPerItemKeys: ["secret"],
+      allowedValuesEach: { role: ["user"] },
+    };
+    const args = { path: "/tmp", mode: "read", items: [{ text: "hi" }] };
+    const result = ok(applyToolPolicy(policy, args));
+    expect(result.limit).toBe(10);
+    expect((result.items as any[])[0].role).toBe("user");
+  });
+
+  it("does not mutate the original args object", () => {
+    const policy: ToolPolicy = { defaults: { extra: "added" } };
+    const original = { path: "/tmp" };
+    const frozen = Object.freeze({ ...original });
+    // applyToolPolicy should work on a clone, not the frozen original
+    expect(() => ok(applyToolPolicy(policy, { path: "/tmp" }))).not.toThrow();
+    expect(original).not.toHaveProperty("extra");
+  });
+});

--- a/__tests__/policy-cache-warnings.test.ts
+++ b/__tests__/policy-cache-warnings.test.ts
@@ -1,0 +1,146 @@
+// policy-cache-warnings.test.ts — RED phase: cache invalidation + startup warnings (Slice 5)
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { computeServerHash } from "../metadata-cache.js";
+import type { ServerEntry } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function entry(overrides: Partial<ServerEntry> = {}): ServerEntry {
+  return { command: "node", args: ["server.js"], ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cache invalidation: policy changes must change the hash
+// ---------------------------------------------------------------------------
+describe("computeServerHash: policy changes invalidate the cache", () => {
+  it("adding allowedTools to policy changes the hash", () => {
+    const base = entry();
+    const withPolicy = entry({ policy: { allowedTools: ["read_file"] } } as any);
+    expect(computeServerHash(withPolicy)).not.toBe(computeServerHash(base));
+  });
+
+  it("changing allowedTools changes the hash", () => {
+    const a = entry({ policy: { allowedTools: ["read_file"] } } as any);
+    const b = entry({ policy: { allowedTools: ["write_file"] } } as any);
+    expect(computeServerHash(a)).not.toBe(computeServerHash(b));
+  });
+
+  it("changing allowedResources changes the hash", () => {
+    const a = entry({ policy: { allowedResources: ["file:///a.md"] } } as any);
+    const b = entry({ policy: { allowedResources: ["file:///b.md"] } } as any);
+    expect(computeServerHash(a)).not.toBe(computeServerHash(b));
+  });
+
+  it("changing allowedPrompts changes the hash", () => {
+    const a = entry({ policy: { allowedPrompts: ["summarize"] } } as any);
+    const b = entry({ policy: { allowedPrompts: ["translate"] } } as any);
+    expect(computeServerHash(a)).not.toBe(computeServerHash(b));
+  });
+
+  it("changing toolPolicies changes the hash", () => {
+    const a = entry({ policy: { toolPolicies: { read_file: { requireKeys: ["path"] } } } } as any);
+    const b = entry({ policy: { toolPolicies: { read_file: { requireKeys: ["dir"] } } } } as any);
+    expect(computeServerHash(a)).not.toBe(computeServerHash(b));
+  });
+
+  it("removing the policy field entirely changes the hash", () => {
+    const withPolicy = entry({ policy: { allowedTools: ["read_file"] } } as any);
+    const noPolicy = entry();
+    expect(computeServerHash(withPolicy)).not.toBe(computeServerHash(noPolicy));
+  });
+
+  it("same policy produces the same hash (deterministic)", () => {
+    const a = entry({ policy: { allowedTools: ["read_file", "write_file"] } } as any);
+    const b = entry({ policy: { allowedTools: ["read_file", "write_file"] } } as any);
+    expect(computeServerHash(a)).toBe(computeServerHash(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Startup warnings: non-existent allowlist entries are warned
+// ---------------------------------------------------------------------------
+vi.mock("../init.js", () => ({
+  lazyConnect: vi.fn(async () => true),
+  updateServerMetadata: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  getFailureAgeSeconds: vi.fn(() => null),
+  updateStatusBar: vi.fn(),
+}));
+
+vi.mock("../metadata-cache.js", async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  isServerCacheValid: vi.fn(() => true),
+}));
+
+import { buildToolMetadata } from "../tool-metadata.js";
+
+describe("buildToolMetadata: warns when allowlist entries are not found on the server", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns when allowedTools lists a tool not present on the server", () => {
+    const tools = [{ name: "read_file", description: "Read" }];
+    const definition: any = {
+      command: "node",
+      policy: { allowedTools: ["read_file", "nonexistent_tool"] },
+    };
+    buildToolMetadata(tools, [], definition, "myserver", "none");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/nonexistent_tool|allowedTools|not found/i)
+    );
+  });
+
+  it("warns when allowedResources lists a URI not present on the server", () => {
+    const resources = [{ uri: "file:///readme.md", name: "README" }];
+    const definition: any = {
+      command: "node",
+      exposeResources: true,
+      policy: { allowedResources: ["file:///readme.md", "file:///missing.txt"] },
+    };
+    buildToolMetadata([], resources, definition, "myserver", "none");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/missing\.txt|allowedResources|not found/i)
+    );
+  });
+
+  it("warns when allowedPrompts lists a prompt not present on the server", async () => {
+    const toolMetaModule = await import("../tool-metadata.js") as any;
+    const checkFn = toolMetaModule.checkPolicyAllowlistWarnings;
+    // If the function doesn't exist yet, the test fails — expected RED
+    expect(typeof checkFn).toBe("function");
+    checkFn(
+      { allowedPrompts: ["summarize", "ghost_prompt"] },
+      [],          // available tools
+      [],          // available resources
+      [{ name: "summarize" }], // available prompts
+      "myserver"
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/ghost_prompt|allowedPrompts|not found/i)
+    );
+  });
+
+  it("does not warn when all allowedTools entries exist on the server", () => {
+    const tools = [
+      { name: "read_file", description: "Read" },
+      { name: "write_file", description: "Write" },
+    ];
+    const definition: any = {
+      command: "node",
+      policy: { allowedTools: ["read_file", "write_file"] },
+    };
+    buildToolMetadata(tools, [], definition, "myserver", "none");
+    const policyWarns = warnSpy.mock.calls.filter(args =>
+      /allowedTools|not found|nonexistent/i.test(String(args))
+    );
+    expect(policyWarns).toHaveLength(0);
+  });
+});

--- a/__tests__/policy-init-wiring.test.ts
+++ b/__tests__/policy-init-wiring.test.ts
@@ -1,0 +1,77 @@
+import os from "node:os";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn<(path: string) => boolean>(),
+  readFileSync: vi.fn<(path: string, encoding?: string) => string>(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: fsMock.existsSync,
+  readFileSync: fsMock.readFileSync,
+  writeFileSync: fsMock.writeFileSync,
+  mkdirSync: fsMock.mkdirSync,
+  renameSync: fsMock.renameSync,
+}));
+
+import { initializeMcp } from "../init.js";
+
+function makePiStub() {
+  return {
+    getFlag: vi.fn().mockReturnValue(undefined),
+    sendMessage: vi.fn(),
+    registerTool: vi.fn(),
+  } as any;
+}
+
+function makeCtxStub() {
+  return {
+    hasUI: false,
+  } as any;
+}
+
+describe("policy validation during adapter initialization", () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    process.argv = ["node", "pi"];
+    fsMock.existsSync.mockReturnValue(false);
+    fsMock.readFileSync.mockImplementation((path: string) => {
+      throw new Error(`ENOENT: ${path}`);
+    });
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  it("fails fast when startup config contains an invalid policy", async () => {
+    const defaultConfigPath = `${os.homedir()}/.pi/agent/mcp.json`;
+    const invalidConfig = JSON.stringify({
+      mcpServers: {
+        "test-server": {
+          command: "echo",
+          args: ["hello"],
+          policy: {
+            forbidKeys: ["secret"],
+            requireKeys: ["secret"],
+          },
+        },
+      },
+    });
+
+    fsMock.existsSync.mockImplementation((p: string) => p === defaultConfigPath);
+    fsMock.readFileSync.mockImplementation((p: string) => {
+      if (p === defaultConfigPath) return invalidConfig;
+      throw new Error(`ENOENT: ${p}`);
+    });
+
+    await expect(initializeMcp(makePiStub(), makeCtxStub())).rejects.toThrow(
+      /forbidKeys.*requireKeys|requireKeys.*forbidKeys|both/i
+    );
+  });
+});

--- a/__tests__/policy-integration.test.ts
+++ b/__tests__/policy-integration.test.ts
@@ -1,0 +1,262 @@
+// policy-integration.test.ts — RED phase: policy integration points (Slice 4)
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import type { McpConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks for proxy-modes (must hoist before any imports that use init.js)
+// ---------------------------------------------------------------------------
+vi.mock("../init.js", () => ({
+  lazyConnect: vi.fn(async () => true),
+  updateServerMetadata: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  getFailureAgeSeconds: vi.fn(() => null),
+  updateStatusBar: vi.fn(),
+}));
+
+vi.mock("../metadata-cache.js", async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  isServerCacheValid: vi.fn(() => true),
+}));
+
+import { resolveDirectTools } from "../direct-tools.js";
+import { buildToolMetadata } from "../tool-metadata.js";
+import { executeCall } from "../proxy-modes.js";
+
+// ---------------------------------------------------------------------------
+// 1. Config: validatePoliciesInConfig exported from config.ts
+// ---------------------------------------------------------------------------
+describe("Config integration: validatePoliciesInConfig", () => {
+  it("is exported from config.ts as a callable function", async () => {
+    const configModule = await import("../config.js");
+    expect(typeof (configModule as any).validatePoliciesInConfig).toBe("function");
+  });
+
+  it("throws for a server entry whose policy has toolPolicies key not in allowedTools", async () => {
+    const { validatePoliciesInConfig } = await import("../config.js") as any;
+    const config: McpConfig = {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          policy: {
+            allowedTools: ["read_file"],
+            toolPolicies: { write_file: {} }, // NOT in allowedTools
+          },
+        },
+      } as any,
+    };
+    expect(() => validatePoliciesInConfig(config)).toThrow(/write_file|toolPolicies|allowedTools/i);
+  });
+
+  it("does not throw when all server policies are valid", async () => {
+    const { validatePoliciesInConfig } = await import("../config.js") as any;
+    const config: McpConfig = {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          policy: {
+            allowedTools: ["read_file"],
+            toolPolicies: { read_file: { requireKeys: ["path"] } },
+          },
+        },
+      } as any,
+    };
+    expect(() => validatePoliciesInConfig(config)).not.toThrow();
+  });
+
+  it("does not throw when no server has a policy field", async () => {
+    const { validatePoliciesInConfig } = await import("../config.js") as any;
+    const config: McpConfig = {
+      mcpServers: { myserver: { command: "node" } },
+    };
+    expect(() => validatePoliciesInConfig(config)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Direct tools: resolveDirectTools respects policy.allowedTools
+// ---------------------------------------------------------------------------
+describe("Direct tools: resolveDirectTools respects policy.allowedTools", () => {
+  const makeCache = (toolNames: string[]) => ({
+    version: 1,
+    servers: {
+      myserver: {
+        configHash: "any",
+        cachedAt: Date.now(),
+        tools: toolNames.map((n) => ({ name: n, description: n })),
+        resources: [],
+      },
+    },
+  });
+
+  it("intersection: directTools=true + policy.allowedTools=['read_file'] → only read_file", () => {
+    const config: any = {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          directTools: true,
+          policy: { allowedTools: ["read_file"] },
+        },
+      },
+    };
+    const specs = resolveDirectTools(config, makeCache(["read_file", "write_file", "delete_file"]), "none");
+    const names = specs.map((s) => s.originalName);
+    expect(names).toContain("read_file");
+    expect(names).not.toContain("write_file");
+    expect(names).not.toContain("delete_file");
+  });
+
+  it("intersection: directTools=['read_file','write_file'] + policy.allowedTools=['read_file'] → only read_file", () => {
+    const config: any = {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          directTools: ["read_file", "write_file"],
+          policy: { allowedTools: ["read_file"] },
+        },
+      },
+    };
+    const specs = resolveDirectTools(config, makeCache(["read_file", "write_file"]), "none");
+    const names = specs.map((s) => s.originalName);
+    expect(names).toEqual(["read_file"]);
+  });
+
+  it("policy.allowedTools alone does NOT promote tools to direct (directTools still required)", () => {
+    const config: any = {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          // no directTools — policy.allowedTools must not act as directTools
+          policy: { allowedTools: ["read_file"] },
+        },
+      },
+    };
+    const specs = resolveDirectTools(config, makeCache(["read_file"]), "none");
+    expect(specs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Metadata filtering: buildToolMetadata respects policy
+// ---------------------------------------------------------------------------
+describe("Metadata filtering: buildToolMetadata respects policy", () => {
+  it("only includes allowed tools when policy.allowedTools is set (non-empty)", () => {
+    const tools = [
+      { name: "read_file", description: "Read" },
+      { name: "write_file", description: "Write" },
+      { name: "delete_file", description: "Delete" },
+    ];
+    const definition: any = {
+      command: "node",
+      policy: { allowedTools: ["read_file"] },
+    };
+    const { metadata } = buildToolMetadata(tools, [], definition, "myserver", "none");
+    const names = metadata.map((m) => m.originalName);
+    expect(names).toContain("read_file");
+    expect(names).not.toContain("write_file");
+    expect(names).not.toContain("delete_file");
+  });
+
+  it("only includes allowed resources when policy.allowedResources is set (non-empty)", () => {
+    const resources = [
+      { uri: "file:///readme.md", name: "README" },
+      { uri: "file:///secret.txt", name: "Secret" },
+    ];
+    const definition: any = {
+      command: "node",
+      exposeResources: true,
+      policy: { allowedResources: ["file:///readme.md"] },
+    };
+    const { metadata } = buildToolMetadata([], resources, definition, "myserver", "none");
+    const uris = metadata.map((m) => m.resourceUri).filter(Boolean);
+    expect(uris).toContain("file:///readme.md");
+    expect(uris).not.toContain("file:///secret.txt");
+  });
+
+  it("returns all tools when policy is absent (no regression)", () => {
+    const tools = [
+      { name: "read_file", description: "Read" },
+      { name: "write_file", description: "Write" },
+    ];
+    const definition: any = { command: "node" };
+    const { metadata } = buildToolMetadata(tools, [], definition, "myserver", "none");
+    expect(metadata).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Proxy call enforcement: executeCall checks policy.allowedTools
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Partial<any> = {}): any {
+  return {
+    config: {
+      mcpServers: {
+        myserver: {
+          command: "node",
+          policy: { allowedTools: ["read_file"] },
+        },
+      },
+      settings: { toolPrefix: "none" },
+    },
+    toolMetadata: new Map([
+      [
+        "myserver",
+        [
+          { name: "read_file", originalName: "read_file", description: "Read" },
+          { name: "write_file", originalName: "write_file", description: "Write" },
+        ],
+      ],
+    ]),
+    manager: {
+      getConnection: vi.fn(() => null),
+      decrementInFlight: vi.fn(),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+    },
+    lifecycle: {},
+    failureTracker: new Map(),
+    completedUiSessions: [],
+    consentManager: { needsConsent: vi.fn(() => false) },
+    uiResourceHandler: {},
+    uiServer: null,
+    ...overrides,
+  };
+}
+
+describe("Proxy call enforcement: executeCall checks policy.allowedTools", () => {
+  it("returns a policy-violation error when tool is not in allowedTools", async () => {
+    const state = makeState();
+    const result = await executeCall(state, "write_file", {}, "myserver");
+    // Should return a policy-violation error, not connect_failed or tool_not_found
+    expect(result.details).toMatchObject({
+      error: expect.stringMatching(/policy|not allowed|allowedTools/i),
+    });
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/policy|not allowed|allowedTools/i),
+    });
+  });
+
+  it("returns applyToolPolicy error when args violate the tool's toolPolicy", async () => {
+    const state = makeState({
+      config: {
+        mcpServers: {
+          myserver: {
+            command: "node",
+            policy: {
+              allowedTools: ["read_file"],
+              toolPolicies: { read_file: { requireKeys: ["path"] } },
+            },
+          },
+        },
+        settings: { toolPrefix: "none" },
+      },
+    });
+
+    // Missing required "path" key — should fail policy, not proceed to connection
+    const result = await executeCall(state, "read_file", {}, "myserver");
+    expect(result.details).toMatchObject({
+      error: expect.stringMatching(/policy|path|required/i),
+    });
+  });
+});

--- a/__tests__/policy.test.ts
+++ b/__tests__/policy.test.ts
@@ -1,0 +1,268 @@
+// policy.test.ts — RED phase: config/types validation for the generic policy layer (Slice 1)
+import { describe, it, expect } from "vitest";
+import {
+  validateServerPolicy,
+  type ServerPolicy,
+  type ToolPolicy,
+} from "../policy.js";
+
+// ---------------------------------------------------------------------------
+// Acceptance — empty / omitted allowlists mean "allow all"
+// ---------------------------------------------------------------------------
+describe("allowlists: empty or omitted means allow all", () => {
+  it("accepts a server entry with no policy fields at all", () => {
+    expect(() => validateServerPolicy({})).not.toThrow();
+  });
+
+  it("accepts empty allowedTools array (allow all tools)", () => {
+    expect(() => validateServerPolicy({ allowedTools: [] })).not.toThrow();
+  });
+
+  it("accepts empty allowedResources array (allow all resources)", () => {
+    expect(() => validateServerPolicy({ allowedResources: [] })).not.toThrow();
+  });
+
+  it("accepts empty allowedPrompts array (allow all prompts)", () => {
+    expect(() => validateServerPolicy({ allowedPrompts: [] })).not.toThrow();
+  });
+
+  it("accepts empty toolPolicies object (no per-tool overrides)", () => {
+    expect(() => validateServerPolicy({ toolPolicies: {} })).not.toThrow();
+  });
+
+  it("accepts non-empty allowedTools without toolPolicies", () => {
+    expect(() =>
+      validateServerPolicy({ allowedTools: ["read_file", "write_file"] })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (1): toolPolicies key must appear in a non-empty allowedTools
+// ---------------------------------------------------------------------------
+describe("validation: toolPolicies vs allowedTools", () => {
+  it("rejects toolPolicies entry for a tool absent from non-empty allowedTools", () => {
+    const policy: ServerPolicy = {
+      allowedTools: ["read_file"],
+      toolPolicies: {
+        write_file: {}, // NOT in allowedTools → invalid
+      },
+    };
+    expect(() => validateServerPolicy(policy)).toThrow(/write_file/);
+  });
+
+  it("accepts toolPolicies entry whose key is listed in allowedTools", () => {
+    const policy: ServerPolicy = {
+      allowedTools: ["read_file", "write_file"],
+      toolPolicies: {
+        write_file: {},
+      },
+    };
+    expect(() => validateServerPolicy(policy)).not.toThrow();
+  });
+
+  it("accepts toolPolicies when allowedTools is omitted (allow all)", () => {
+    const policy: ServerPolicy = {
+      toolPolicies: {
+        any_tool: {},
+      },
+    };
+    expect(() => validateServerPolicy(policy)).not.toThrow();
+  });
+
+  it("accepts toolPolicies when allowedTools is empty (allow all)", () => {
+    const policy: ServerPolicy = {
+      allowedTools: [],
+      toolPolicies: {
+        any_tool: {},
+      },
+    };
+    expect(() => validateServerPolicy(policy)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (2): same key in both forbidKeys and requireKeys
+// ---------------------------------------------------------------------------
+describe("validation: forbidKeys vs requireKeys", () => {
+  it("rejects a key present in both forbidKeys and requireKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      forbidKeys: ["dangerous"],
+      requireKeys: ["dangerous"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/dangerous/);
+  });
+
+  it("accepts distinct forbidKeys and requireKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      forbidKeys: ["dangerous"],
+      requireKeys: ["safe"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (3): same key in both forbidPerItemKeys and requirePerItemKeys
+// ---------------------------------------------------------------------------
+describe("validation: forbidPerItemKeys vs requirePerItemKeys", () => {
+  it("rejects a key present in both forbidPerItemKeys and requirePerItemKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      forbidPerItemKeys: ["id"],
+      requirePerItemKeys: ["id"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/id/);
+  });
+
+  it("accepts distinct forbidPerItemKeys and requirePerItemKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      forbidPerItemKeys: ["secret"],
+      requirePerItemKeys: ["name"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (4): same key in both defaults and forbidKeys
+// ---------------------------------------------------------------------------
+describe("validation: defaults vs forbidKeys", () => {
+  it("rejects a key present in both defaults and forbidKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      defaults: { mode: "strict" },
+      forbidKeys: ["mode"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/mode/);
+  });
+
+  it("accepts defaults and forbidKeys with no overlapping keys", () => {
+    const toolPolicy: ToolPolicy = {
+      defaults: { mode: "strict" },
+      forbidKeys: ["other"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (5): same key in both injectIntoEachItem and forbidPerItemKeys
+// ---------------------------------------------------------------------------
+describe("validation: injectIntoEachItem vs forbidPerItemKeys", () => {
+  it("rejects a key present in both injectIntoEachItem and forbidPerItemKeys", () => {
+    const toolPolicy: ToolPolicy = {
+      injectIntoEachItem: { tag: "auto" },
+      forbidPerItemKeys: ["tag"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/tag/);
+  });
+
+  it("accepts injectIntoEachItem and forbidPerItemKeys with no overlap", () => {
+    const toolPolicy: ToolPolicy = {
+      injectIntoEachItem: { tag: "auto" },
+      forbidPerItemKeys: ["secret"],
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation (6): non-primitive values in allowedValues / allowedValuesEach
+// ---------------------------------------------------------------------------
+describe("validation: allowedValues and allowedValuesEach must contain only primitives", () => {
+  it("rejects an object value inside allowedValues", () => {
+    const toolPolicy: ToolPolicy = {
+      allowedValues: {
+        mode: [{ nested: true } as unknown as string | number | boolean | null],
+      },
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/allowedValues/);
+  });
+
+  it("rejects an array value inside allowedValues", () => {
+    const toolPolicy: ToolPolicy = {
+      allowedValues: {
+        tags: [["a", "b"] as unknown as string | number | boolean | null],
+      },
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/allowedValues/);
+  });
+
+  it("accepts only primitive values inside allowedValues", () => {
+    const toolPolicy: ToolPolicy = {
+      allowedValues: {
+        mode: ["read", "write", null],
+        count: [1, 2, 3],
+        flag: [true, false],
+      },
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+
+  it("rejects an object value inside allowedValuesEach", () => {
+    const toolPolicy: ToolPolicy = {
+      allowedValuesEach: {
+        items: [{ id: 1 } as unknown as string | number | boolean | null],
+      },
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).toThrow(/allowedValuesEach/);
+  });
+
+  it("accepts only primitive values inside allowedValuesEach", () => {
+    const toolPolicy: ToolPolicy = {
+      allowedValuesEach: {
+        kind: ["file", "dir"],
+      },
+    };
+    expect(() =>
+      validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple violations reported together
+// ---------------------------------------------------------------------------
+describe("validation: reports all violations, not just the first", () => {
+  it("reports both a forbidKeys/requireKeys clash and a defaults/forbidKeys clash", () => {
+    const toolPolicy: ToolPolicy = {
+      defaults: { level: "high" },
+      forbidKeys: ["level", "shared"],
+      requireKeys: ["shared"],
+    };
+    const err = (() => {
+      try {
+        validateServerPolicy({ toolPolicies: { my_tool: toolPolicy } });
+        return null;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(err).not.toBeNull();
+    expect(err!.message).toMatch(/level/);
+    expect(err!.message).toMatch(/shared/);
+  });
+});

--- a/config.ts
+++ b/config.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "
 import { homedir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import type { McpConfig, ServerEntry, McpSettings, ImportKind, ServerProvenance } from "./types.js";
+import { validateServerPolicy, type ToolPolicy } from "./policy.js";
 
 const DEFAULT_CONFIG_PATH = join(homedir(), ".pi", "agent", "mcp.json");
 const PROJECT_CONFIG_NAME = ".pi/mcp.json";
@@ -222,5 +223,41 @@ export function writeDirectToolsConfig(
     const tmpPath = `${filePath}.${process.pid}.tmp`;
     writeFileSync(tmpPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
     renameSync(tmpPath, filePath);
+  }
+}
+
+
+export function validatePoliciesInConfig(config: McpConfig): void {
+  for (const [, definition] of Object.entries(config.mcpServers)) {
+    if (!definition.policy) continue;
+
+    validateServerPolicy(definition.policy);
+    validateInlineToolPolicy(definition.policy as ToolPolicy);
+  }
+}
+
+function validateInlineToolPolicy(policy: ToolPolicy): void {
+  for (const key of policy.forbidKeys ?? []) {
+    if (policy.requireKeys?.includes(key)) {
+      throw new Error(`"${key}" is in both forbidKeys and requireKeys`);
+    }
+  }
+
+  for (const key of policy.forbidPerItemKeys ?? []) {
+    if (policy.requirePerItemKeys?.includes(key)) {
+      throw new Error(`"${key}" is in both forbidPerItemKeys and requirePerItemKeys`);
+    }
+  }
+
+  for (const key of Object.keys(policy.defaults ?? {})) {
+    if (policy.forbidKeys?.includes(key)) {
+      throw new Error(`"${key}" is in both defaults and forbidKeys`);
+    }
+  }
+
+  for (const key of Object.keys(policy.injectIntoEachItem ?? {})) {
+    if (policy.forbidPerItemKeys?.includes(key)) {
+      throw new Error(`"${key}" is in both injectIntoEachItem and forbidPerItemKeys`);
+    }
   }
 }

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -66,8 +66,17 @@ export function resolveDirectTools(
 
     if (!toolFilter) continue;
 
+    // Intersect with policy.allowedTools when non-empty
+    const policyAllowed = definition.policy?.allowedTools;
+    const effectiveFilter: true | string[] =
+      policyAllowed && policyAllowed.length > 0
+        ? toolFilter === true
+          ? policyAllowed
+          : toolFilter.filter((t) => policyAllowed.includes(t))
+        : toolFilter;
+
     for (const tool of serverCache.tools ?? []) {
-      if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
+      if (effectiveFilter !== true && !effectiveFilter.includes(tool.name)) continue;
       const prefixedName = formatToolName(tool.name, serverName, prefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);

--- a/init.ts
+++ b/init.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import type { McpExtensionState } from "./state.js";
 import type { ToolMetadata } from "./types.js";
 import { existsSync } from "node:fs";
-import { loadMcpConfig } from "./config.js";
+import { loadMcpConfig, validatePoliciesInConfig } from "./config.js";
 import { ConsentManager } from "./consent-manager.js";
 import { McpLifecycleManager } from "./lifecycle.js";
 import {
@@ -30,6 +30,7 @@ export async function initializeMcp(
 ): Promise<McpExtensionState> {
   const configPath = pi.getFlag("mcp-config") as string | undefined;
   const config = loadMcpConfig(configPath);
+  validatePoliciesInConfig(config);
 
   const manager = new McpServerManager();
   const lifecycle = new McpLifecycleManager(manager);

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -95,6 +95,7 @@ export function computeServerHash(definition: ServerEntry): string {
     bearerToken: definition.bearerToken,
     bearerTokenEnv: definition.bearerTokenEnv,
     exposeResources: definition.exposeResources,
+    policy: definition.policy,
   };
   const normalized = stableStringify(identity);
   return createHash("sha256").update(normalized).digest("hex");

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tool-metadata.ts",
     "init.ts",
     "ui-session.ts",
+    "policy.ts",
     "proxy-modes.ts",
     "direct-tools.ts",
     "commands.ts",

--- a/policy.ts
+++ b/policy.ts
@@ -1,0 +1,204 @@
+// policy.ts — TYPE STUBS ONLY (no business logic)
+// Real implementation will be added by tdd-green.
+
+export type Primitive = string | number | boolean | null;
+
+export interface ToolPolicy {
+  forbidKeys?: string[];
+  requireKeys?: string[];
+  forbidPerItemKeys?: string[];
+  requirePerItemKeys?: string[];
+  defaults?: Record<string, unknown>;
+  injectIntoEachItem?: Record<string, unknown>;
+  allowedValues?: Record<string, Primitive[]>;
+  allowedValuesEach?: Record<string, Primitive[]>;
+}
+
+export interface ServerPolicy {
+  allowedTools?: string[];
+  allowedResources?: string[];
+  allowedPrompts?: string[];
+  toolPolicies?: Record<string, ToolPolicy>;
+}
+
+export function validateServerPolicy(policy: ServerPolicy): void {
+  const errors: string[] = [];
+  const { allowedTools, toolPolicies } = policy;
+  const hasAllowList = allowedTools && allowedTools.length > 0;
+
+  if (toolPolicies) {
+    for (const [toolName, tp] of Object.entries(toolPolicies)) {
+      if (hasAllowList && !allowedTools!.includes(toolName)) {
+        errors.push(`toolPolicies key "${toolName}" is not in allowedTools`);
+      }
+      for (const k of tp.forbidKeys ?? []) {
+        if (tp.requireKeys?.includes(k)) {
+          errors.push(`"${k}" is in both forbidKeys and requireKeys`);
+        }
+      }
+      for (const k of tp.forbidPerItemKeys ?? []) {
+        if (tp.requirePerItemKeys?.includes(k)) {
+          errors.push(`"${k}" is in both forbidPerItemKeys and requirePerItemKeys`);
+        }
+      }
+      for (const k of Object.keys(tp.defaults ?? {})) {
+        if (tp.forbidKeys?.includes(k)) {
+          errors.push(`"${k}" is in both defaults and forbidKeys`);
+        }
+      }
+      for (const k of Object.keys(tp.injectIntoEachItem ?? {})) {
+        if (tp.forbidPerItemKeys?.includes(k)) {
+          errors.push(`"${k}" is in both injectIntoEachItem and forbidPerItemKeys`);
+        }
+      }
+      for (const [key, vals] of Object.entries(tp.allowedValues ?? {})) {
+        for (const v of vals) {
+          if (v !== null && typeof v === 'object') {
+            errors.push(`allowedValues["${key}"] contains a non-primitive value`);
+            break;
+          }
+        }
+      }
+      for (const [key, vals] of Object.entries(tp.allowedValuesEach ?? {})) {
+        for (const v of vals) {
+          if (v !== null && typeof v === 'object') {
+            errors.push(`allowedValuesEach["${key}"] contains a non-primitive value`);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join('; '));
+  }
+}
+
+export function isToolAllowed(policy: ServerPolicy, toolName: string): boolean {
+  const list = policy.allowedTools;
+  return !list || list.length === 0 || list.includes(toolName);
+}
+
+export function isResourceAllowed(policy: ServerPolicy, resourceUri: string): boolean {
+  const list = policy.allowedResources;
+  return !list || list.length === 0 || list.includes(resourceUri);
+}
+
+export function isPromptAllowed(policy: ServerPolicy, promptName: string): boolean {
+  const list = policy.allowedPrompts;
+  return !list || list.length === 0 || list.includes(promptName);
+}
+
+export function filterAllowedTools<T extends { name: string }>(policy: ServerPolicy, tools: T[]): T[] {
+  const list = policy.allowedTools;
+  return (!list || list.length === 0) ? tools : tools.filter(t => list.includes(t.name));
+}
+
+export function filterAllowedResources<T extends { uri: string }>(policy: ServerPolicy, resources: T[]): T[] {
+  const list = policy.allowedResources;
+  return (!list || list.length === 0) ? resources : resources.filter(r => list.includes(r.uri));
+}
+
+export function filterAllowedPrompts<T extends { name: string }>(policy: ServerPolicy, prompts: T[]): T[] {
+  const list = policy.allowedPrompts;
+  return (!list || list.length === 0) ? prompts : prompts.filter(p => list.includes(p.name));
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) && Object.getPrototypeOf(v) === Object.prototype;
+}
+
+export function applyToolPolicy(
+  policy: ToolPolicy,
+  args: unknown
+): { ok: true; args: Record<string, unknown> } | { ok: false; error: string } {
+  // 1. Shape check
+  if (!isPlainObject(args)) {
+    return { ok: false, error: 'args must be a plain object' };
+  }
+
+  // 2. items must be array if present
+  if ('items' in args && !Array.isArray(args.items)) {
+    return { ok: false, error: 'items must be an array' };
+  }
+
+  // 3. each item must be plain object
+  const items = args.items as unknown[] | undefined;
+  if (items) {
+    for (const item of items) {
+      if (!isPlainObject(item)) {
+        return { ok: false, error: 'each item in items must be a plain object' };
+      }
+    }
+  }
+
+  // 4. Clone args (shallow)
+  const result: Record<string, unknown> = { ...args };
+  const clonedItems: Record<string, unknown>[] | undefined = items
+    ? items.map(item => ({ ...(item as Record<string, unknown>) }))
+    : undefined;
+  if (clonedItems !== undefined) result.items = clonedItems;
+
+  // 5. Apply defaults
+  for (const [k, v] of Object.entries(policy.defaults ?? {})) {
+    if (!(k in result)) result[k] = v;
+  }
+
+  // 6. Check forbidKeys
+  for (const k of policy.forbidKeys ?? []) {
+    if (k in result) return { ok: false, error: `key "${k}" is forbidden` };
+  }
+
+  // 7. Check requireKeys
+  for (const k of policy.requireKeys ?? []) {
+    if (!(k in result)) return { ok: false, error: `required key "${k}" is missing` };
+  }
+
+  // 8. Check allowedValues
+  for (const [k, allowed] of Object.entries(policy.allowedValues ?? {})) {
+    if (k in result && !allowed.includes(result[k] as Primitive)) {
+      return { ok: false, error: `value for "${k}" is not in allowed list` };
+    }
+  }
+
+  // 9. injectIntoEachItem
+  if (clonedItems) {
+    for (const item of clonedItems) {
+      for (const [k, v] of Object.entries(policy.injectIntoEachItem ?? {})) {
+        if (!(k in item)) item[k] = v;
+      }
+    }
+  }
+
+  // 10. forbidPerItemKeys
+  if (clonedItems) {
+    for (const item of clonedItems) {
+      for (const k of policy.forbidPerItemKeys ?? []) {
+        if (k in item) return { ok: false, error: `per-item key "${k}" is forbidden` };
+      }
+    }
+  }
+
+  // 11. requirePerItemKeys
+  if (clonedItems) {
+    for (const item of clonedItems) {
+      for (const k of policy.requirePerItemKeys ?? []) {
+        if (!(k in item)) return { ok: false, error: `required per-item key "${k}" is missing` };
+      }
+    }
+  }
+
+  // 12. allowedValuesEach
+  if (clonedItems) {
+    for (const item of clonedItems) {
+      for (const [k, allowed] of Object.entries(policy.allowedValuesEach ?? {})) {
+        if (k in item && !allowed.includes(item[k] as Primitive)) {
+          return { ok: false, error: `per-item value for "${k}" is not in allowed list` };
+        }
+      }
+    }
+  }
+
+  return { ok: true, args: result };
+}

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -7,6 +7,7 @@ import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from ".
 import { transformMcpContent } from "./tool-registrar.js";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.js";
 import { truncateAtWord } from "./utils.js";
+import { isToolAllowed, applyToolPolicy } from "./policy.js";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -469,6 +470,31 @@ export async function executeCall(
       content: [{ type: "text" as const, text: msg }],
       details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer },
     };
+  }
+
+  // Policy enforcement
+  const serverPolicy = state.config.mcpServers[serverName]?.policy;
+  if (serverPolicy) {
+    const originalName = toolMeta.originalName;
+    if (!isToolAllowed(serverPolicy, originalName)) {
+      const msg = `Tool "${originalName}" is not allowed by policy (not in allowedTools)`;
+      return {
+        content: [{ type: 'text' as const, text: msg }],
+        details: { mode: 'call', error: msg, server: serverName },
+      };
+    }
+    const toolPolicy = serverPolicy.toolPolicies?.[originalName];
+    if (toolPolicy) {
+      const policyResult = applyToolPolicy(toolPolicy, args ?? {});
+      if (!policyResult.ok) {
+        const msg = `Policy violation: ${policyResult.error}`;
+        return {
+          content: [{ type: 'text' as const, text: msg }],
+          details: { mode: 'call', error: msg, server: serverName },
+        };
+      }
+      args = policyResult.args;
+    }
   }
 
   let connection = state.manager.getConnection(serverName);

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,9 +1,41 @@
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { filterAllowedTools, filterAllowedResources } from "./policy.js";
+import type { ServerPolicy } from "./policy.js";
 import type { McpExtensionState } from "./state.js";
 import type { ToolMetadata, McpTool, McpResource, ServerEntry } from "./types.js";
 import { formatToolName } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
 import { extractToolUiStreamMode } from "./utils.js";
+
+export function checkPolicyAllowlistWarnings(
+  policy: ServerPolicy,
+  tools: Array<{ name: string }>,
+  resources: Array<{ uri: string }>,
+  prompts: Array<{ name: string }> | undefined,
+  serverName: string
+): void {
+  const toolNames = new Set(tools.map(t => t.name));
+  const resourceUris = new Set(resources.map(r => r.uri));
+
+  for (const name of policy.allowedTools ?? []) {
+    if (!toolNames.has(name)) {
+      console.warn(`MCP [${serverName}]: allowedTools entry "${name}" not found on server`);
+    }
+  }
+  for (const uri of policy.allowedResources ?? []) {
+    if (!resourceUris.has(uri)) {
+      console.warn(`MCP [${serverName}]: allowedResources entry "${uri}" not found on server`);
+    }
+  }
+  if (prompts !== undefined) {
+    const promptNames = new Set(prompts.map(p => p.name));
+    for (const name of policy.allowedPrompts ?? []) {
+      if (!promptNames.has(name)) {
+        console.warn(`MCP [${serverName}]: allowedPrompts entry "${name}" not found on server`);
+      }
+    }
+  }
+}
 
 export function buildToolMetadata(
   tools: McpTool[],
@@ -15,7 +47,13 @@ export function buildToolMetadata(
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
 
-  for (const tool of tools) {
+  const filteredTools = definition.policy ? filterAllowedTools(definition.policy, tools) : tools;
+  if (definition.policy) {
+    checkPolicyAllowlistWarnings(definition.policy, tools, resources, undefined, serverName);
+  }
+  const filteredResources = definition.policy ? filterAllowedResources(definition.policy, resources) : resources;
+
+  for (const tool of filteredTools) {
     if (!tool?.name) {
       failedTools.push("(unnamed)");
       continue;
@@ -37,7 +75,7 @@ export function buildToolMetadata(
   }
 
   if (definition.exposeResources !== false) {
-    for (const resource of resources) {
+    for (const resource of filteredResources) {
       const baseName = `get_${resourceNameToToolName(resource.name)}`;
       metadata.push({
         name: formatToolName(baseName, serverName, prefix),

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import type { ServerPolicy } from "./policy.js";
+
 // types.ts - Core type definitions
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -281,6 +283,8 @@ export interface ServerEntry {
   directTools?: boolean | string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
+  // Policy
+  policy?: ServerPolicy;
 }
 
 // Settings


### PR DESCRIPTION
## Problem
The adapter currently exposes all tools and resources from a configured MCP server and forwards tool arguments without an adapter-side policy layer. That makes it hard to enforce allowlists and request-shaping rules for higher-risk servers.

## Root Cause
Server definitions only described connection and exposure settings. There was no config-level policy model to:
- limit which tools/resources remain visible
- reject disallowed tool calls before they reach the MCP server
- inject or validate required request fields consistently at adapter startup and call time

## Fix
- add a per-server `policy` model with allowlists for tools, resources, and prompts
- add per-tool request rules for defaults, required keys, forbidden keys, allowed values, and per-item validation/injection
- validate policy config fail-fast during adapter initialization
- filter visible tools/resources and intersect direct-tool exposure with policy allowlists
- enforce policy at MCP call time before dispatching requests
- include policy in metadata cache hashing so cached metadata reflects policy changes

## Summary
- add new `policy.ts` implementation and `ServerEntry.policy` typing
- extend config validation with `validatePoliciesInConfig()`
- apply policy filtering in metadata/direct-tool paths
- apply policy enforcement in proxy call execution
- document the feature in `README.md`
- add focused policy tests only

## Testing
### Policy test suite
```bash
npx vitest run __tests__/policy.test.ts __tests__/policy-apply.test.ts __tests__/policy-allowlist.test.ts __tests__/policy-cache-warnings.test.ts __tests__/policy-init-wiring.test.ts __tests__/policy-integration.test.ts
```

```text
 RUN  v3.2.4 /tmp/pi-mcp-adapter-pr2

 ✓ __tests__/policy.test.ts (24 tests) 5ms
 ✓ __tests__/policy-allowlist.test.ts (24 tests) 5ms
 ✓ __tests__/policy-apply.test.ts (28 tests) 6ms
 ✓ __tests__/policy-cache-warnings.test.ts (11 tests) 7ms
 ✓ __tests__/policy-integration.test.ts (12 tests) 8ms
 ✓ __tests__/policy-init-wiring.test.ts (1 test) 3ms

 Test Files  6 passed (6)
      Tests  100 passed (100)
   Duration  386ms
```

## Standalone note
This PR is intentionally based directly on `upstream/main` and does not include the repeated `--mcp-config` work from PR #29.

The only startup wiring change here is the standalone-compatible `init.ts` addition of:
- `validatePoliciesInConfig(config)`

while preserving upstream's existing single-config loading:
- `const configPath = pi.getFlag("mcp-config") as string | undefined;`
- `const config = loadMcpConfig(configPath);`
