### PR TITLE
feat: Add automatic OAuth refresh and browser re-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Interactive OAuth browser flow for `/mcp-auth` using discovery, dynamic client registration, PKCE, and a localhost callback.
+- Automatic OAuth access-token refresh using persisted token endpoint/client metadata.
+- Automatic interactive browser re-auth on session start and lazy connect when no valid OAuth token remains.
+- `settings.autoOauthBrowserAuth` to disable automatic browser popups and require manual `/mcp-auth` instead.
+
+### Changed
+- OAuth-backed HTTP servers now attempt silent refresh before failing authentication.
+
 ## [2.2.2] - 2026-04-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Two calls instead of 26 tools cluttering the context.
 {
   "settings": {
     "toolPrefix": "server",
-    "idleTimeout": 10
+    "idleTimeout": 10,
+    "autoOauthBrowserAuth": true
   },
   "mcpServers": { }
 }
@@ -115,6 +116,7 @@ Two calls instead of 26 tools cluttering the context.
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
+| `autoOauthBrowserAuth` | Automatically open the browser for OAuth re-auth in interactive sessions when tokens are missing/expired and refresh fails (default: `true`). Set to `false` to require manual `/mcp-auth`. |
 
 Per-server `idleTimeout` overrides the global setting.
 
@@ -173,6 +175,8 @@ Each direct tool costs ~150-300 tokens in the system prompt (name + description 
 Direct tools register from the metadata cache (`~/.pi/agent/mcp-cache.json`), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only and the cache populates in the background. Restart Pi and they'll be available. To force it: `/mcp reconnect <server>` then restart.
 
 **Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers, initiate OAuth, and toggle tools between direct and proxy — all from one overlay. Changes are written to your config file; restart Pi to apply.
+
+**OAuth behavior:** `/mcp-auth <server>` now opens the browser for OAuth using discovery, dynamic client registration, PKCE, and a localhost callback. Expired access tokens are refreshed automatically when possible. In interactive sessions, if refresh fails or no valid token exists, the adapter can automatically trigger browser re-auth on session start or first lazy connect. Disable that behavior with `settings.autoOauthBrowserAuth: false` if you prefer manual authentication only.
 
 **Subagent integration:** If you use the subagent extension, agents can request direct MCP tools in their frontmatter with `mcp:server-name` syntax. See the subagent README for details.
 
@@ -276,7 +280,7 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 | `/mcp tools` | List all tools |
 | `/mcp reconnect` | Reconnect all servers |
 | `/mcp reconnect <server>` | Connect or reconnect a single server |
-| `/mcp-auth <server>` | OAuth setup |
+| `/mcp-auth <server>` | Start interactive OAuth browser authentication |
 
 ## How It Works
 
@@ -291,6 +295,6 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 
 ## Limitations
 
-- OAuth tokens obtained externally (no browser flow)
-- No automatic token refresh
+- Automatic browser OAuth re-auth only runs in interactive sessions with UI available
+- Non-interactive sessions still fail closed and require pre-existing valid tokens
 - Cross-session server sharing not yet implemented (each Pi session runs its own server processes)

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   showTools: vi.fn(),
   reconnectServers: vi.fn(),
   authenticateServer: vi.fn(),
+  autoAuthenticateOAuthServers: vi.fn(),
   openMcpPanel: vi.fn(),
   executeCall: vi.fn(),
   executeConnect: vi.fn(),
@@ -50,6 +51,7 @@ vi.mock("../commands.js", () => ({
   showTools: mocks.showTools,
   reconnectServers: mocks.reconnectServers,
   authenticateServer: mocks.authenticateServer,
+  autoAuthenticateOAuthServers: mocks.autoAuthenticateOAuthServers,
   openMcpPanel: mocks.openMcpPanel,
 }));
 
@@ -123,6 +125,7 @@ describe("mcpAdapter session lifecycle", () => {
     mocks.resolveDirectTools.mockReturnValue([]);
     mocks.getConfigPathFromArgv.mockReturnValue(undefined);
     mocks.truncateAtWord.mockImplementation((text: string) => text);
+    mocks.autoAuthenticateOAuthServers.mockResolvedValue(undefined);
   });
 
   it("starts a replacement init immediately and shuts down stale init results", async () => {
@@ -151,6 +154,7 @@ describe("mcpAdapter session lifecycle", () => {
     await Promise.resolve();
 
     expect(mocks.updateStatusBar).toHaveBeenCalledWith(activeState);
+    expect(mocks.autoAuthenticateOAuthServers).toHaveBeenCalledWith(activeState);
     expect(activeState.lifecycle.gracefulShutdown).not.toHaveBeenCalled();
 
     const staleState = createState();

--- a/__tests__/oauth-handler.test.ts
+++ b/__tests__/oauth-handler.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tempHome: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "pi-mcp-oauth-"));
+  vi.stubEnv("HOME", tempHome);
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("oauth-handler", () => {
+  it("persists tokens with refresh metadata and reads them back", async () => {
+    const mod = await import("../oauth-handler.ts");
+
+    const path = mod.persistOAuthTokens(
+      "test-server",
+      {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "bearer",
+        expires_in: 3600,
+      },
+      {
+        client_id: "client-1",
+        token_endpoint: "https://example.com/token",
+        token_endpoint_auth_method: "none",
+      },
+    );
+
+    expect(path).toContain("test-server/tokens.json");
+
+    const stored = mod.readStoredTokens("test-server");
+    expect(stored?.access_token).toBe("access-1");
+    expect(stored?.refresh_token).toBe("refresh-1");
+    expect(stored?.client_id).toBe("client-1");
+    expect(stored?.token_endpoint).toBe("https://example.com/token");
+    expect(stored?.expiresAt).toBeTypeOf("number");
+  });
+
+  it("refreshes expired tokens in ensureStoredTokens", async () => {
+    const mod = await import("../oauth-handler.ts");
+
+    mod.persistOAuthTokens(
+      "test-server",
+      {
+        access_token: "expired-access",
+        refresh_token: "refresh-1",
+        token_type: "bearer",
+        expires_in: -1,
+      },
+      {
+        client_id: "client-1",
+        token_endpoint: "https://example.com/token",
+        token_endpoint_auth_method: "none",
+      },
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({
+        access_token: "access-2",
+        refresh_token: "refresh-2",
+        token_type: "bearer",
+        expires_in: 1200,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const ensured = await mod.ensureStoredTokens("test-server");
+    expect(ensured?.access_token).toBe("access-2");
+    expect(ensured?.refresh_token).toBe("refresh-2");
+
+    const stored = mod.readStoredTokens("test-server");
+    expect(stored?.access_token).toBe("access-2");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when refresh fails", async () => {
+    const mod = await import("../oauth-handler.ts");
+
+    mod.persistOAuthTokens(
+      "test-server",
+      {
+        access_token: "expired-access",
+        refresh_token: "refresh-1",
+        token_type: "bearer",
+        expires_in: -1,
+      },
+      {
+        client_id: "client-1",
+        token_endpoint: "https://example.com/token",
+        token_endpoint_auth_method: "none",
+      },
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ error: "invalid_grant" }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const ensured = await mod.ensureStoredTokens("test-server");
+    expect(ensured).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -1,10 +1,12 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { McpExtensionState } from "./state.js";
 import type { McpConfig, ServerEntry, McpPanelCallbacks, McpPanelResult } from "./types.js";
+import { createServer } from "node:http";
+import { createHash, randomBytes } from "node:crypto";
 import { getServerProvenance, writeDirectToolsConfig } from "./config.js";
 import { lazyConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds } from "./init.js";
 import { loadMetadataCache } from "./metadata-cache.js";
-import { getStoredTokens } from "./oauth-handler.js";
+import { ensureStoredTokens, persistOAuthTokens, readStoredTokens } from "./oauth-handler.js";
 import { buildToolMetadata } from "./tool-metadata.js";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
@@ -113,51 +115,359 @@ export async function reconnectServers(
   updateStatusBar(state);
 }
 
+type OAuthServerMetadata = {
+  issuer?: string;
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  registration_endpoint?: string;
+};
+
+function toBase64Url(buffer: Buffer): string {
+  return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = toBase64Url(randomBytes(32));
+  const challenge = toBase64Url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+async function fetchOAuthMetadata(serverUrl: string): Promise<Required<OAuthServerMetadata>> {
+  const origin = new URL(serverUrl).origin;
+  const metadataUrl = new URL("/.well-known/oauth-authorization-server", origin);
+  const response = await fetch(metadataUrl, {
+    headers: { accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`OAuth discovery failed (${response.status} ${response.statusText})`);
+  }
+
+  const metadata = (await response.json()) as OAuthServerMetadata;
+  if (!metadata.authorization_endpoint || !metadata.token_endpoint || !metadata.registration_endpoint) {
+    throw new Error("OAuth discovery response is missing required endpoints");
+  }
+
+  return {
+    issuer: metadata.issuer ?? origin,
+    authorization_endpoint: metadata.authorization_endpoint,
+    token_endpoint: metadata.token_endpoint,
+    registration_endpoint: metadata.registration_endpoint,
+  };
+}
+
+async function registerOAuthClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+): Promise<{ client_id: string; client_secret?: string; token_endpoint_auth_method?: string }> {
+  const response = await fetch(registrationEndpoint, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_name: "pi-mcp-adapter",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`OAuth client registration failed (${response.status}): ${body}`);
+  }
+
+  const json = JSON.parse(body) as { client_id?: string; client_secret?: string; token_endpoint_auth_method?: string };
+  if (!json.client_id) {
+    throw new Error("OAuth client registration did not return a client_id");
+  }
+
+  return {
+    client_id: json.client_id,
+    client_secret: json.client_secret,
+    token_endpoint_auth_method: json.token_endpoint_auth_method,
+  };
+}
+
+async function startOAuthCallbackServer(
+  expectedState: string,
+): Promise<{ redirectUri: string; waitForResult: Promise<{ callbackUrl: string; code: string }> }> {
+  const host = "127.0.0.1";
+
+  return new Promise((resolve, reject) => {
+    const timeoutMs = 5 * 60 * 1000;
+    let settled = false;
+
+    const server = createServer((req, res) => {
+      const requestUrl = new URL(req.url ?? "/", `http://${host}`);
+      if (requestUrl.pathname !== "/callback") {
+        res.statusCode = 404;
+        res.end("Not found");
+        return;
+      }
+
+      const state = requestUrl.searchParams.get("state");
+      const code = requestUrl.searchParams.get("code");
+      const error = requestUrl.searchParams.get("error");
+      const errorDescription = requestUrl.searchParams.get("error_description");
+
+      res.setHeader("content-type", "text/html; charset=utf-8");
+
+      const closeServer = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        server.close();
+      };
+
+      if (error) {
+        res.end(`<html><body><h1>Authentication failed</h1><p>${error}: ${errorDescription ?? "Unknown error"}</p><p>You can close this window.</p></body></html>`);
+        closeServer();
+        waiterReject(new Error(`OAuth authorization failed: ${error}${errorDescription ? ` - ${errorDescription}` : ""}`));
+        return;
+      }
+
+      if (!code) {
+        res.end("<html><body><h1>Authentication failed</h1><p>Missing authorization code.</p><p>You can close this window.</p></body></html>");
+        closeServer();
+        waiterReject(new Error("OAuth authorization failed: missing code in callback"));
+        return;
+      }
+
+      if (state !== expectedState) {
+        res.end("<html><body><h1>Authentication failed</h1><p>State mismatch.</p><p>You can close this window.</p></body></html>");
+        closeServer();
+        waiterReject(new Error("OAuth authorization failed: state mismatch"));
+        return;
+      }
+
+      res.end("<html><body><h1>Authentication complete</h1><p>You can close this window and return to pi.</p></body></html>");
+      closeServer();
+      waiterResolve({ callbackUrl: requestUrl.toString(), code });
+    });
+
+    let waiterResolve!: (value: { callbackUrl: string; code: string }) => void;
+    let waiterReject!: (reason?: unknown) => void;
+    const waitForResult = new Promise<{ callbackUrl: string; code: string }>((resolveWait, rejectWait) => {
+      waiterResolve = resolveWait;
+      waiterReject = rejectWait;
+    });
+
+    const timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      server.close();
+      waiterReject(new Error("Timed out waiting for OAuth callback"));
+    }, timeoutMs);
+
+    server.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      waiterReject(error);
+      reject(error);
+    });
+
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeoutId);
+          waiterReject(new Error("Failed to bind local OAuth callback server"));
+          reject(new Error("Failed to bind local OAuth callback server"));
+        }
+        return;
+      }
+
+      resolve({
+        redirectUri: `http://${host}:${address.port}/callback`,
+        waitForResult,
+      });
+    });
+  });
+}
+
+async function exchangeAuthorizationCode(
+  metadata: Required<OAuthServerMetadata>,
+  client: { client_id: string; client_secret?: string; token_endpoint_auth_method?: string },
+  redirectUri: string,
+  code: string,
+  codeVerifier: string,
+): Promise<Record<string, unknown>> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: client.client_id,
+    redirect_uri: redirectUri,
+    code,
+    code_verifier: codeVerifier,
+  });
+
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/x-www-form-urlencoded",
+  };
+
+  if (client.client_secret) {
+    if (client.token_endpoint_auth_method === "client_secret_basic") {
+      headers.authorization = `Basic ${Buffer.from(`${client.client_id}:${client.client_secret}`).toString("base64")}`;
+      params.delete("client_id");
+    } else if (client.token_endpoint_auth_method === "client_secret_post") {
+      params.set("client_secret", client.client_secret);
+    }
+  }
+
+  const response = await fetch(metadata.token_endpoint, {
+    method: "POST",
+    headers,
+    body: params.toString(),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`OAuth token exchange failed (${response.status}): ${body}`);
+  }
+
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+function extractCodeFromCallbackUrl(callbackUrl: string, expectedState: string): string {
+  const parsed = new URL(callbackUrl);
+  const state = parsed.searchParams.get("state");
+  const code = parsed.searchParams.get("code");
+  const error = parsed.searchParams.get("error");
+  const errorDescription = parsed.searchParams.get("error_description");
+
+  if (error) {
+    throw new Error(`OAuth authorization failed: ${error}${errorDescription ? ` - ${errorDescription}` : ""}`);
+  }
+  if (!code) {
+    throw new Error("OAuth authorization failed: missing code in callback URL");
+  }
+  if (state !== expectedState) {
+    throw new Error("OAuth authorization failed: state mismatch");
+  }
+
+  return code;
+}
+
+type AuthenticateServerOptions = {
+  reconnect?: boolean;
+  reason?: string;
+};
+
 export async function authenticateServer(
   serverName: string,
-  config: McpConfig,
-  ctx: ExtensionContext
-): Promise<void> {
-  if (!ctx.hasUI) return;
+  state: McpExtensionState,
+  ui = state.ui,
+  options: AuthenticateServerOptions = {},
+): Promise<boolean> {
+  if (!ui) return false;
 
-  const definition = config.mcpServers[serverName];
+  const definition = state.config.mcpServers[serverName];
   if (!definition) {
-    ctx.ui.notify(`Server "${serverName}" not found in config`, "error");
-    return;
+    ui.notify(`Server "${serverName}" not found in config`, "error");
+    return false;
   }
 
   if (definition.auth !== "oauth") {
-    ctx.ui.notify(
+    ui.notify(
       `Server "${serverName}" does not use OAuth authentication.\n` +
       `Current auth mode: ${definition.auth ?? "none"}`,
       "error"
     );
-    return;
+    return false;
   }
 
   if (!definition.url) {
-    ctx.ui.notify(
+    ui.notify(
       `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`,
       "error"
     );
-    return;
+    return false;
   }
 
-  const tokenPath = `~/.pi/agent/mcp-oauth/${serverName}/tokens.json`;
+  try {
+    const reason = options.reason ? ` (${options.reason})` : "";
+    ui.notify(`MCP: Starting OAuth flow for ${serverName}${reason}...`, "info");
 
-  ctx.ui.notify(
-    `OAuth setup for "${serverName}":\n\n` +
-    `1. Obtain an access token from your OAuth provider\n` +
-    `2. Create the token file:\n` +
-    `   ${tokenPath}\n\n` +
-    `3. Add your token:\n` +
-    `   {\n` +
-    `     "access_token": "your-token-here",\n` +
-    `     "token_type": "bearer"\n` +
-    `   }\n\n` +
-    `4. Run /mcp reconnect to connect with the token`,
-    "info"
-  );
+    const metadata = await fetchOAuthMetadata(definition.url);
+    const stateToken = toBase64Url(randomBytes(24));
+    const { verifier, challenge } = createPkcePair();
+    const { redirectUri, waitForResult } = await startOAuthCallbackServer(stateToken);
+    const client = await registerOAuthClient(metadata.registration_endpoint, redirectUri);
+
+    const authUrl = new URL(metadata.authorization_endpoint);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("client_id", client.client_id);
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("code_challenge", challenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+    authUrl.searchParams.set("state", stateToken);
+
+    await state.openBrowser(authUrl.toString());
+    ui.notify(
+      `Complete Atlassian login in your browser.\n\nIf automatic callback fails, copy the full redirected URL and keep it handy — pi will ask for it.`,
+      "info"
+    );
+
+    let code: string;
+    try {
+      const result = await waitForResult;
+      code = result.code;
+    } catch (error) {
+      const pasted = await ui.input(
+        "Paste redirected callback URL",
+        `${redirectUri}?code=...&state=...`,
+      );
+      if (!pasted) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+      code = extractCodeFromCallbackUrl(pasted.trim(), stateToken);
+    }
+
+    const tokenPayload = await exchangeAuthorizationCode(metadata, client, redirectUri, code, verifier);
+    const tokenPath = persistOAuthTokens(serverName, tokenPayload, {
+      client_id: client.client_id,
+      client_secret: client.client_secret,
+      token_endpoint_auth_method: client.token_endpoint_auth_method,
+      token_endpoint: metadata.token_endpoint,
+      issuer: metadata.issuer,
+      server_url: definition.url,
+    });
+
+    ui.notify(`OAuth complete for ${serverName}. Saved token to ${tokenPath}`, "info");
+
+    if (options.reconnect !== false) {
+      await reconnectServers(state, { hasUI: true, ui } as ExtensionContext, serverName);
+    }
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ui.notify(`OAuth failed for ${serverName}: ${message}`, "error");
+    return false;
+  }
+}
+
+export async function autoAuthenticateOAuthServers(state: McpExtensionState): Promise<void> {
+  const ui = state.ui;
+  if (!ui) return;
+
+  for (const [serverName, definition] of Object.entries(state.config.mcpServers)) {
+    if (definition.auth !== "oauth") continue;
+
+    const tokens = await ensureStoredTokens(serverName);
+    if (tokens) continue;
+
+    const ok = await authenticateServer(serverName, state, ui, {
+      reason: "session start",
+      reconnect: true,
+    });
+    if (!ok) break;
+  }
 }
 
 export async function openMcpPanel(
@@ -176,7 +486,7 @@ export async function openMcpPanel(
     },
     getConnectionStatus: (serverName: string) => {
       const definition = config.mcpServers[serverName];
-      if (definition?.auth === "oauth" && getStoredTokens(serverName) === undefined) {
+      if (definition?.auth === "oauth" && readStoredTokens(serverName) === undefined) {
         return "needs-auth";
       }
       const connection = state.manager.getConnection(serverName);

--- a/commands.ts
+++ b/commands.ts
@@ -359,6 +359,10 @@ type AuthenticateServerOptions = {
   reason?: string;
 };
 
+function isAutoOauthBrowserAuthEnabled(state: McpExtensionState): boolean {
+  return state.config.settings?.autoOauthBrowserAuth !== false;
+}
+
 export async function authenticateServer(
   serverName: string,
   state: McpExtensionState,
@@ -455,6 +459,7 @@ export async function authenticateServer(
 export async function autoAuthenticateOAuthServers(state: McpExtensionState): Promise<void> {
   const ui = state.ui;
   if (!ui) return;
+  if (!isAutoOauthBrowserAuthEnabled(state)) return;
 
   for (const [serverName, definition] of Object.entries(state.config.mcpServers)) {
     if (definition.auth !== "oauth") continue;

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
 import type { McpExtensionState } from "./state.js";
 import { Type } from "@sinclair/typebox";
-import { showStatus, showTools, reconnectServers, authenticateServer, openMcpPanel } from "./commands.js";
+import { showStatus, showTools, reconnectServers, authenticateServer, autoAuthenticateOAuthServers, openMcpPanel } from "./commands.js";
 import { loadMcpConfig } from "./config.js";
 import { buildProxyDescription, createDirectToolExecutor, resolveDirectTools } from "./direct-tools.js";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js";
@@ -109,6 +109,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       state = nextState;
       updateStatusBar(nextState);
       initPromise = null;
+
+      try {
+        await autoAuthenticateOAuthServers(nextState);
+      } catch (error) {
+        console.error("MCP: automatic OAuth authentication failed", error);
+      }
     }).catch(err => {
       if (generation !== lifecycleGeneration) {
         return;
@@ -198,7 +204,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         return;
       }
 
-      await authenticateServer(serverName, state.config, ctx);
+      await authenticateServer(serverName, state, ctx.ui);
     },
   });
 

--- a/init.ts
+++ b/init.ts
@@ -301,6 +301,23 @@ export async function lazyConnect(state: McpExtensionState, serverName: string):
     updateStatusBar(state);
     return true;
   } catch {
+    if (definition.auth === "oauth" && state.ui) {
+      try {
+        const { authenticateServer } = await import("./commands.js");
+        const authenticated = await authenticateServer(serverName, state, state.ui, {
+          reason: "expired or missing OAuth token",
+          reconnect: true,
+        });
+        if (authenticated) {
+          state.failureTracker.delete(serverName);
+          updateStatusBar(state);
+          return true;
+        }
+      } catch {
+        // fall through to failure tracking below
+      }
+    }
+
     state.failureTracker.set(serverName, Date.now());
     updateStatusBar(state);
     return false;

--- a/init.ts
+++ b/init.ts
@@ -301,7 +301,11 @@ export async function lazyConnect(state: McpExtensionState, serverName: string):
     updateStatusBar(state);
     return true;
   } catch {
-    if (definition.auth === "oauth" && state.ui) {
+    if (
+      definition.auth === "oauth" &&
+      state.ui &&
+      state.config.settings?.autoOauthBrowserAuth !== false
+    ) {
       try {
         const { authenticateServer } = await import("./commands.js");
         const authenticated = await authenticateServer(serverName, state, state.ui, {

--- a/oauth-handler.ts
+++ b/oauth-handler.ts
@@ -1,56 +1,176 @@
 // oauth-handler.ts - OAuth token management for MCP servers
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 
+export interface StoredOAuthTokens extends OAuthTokens {
+  expiresAt?: number;
+  client_id?: string;
+  client_secret?: string;
+  token_endpoint_auth_method?: string;
+  token_endpoint?: string;
+  issuer?: string;
+  server_url?: string;
+}
+
 // Token storage path for a server
-function getTokensPath(serverName: string): string {
+export function getTokensPath(serverName: string): string {
   return join(homedir(), ".pi", "agent", "mcp-oauth", serverName, "tokens.json");
+}
+
+export function readStoredTokens(serverName: string): StoredOAuthTokens | undefined {
+  const tokensPath = getTokensPath(serverName);
+  if (!existsSync(tokensPath)) return undefined;
+
+  try {
+    const stored = JSON.parse(readFileSync(tokensPath, "utf-8"));
+    if (!stored.access_token || typeof stored.access_token !== "string") {
+      return undefined;
+    }
+
+    return {
+      access_token: stored.access_token,
+      token_type: stored.token_type ?? "bearer",
+      refresh_token: typeof stored.refresh_token === "string" ? stored.refresh_token : undefined,
+      expires_in: typeof stored.expires_in === "number"
+        ? stored.expires_in
+        : typeof stored.expires_in === "string"
+          ? Number(stored.expires_in)
+          : undefined,
+      expiresAt: typeof stored.expiresAt === "number" ? stored.expiresAt : undefined,
+      client_id: typeof stored.client_id === "string" ? stored.client_id : undefined,
+      client_secret: typeof stored.client_secret === "string" ? stored.client_secret : undefined,
+      token_endpoint_auth_method: typeof stored.token_endpoint_auth_method === "string"
+        ? stored.token_endpoint_auth_method
+        : undefined,
+      token_endpoint: typeof stored.token_endpoint === "string" ? stored.token_endpoint : undefined,
+      issuer: typeof stored.issuer === "string" ? stored.issuer : undefined,
+      server_url: typeof stored.server_url === "string" ? stored.server_url : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function isTokenExpired(tokens: Pick<StoredOAuthTokens, "expiresAt"> | undefined, skewMs = 30_000): boolean {
+  if (!tokens?.expiresAt || typeof tokens.expiresAt !== "number") return false;
+  return Date.now() + skewMs >= tokens.expiresAt;
+}
+
+function toOAuthTokens(tokens: StoredOAuthTokens | undefined): OAuthTokens | undefined {
+  if (!tokens) return undefined;
+  return {
+    access_token: tokens.access_token,
+    token_type: tokens.token_type ?? "bearer",
+    refresh_token: tokens.refresh_token,
+    expires_in: tokens.expires_in,
+  };
 }
 
 /**
  * Get stored OAuth tokens for a server (if any).
- * Returns undefined if no tokens or tokens are expired.
- * 
- * Token file location: ~/.pi/agent/mcp-oauth/<server>/tokens.json
- * 
- * Expected format:
- * {
- *   "access_token": "...",
- *   "token_type": "bearer",
- *   "refresh_token": "...",  // optional
- *   "expires_in": 3600,      // optional, seconds
- *   "expiresAt": 1234567890  // optional, absolute timestamp ms
- * }
+ * Returns undefined if no tokens or access token is expired.
  */
 export function getStoredTokens(serverName: string): OAuthTokens | undefined {
-  const tokensPath = getTokensPath(serverName);
-  
-  if (!existsSync(tokensPath)) return undefined;
-  
+  const stored = readStoredTokens(serverName);
+  if (!stored || isTokenExpired(stored)) return undefined;
+  return toOAuthTokens(stored);
+}
+
+export function persistOAuthTokens(
+  serverName: string,
+  tokenPayload: Record<string, unknown>,
+  extras: Record<string, unknown> = {},
+): string {
+  const tokenPath = getTokensPath(serverName);
+  mkdirSync(dirname(tokenPath), { recursive: true });
+
+  const expiresIn = typeof tokenPayload.expires_in === "number"
+    ? tokenPayload.expires_in
+    : typeof tokenPayload.expires_in === "string"
+      ? Number(tokenPayload.expires_in)
+      : undefined;
+
+  const existing = readStoredTokens(serverName);
+  const data = {
+    access_token: tokenPayload.access_token,
+    token_type: tokenPayload.token_type ?? existing?.token_type ?? "bearer",
+    refresh_token: tokenPayload.refresh_token ?? existing?.refresh_token,
+    expires_in: expiresIn,
+    expiresAt: typeof expiresIn === "number" && Number.isFinite(expiresIn)
+      ? Date.now() + expiresIn * 1000
+      : undefined,
+    client_id: extras.client_id ?? existing?.client_id,
+    client_secret: extras.client_secret ?? existing?.client_secret,
+    token_endpoint_auth_method: extras.token_endpoint_auth_method ?? existing?.token_endpoint_auth_method,
+    token_endpoint: extras.token_endpoint ?? existing?.token_endpoint,
+    issuer: extras.issuer ?? existing?.issuer,
+    server_url: extras.server_url ?? existing?.server_url,
+  };
+
+  writeFileSync(tokenPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  return tokenPath;
+}
+
+export async function refreshStoredTokens(serverName: string): Promise<StoredOAuthTokens | undefined> {
+  const stored = readStoredTokens(serverName);
+  if (!stored?.refresh_token || !stored.token_endpoint || !stored.client_id) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: stored.refresh_token,
+    client_id: stored.client_id,
+  });
+
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/x-www-form-urlencoded",
+  };
+
+  if (stored.client_secret) {
+    if (stored.token_endpoint_auth_method === "client_secret_basic") {
+      headers.authorization = `Basic ${Buffer.from(`${stored.client_id}:${stored.client_secret}`).toString("base64")}`;
+      params.delete("client_id");
+    } else if (stored.token_endpoint_auth_method === "client_secret_post") {
+      params.set("client_secret", stored.client_secret);
+    }
+  }
+
+  const response = await fetch(stored.token_endpoint, {
+    method: "POST",
+    headers,
+    body: params.toString(),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`OAuth refresh failed (${response.status}): ${body}`);
+  }
+
+  const refreshed = JSON.parse(body) as Record<string, unknown>;
+  persistOAuthTokens(serverName, refreshed, {
+    client_id: stored.client_id,
+    client_secret: stored.client_secret,
+    token_endpoint_auth_method: stored.token_endpoint_auth_method,
+    token_endpoint: stored.token_endpoint,
+    issuer: stored.issuer,
+    server_url: stored.server_url,
+  });
+
+  return readStoredTokens(serverName);
+}
+
+export async function ensureStoredTokens(serverName: string): Promise<OAuthTokens | undefined> {
+  const stored = readStoredTokens(serverName);
+  if (!stored) return undefined;
+  if (!isTokenExpired(stored)) return toOAuthTokens(stored);
+
   try {
-    const stored = JSON.parse(readFileSync(tokensPath, "utf-8"));
-    
-    // Validate required field
-    if (!stored.access_token || typeof stored.access_token !== "string") {
-      return undefined;
-    }
-    
-    // Check expiration if expiresAt is set
-    if (stored.expiresAt && typeof stored.expiresAt === "number") {
-      if (Date.now() > stored.expiresAt) {
-        // Token expired
-        return undefined;
-      }
-    }
-    
-    return {
-      access_token: stored.access_token,
-      token_type: stored.token_type ?? "bearer",
-      refresh_token: stored.refresh_token,
-      expires_in: stored.expires_in,
-    };
+    const refreshed = await refreshStoredTokens(serverName);
+    return toOAuthTokens(refreshed);
   } catch {
     return undefined;
   }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -11,7 +11,7 @@ import type {
   Transport,
 } from "./types.js";
 import { serverStreamResultPatchNotificationSchema } from "./types.js";
-import { getStoredTokens } from "./oauth-handler.js";
+import { ensureStoredTokens } from "./oauth-handler.js";
 import { resolveNpxBinary } from "./npx-resolver.js";
 import { logger } from "./logger.js";
 
@@ -139,10 +139,10 @@ export class McpServerManager {
       if (!serverName) {
         throw new Error("Server name required for OAuth authentication");
       }
-      const tokens = getStoredTokens(serverName);
+      const tokens = await ensureStoredTokens(serverName);
       if (!tokens) {
         throw new Error(
-          `No OAuth tokens found for "${serverName}". Run /mcp-auth ${serverName} to authenticate.`
+          `No valid OAuth tokens found for "${serverName}". Run /mcp-auth ${serverName} to authenticate.`
         );
       }
       headers["Authorization"] = `Bearer ${tokens.access_token}`;

--- a/types.ts
+++ b/types.ts
@@ -288,6 +288,7 @@ export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
   idleTimeout?: number; // minutes, default 10, 0 to disable
   directTools?: boolean;
+  autoOauthBrowserAuth?: boolean; // default true in interactive sessions
 }
 
 // Root config


### PR DESCRIPTION
## Summary
- add OAuth browser sign-in flow to `/mcp-auth` using discovery, dynamic client registration, PKCE, and localhost callback
- persist OAuth metadata needed for token refresh
- refresh expired access tokens automatically before connecting
- trigger interactive browser re-auth on session start or lazy connect when no valid OAuth token remains
- add `settings.autoOauthBrowserAuth` (default `true`) so automatic browser popup behavior is configurable

## Docs
- update README to document browser-based OAuth, automatic refresh/re-auth, and the new `autoOauthBrowserAuth` setting
- update changelog `Unreleased` section

## Notes
- browser-based re-auth only runs in interactive sessions
- non-interactive sessions still fail closed with needs-auth behavior
- automatic browser popup is enabled by default, but can be disabled with `settings.autoOauthBrowserAuth: false`

## Tested
- completed Atlassian Rovo MCP OAuth flow locally
- verified token persistence and successful initialize request against `https://mcp.atlassian.com/v1/mcp`
- verified module import after patching with `tsx`
- added focused tests for oauth token persistence/refresh and updated lifecycle mocks for session-start auto auth
