### PR TITLE
fix(oauth): surface UnauthorizedError when SDK enters authorize fallback

### DIFF
--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -14,7 +14,8 @@ const TEST_DIR = join(tmpdir(), `mcp-oauth-test-${randomBytes(4).toString('hex')
 process.env.MCP_OAUTH_DIR = TEST_DIR
 
 import { McpOAuthProvider } from "./mcp-oauth-provider.js"
-import { saveAuthEntry } from "./mcp-auth.js"
+import { saveAuthEntry, updateOAuthState } from "./mcp-auth.js"
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
 
 describe("McpOAuthProvider", () => {
@@ -234,13 +235,29 @@ describe("McpOAuthProvider", () => {
   })
 
   describe("redirectToAuthorization", () => {
-    it("should call onRedirect with URL", async () => {
-      const provider = createProvider()
+    it("should call onRedirect with URL when a flow is in progress", async () => {
+      const provider = new McpOAuthProvider("redirect-with-state", serverUrl, {}, {
+        onRedirect: async (url) => {
+          redirectCaptured = url
+        },
+      })
+      await updateOAuthState("redirect-with-state", "state-abc")
       const testUrl = new URL("https://example.com/auth")
 
       await provider.redirectToAuthorization(testUrl)
 
       assert.strictEqual(redirectCaptured, testUrl)
+    })
+
+    it("should throw UnauthorizedError when no flow is in progress", async () => {
+      const provider = new McpOAuthProvider("redirect-no-state", serverUrl, {}, {
+        onRedirect: async () => {},
+      })
+
+      await assert.rejects(
+        async () => provider.redirectToAuthorization(new URL("https://example.com/auth")),
+        (err: unknown) => err instanceof UnauthorizedError && /Re-authentication required/.test((err as Error).message),
+      )
     })
   })
 
@@ -280,14 +297,14 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(state, "state-xyz-789")
     })
 
-    it("should throw when no state", async () => {
+    it("should throw UnauthorizedError when no state is saved", async () => {
       const provider = new McpOAuthProvider("state-test-throw", serverUrl, {}, {
         onRedirect: async () => {},
       })
 
       await assert.rejects(
         async () => provider.state(),
-        /No OAuth state saved/
+        (err: unknown) => err instanceof UnauthorizedError && /Re-authentication required/.test((err as Error).message),
       )
     })
   })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
   OAuthClientMetadata,
   OAuthTokens,
@@ -200,10 +201,22 @@ export class McpOAuthProvider implements OAuthClientProvider {
   /**
    * Redirect the user to the authorization URL.
    * This opens the browser for the user to authenticate.
+   *
+   * Throws UnauthorizedError when called outside of a user-initiated flow
+   * (no oauthState saved by startAuth). That path is reached when the SDK
+   * falls through from a failed refresh into a fresh authorization_code
+   * flow, which library hosts cannot complete in-process.
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
     if (this.usesClientCredentials) {
       throw new Error("redirectToAuthorization is not used for client_credentials flow")
+    }
+    // No saved oauthState means we're on the post-refresh authorize fallback.
+    const entry = await getAuthEntry(this.serverName)
+    if (!entry?.oauthState) {
+      throw new UnauthorizedError(
+        `Re-authentication required for MCP server: ${this.serverName}`,
+      )
     }
     // URL is passed to callback, not logged (may contain sensitive params)
     await this.callbacks.onRedirect(authorizationUrl)
@@ -240,7 +253,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   /**
    * Get the stored OAuth state parameter.
-   * @throws Error if no state is stored
+   * @throws UnauthorizedError if no flow is in progress (see redirectToAuthorization)
    */
   async state(): Promise<string> {
     if (this.usesClientCredentials) {
@@ -248,7 +261,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     const entry = await getAuthEntry(this.serverName)
     if (!entry?.oauthState) {
-      throw new Error(`No OAuth state saved for MCP server: ${this.serverName}`)
+      throw new UnauthorizedError(
+        `Re-authentication required for MCP server: ${this.serverName}`,
+      )
     }
     return entry.oauthState
   }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -16,7 +16,11 @@ type AutoAuthResult =
   | { status: "success" }
   | { status: "failed"; message: string };
 
-function getAuthRequiredMessage(serverName: string): string {
+function getAuthRequiredMessage(state: McpExtensionState, serverName: string): string {
+  const template = state.config.settings?.authRequiredMessage;
+  if (template) {
+    return template.replaceAll("${server}", serverName);
+  }
   return `Server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} first.`;
 }
 
@@ -433,7 +437,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
         connection = await state.manager.connect(serverName, definition);
       }
       if (connection.status === "needs-auth") {
-        const message = getAuthRequiredMessage(serverName);
+        const message = getAuthRequiredMessage(state, serverName);
         return {
           content: [{ type: "text" as const, text: message }],
           details: { mode: "connect", error: "auth_required", server: serverName, message },
@@ -522,7 +526,7 @@ export async function executeCall(
         }
 
         if (!toolMeta && state.manager.getConnection(serverName)?.status === "needs-auth") {
-          const message = getAuthRequiredMessage(serverName);
+          const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
             details: { mode: "call", error: "auth_required", server: serverName, message },
@@ -616,7 +620,7 @@ export async function executeCall(
     }
 
     if (connection?.status === "needs-auth") {
-      const message = getAuthRequiredMessage(serverName);
+      const message = getAuthRequiredMessage(state, serverName);
       return {
         content: [{ type: "text" as const, text: message }],
         details: { mode: "call", error: "auth_required", server: serverName, message },
@@ -662,7 +666,7 @@ export async function executeCall(
         }
 
         if (connection.status === "needs-auth") {
-          const message = getAuthRequiredMessage(serverName);
+          const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
             details: { mode: "call", error: "auth_required", server: serverName, message },

--- a/types.ts
+++ b/types.ts
@@ -318,6 +318,12 @@ export interface McpSettings {
   directTools?: boolean;
   disableProxyTool?: boolean;
   autoAuth?: boolean;
+  /**
+   * Message returned in tool results when a server needs (re-)authentication.
+   * "${server}" is substituted with the server name. Defaults to a TUI
+   * instruction when unset.
+   */
+  authRequiredMessage?: string;
 }
 
 // Root config


### PR DESCRIPTION
## Summary

Two small, orthogonal changes that make the adapter usable for library hosts that embed it without a TUI/browser (e.g. SDK mode, server-side agents where OAuth is driven out-of-band by the host).

1. `McpOAuthProvider.state()` and `McpOAuthProvider.redirectToAuthorization()` throw `UnauthorizedError` — instead of a generic `Error` or a no-op redirect — when the SDK enters a fresh `authorization_code` flow with no user-initiated flow in progress. That path is only reached when a stored refresh_token has just been rejected and the SDK is trying to recover on its own.

2. `McpSettings.authRequiredMessage` (new, optional) lets the host customize the message surfaced in `needs-auth` tool results. The default is unchanged.

## Problem

When a stored refresh_token is rejected (Linear rotates and invalidates the previous refresh token on use, and expiry windows are tight), the MCP SDK's refresh path inside `client.connect()` transparently falls through to a fresh `authorization_code` flow:

1. SDK calls `provider.invalidateCredentials("tokens")` → the on-disk `tokens` field is cleared.
2. SDK builds an auth URL, calling `provider.state()` to obtain a CSRF state.
3. `state()` throws `Error("No OAuth state saved for MCP server: <name>")` because `startAuth()` — the only place that writes `oauthState` — was never called on this code path.

For TUI hosts this is mostly invisible: the user's next action is `/mcp-auth <server>`, which calls `startAuth()` and recovers.

For library/SDK hosts the failure is worse:

- The generic `Error` does not match `instanceof UnauthorizedError`, so [`server-manager.createConnection()`](https://github.com/nicobailon/pi-mcp-adapter/blob/main/server-manager.ts#L117-L135) re-throws instead of returning `{ status: "needs-auth" }`.
- The caller sees `Failed to connect to "<server>": No OAuth state saved for MCP server: <server>` — cryptic and host-neutral.
- Even if `state()` did not throw, `redirectToAuthorization()` would fire `onRedirect(authUrl)` in a process where no browser exists, and the fallback message `Run /mcp-auth <server> first.` is a slash command the host does not expose.

We hit this in production for the Linear MCP server: the majority of affected users end up with a half-wiped `tokens.json` (only `clientInfo` + `serverUrl`, no `tokens`) as a side effect of step 1, and their next tool call surfaces the cryptic error instead of a clean "please reconnect".

## Repro

```ts
// 1. Establish a server with valid tokens via startAuth() / completeAuth().
// 2. Corrupt the stored refreshToken (simulate rotation / invalidation).
// 3. Advance time past expiresAt.
// 4. Call server-manager.connect(serverName, definition).
//
// Actual:   throws `Error: No OAuth state saved for MCP server: ...`
// Expected: resolves to `{ status: "needs-auth", ... }`
```

See also the updated unit test `should throw UnauthorizedError when no flow is in progress` in this PR.

## Changes

### Commit 1 — `fix(oauth): surface UnauthorizedError when SDK enters authorize fallback`

`mcp-oauth-provider.ts`:

- Import `UnauthorizedError` from `@modelcontextprotocol/sdk/client/auth.js`.
- `redirectToAuthorization()`: if `oauthState` is not saved for this server, throw `UnauthorizedError` before invoking `onRedirect`. The JSDoc explains why.
- `state()`: same treatment — throw `UnauthorizedError` instead of the generic `Error`.

`mcp-oauth-provider.test.ts`:

- Update the existing `state should throw` case to assert `instanceof UnauthorizedError` and match the new message.
- Split the existing `redirectToAuthorization should call onRedirect with URL` into two cases: one that seeds `oauthState` first (original behavior preserved), one that asserts `UnauthorizedError` when no flow is in progress.

Why patch both `state()` and `redirectToAuthorization()`: `state()` is the method that throws today; patching it alone fixes the visible bug. Patching `redirectToAuthorization()` too is defense in depth — if a future SDK version reorders its calls and reaches the redirect before `state()`, we still do the right thing, and the intent ("no browser available here") lives next to the call it guards.

### Commit 2 — `feat(proxy): allow host to override the needs-auth tool-result message`

`types.ts`:

```ts
export interface McpSettings {
  // ... existing fields
  /**
   * Message returned in tool results when a server needs (re-)authentication.
   * "${server}" is substituted with the server name. Defaults to a TUI
   * instruction when unset.
   */
  authRequiredMessage?: string;
}
```

`proxy-modes.ts`: `getAuthRequiredMessage()` now takes `state` and uses `state.config.settings?.authRequiredMessage` when present, falling back to the existing TUI default. Threaded through the four call sites.

String template only (no function), because `McpSettings` round-trips through JSON.

## What does not change

- Public types of `OAuthClientProvider`, `McpConfig.mcpServers`, or any of the `connect` / `call` / `list` proxy entry points.
- Behavior of the TUI host with default settings — the fallback message is unchanged when `authRequiredMessage` is unset, and in the TUI flow `startAuth()` always writes `oauthState` before the SDK can reach the guarded branches, so the new throws are never hit on that path.
- The SDK's own `invalidateCredentials("tokens")` side effect. A rejected refresh genuinely means those tokens are dead; this PR just makes sure the adapter reports the resulting state cleanly.

## Rollout notes

`UnauthorizedError` is already the contract for "host must drive auth" out of `server-manager.createConnection()`, so any consumer that was `catch`-string-matching `"No OAuth state saved"` should migrate to `instanceof UnauthorizedError`. In practice the old error was a crash rather than a handled state, so I would not expect live consumers beyond the tests this PR updates. Worth calling out in the changelog though.

## Testing

- `node --test mcp-oauth-provider.test.ts` → 21/21 pass (includes three new/updated cases).
- `npx vitest run` → same 213/215 pass as `main` (same two pre-existing failures in `interactive-visualizer-server.test.ts` and `mcp-panel-exclude-tools.test.ts`, both unrelated to this patch — missing build artifacts and a `@mariozechner/pi-tui` import).
- `tsc --noEmit` error count unchanged from `main`.
