### PR TITLE
fix: support Codex MCP import from TOML config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added Codex MCP imports from `.codex/config.toml`, with fallback to the existing JSON config. Thanks @npo-mmenke for PR #31.
 - Added environment-variable interpolation for HTTP MCP server URLs, with missing URL variables failing closed before requests are sent. Thanks @ozeias for PR #206.
 - Added `settings.oauthDir` to store MCP OAuth credentials in a project-specific directory, with `MCP_OAUTH_DIR` still taking precedence. Thanks @Termina1 for PR #105.
 - Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -55,6 +55,28 @@ describe("cli init helper", () => {
     expect(logs.join("\n")).toContain("Updated");
   });
 
+  it("detects TOML-only Codex config during dry-run", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-cli-codex-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-cli-codex-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const codexConfigPath = join(home, ".codex", "config.toml");
+    mkdirSync(dirname(codexConfigPath), { recursive: true });
+    writeFileSync(codexConfigPath, '[mcp_servers.context7]\nurl = "https://mcp.context7.com/mcp"\n', "utf-8");
+
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const { main } = await import("../cli.js");
+    const exitCode = await main(["init", "--dry-run"], (line) => logs.push(line), (line) => errors.push(line));
+
+    expect(exitCode).toBe(0);
+    expect(errors).toEqual([]);
+    expect(logs.join("\n")).toContain(`codex: ${codexConfigPath}`);
+    expect(logs.join("\n")).toContain("Detected host configs to import into Pi: codex");
+    expect(existsSync(join(home, ".pi", "agent", "mcp.json"))).toBe(false);
+  });
+
   it("writes detected host imports to PI_CODING_AGENT_DIR when set", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-cli-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-cli-agent-"));

--- a/__tests__/config-imports.test.ts
+++ b/__tests__/config-imports.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const originalHome = process.env.HOME;
+const originalCwd = process.cwd();
+const tempHomes: string[] = [];
+
+async function loadConfigModule() {
+  vi.resetModules();
+  return import("../config.ts");
+}
+
+function createTestHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "pi-mcp-adapter-home-"));
+  tempHomes.push(home);
+  process.env.HOME = home;
+  process.chdir(home);
+  mkdirSync(join(home, ".pi", "agent"), { recursive: true });
+  mkdirSync(join(home, ".codex"), { recursive: true });
+  writeFileSync(
+    join(home, ".pi", "agent", "mcp.json"),
+    JSON.stringify({ imports: ["codex"], mcpServers: {} }),
+  );
+  return home;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  process.chdir(originalCwd);
+  while (tempHomes.length > 0) {
+    const home = tempHomes.pop();
+    if (home) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("loadMcpConfig imports", () => {
+  it("imports Codex MCP servers from config.toml", async () => {
+    const home = createTestHome();
+
+    writeFileSync(
+      join(home, ".codex", "config.toml"),
+      [
+        '[mcp_servers.context7]',
+        'url = "https://mcp.context7.com/mcp"',
+        '',
+        '[mcp_servers.serena]',
+        'command = "uvx"',
+        'args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"]',
+      ].join("\n"),
+    );
+
+    const { loadMcpConfig } = await loadConfigModule();
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.context7).toEqual({
+      url: "https://mcp.context7.com/mcp",
+    });
+    expect(config.mcpServers.serena).toEqual({
+      command: "uvx",
+      args: ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"],
+    });
+  });
+
+  it("falls back to Codex config.json when config.toml is absent", async () => {
+    const home = createTestHome();
+
+    writeFileSync(
+      join(home, ".codex", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          exa: {
+            url: "https://mcp.exa.ai/mcp",
+          },
+        },
+      }),
+    );
+
+    const { loadMcpConfig } = await loadConfigModule();
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.exa).toEqual({
+      url: "https://mcp.exa.ai/mcp",
+    });
+  });
+
+  it("falls back to Codex config.json when config.toml is invalid", async () => {
+    const home = createTestHome();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    writeFileSync(join(home, ".codex", "config.toml"), "[mcp_servers.exa\nurl = \"broken\"\n");
+    writeFileSync(
+      join(home, ".codex", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          exa: {
+            url: "https://mcp.exa.ai/mcp",
+          },
+        },
+      }),
+    );
+
+    const { loadMcpConfig } = await loadConfigModule();
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.exa).toEqual({
+      url: "https://mcp.exa.ai/mcp",
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("getServerProvenance imports", () => {
+  it("falls back to Codex config.json when config.toml is invalid", async () => {
+    const home = createTestHome();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    writeFileSync(join(home, ".codex", "config.toml"), "[mcp_servers.exa\nurl = \"broken\"\n");
+    writeFileSync(
+      join(home, ".codex", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          exa: {
+            url: "https://mcp.exa.ai/mcp",
+          },
+        },
+      }),
+    );
+
+    const { getServerProvenance } = await loadConfigModule();
+    const provenance = getServerProvenance();
+
+    expect(provenance.get("exa")).toEqual({
+      path: join(home, ".pi", "agent", "mcp.json"),
+      kind: "import",
+      importKind: "codex",
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -112,6 +112,145 @@ describe("config discovery", () => {
     );
   });
 
+  it("imports Codex MCP servers from config.toml", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-codex-toml-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-codex-toml-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), {
+      imports: ["codex"],
+      mcpServers: {},
+    });
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "config.toml"),
+      [
+        "[mcp_servers.context7]",
+        'url = "https://mcp.context7.com/mcp"',
+        "",
+        "[mcp_servers.serena]",
+        'command = "uvx"',
+        'args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"]',
+      ].join("\n"),
+    );
+
+    const { loadMcpConfig, getMcpDiscoverySummary, getServerProvenance } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers).toEqual({
+      context7: { url: "https://mcp.context7.com/mcp" },
+      serena: {
+        command: "uvx",
+        args: ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"],
+      },
+    });
+    expect(getMcpDiscoverySummary().imports).toEqual([
+      expect.objectContaining({ kind: "codex", path: join(home, ".codex", "config.toml"), serverCount: 2 }),
+    ]);
+    expect(getServerProvenance().get("context7")).toEqual({
+      path: join(home, ".pi", "agent", "mcp.json"),
+      kind: "import",
+      importKind: "codex",
+    });
+  });
+
+  it("maps Codex HTTP authentication fields to adapter fields", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-codex-http-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-codex-http-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), { imports: ["codex"], mcpServers: {} });
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "config.toml"),
+      [
+        "[mcp_servers.remote]",
+        'url = "https://mcp.example.com/mcp"',
+        'bearer_token_env_var = "CODEX_TOKEN"',
+        'http_headers = { "X-API-Key" = "literal-key" }',
+        'env_http_headers = { "X-Trace-ID" = "CODEX_TRACE_ID" }',
+      ].join("\n"),
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers.remote).toEqual({
+      url: "https://mcp.example.com/mcp",
+      auth: "bearer",
+      bearerTokenEnv: "CODEX_TOKEN",
+      headers: {
+        "X-API-Key": "literal-key",
+        "X-Trace-ID": "$env:CODEX_TRACE_ID",
+      },
+    });
+  });
+
+  it("preserves invalid TOML warnings and JSON fallback in provenance", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-codex-fallback-provenance-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-codex-fallback-provenance-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), { imports: ["codex"], mcpServers: {} });
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(join(home, ".codex", "config.toml"), "[mcp_servers.exa\\nurl = \\\"broken\\\"\\n");
+    writeJson(join(home, ".codex", "config.json"), {
+      mcpServers: { exa: { url: "https://mcp.exa.ai/mcp" } },
+    });
+
+    const { getServerProvenance } = await import("../config.ts");
+    expect(getServerProvenance().get("exa")).toEqual({
+      path: join(home, ".pi", "agent", "mcp.json"),
+      kind: "import",
+      importKind: "codex",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to inspect imported MCP config from codex:"),
+      expect.anything(),
+    );
+  });
+
+  it("reports invalid TOML warnings while discovering the JSON fallback", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-codex-fallback-discovery-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-codex-fallback-discovery-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(join(home, ".codex", "config.toml"), "[mcp_servers.exa\\nurl = \\\"broken\\\"\\n");
+    writeJson(join(home, ".codex", "config.json"), {
+      mcpServers: { exa: { url: "https://mcp.exa.ai/mcp" } },
+    });
+
+    const { findAvailableImportConfigs, getMcpDiscoverySummary } = await import("../config.ts");
+    expect(findAvailableImportConfigs()).toContainEqual({ kind: "codex", path: join(home, ".codex", "config.json") });
+    expect(getMcpDiscoverySummary().imports).toEqual([
+      expect.objectContaining({ kind: "codex", path: join(home, ".codex", "config.json"), serverCount: 1 }),
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to discover imported MCP config from codex:"),
+      expect.anything(),
+    );
+  });
+
+  it("keeps Codex JSON imports working when config.toml is absent", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-codex-json-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-codex-json-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), { imports: ["codex"], mcpServers: {} });
+    writeJson(join(home, ".codex", "config.json"), {
+      mcpServers: { exa: { url: "https://mcp.exa.ai/mcp" } },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toEqual({ exa: { url: "https://mcp.exa.ai/mcp" } });
+  });
+
   it("merges partial Pi overrides into shared and imported server definitions", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-merge-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-merge-project-"));

--- a/cli.js
+++ b/cli.js
@@ -29,7 +29,10 @@ const IMPORT_PATHS = {
     path.join(HOME, ".claude", "claude_desktop_config.json"),
   ],
   "claude-desktop": [path.join(HOME, "Library", "Application Support", "Claude", "claude_desktop_config.json")],
-  codex: [path.join(HOME, ".codex", "config.json")],
+  codex: [
+    path.join(HOME, ".codex", "config.toml"),
+    path.join(HOME, ".codex", "config.json"),
+  ],
   windsurf: [path.join(HOME, ".windsurf", "mcp.json")],
   vscode: [path.resolve(process.cwd(), ".vscode", "mcp.json")],
 };

