### PR TITLE
fix: shut down OAuth callback server on session end

### DIFF
--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   updateStatusBar: vi.fn(),
   flushMetadataCache: vi.fn(),
   initializeOAuth: vi.fn().mockResolvedValue(undefined),
+  shutdownOAuth: vi.fn().mockResolvedValue(undefined),
   loadMcpConfig: vi.fn(() => ({ mcpServers: {} })),
   loadMetadataCache: vi.fn(() => null),
   buildProxyDescription: vi.fn(() => "MCP gateway"),
@@ -34,6 +35,7 @@ vi.mock("../init.js", () => ({
 
 vi.mock("../mcp-auth-flow.js", () => ({
   initializeOAuth: mocks.initializeOAuth,
+  shutdownOAuth: mocks.shutdownOAuth,
 }));
 
 vi.mock("../config.js", () => ({
@@ -122,6 +124,7 @@ describe("mcpAdapter session lifecycle", () => {
     }
 
     mocks.initializeOAuth.mockResolvedValue(undefined);
+    mocks.shutdownOAuth.mockResolvedValue(undefined);
     mocks.loadMcpConfig.mockReturnValue({ mcpServers: {} });
     mocks.loadMetadataCache.mockReturnValue(null);
     mocks.buildProxyDescription.mockReturnValue("MCP gateway");
@@ -195,5 +198,29 @@ describe("mcpAdapter session lifecycle", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("shuts down OAuth callback infrastructure on session shutdown", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const sessionStart = handlers.get("session_start");
+    const sessionShutdown = handlers.get("session_shutdown");
+    expect(sessionStart).toBeTypeOf("function");
+    expect(sessionShutdown).toBeTypeOf("function");
+
+    await sessionStart?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await sessionShutdown?.();
+
+    expect(mocks.flushMetadataCache).toHaveBeenCalledWith(state);
+    expect(state.lifecycle.gracefulShutdown).toHaveBeenCalledTimes(1);
+    expect(mocks.shutdownOAuth).toHaveBeenCalledTimes(1);
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js";
 import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
-import { initializeOAuth } from "./mcp-auth-flow.js";
+import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
@@ -136,6 +136,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       await shutdownState(currentState, "session_shutdown");
     } catch (error) {
       console.error("MCP: session shutdown cleanup failed", error);
+    }
+
+    try {
+      await shutdownOAuth();
+    } catch (error) {
+      console.error("MCP: OAuth shutdown cleanup failed", error);
     }
   });
 


### PR DESCRIPTION
The OAuth callback HTTP server was started on every session_start but never stopped on session_shutdown, keeping the Node process alive indefinitely. This caused non-interactive pi runs to hang after completing their output. Discovered this because subagents (from pi-subagents) would hang forever.
