### PR TITLE
fix: use localhost and /callback path for OAuth redirect URI (fixes Slack MCP)

### DIFF
--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -178,7 +178,7 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
           reject(err)
         })
 
-        candidateServer.listen(candidatePort, "127.0.0.1", () => {
+        candidateServer.listen(candidatePort, "localhost", () => {
           resolve()
         })
       })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -28,7 +28,7 @@ import {
 
 // Callback server configuration
 const DEFAULT_OAUTH_CALLBACK_PORT = 19876
-const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+const OAUTH_CALLBACK_PATH = process.env.MCP_OAUTH_CALLBACK_PATH ?? "/callback"
 
 let configuredOAuthCallbackPort = DEFAULT_OAUTH_CALLBACK_PORT
 
@@ -88,7 +88,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   get redirectUrl(): string | undefined {
     if (this.usesClientCredentials) return undefined
-    return `http://127.0.0.1:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+    return `http://localhost:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
   }
 
   /**


### PR DESCRIPTION
## Problem

OAuth with pre-registered clients like Slack MCP (`clientId: 1601185624273.8899143856786`) fails with:

```
redirect_uri did not match any configured URIs.
Passed URI: http://127.0.0.1:<port>/mcp/oauth/callback
```

The Slack OAuth app has `http://localhost:3118/callback` registered — matching Claude Code's format — but pi-mcp-adapter sends `http://127.0.0.1:<port>/mcp/oauth/callback`, which doesn't match on either the host or the path.

## Changes

### `mcp-oauth-provider.ts`
- Change redirect host from `127.0.0.1` to `localhost`
- Change default callback path from `/mcp/oauth/callback` to `/callback` (overridable via `MCP_OAUTH_CALLBACK_PATH` env var for backwards compatibility)

### `mcp-callback-server.ts`
- Bind the callback server to `localhost` instead of `127.0.0.1` so it accepts connections on the same interface as the redirect URI

## References
- Slack MCP plugin issue: https://github.com/slackapi/slack-mcp-plugin/issues/7
- Claude Code issue: https://github.com/anthropics/claude-code/issues/37714 — confirms `http://localhost:3118/callback` is the registered URI