### PR TITLE
feat: add excludeTools option to blacklist tools per server

### DIFF
--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -66,7 +66,10 @@ export function resolveDirectTools(
 
     if (!toolFilter) continue;
 
+    const excludeSet = definition.excludeTools ? new Set(definition.excludeTools) : null;
+
     for (const tool of serverCache.tools ?? []) {
+      if (excludeSet && (excludeSet.has(tool.name) || excludeSet.has(formatToolName(tool.name, serverName, prefix)))) continue;
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
       const prefixedName = formatToolName(tool.name, serverName, prefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
@@ -92,6 +95,7 @@ export function resolveDirectTools(
     if (definition.exposeResources !== false) {
       for (const resource of serverCache.resources ?? []) {
         const baseName = `get_${resourceNameToToolName(resource.name)}`;
+        if (excludeSet && (excludeSet.has(baseName) || excludeSet.has(formatToolName(baseName, serverName, prefix)))) continue;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
         const prefixedName = formatToolName(baseName, serverName, prefix);
         if (BUILTIN_NAMES.has(prefixedName)) {

--- a/init.ts
+++ b/init.ts
@@ -89,7 +89,7 @@ export async function initializeMcp(
     }
 
     if (cache?.servers?.[name] && isServerCacheValid(cache.servers[name], definition)) {
-      const metadata = reconstructToolMetadata(name, cache.servers[name], prefix, definition.exposeResources);
+      const metadata = reconstructToolMetadata(name, cache.servers[name], prefix, definition.exposeResources, definition.excludeTools);
       toolMetadata.set(name, metadata);
     }
   }

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,6 +1,7 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
+import { formatToolName } from "./types.js";
 import type { MetadataCache, ServerCacheEntry, CachedTool } from "./metadata-cache.js";
 
 interface PanelTheme {
@@ -145,9 +146,13 @@ class McpPanel {
         toolFilter = globalDirect;
       }
 
+      const prefix = config.settings?.toolPrefix ?? "server";
+      const excludeSet = definition.excludeTools ? new Set(definition.excludeTools) : null;
+
       const tools: ToolState[] = [];
       if (serverCache) {
         for (const tool of serverCache.tools ?? []) {
+          if (excludeSet && (excludeSet.has(tool.name) || excludeSet.has(formatToolName(tool.name, serverName, prefix)))) continue;
           const isDirect = toolFilter === true || (Array.isArray(toolFilter) && toolFilter.includes(tool.name));
           tools.push({
             name: tool.name,
@@ -160,6 +165,7 @@ class McpPanel {
         if (definition.exposeResources !== false) {
           for (const resource of serverCache.resources ?? []) {
             const baseName = `get_${resourceNameToToolName(resource.name)}`;
+            if (excludeSet && (excludeSet.has(baseName) || excludeSet.has(formatToolName(baseName, serverName, prefix)))) continue;
             const isDirect = toolFilter === true || (Array.isArray(toolFilter) && toolFilter.includes(baseName));
             const ct: CachedTool = { name: baseName, description: resource.description };
             tools.push({

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -115,12 +115,15 @@ export function reconstructToolMetadata(
   serverName: string,
   entry: ServerCacheEntry,
   prefix: "server" | "none" | "short",
-  exposeResources?: boolean
+  exposeResources?: boolean,
+  excludeTools?: string[]
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
+  const excludeSet = excludeTools ? new Set(excludeTools) : null;
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
+    if (excludeSet && (excludeSet.has(tool.name) || excludeSet.has(formatToolName(tool.name, serverName, prefix)))) continue;
     metadata.push({
       name: formatToolName(tool.name, serverName, prefix),
       originalName: tool.name,
@@ -135,6 +138,7 @@ export function reconstructToolMetadata(
     for (const resource of entry.resources ?? []) {
       if (!resource?.name || !resource?.uri) continue;
       const baseName = `get_${resourceNameToToolName(resource.name)}`;
+      if (excludeSet && (excludeSet.has(baseName) || excludeSet.has(formatToolName(baseName, serverName, prefix)))) continue;
       metadata.push({
         name: formatToolName(baseName, serverName, prefix),
         originalName: baseName,

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -15,11 +15,14 @@ export function buildToolMetadata(
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
 
+  const excludeSet = definition.excludeTools ? new Set(definition.excludeTools) : null;
+
   for (const tool of tools) {
     if (!tool?.name) {
       failedTools.push("(unnamed)");
       continue;
     }
+    if (excludeSet && (excludeSet.has(tool.name) || excludeSet.has(formatToolName(tool.name, serverName, prefix)))) continue;
     let uiResourceUri: string | undefined;
     try {
       uiResourceUri = getToolUiResourceUri({ _meta: tool._meta });
@@ -39,6 +42,7 @@ export function buildToolMetadata(
   if (definition.exposeResources !== false) {
     for (const resource of resources) {
       const baseName = `get_${resourceNameToToolName(resource.name)}`;
+      if (excludeSet && (excludeSet.has(baseName) || excludeSet.has(formatToolName(baseName, serverName, prefix)))) continue;
       metadata.push({
         name: formatToolName(baseName, serverName, prefix),
         originalName: baseName,

--- a/types.ts
+++ b/types.ts
@@ -279,6 +279,7 @@ export interface ServerEntry {
   exposeResources?: boolean;
   // Direct tool registration
   directTools?: boolean | string[];
+  excludeTools?: string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
 }


### PR DESCRIPTION
Closes #36

## Summary

Adds an `excludeTools` server config option that accepts an array of tool names to exclude. This complements `directTools` by allowing a blacklist approach: register all tools except specific ones, rather than maintaining an explicit allowlist.

## Changes

| File | Change |
|------|--------|
| `types.ts` | Added `excludeTools?: string[]` to `ServerEntry` |
| `tool-metadata.ts` | `buildToolMetadata` skips excluded tools (live connections) |
| `metadata-cache.ts` | `reconstructToolMetadata` accepts + applies `excludeTools` (cached metadata) |
| `init.ts` | Passes `definition.excludeTools` to `reconstructToolMetadata` |
| `direct-tools.ts` | Skips excluded tools when registering direct tools |
| `mcp-panel.ts` | Skips excluded tools in the `/mcp` panel UI |

## Behavior

- Matches against both original MCP names (`get_screenshot`) and prefixed names (`figma_get_screenshot`), so either format works
- Excluded tools are filtered from direct registration, proxy search/list/describe, and the `/mcp` panel
- Excluded tools cannot be called via `mcp({ tool: ... })` either, since they're removed from the metadata map
- Works with `directTools: true`, `directTools: ["..."] `, or proxy-only mode

## Example Config

```json
{
  "mcpServers": {
    "figma": {
      "url": "http://localhost:3845/mcp",
      "directTools": true,
      "excludeTools": ["get_code_connect_map", "get_figjam"]
    }
  }
}
```