--- a/config.ts
+++ b/config.ts
@@ -2,19 +2,23 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, dirname } from "node:path";
+import { parse as parseToml } from "smol-toml";
 import type { McpConfig, ServerEntry, McpSettings, ImportKind, ServerProvenance } from "./types.js";
 
 const DEFAULT_CONFIG_PATH = join(homedir(), ".pi", "agent", "mcp.json");
 const PROJECT_CONFIG_NAME = ".pi/mcp.json";
 
 // Import source paths for other tools
-const IMPORT_PATHS: Record<ImportKind, string> = {
-  "cursor": join(homedir(), ".cursor", "mcp.json"),
-  "claude-code": join(homedir(), ".claude", "claude_desktop_config.json"),
-  "claude-desktop": join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json"),
-  "codex": join(homedir(), ".codex", "config.json"),
-  "windsurf": join(homedir(), ".windsurf", "mcp.json"),
-  "vscode": ".vscode/mcp.json", // Relative to project
+const IMPORT_PATHS: Record<ImportKind, string[]> = {
+  "cursor": [join(homedir(), ".cursor", "mcp.json")],
+  "claude-code": [join(homedir(), ".claude", "claude_desktop_config.json")],
+  "claude-desktop": [join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json")],
+  "codex": [
+    join(homedir(), ".codex", "config.toml"),
+    join(homedir(), ".codex", "config.json"),
+  ],
+  "windsurf": [join(homedir(), ".windsurf", "mcp.json")],
+  "vscode": [".vscode/mcp.json"], // Relative to project
 };
 
 export function loadMcpConfig(overridePath?: string): McpConfig {
@@ -35,27 +39,19 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
   // Process imports from other tools
   if (config.imports?.length) {
     for (const importKind of config.imports) {
-      const importPath = IMPORT_PATHS[importKind];
-      if (!importPath) continue;
-      
-      const fullPath = importPath.startsWith(".") 
-        ? resolve(process.cwd(), importPath) 
-        : importPath;
-      
-      if (!existsSync(fullPath)) continue;
-      
-      try {
-        const imported = JSON.parse(readFileSync(fullPath, "utf-8"));
-        const servers = extractServers(imported, importKind);
-        
-        // Merge - local config takes precedence over imports
-        for (const [name, def] of Object.entries(servers)) {
-          if (!config.mcpServers[name]) {
-            config.mcpServers[name] = def;
-          }
+      const importPaths = IMPORT_PATHS[importKind];
+      if (!importPaths?.length) continue;
+
+      const imported = loadImportedConfig(importPaths, importKind, "Failed to import MCP config from");
+      if (!imported) continue;
+
+      const servers = extractServers(imported, importKind);
+
+      // Merge - local config takes precedence over imports
+      for (const [name, def] of Object.entries(servers)) {
+        if (!config.mcpServers[name]) {
+          config.mcpServers[name] = def;
         }
-      } catch (error) {
-        console.warn(`Failed to import MCP config from ${importKind}:`, error);
       }
     }
   }
@@ -78,6 +74,41 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
   }
   
   return config;
+}
+
+function resolveImportPaths(paths: string[]): string[] {
+  return paths.map((importPath) => importPath.startsWith(".")
+    ? resolve(process.cwd(), importPath)
+    : importPath,
+  );
+}
+
+function readImportedConfig(path: string): unknown {
+  const raw = readFileSync(path, "utf-8");
+
+  if (path.endsWith(".toml")) {
+    return parseToml(raw);
+  }
+
+  return JSON.parse(raw);
+}
+
+function loadImportedConfig(
+  paths: string[],
+  importKind: ImportKind,
+  warningPrefix: string,
+): unknown | undefined {
+  for (const fullPath of resolveImportPaths(paths)) {
+    if (!existsSync(fullPath)) continue;
+
+    try {
+      return readImportedConfig(fullPath);
+    } catch (error) {
+      console.warn(`${warningPrefix} ${importKind}:`, error);
+    }
+  }
+
+  return undefined;
 }
 
 function validateConfig(raw: unknown): McpConfig {
@@ -109,8 +140,10 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
   switch (kind) {
     case "claude-desktop":
     case "claude-code":
-    case "codex":
       servers = obj.mcpServers;
+      break;
+    case "codex":
+      servers = obj.mcp_servers ?? obj.mcpServers;
       break;
     case "cursor":
     case "windsurf":
@@ -144,21 +177,16 @@ export function getServerProvenance(overridePath?: string): Map<string, ServerPr
 
   if (userConfig.imports?.length) {
     for (const importKind of userConfig.imports) {
-      const importPath = IMPORT_PATHS[importKind];
-      if (!importPath) continue;
-      const fullPath = importPath.startsWith(".")
-        ? resolve(process.cwd(), importPath)
-        : importPath;
-      if (!existsSync(fullPath)) continue;
-      try {
-        const imported = JSON.parse(readFileSync(fullPath, "utf-8"));
-        const servers = extractServers(imported, importKind);
-        for (const name of Object.keys(servers)) {
-          if (!provenance.has(name)) {
-            provenance.set(name, { path: userPath, kind: "import", importKind });
-          }
+      const importPaths = IMPORT_PATHS[importKind];
+      if (!importPaths?.length) continue;
+      const imported = loadImportedConfig(importPaths, importKind, "Failed to inspect imported MCP config from");
+      if (!imported) continue;
+      const servers = extractServers(imported, importKind);
+      for (const name of Object.keys(servers)) {
+        if (!provenance.has(name)) {
+          provenance.set(name, { path: userPath, kind: "import", importKind });
         }
-      } catch {}
+      }
     }
   }
 

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { parse as parseToml } from "smol-toml";
 import { getAgentPath } from "./agent-dir.ts";
 import type { McpConfig, ServerEntry, McpSettings, ImportKind, ServerProvenance } from "./types.ts";
 
@@ -21,7 +22,10 @@ const IMPORT_PATHS: Record<ImportKind, string[]> = {
     join(homedir(), ".claude", "claude_desktop_config.json"),
   ],
   "claude-desktop": [join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json")],
-  codex: [join(homedir(), ".codex", "config.json")],
+  codex: [
+    join(homedir(), ".codex", "config.toml"),
+    join(homedir(), ".codex", "config.json"),
+  ],
   windsurf: [join(homedir(), ".windsurf", "mcp.json")],
   vscode: [".vscode/mcp.json"],
 };
@@ -142,12 +146,12 @@ export function getMcpDiscoverySummary(overridePath?: string, cwd = process.cwd(
 
   const imports = (Object.keys(IMPORT_PATHS) as ImportKind[])
     .map((kind) => {
-      const path = resolveImportPath(kind, cwd);
-      if (!path) return null;
+      const imported = loadImportedConfig(kind, cwd, `Failed to inspect imported MCP config from ${kind}:`);
+      if (!imported) return null;
       return {
         kind,
-        path,
-        serverCount: getImportServerCount(kind, path),
+        path: imported.path,
+        serverCount: Object.keys(extractServers(imported.value, kind)).length,
       } satisfies ImportConfigSummary;
     })
     .filter((value): value is ImportConfigSummary => value !== null);
@@ -306,19 +310,14 @@ function expandImports(config: McpConfig, cwd = process.cwd()): McpConfig {
 
   const importedServers: Record<string, ServerEntry> = {};
   for (const importKind of config.imports) {
-    const importPath = resolveImportPath(importKind, cwd);
-    if (!importPath) continue;
+    const imported = loadImportedConfig(importKind, cwd, `Failed to import MCP config from ${importKind}:`);
+    if (!imported) continue;
 
-    try {
-      const imported = JSON.parse(readFileSync(importPath, "utf-8"));
-      const servers = extractServers(imported, importKind);
-      for (const [name, definition] of Object.entries(servers)) {
-        if (!importedServers[name]) {
-          importedServers[name] = definition;
-        }
+    const servers = extractServers(imported.value, importKind);
+    for (const [name, definition] of Object.entries(servers)) {
+      if (!importedServers[name]) {
+        importedServers[name] = definition;
       }
-    } catch (error) {
-      console.warn(`Failed to import MCP config from ${importKind}:`, error);
     }
   }
 
@@ -329,24 +328,37 @@ function expandImports(config: McpConfig, cwd = process.cwd()): McpConfig {
   };
 }
 
-function resolveImportPath(importKind: ImportKind, cwd = process.cwd()): string | null {
-  const candidates = IMPORT_PATHS[importKind] ?? [];
-  for (const candidate of candidates) {
-    const fullPath = candidate.startsWith(".") ? resolve(cwd, candidate) : candidate;
-    if (existsSync(fullPath)) {
-      return fullPath;
+function resolveImportCandidates(importKind: ImportKind, cwd: string): string[] {
+  return (IMPORT_PATHS[importKind] ?? []).map((candidate) =>
+    candidate.startsWith(".") ? resolve(cwd, candidate) : candidate,
+  );
+}
+
+function readImportedConfig(path: string): unknown {
+  const raw = readFileSync(path, "utf-8");
+  return path.endsWith(".toml") ? parseToml(raw) : JSON.parse(raw);
+}
+
+function loadImportedConfig(
+  importKind: ImportKind,
+  cwd: string,
+  warningPrefix: string,
+): { path: string; value: unknown } | null {
+  for (const path of resolveImportCandidates(importKind, cwd)) {
+    if (!existsSync(path)) continue;
+
+    try {
+      return { path, value: readImportedConfig(path) };
+    } catch (error) {
+      console.warn(warningPrefix, error);
     }
   }
+
   return null;
 }
 
-function getImportServerCount(importKind: ImportKind, path: string): number {
-  try {
-    const raw = JSON.parse(readFileSync(path, "utf-8"));
-    return Object.keys(extractServers(raw, importKind)).length;
-  } catch {
-    return 0;
-  }
+function resolveImportPath(importKind: ImportKind, cwd = process.cwd()): string | null {
+  return loadImportedConfig(importKind, cwd, `Failed to discover imported MCP config from ${importKind}:`)?.path ?? null;
 }
 
 function readValidatedConfig(path: string, label: string): McpConfig | null {
@@ -388,8 +400,10 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
   switch (kind) {
     case "claude-desktop":
     case "claude-code":
-    case "codex":
       servers = obj.mcpServers;
+      break;
+    case "codex":
+      servers = obj.mcp_servers ?? obj.mcpServers;
       break;
     case "cursor":
     case "windsurf":
@@ -404,7 +418,40 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
     return {};
   }
 
-  return servers as Record<string, ServerEntry>;
+  const mappedServers: Record<string, ServerEntry> = {};
+  for (const [name, entry] of Object.entries(servers)) {
+    if (kind !== "codex" || !entry || typeof entry !== "object" || Array.isArray(entry)) {
+      mappedServers[name] = entry as ServerEntry;
+      continue;
+    }
+
+    const mapped = { ...(entry as Record<string, unknown>) };
+    const bearerTokenEnv = mapped.bearer_token_env_var;
+    const httpHeaders = mapped.http_headers;
+    const envHttpHeaders = mapped.env_http_headers;
+
+    if (typeof bearerTokenEnv === "string") {
+      mapped.bearerTokenEnv = bearerTokenEnv;
+      if (mapped.auth === undefined) mapped.auth = "bearer";
+    }
+    if (httpHeaders && typeof httpHeaders === "object" && !Array.isArray(httpHeaders)) {
+      mapped.headers = { ...(mapped.headers as Record<string, string> | undefined), ...(httpHeaders as Record<string, string>) };
+    }
+    if (envHttpHeaders && typeof envHttpHeaders === "object" && !Array.isArray(envHttpHeaders)) {
+      const headers = { ...(mapped.headers as Record<string, string> | undefined) };
+      for (const [header, envVar] of Object.entries(envHttpHeaders)) {
+        if (typeof envVar === "string" && headers[header] === undefined) headers[header] = `$env:${envVar}`;
+      }
+      mapped.headers = headers;
+    }
+
+    delete mapped.bearer_token_env_var;
+    delete mapped.http_headers;
+    delete mapped.env_http_headers;
+    mappedServers[name] = mapped as ServerEntry;
+  }
+
+  return mappedServers;
 }
 
 function serializeRawConfig(raw: Record<string, unknown>): string {
@@ -640,18 +687,15 @@ export function getServerProvenance(overridePath?: string, cwd = process.cwd()):
 
     if (loaded.imports?.length) {
       for (const importKind of loaded.imports) {
-        const importPath = resolveImportPath(importKind, cwd);
-        if (!importPath) continue;
+        const imported = loadImportedConfig(importKind, cwd, `Failed to inspect imported MCP config from ${importKind}:`);
+        if (!imported) continue;
 
-        try {
-          const imported = JSON.parse(readFileSync(importPath, "utf-8"));
-          const servers = extractServers(imported, importKind);
-          for (const name of Object.keys(servers)) {
-            if (!provenance.has(name)) {
-              provenance.set(name, { path: userPath, kind: "import", importKind });
-            }
+        const servers = extractServers(imported.value, importKind);
+        for (const name of Object.keys(servers)) {
+          if (!provenance.has(name)) {
+            provenance.set(name, { path: userPath, kind: "import", importKind });
           }
-        } catch {}
+        }
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "pi-mcp-adapter",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-mcp-adapter",
-      "version": "2.1.2",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@sinclair/typebox": "^0.32.0",
+        "smol-toml": "^1.6.1",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -518,7 +519,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
       "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -940,7 +940,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1487,7 +1486,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2024,7 +2022,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2349,6 +2346,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2524,7 +2533,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2733,7 +2741,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cross-spawn": "^7.0.6",
         "open": "^10.2.0",
         "recheck": "^4.5.0",
+        "smol-toml": "^1.6.1",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -5736,6 +5737,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@sinclair/typebox": "^0.32.0",
+    "smol-toml": "^1.6.1",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "cross-spawn": "^7.0.6",
     "open": "^10.2.0",
     "recheck": "^4.5.0",
+    "smol-toml": "^1.6.1",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Problem

`pi-mcp-adapter` currently imports Codex MCP servers from `~/.codex/config.json`
and expects them under `mcpServers`.

In current Codex installations, MCP servers are stored in
`~/.codex/config.toml` under `[mcp_servers.<name>]` instead.

That means Pi's `imports: ["codex"]` does not pick up MCP servers from a
modern Codex setup, even though `codex mcp list` shows them correctly.

## What this changes

- prefer `~/.codex/config.toml` when importing Codex MCP config
- read Codex TOML entries from `mcp_servers`
- fall back to `~/.codex/config.json` / `mcpServers` for backward compatibility
- continue to the JSON fallback if `config.toml` exists but is invalid
- surface warnings during provenance/import parsing instead of silently swallowing them

## Tests

Added coverage for:
- importing Codex MCP servers from TOML
- falling back to JSON when TOML is absent
- falling back to JSON when TOML is invalid
- provenance behavior for invalid TOML fallback

## Verification

- `npm test -- __tests__/config-imports.test.ts`
- `npm test`