### PR TITLE
Add MCP tool result rendering and output guarding

### DIFF
--- a/CHANGE_REQUEST_CODEX_FAST_PI_EXTENSION.md
+++ b/CHANGE_REQUEST_CODEX_FAST_PI_EXTENSION.md
@@ -1,0 +1,98 @@
+# Запрос на изменение: расширение pi для Codex Fast mode
+
+Нужно добавить расширение pi, которое включает Codex Fast mode для провайдера `openai-codex` при входе через ChatGPT OAuth. Изменение нужно, потому что pi не имеет встроенной команды `/fast` и не читает `~/.codex/config.toml`, а Fast mode управляется полем запроса к Codex backend.
+
+## Термины и сокращения
+
+- DEF-01: `openai-codex` — провайдер pi для ChatGPT Plus/Pro Codex через OAuth.
+- DEF-02: Codex Fast mode — режим OpenAI Codex, который ускоряет поддерживаемые модели за повышенный расход кредитов.
+- DEF-03: `service_tier: "priority"` — значение, которое должно попадать в payload запроса pi для включения Fast mode на уровне backend.
+- DEF-04: `service_tier = "fast"` — значение конфигурации Codex CLI, которое Codex CLI перед отправкой запроса преобразует в `service_tier: "priority"`.
+
+## Область изменения
+
+Входит в область:
+- ISP-01: Создать расширение pi, которое добавляет `service_tier: "priority"` в payload только для `openai-codex`.
+- ISP-02: Ограничить включение Fast mode моделями `gpt-5.4` и `gpt-5.5`.
+- ISP-03: Добавить безопасную проверку, которая не выводит токены, headers и полный payload.
+
+Не входит в область:
+- OSP-01: Не изменять исходный код установленного pi.
+- OSP-02: Не изменять `~/.codex/config.toml`, потому что этот файл относится к Codex CLI, а не к pi.
+- OSP-03: Не применять настройку к провайдеру `openai`, потому что OpenAI docs указывают, что Fast mode credits недоступны при API key.
+
+## Запрошенные изменения
+
+- FRQ-01: Расширение должно использовать hook `before_provider_request`.
+- FRQ-02: Расширение должно проверять `ctx.model.provider === "openai-codex"`.
+- FRQ-03: Расширение должно применять изменение только для `ctx.model.id` из набора `gpt-5.4`, `gpt-5.5`.
+- FRQ-04: Расширение должно проверять, что `event.payload` является JSON object.
+- FRQ-05: Расширение должно возвращать копию payload с добавленным или заменённым полем `service_tier: "priority"`.
+- FRQ-06: Расширение не должно менять `model`, `reasoning`, `reasoning.effort`, `instructions`, `input`, `tools`, `headers`, `auth` и `transport`.
+
+Ожидаемый код расширения:
+
+```ts
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const fastCapableCodexModels = new Set(["gpt-5.4", "gpt-5.5"]);
+
+export default function codexFastMode(pi: ExtensionAPI) {
+  pi.on("before_provider_request", (event, ctx) => {
+    const model = ctx.model;
+
+    if (model?.provider !== "openai-codex") return;
+    if (!fastCapableCodexModels.has(model.id)) return;
+    if (!isObjectPayload(event.payload)) return;
+
+    return {
+      ...event.payload,
+      service_tier: "priority",
+    };
+  });
+}
+
+function isObjectPayload(payload: unknown): payload is Record<string, unknown> {
+  return typeof payload === "object" && payload !== null && !Array.isArray(payload);
+}
+```
+
+## Затронутые области
+
+- CMP-01: pi extensions — будет добавлен новый пользовательский extension.
+- CMP-02: `openai-codex` provider payload — будет изменено только поле `service_tier` перед отправкой запроса.
+- CMP-03: Отображение стоимости в pi — может зависеть от того, вернёт ли backend поле `response.service_tier`.
+
+## Ограничения и риски
+
+- CNS-01: Расширение не должно логировать полный payload, headers, токены и переменные окружения.
+- RSK-01: Backend может отклонить `service_tier: "priority"`, если у аккаунта нет доступа к Fast mode или модель не поддерживает режим.
+- RSK-02: pi может показать неточную стоимость, если backend не вернёт `response.service_tier`.
+- RSK-03: Применение к неподдерживаемым моделям может дать ошибку или не включить Fast mode.
+
+## Критерии приёмки
+
+- ACC-01: Для `openai-codex/gpt-5.4` extension добавляет `service_tier: "priority"` в payload.
+- ACC-02: Для `openai-codex/gpt-5.5` extension добавляет `service_tier: "priority"` в payload.
+- ACC-03: Для моделей вне `gpt-5.4` и `gpt-5.5` payload не изменяется.
+- ACC-04: Для провайдеров кроме `openai-codex` payload не изменяется.
+- ACC-05: Минимальный запрос `Reply with exactly: ok` успешно выполняется на поддерживаемой модели или возвращает понятную ошибку backend о доступе или service tier.
+- ACC-06: Проверочный запуск выводит только provider, model и `service_tier=priority`.
+
+## Предположения
+
+- ASM-01: Пользователь использует pi с ChatGPT OAuth для `openai-codex`. Проверка: `/model` в pi показывает выбранный provider `openai-codex`.
+- ASM-02: У пользователя есть доступ к `gpt-5.4` или `gpt-5.5`. Проверка: список моделей pi или `/model` содержит одну из этих моделей.
+
+## Открытые вопросы
+
+- QST-01: Возвращает ли backend `response.service_tier: "priority"` при запросе через pi? Влияет на точность стоимости в pi. Решение: выполнить один минимальный запрос с безопасным проверочным extension.
+- QST-02: Есть ли у конкретного аккаунта доступ к Fast mode credits? Влияет на успешность запроса. Решение: выполнить один минимальный запрос на `gpt-5.4` или `gpt-5.5`.
+
+## Ссылки
+
+- REF-01: `https://developers.openai.com/codex/speed` — описание Codex Fast mode, поддерживаемые модели и ограничения API key.
+- REF-02: `https://developers.openai.com/codex/config-reference` — значения `service_tier` для Codex CLI config.
+- REF-03: `https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs` — маппинг `ServiceTier::Fast` в payload `service_tier: "priority"`.
+- REF-04: `/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/docs/extensions.md` — описание hook `before_provider_request`.
+- REF-05: `/opt/homebrew/lib/node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai/dist/providers/openai-codex-responses.js` — построение payload для `openai-codex`.

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -88,6 +89,341 @@ describe("direct tools auto auth", () => {
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
     expect(result.content[0].text).toContain("ok");
+  });
+
+  it("stores oversized direct tool text in a temp file and returns a bounded preview", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const omittedPrefix = "omitted-prefix".repeat(6000);
+    const visibleTail = "visible-tail";
+    const oversizedText = `${omittedPrefix}\n${visibleTail}`;
+    const connected = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [{ type: "text", text: oversizedText }],
+        })),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search",
+      },
+    );
+
+    const result = await executor("id", { q: "hello" }, undefined as any, () => {}, undefined as any);
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(text.length).toBeLessThan(oversizedText.length);
+      expect(text).not.toContain(omittedPrefix);
+      expect(text).toContain(visibleTail);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).toContain(oversizedText);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("stores oversized direct resource text in a temp file and returns a bounded preview", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const omittedPrefix = "resource-prefix".repeat(6000);
+    const visibleTail = "resource-tail";
+    const oversizedText = `${omittedPrefix}\n${visibleTail}`;
+    const connected = {
+      status: "connected",
+      client: {
+        readResource: vi.fn(async () => ({
+          contents: [{ uri: "demo://large", text: oversizedText }],
+        })),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "large_resource",
+        prefixedName: "demo_large_resource",
+        description: "Large resource",
+        resourceUri: "demo://large",
+      },
+    );
+
+    const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(text.length).toBeLessThan(oversizedText.length);
+      expect(text).not.toContain(omittedPrefix);
+      expect(text).toContain(visibleTail);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).toContain(oversizedText);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("keeps oversized direct error output within final Pi limits after schema text is appended", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const omittedPrefix = "direct-error-prefix".repeat(6000);
+    const visibleTail = "direct-error-tail";
+    const oversizedText = `${omittedPrefix}\n${visibleTail}`;
+    const largeInputSchema = {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 500 }, (_, index) => [`field_${index}`, { type: "string", description: "schema-description".repeat(10) }]),
+      ),
+    };
+    const connected = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: true,
+          content: [{ type: "text", text: oversizedText }],
+        })),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search",
+        inputSchema: largeInputSchema,
+      },
+    );
+
+    const result = await executor("id", { q: "hello" }, undefined as any, () => {}, undefined as any);
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(50 * 1024);
+      expect(text.split("\n").length).toBeLessThanOrEqual(2000);
+      expect(text).toContain("Error:");
+      expect(text).toContain("Expected parameters:");
+      expect(text).toContain(visibleTail);
+      expect(text).not.toContain(omittedPrefix);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("keeps thrown direct call errors within final Pi limits", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const omittedPrefix = "direct-throw-prefix".repeat(6000);
+    const visibleTail = "direct-throw-tail";
+    const connected = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => {
+          throw new Error(`${omittedPrefix}\n${visibleTail}`);
+        }),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search",
+      },
+    );
+
+    const result = await executor("id", { q: "hello" }, undefined as any, () => {}, undefined as any);
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(50 * 1024);
+      expect(text).toContain("Failed to call tool:");
+      expect(text).toContain(visibleTail);
+      expect(text).not.toContain(omittedPrefix);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("replaces oversized direct image payloads with metadata", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const payload = "a".repeat(60000);
+    const connected = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [{ type: "image", data: payload, mimeType: "image/png" }],
+        })),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "image",
+        prefixedName: "demo_image",
+        description: "Image",
+      },
+    );
+
+    const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(result.content[0].type).toBe("text");
+      expect(text).toContain("[Image content: image/png");
+      expect(text).not.toContain(payload);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).not.toContain(payload);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
   });
 
   it("fails fast in non-ui context for browser-based OAuth", async () => {

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -150,6 +150,15 @@ describe("direct tools auto auth", () => {
       expect(fullOutputPath).toBeTruthy();
       expect(existsSync(fullOutputPath!)).toBe(true);
       expect(readFileSync(fullOutputPath!, "utf-8")).toContain(oversizedText);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(result.details).toMatchObject({
+        server: "demo",
+        tool: "search",
+        output: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {
         unlinkSync(fullOutputPath);
@@ -216,6 +225,15 @@ describe("direct tools auto auth", () => {
       expect(fullOutputPath).toBeTruthy();
       expect(existsSync(fullOutputPath!)).toBe(true);
       expect(readFileSync(fullOutputPath!, "utf-8")).toContain(oversizedText);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(result.details).toMatchObject({
+        server: "demo",
+        resourceUri: "demo://large",
+        output: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {
         unlinkSync(fullOutputPath);
@@ -291,6 +309,15 @@ describe("direct tools auto auth", () => {
       expect(text).not.toContain(omittedPrefix);
       expect(fullOutputPath).toBeTruthy();
       expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(result.details).toMatchObject({
+        error: "tool_error",
+        server: "demo",
+        output: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {
         unlinkSync(fullOutputPath);
@@ -355,6 +382,15 @@ describe("direct tools auto auth", () => {
       expect(text).not.toContain(omittedPrefix);
       expect(fullOutputPath).toBeTruthy();
       expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(result.details).toMatchObject({
+        error: "call_failed",
+        server: "demo",
+        output: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {
         unlinkSync(fullOutputPath);
@@ -419,11 +455,81 @@ describe("direct tools auto auth", () => {
       expect(fullOutputPath).toBeTruthy();
       expect(existsSync(fullOutputPath!)).toBe(true);
       expect(readFileSync(fullOutputPath!, "utf-8")).not.toContain(payload);
+      expect(JSON.stringify(result.details)).not.toContain(payload);
+      expect(result.details).toMatchObject({
+        server: "demo",
+        tool: "image",
+        output: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {
         unlinkSync(fullOutputPath);
       }
     }
+  });
+
+  it("omits resource blob payloads and sanitizes audio MIME labels in direct tool results", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const blobPayload = "base64-secret-ABC123";
+    const unsafeMimeType = "audio-secret\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007";
+    const connected = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [
+            { type: "resource", mimeType: unsafeMimeType, resource: { uri: "demo://blob", blob: blobPayload } },
+            { type: "audio", mimeType: unsafeMimeType, data: blobPayload },
+          ],
+        })),
+      },
+    };
+
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager: {
+        close: vi.fn(async () => {}),
+        getConnection: vi.fn(() => connected),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "media",
+        prefixedName: "demo_media",
+        description: "Media",
+      },
+    );
+
+    const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
+    const text = result.content.map((block: any) => block.text ?? "").join("\n");
+
+    expect(text).toContain("[Resource: demo://blob]");
+    expect(text).toContain("[Binary data: application/octet-stream");
+    expect(text).toContain("[Audio content: audio/*]");
+    expect(text).not.toContain(blobPayload);
+    expect(text).not.toContain("audio-secret");
+    expect(text).not.toContain("https://example.com");
   });
 
   it("fails fast in non-ui context for browser-based OAuth", async () => {

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -160,8 +160,8 @@ describe("mcpAdapter session lifecycle", () => {
     const { api } = createPi();
     mcpAdapter(api);
 
-    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
-    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search", renderResult: expect.any(Function) }));
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp", renderResult: expect.any(Function) }));
   });
 
   it("skips the proxy tool once direct tools are fully available", async () => {
@@ -184,7 +184,7 @@ describe("mcpAdapter session lifecycle", () => {
     const { api } = createPi();
     mcpAdapter(api);
 
-    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search", renderResult: expect.any(Function) }));
     expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
   });
 

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -42,6 +42,58 @@ describe("mcp output guard", () => {
     }
   });
 
+  it("does not show the byte-read hint when byte truncation keeps complete lines", async () => {
+    const result = await guardMcpOutput([{
+      type: "text",
+      text: Array.from({ length: 100 }, (_, index) => `${index}-` + "x".repeat(1000)).join("\n"),
+    }]);
+    const text = result.content[0].type === "text" ? result.content[0].text : "";
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(maxOutputBytes);
+      expect(text.split("\n").length).toBeLessThanOrEqual(maxOutputLines);
+      expect(fullOutputPath).toBeTruthy();
+      expect(text).toContain("Full output:");
+      expect(text).not.toContain("bash head -c");
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("sanitizes image MIME metadata on returned image blocks when output is not truncated", async () => {
+    const unsafeMimeType = `mime-secret-${"x".repeat(200)}\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007`;
+    const result = await guardMcpOutput([{ type: "image", data: "abc", mimeType: unsafeMimeType }]);
+
+    expect(result.content[0]).toMatchObject({ type: "image", data: "abc", mimeType: "image/*" });
+    expect(JSON.stringify(result.content)).not.toContain("mime-secret");
+    expect(JSON.stringify(result.content)).not.toContain("https://example.com");
+    expect(result.details).toBeUndefined();
+  });
+
+  it("sanitizes image MIME metadata before returning model-facing placeholders", async () => {
+    const payload = "a".repeat(60000);
+    const unsafeMimeType = `mime-secret-${"x".repeat(200)}\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007`;
+    const result = await guardMcpOutput([{ type: "image", data: payload, mimeType: unsafeMimeType }]);
+    const text = result.content[0].type === "text" ? result.content[0].text : "";
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(text).toContain("[Image content: image/*");
+      expect(text).not.toContain("mime-secret");
+      expect(text).not.toContain("https://example.com");
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
   it("replaces oversized image payloads with text metadata before returning model-facing content", async () => {
     const payload = "a".repeat(60000);
     const result = await guardMcpOutput([{ type: "image", data: payload, mimeType: "image/png" }]);

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -33,6 +33,7 @@ describe("mcp output guard", () => {
       expect(text.split("\n").length).toBeLessThanOrEqual(maxOutputLines);
       expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(maxOutputBytes);
       expect(fullOutputPath).toBeTruthy();
+      expect(text).not.toContain("bash head -c");
       expect(existsSync(fullOutputPath!)).toBe(true);
     } finally {
       if (fullOutputPath && existsSync(fullOutputPath)) {

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { guardMcpOutput } from "../mcp-output-guard.ts";
+
+const maxOutputBytes = 50 * 1024;
+const maxOutputLines = 2000;
+
+describe("mcp output guard", () => {
+  it("keeps the final text response within Pi byte and line limits", async () => {
+    const result = await guardMcpOutput([{ type: "text", text: "x".repeat(60000) }]);
+    const text = result.content[0].type === "text" ? result.content[0].text : "";
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(maxOutputBytes);
+      expect(text.split("\n").length).toBeLessThanOrEqual(maxOutputLines);
+      expect(fullOutputPath).toBeTruthy();
+      expect(text).toContain(`bash head -c 51200 ${fullOutputPath}`);
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("keeps the final multiline response within Pi line limits", async () => {
+    const result = await guardMcpOutput([{ type: "text", text: Array.from({ length: 2500 }, (_, index) => `line-${index}`).join("\n") }]);
+    const text = result.content[0].type === "text" ? result.content[0].text : "";
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(text.split("\n").length).toBeLessThanOrEqual(maxOutputLines);
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(maxOutputBytes);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("replaces oversized image payloads with text metadata before returning model-facing content", async () => {
+    const payload = "a".repeat(60000);
+    const result = await guardMcpOutput([{ type: "image", data: payload, mimeType: "image/png" }]);
+    const text = result.content[0].type === "text" ? result.content[0].text : "";
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(result.content[0].type).toBe("text");
+      expect(text).toContain("[Image content: image/png");
+      expect(text).not.toContain(payload);
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(maxOutputBytes);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).not.toContain(payload);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+});

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -143,6 +144,312 @@ describe("proxy auto auth", () => {
 
     expect(mocks.authenticate).not.toHaveBeenCalled();
     expect(result.content[0].text).toBe("Reconnect demo from the host app.");
+  });
+
+  it("stores oversized proxy tool text in a temp file and keeps details bounded", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const omittedPrefix = "proxy-prefix".repeat(6000);
+    const visibleTail = "proxy-tail";
+    const oversizedText = `${omittedPrefix}\n${visibleTail}`;
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [{ type: "text", text: oversizedText }],
+        })),
+      },
+      tools: [{ name: "search", description: "Search" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_search",
+              originalName: "search",
+              description: "Search",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(text.length).toBeLessThan(oversizedText.length);
+      expect(text).not.toContain(omittedPrefix);
+      expect(text).toContain(visibleTail);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).toContain(oversizedText);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(result.details).toMatchObject({
+        mode: "call",
+        mcpResult: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("replaces oversized proxy image payloads with metadata and bounded details", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const payload = "a".repeat(60000);
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [{ type: "image", data: payload, mimeType: "image/png" }],
+        })),
+      },
+      tools: [{ name: "image", description: "Image" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_image",
+              originalName: "image",
+              description: "Image",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_image", {}, "demo");
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(result.content[0].type).toBe("text");
+      expect(text).toContain("[Image content: image/png");
+      expect(text).not.toContain(payload);
+      expect(JSON.stringify(result.details)).not.toContain(payload);
+      expect(result.details).toMatchObject({
+        mode: "call",
+        mcpResult: {
+          truncated: true,
+          fullOutputPath,
+        },
+      });
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(readFileSync(fullOutputPath!, "utf-8")).not.toContain(payload);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("keeps oversized proxy error output within final Pi limits after schema text is appended", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const omittedPrefix = "proxy-error-prefix".repeat(6000);
+    const visibleTail = "proxy-error-tail";
+    const oversizedText = `${omittedPrefix}\n${visibleTail}`;
+    const largeInputSchema = {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 500 }, (_, index) => [`field_${index}`, { type: "string", description: "schema-description".repeat(10) }]),
+      ),
+    };
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: true,
+          content: [{ type: "text", text: oversizedText }],
+        })),
+      },
+      tools: [{ name: "search", description: "Search" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_search",
+              originalName: "search",
+              description: "Search",
+              inputSchema: largeInputSchema,
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(50 * 1024);
+      expect(text.split("\n").length).toBeLessThanOrEqual(2000);
+      expect(text).toContain("Error:");
+      expect(text).toContain("Expected parameters:");
+      expect(text).toContain(visibleTail);
+      expect(text).not.toContain(omittedPrefix);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
+  });
+
+  it("keeps thrown proxy call errors within final Pi limits", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const omittedPrefix = "proxy-throw-prefix".repeat(6000);
+    const visibleTail = "proxy-throw-tail";
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => {
+          throw new Error(`${omittedPrefix}\n${visibleTail}`);
+        }),
+      },
+      tools: [{ name: "search", description: "Search" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_search",
+              originalName: "search",
+              description: "Search",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+    const text = result.content[0].text;
+    const fullOutputPath = text.match(/Full output: (.+?)\]/)?.[1];
+
+    try {
+      expect(Buffer.byteLength(text, "utf-8")).toBeLessThanOrEqual(50 * 1024);
+      expect(text).toContain("Failed to call tool:");
+      expect(text).toContain(visibleTail);
+      expect(text).not.toContain(omittedPrefix);
+      expect(JSON.stringify(result.details)).not.toContain(omittedPrefix);
+      expect(fullOutputPath).toBeTruthy();
+      expect(existsSync(fullOutputPath!)).toBe(true);
+    } finally {
+      if (fullOutputPath && existsSync(fullOutputPath)) {
+        unlinkSync(fullOutputPath);
+      }
+    }
   });
 
   it("auto-authenticates and retries executeCall once", async () => {

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -225,6 +225,79 @@ describe("proxy auto auth", () => {
     }
   });
 
+  it("summarizes proxy result details without copying raw structured content", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const secretPayload = "structured-secret".repeat(6000);
+    const unsafeKey = "key-secret\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007";
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [{ type: "text", text: "ok" }],
+          structuredContent: { [unsafeKey]: secretPayload },
+          _meta: { [unsafeKey]: secretPayload },
+          [unsafeKey]: secretPayload,
+        })),
+      },
+      tools: [{ name: "search", description: "Search" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_search",
+              originalName: "search",
+              description: "Search",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+
+    expect(result.content[0].text).toContain("ok");
+    expect(JSON.stringify(result.details)).not.toContain(secretPayload);
+    expect(JSON.stringify(result.details)).not.toContain("key-secret");
+    expect(JSON.stringify(result.details)).not.toContain("https://example.com");
+    expect(result.details).toMatchObject({
+      mode: "call",
+      mcpResult: {
+        isError: false,
+        contentSummary: [{ type: "text", textOmitted: true }],
+        structuredContent: { type: "object", omitted: true },
+        meta: { type: "object", omitted: true },
+        extraFields: [{ key: { keyOmitted: true }, omitted: true }],
+      },
+    });
+  });
+
   it("replaces oversized proxy image payloads with metadata and bounded details", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
 
@@ -300,6 +373,143 @@ describe("proxy auto auth", () => {
         unlinkSync(fullOutputPath);
       }
     }
+  });
+
+  it("bounds proxy content summary metadata without copying unsafe MIME labels", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const unsafeMimeType = `mime-secret-${"x".repeat(200)}\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007`;
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [
+            { type: "image", data: "abc", mimeType: unsafeMimeType },
+            ...Array.from({ length: 30 }, () => ({ type: "image", data: "def", mimeType: unsafeMimeType })),
+          ],
+        })),
+      },
+      tools: [{ name: "image", description: "Image" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_image",
+              originalName: "image",
+              description: "Image",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_image", {}, "demo");
+    const detailsText = JSON.stringify(result.details);
+
+    expect(detailsText).not.toContain("mime-secret");
+    expect(detailsText).not.toContain("https://example.com");
+    expect(result.details).toMatchObject({ mode: "call" });
+    const contentSummary = (result.details as any).mcpResult.contentSummary;
+    expect(contentSummary).toHaveLength(21);
+    expect(contentSummary[0]).toMatchObject({ type: "image", mimeType: "image/*", dataOmitted: true });
+    expect(contentSummary[1]).toMatchObject({ type: "image", mimeType: "image/*", dataOmitted: true });
+    expect(contentSummary.at(-1)).toEqual({ type: "omitted", count: 11 });
+  });
+
+  it("omits resource blob payloads and sanitizes audio MIME labels in proxy tool results", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const blobPayload = "base64-secret-ABC123";
+    const unsafeMimeType = "audio-secret\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007";
+    const current = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async () => ({
+          isError: false,
+          content: [
+            { type: "resource", mimeType: unsafeMimeType, resource: { uri: "demo://blob", blob: blobPayload } },
+            { type: "audio", mimeType: unsafeMimeType, data: blobPayload },
+          ],
+        })),
+      },
+      tools: [{ name: "media", description: "Media" }],
+      resources: [],
+    };
+
+    const manager = {
+      connect: vi.fn(async () => current),
+      close: vi.fn(async () => {}),
+      getConnection: vi.fn(() => current),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: {
+          demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        },
+      },
+      manager,
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_media",
+              originalName: "media",
+              description: "Media",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_media", {}, "demo");
+    const text = result.content.map((block: any) => block.text ?? "").join("\n");
+    const detailsText = JSON.stringify(result.details);
+
+    expect(text).toContain("[Resource: demo://blob]");
+    expect(text).toContain("[Binary data: application/octet-stream");
+    expect(text).toContain("[Audio content: audio/*]");
+    expect(text).not.toContain(blobPayload);
+    expect(text).not.toContain("audio-secret");
+    expect(text).not.toContain("https://example.com");
+    expect(detailsText).not.toContain(blobPayload);
+    expect(detailsText).not.toContain("audio-secret");
+    expect(detailsText).not.toContain("https://example.com");
   });
 
   it("keeps oversized proxy error output within final Pi limits after schema text is appended", async () => {

--- a/__tests__/tool-rendering.test.ts
+++ b/__tests__/tool-rendering.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { renderMcpResult } from "../tool-rendering.js";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+};
+
+/**
+ * Verify MCP result rendering without Pi runtime packages so the adapter stays testable outside Pi.
+ */
+describe("renderMcpResult", () => {
+  /**
+   * Collapsed output follows Pi's standard text-tool shape: leading spacer, first lines, hint at bottom.
+   */
+  it("limits collapsed output using the standard Pi preview shape", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "text", text: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n") }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(80)).toEqual([
+      "",
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+      "... (2 more lines, ctrl+o to expand)",
+    ]);
+  });
+
+  /**
+   * Expanded view shows the full result after the user explicitly expands the tool output.
+   */
+  it("shows all lines in expanded mode", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "text", text: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n") }],
+        details: {},
+      },
+      { expanded: true, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(80)).toEqual([
+      "",
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+      "line 11",
+      "line 12",
+    ]);
+  });
+
+  /**
+   * Long preview lines are clipped to the render width because custom components must not exceed it.
+   */
+  it("clips preview lines to render width", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "text", text: "abcdefghij" }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(4)).toEqual(["", "a..."]);
+  });
+});

--- a/__tests__/tool-rendering.test.ts
+++ b/__tests__/tool-rendering.test.ts
@@ -86,4 +86,21 @@ describe("renderMcpResult", () => {
 
     expect(result.render(4)).toEqual(["", "a..."]);
   });
+
+  /**
+   * Tabs are expanded before rendering because raw tabs can corrupt terminal layout inside boxed tool output.
+   */
+  it("expands tabs before rendering", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "text", text: "\t\"bytes\"" }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(80)).toEqual(["", "   \"bytes\""]);
+  });
 });

--- a/__tests__/tool-rendering.test.ts
+++ b/__tests__/tool-rendering.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderMcpResult } from "../tool-rendering.js";
 
 const theme = {
@@ -9,6 +9,9 @@ const theme = {
  * Verify MCP result rendering without Pi runtime packages so the adapter stays testable outside Pi.
  */
 describe("renderMcpResult", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+  });
   /**
    * Collapsed output follows Pi's standard text-tool shape: leading spacer, first lines, hint at bottom.
    */
@@ -102,5 +105,84 @@ describe("renderMcpResult", () => {
     );
 
     expect(result.render(80)).toEqual(["", "   \"bytes\""]);
+  });
+
+  /**
+   * External MCP text is sanitized before terminal rendering because control sequences can corrupt display state.
+   */
+  it("removes terminal control sequences from text output", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "text", text: "\u001b[31mred\u001b[0m\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007\r\u0007ok" }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(120)).toEqual(["", "redlinkok"]);
+  });
+
+  /**
+   * Image metadata is sanitized because MIME labels are external MCP input.
+   */
+  it("sanitizes image MIME metadata before terminal rendering", () => {
+    const result = renderMcpResult(
+      {
+        content: [{ type: "image", data: "abc", mimeType: "text/plain\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007" }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(120)).toEqual(["", "[Image content: image/*, 3B base64 payload omitted]"]);
+  });
+
+  /**
+   * Image-only results are real MCP output and must not be shown as an empty result.
+   */
+  it("renders image-only results as metadata without raw payload", () => {
+    const payload = "a".repeat(120);
+    const result = renderMcpResult(
+      {
+        content: [{ type: "image", data: payload, mimeType: "image/png" }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(120)).toEqual(["", "[Image content: image/png, 120B base64 payload omitted]"]);
+    expect(result.render(120).join("\n")).not.toContain(payload);
+  });
+
+  /**
+   * Keybinding lookup is cached because render can be called repeatedly for the same tool output.
+   */
+  it("caches configured keybinding text across repeated renders", async () => {
+    vi.resetModules();
+    const existsSync = vi.fn(() => true);
+    const readFileSync = vi.fn(() => JSON.stringify({ "app.tools.expand": "ctrl+x" }));
+    vi.doMock("node:fs", () => ({ existsSync, readFileSync }));
+
+    const { renderMcpResult: renderWithMockedFs } = await import("../tool-rendering.ts");
+    const result = renderWithMockedFs(
+      {
+        content: [{ type: "text", text: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n") }],
+        details: {},
+      },
+      { expanded: false, isPartial: false },
+      theme,
+      {} as never,
+    );
+
+    expect(result.render(80).at(-1)).toBe("... (2 more lines, ctrl+x to expand)");
+    expect(result.render(80).at(-1)).toBe("... (2 more lines, ctrl+x to expand)");
+    expect(existsSync).toHaveBeenCalledTimes(1);
+    expect(readFileSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -11,6 +11,7 @@ import { formatToolName, isToolExcluded } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js";
 import { formatAuthRequiredMessage } from "./utils.js";
+import { guardMcpOutput } from "./mcp-output-guard.js";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 
@@ -344,9 +345,10 @@ export function createDirectToolExecutor(
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
         }));
+        const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }]);
         return {
-          content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
-          details: { server: spec.serverName, resourceUri: spec.resourceUri },
+          content: guarded.content,
+          details: { server: spec.serverName, resourceUri: spec.resourceUri, ...(guarded.details ? { output: guarded.details } : {}) },
         };
       }
 
@@ -372,43 +374,41 @@ export function createDirectToolExecutor(
 
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
       if (result.isError) {
-        let errorText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "Tool execution failed";
-        if (spec.inputSchema) {
-          errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`;
-        }
+        const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
+        const guardedError = await guardMcpOutput(outputContent, { prefix: "Error: ", suffix: schemaText });
         return {
-          content: [{ type: "text" as const, text: `Error: ${errorText}` }],
-          details: { error: "tool_error", server: spec.serverName },
+          content: guardedError.content,
+          details: { error: "tool_error", server: spec.serverName, ...(guardedError.details ? { output: guardedError.details } : {}) },
         };
       }
 
-      const resultText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "(empty result)";
+      const guarded = await guardMcpOutput(outputContent);
       if (hasUi) {
         const uiMessage = uiSession?.reused
           ? "Updated the open UI."
           : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
+        const guardedUi = await guardMcpOutput(outputContent, { suffix: `\n\n${uiMessage}` });
         return {
-          content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
-          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true },
+          content: guardedUi.content,
+          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...(guardedUi.details ? { output: guardedUi.details } : {}) },
         };
       }
 
       return {
-        content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
-        details: { server: spec.serverName, tool: spec.originalName },
+        content: guarded.content,
+        details: { server: spec.serverName, tool: spec.originalName, ...(guarded.details ? { output: guarded.details } : {}) },
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       uiSession?.sendToolCancelled(message);
-      let errorText = `Failed to call tool: ${message}`;
-      if (spec.inputSchema) {
-        errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`;
-      }
+      const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
+      const guardedError = await guardMcpOutput([{ type: "text" as const, text: message }], { prefix: "Failed to call tool: ", suffix: schemaText });
       return {
-        content: [{ type: "text" as const, text: errorText }],
-        details: { error: "call_failed", server: spec.serverName },
+        content: guardedError.content,
+        details: { error: "call_failed", server: spec.serverName, ...(guardedError.details ? { output: guardedError.details } : {}) },
       };
     } finally {
       if (uiSession?.reused) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -11,6 +11,7 @@ import { formatToolName, isToolExcluded } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js";
 import { formatAuthRequiredMessage } from "./utils.js";
+import { sanitizeMimeType } from "./mcp-content-formatting.js";
 import { guardMcpOutput } from "./mcp-output-guard.js";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
@@ -343,7 +344,7 @@ export function createDirectToolExecutor(
         const result = await connection.client.readResource({ uri: spec.resourceUri });
         const content = (result.contents ?? []).map(c => ({
           type: "text" as const,
-          text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
+          text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${sanitizeMimeType((c as { mimeType?: string }).mimeType ?? "", "application/octet-stream")}]` : JSON.stringify(c)),
         }));
         const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }]);
         return {
@@ -385,7 +386,6 @@ export function createDirectToolExecutor(
         };
       }
 
-      const guarded = await guardMcpOutput(outputContent);
       if (hasUi) {
         const uiMessage = uiSession?.reused
           ? "Updated the open UI."
@@ -397,6 +397,7 @@ export function createDirectToolExecutor(
         };
       }
 
+      const guarded = await guardMcpOutput(outputContent);
       return {
         content: guarded.content,
         details: { server: spec.serverName, tool: spec.originalName, ...(guarded.details ? { output: guarded.details } : {}) },

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
+import { renderMcpResult } from "./tool-rendering.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
@@ -73,6 +74,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
       parameters: Type.Unsafe<Record<string, unknown>>(spec.inputSchema || { type: "object", properties: {} }),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
+      renderResult: renderMcpResult,
     });
   }
 
@@ -247,6 +249,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" })),
       }),
+      renderResult: renderMcpResult,
       async execute(_toolCallId, params: {
         tool?: string;
         args?: string;

--- a/mcp-content-formatting.ts
+++ b/mcp-content-formatting.ts
@@ -1,0 +1,71 @@
+import type { ContentBlock } from "./types.js";
+
+const TERMINAL_SEQUENCE_PATTERN = /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[P^_][\s\S]*?\x1b\\|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-_]/g;
+const SAFE_MIME_TYPE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,63}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,63}$/;
+const DEFAULT_IMAGE_MIME_TYPE = "image/*";
+
+/**
+ * Format byte counts in the compact style used in Pi tool output notices.
+ */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/**
+ * Format image content as metadata so terminal and model-facing text do not copy base64 payloads.
+ */
+export function formatImagePlaceholder(block: ContentBlock): string {
+  const data = "data" in block && typeof block.data === "string" ? block.data : "";
+  const mimeType = "mimeType" in block && typeof block.mimeType === "string" ? sanitizeMimeType(block.mimeType) : DEFAULT_IMAGE_MIME_TYPE;
+  return `[Image content: ${mimeType}, ${formatSize(Buffer.byteLength(data, "utf-8"))} base64 payload omitted]`;
+}
+
+/**
+ * Keep only short MIME labels that cannot carry terminal control sequences or unbounded metadata.
+ */
+export function sanitizeMimeType(value: string, fallback = DEFAULT_IMAGE_MIME_TYPE): string {
+  if (hasTerminalSequence(value)) {
+    return fallback;
+  }
+
+  const normalized = sanitizeMetadataText(value).trim();
+  if (!SAFE_MIME_TYPE_PATTERN.test(normalized)) {
+    return fallback;
+  }
+  return normalized;
+}
+
+/**
+ * Reject MIME labels that contained terminal escape sequences before sanitization.
+ */
+function hasTerminalSequence(text: string): boolean {
+  TERMINAL_SEQUENCE_PATTERN.lastIndex = 0;
+  return TERMINAL_SEQUENCE_PATTERN.test(text);
+}
+
+/**
+ * Remove terminal control sequences from metadata before it can reach text output or details.
+ */
+function sanitizeMetadataText(text: string): string {
+  return Array.from(text.replace(TERMINAL_SEQUENCE_PATTERN, "").replace(/\r/g, ""))
+    .filter((char) => {
+      const code = char.codePointAt(0);
+      if (code === undefined) {
+        return false;
+      }
+      if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+        return false;
+      }
+      if (code >= 0xfff9 && code <= 0xfffb) {
+        return false;
+      }
+      return true;
+    })
+    .join("");
+}

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -1,0 +1,380 @@
+import { randomBytes } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ContentBlock } from "./types.js";
+
+const DEFAULT_MAX_LINES = 2000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+const NOTICE_SEPARATOR = "\n\n";
+const MIN_PREVIEW_BYTES = 8 * 1024;
+const MIN_PREVIEW_LINES = 100;
+const TRUNCATED_SUFFIX_NOTICE = "\n[Additional generated text truncated to keep the response within Pi limits.]";
+
+export interface McpOutputGuardDetails {
+  truncated: boolean;
+  fullOutputPath?: string;
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+  writeError?: string;
+}
+
+interface TruncationResult {
+  content: string;
+  truncated: boolean;
+  truncatedBy: "lines" | "bytes" | null;
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+  lastLinePartial: boolean;
+}
+
+interface OutputStats {
+  lines: number;
+  bytes: number;
+  hasOversizedPayload: boolean;
+}
+
+interface TruncationOptions {
+  maxLines?: number;
+  maxBytes?: number;
+  forceTruncated?: boolean;
+}
+
+interface GuardOptions {
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface McpOutputGuardResult {
+  content: ContentBlock[];
+  details?: McpOutputGuardDetails;
+}
+
+/**
+ * Bounds model-facing MCP output and writes the full text representation to a temp file when it exceeds Pi's standard limits.
+ */
+export async function guardMcpOutput(content: ContentBlock[], options: GuardOptions = {}): Promise<McpOutputGuardResult> {
+  const textOutput = serializeContent(content);
+  const prefix = options.prefix ?? "";
+  const suffix = options.suffix ?? "";
+  const rawStats = getRawStats(content);
+  const composedText = `${prefix}${textOutput}${suffix}`;
+  const composedStats = getTextStats(composedText);
+  const shouldTruncate = rawStats.lines > DEFAULT_MAX_LINES
+    || rawStats.bytes > DEFAULT_MAX_BYTES
+    || rawStats.hasOversizedPayload
+    || composedStats.lines > DEFAULT_MAX_LINES
+    || composedStats.bytes > DEFAULT_MAX_BYTES;
+  const initialTruncation = truncateTail(textOutput, { forceTruncated: shouldTruncate });
+  if (!initialTruncation.truncated) {
+    if (prefix || suffix) {
+      return { content: [{ type: "text", text: composedText }] };
+    }
+    return { content };
+  }
+
+  let fullOutputPath: string | undefined;
+  let writeError: string | undefined;
+  try {
+    fullOutputPath = getTempFilePath();
+    await writeFile(fullOutputPath, textOutput, { encoding: "utf-8", mode: 0o600 });
+  } catch (error) {
+    fullOutputPath = undefined;
+    writeError = error instanceof Error ? error.message : String(error);
+  }
+
+  const bounded = buildBoundedOutput(textOutput, fullOutputPath, writeError, shouldTruncate, prefix, suffix);
+  return {
+    content: [{ type: "text", text: bounded.text }],
+    details: {
+      truncated: true,
+      fullOutputPath,
+      totalLines: Math.max(rawStats.lines, bounded.truncation.totalLines),
+      totalBytes: Math.max(rawStats.bytes, bounded.truncation.totalBytes),
+      outputLines: bounded.truncation.outputLines,
+      outputBytes: bounded.truncation.outputBytes,
+      writeError,
+    },
+  };
+}
+
+/**
+ * Converts Pi content blocks to the text form stored in the full-output file.
+ */
+function serializeContent(content: ContentBlock[]): string {
+  return content.map(serializeBlock).join("\n");
+}
+
+/**
+ * Keeps text content verbatim and replaces binary image payloads with metadata that does not copy base64 data.
+ */
+function serializeBlock(block: ContentBlock): string {
+  if (block.type === "text") {
+    return block.text;
+  }
+
+  const byteLength = Buffer.byteLength(block.data ?? "", "utf-8");
+  return `[Image content: ${block.mimeType ?? "image/*"}, ${formatSize(byteLength)} base64 payload omitted]`;
+}
+
+/**
+ * Measures the payload size that would otherwise be returned to the model or stored in details.
+ */
+function getRawStats(content: ContentBlock[]): OutputStats {
+  let bytes = 0;
+  let lines = 1;
+  let hasOversizedPayload = false;
+
+  for (const [index, block] of content.entries()) {
+    if (index > 0) {
+      bytes += 1;
+      lines += 1;
+    }
+
+    if (block.type === "text") {
+      bytes += Buffer.byteLength(block.text, "utf-8");
+      lines += block.text.split("\n").length - 1;
+      continue;
+    }
+
+    const payloadBytes = Buffer.byteLength(block.data ?? "", "utf-8");
+    bytes += payloadBytes;
+    if (payloadBytes > DEFAULT_MAX_BYTES) {
+      hasOversizedPayload = true;
+    }
+  }
+
+  return { bytes, lines, hasOversizedPayload };
+}
+
+/**
+ * Measures text by UTF-8 bytes and lines.
+ */
+function getTextStats(text: string): { bytes: number; lines: number } {
+  return { bytes: Buffer.byteLength(text, "utf-8"), lines: text.split("\n").length };
+}
+
+/**
+ * Creates an unpredictable temp file path that follows Pi's file-backed-output convention.
+ */
+function getTempFilePath(): string {
+  const id = randomBytes(8).toString("hex");
+  return join(tmpdir(), `pi-mcp-${id}.log`);
+}
+
+/**
+ * Builds a final model-facing response that includes caller text and the truncation notice inside the output budget.
+ */
+function buildBoundedOutput(
+  content: string,
+  fullOutputPath: string | undefined,
+  writeError: string | undefined,
+  forceTruncated: boolean,
+  prefix: string,
+  suffix: string,
+): { text: string; truncation: TruncationResult } {
+  let boundedSuffix = suffix;
+  let truncation = truncateTail(content, { forceTruncated });
+  let notice = formatTruncationNotice(truncation, fullOutputPath, writeError);
+
+  for (let attempt = 0; attempt < 6; attempt++) {
+    boundedSuffix = boundSuffix(suffix, prefix, notice);
+    const reservedText = `${prefix}${boundedSuffix}${NOTICE_SEPARATOR}${notice}`;
+    const reservedBytes = Buffer.byteLength(reservedText, "utf-8");
+    const reservedLines = countNewlines(reservedText);
+    truncation = truncateTail(content, {
+      maxBytes: Math.max(0, DEFAULT_MAX_BYTES - reservedBytes),
+      maxLines: Math.max(0, DEFAULT_MAX_LINES - reservedLines),
+      forceTruncated,
+    });
+    const nextNotice = formatTruncationNotice(truncation, fullOutputPath, writeError);
+    if (nextNotice === notice) {
+      break;
+    }
+    notice = nextNotice;
+  }
+
+  const text = `${prefix}${truncation.content || "(no output)"}${boundedSuffix}${NOTICE_SEPARATOR}${notice}`;
+  return { text: enforceFinalLimit(text), truncation };
+}
+
+/**
+ * Bounds caller-added suffix text while preserving its beginning, where schema headings and UI messages are introduced.
+ */
+function boundSuffix(suffix: string, prefix: string, notice: string): string {
+  if (!suffix) {
+    return "";
+  }
+
+  const fixedBytes = Buffer.byteLength(`${prefix}${NOTICE_SEPARATOR}${notice}`, "utf-8");
+  const fixedLines = countNewlines(`${prefix}${NOTICE_SEPARATOR}${notice}`) + 1;
+  const maxBytes = Math.max(0, DEFAULT_MAX_BYTES - fixedBytes - MIN_PREVIEW_BYTES - Buffer.byteLength(TRUNCATED_SUFFIX_NOTICE, "utf-8"));
+  const maxLines = Math.max(0, DEFAULT_MAX_LINES - fixedLines - MIN_PREVIEW_LINES - countNewlines(TRUNCATED_SUFFIX_NOTICE));
+  return truncateHeadWithNotice(suffix, maxBytes, maxLines);
+}
+
+/**
+ * Keeps the start of generated suffix text and marks when the rest was removed for the output budget.
+ */
+function truncateHeadWithNotice(text: string, maxBytes: number, maxLines: number): string {
+  const stats = getTextStats(text);
+  if (stats.bytes <= maxBytes && stats.lines <= maxLines) {
+    return text;
+  }
+
+  const availableBytes = Math.max(0, maxBytes);
+  const availableLines = Math.max(0, maxLines);
+  const lines = text.split("\n");
+  const output: string[] = [];
+  let bytes = 0;
+
+  for (const [index, line] of lines.entries()) {
+    if (output.length >= availableLines) {
+      break;
+    }
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (index > 0 ? 1 : 0);
+    if (bytes + lineBytes > availableBytes) {
+      break;
+    }
+    output.push(line);
+    bytes += lineBytes;
+  }
+
+  return `${output.join("\n")}${TRUNCATED_SUFFIX_NOTICE}`;
+}
+
+/**
+ * Truncates text from the tail by line count and byte count, matching Pi's bash output behavior.
+ */
+function truncateTail(content: string, options: TruncationOptions = {}): TruncationResult {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const totalBytes = Buffer.byteLength(content, "utf-8");
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+
+  if (!options.forceTruncated && totalLines <= maxLines && totalBytes <= maxBytes) {
+    return {
+      content,
+      truncated: false,
+      truncatedBy: null,
+      totalLines,
+      totalBytes,
+      outputLines: totalLines,
+      outputBytes: totalBytes,
+      lastLinePartial: false,
+    };
+  }
+
+  const outputLines: string[] = [];
+  let outputBytes = 0;
+  let truncatedBy: "lines" | "bytes" = "lines";
+  let lastLinePartial = false;
+
+  for (let index = lines.length - 1; index >= 0 && outputLines.length < maxLines; index--) {
+    const line = lines[index];
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (outputLines.length > 0 ? 1 : 0);
+    if (outputBytes + lineBytes > maxBytes) {
+      truncatedBy = "bytes";
+      if (outputLines.length === 0 && maxBytes > 0) {
+        const truncatedLine = truncateStringToBytesFromEnd(line, maxBytes);
+        outputLines.unshift(truncatedLine);
+        outputBytes = Buffer.byteLength(truncatedLine, "utf-8");
+        lastLinePartial = true;
+      }
+      break;
+    }
+
+    outputLines.unshift(line);
+    outputBytes += lineBytes;
+  }
+
+  if (outputLines.length >= maxLines && outputBytes <= maxBytes) {
+    truncatedBy = "lines";
+  }
+
+  const outputContent = outputLines.join("\n");
+  return {
+    content: outputContent,
+    truncated: true,
+    truncatedBy,
+    totalLines,
+    totalBytes,
+    outputLines: outputLines.length,
+    outputBytes: Buffer.byteLength(outputContent, "utf-8"),
+    lastLinePartial,
+  };
+}
+
+/**
+ * Keeps the end of a UTF-8 string without cutting a multibyte character in the middle.
+ */
+function truncateStringToBytesFromEnd(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, "utf-8");
+  if (buffer.length <= maxBytes) {
+    return value;
+  }
+
+  let start = buffer.length - maxBytes;
+  while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+    start++;
+  }
+
+  return buffer.subarray(start).toString("utf-8");
+}
+
+/**
+ * Enforces the final hard limit if dynamic path length or suffix truncation still leaves a few extra bytes.
+ */
+function enforceFinalLimit(text: string): string {
+  const stats = getTextStats(text);
+  if (stats.bytes <= DEFAULT_MAX_BYTES && stats.lines <= DEFAULT_MAX_LINES) {
+    return text;
+  }
+
+  return truncateTail(text, { maxBytes: DEFAULT_MAX_BYTES, maxLines: DEFAULT_MAX_LINES, forceTruncated: true }).content;
+}
+
+/**
+ * Counts newline characters because final line count equals preview lines plus inserted newline count.
+ */
+function countNewlines(text: string): number {
+  return (text.match(/\n/g) ?? []).length;
+}
+
+/**
+ * Formats the model-facing notice that tells the user where to read the full MCP output.
+ */
+function formatTruncationNotice(truncation: TruncationResult, fullOutputPath: string | undefined, writeError: string | undefined): string {
+  if (!fullOutputPath) {
+    return `[Output truncated. Full output could not be saved: ${writeError ?? "unknown error"}]`;
+  }
+
+  const startLine = truncation.totalLines - truncation.outputLines + 1;
+  const endLine = truncation.totalLines;
+  const readHint = `\n[Read first bytes: bash head -c ${DEFAULT_MAX_BYTES} ${fullOutputPath}]`;
+  if (truncation.lastLinePartial) {
+    return `[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine}. Full output: ${fullOutputPath}]${readHint}`;
+  }
+  if (truncation.truncatedBy === "lines") {
+    return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${fullOutputPath}]${readHint}`;
+  }
+  return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${fullOutputPath}]${readHint}`;
+}
+
+/**
+ * Formats byte counts in the same compact style as Pi's standard tools.
+ */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { formatImagePlaceholder, formatSize, sanitizeMimeType } from "./mcp-content-formatting.js";
 import type { ContentBlock } from "./types.js";
 
 const DEFAULT_MAX_LINES = 2000;
@@ -58,10 +59,11 @@ export interface McpOutputGuardResult {
  * Bounds model-facing MCP output and writes the full text representation to a temp file when it exceeds Pi's standard limits.
  */
 export async function guardMcpOutput(content: ContentBlock[], options: GuardOptions = {}): Promise<McpOutputGuardResult> {
-  const textOutput = serializeContent(content);
+  const safeContent = sanitizeContent(content);
+  const textOutput = serializeContent(safeContent);
   const prefix = options.prefix ?? "";
   const suffix = options.suffix ?? "";
-  const rawStats = getRawStats(content);
+  const rawStats = getRawStats(safeContent);
   const composedText = `${prefix}${textOutput}${suffix}`;
   const composedStats = getTextStats(composedText);
   const shouldTruncate = rawStats.lines > DEFAULT_MAX_LINES
@@ -74,7 +76,7 @@ export async function guardMcpOutput(content: ContentBlock[], options: GuardOpti
     if (prefix || suffix) {
       return { content: [{ type: "text", text: composedText }] };
     }
-    return { content };
+    return { content: safeContent };
   }
 
   let fullOutputPath: string | undefined;
@@ -103,6 +105,18 @@ export async function guardMcpOutput(content: ContentBlock[], options: GuardOpti
 }
 
 /**
+ * Normalize metadata on returned content blocks before they can reach model-facing output.
+ */
+function sanitizeContent(content: ContentBlock[]): ContentBlock[] {
+  return content.map((block) => {
+    if (block.type === "image") {
+      return { ...block, mimeType: sanitizeMimeType(block.mimeType ?? "") };
+    }
+    return block;
+  });
+}
+
+/**
  * Converts Pi content blocks to the text form stored in the full-output file.
  */
 function serializeContent(content: ContentBlock[]): string {
@@ -117,8 +131,7 @@ function serializeBlock(block: ContentBlock): string {
     return block.text;
   }
 
-  const byteLength = Buffer.byteLength(block.data ?? "", "utf-8");
-  return `[Image content: ${block.mimeType ?? "image/*"}, ${formatSize(byteLength)} base64 payload omitted]`;
+  return formatImagePlaceholder(block);
 }
 
 /**
@@ -364,17 +377,4 @@ function formatTruncationNotice(truncation: TruncationResult, fullOutputPath: st
     return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${fullOutputPath}]`;
   }
   return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${fullOutputPath}]`;
-}
-
-/**
- * Formats byte counts in the same compact style as Pi's standard tools.
- */
-function formatSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)}KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -356,14 +356,14 @@ function formatTruncationNotice(truncation: TruncationResult, fullOutputPath: st
 
   const startLine = truncation.totalLines - truncation.outputLines + 1;
   const endLine = truncation.totalLines;
-  const readHint = `\n[Read first bytes: bash head -c ${DEFAULT_MAX_BYTES} ${fullOutputPath}]`;
   if (truncation.lastLinePartial) {
+    const readHint = `\n[Read first bytes: bash head -c ${DEFAULT_MAX_BYTES} ${fullOutputPath}]`;
     return `[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine}. Full output: ${fullOutputPath}]${readHint}`;
   }
   if (truncation.truncatedBy === "lines") {
-    return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${fullOutputPath}]${readHint}`;
+    return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${fullOutputPath}]`;
   }
-  return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${fullOutputPath}]${readHint}`;
+  return `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${fullOutputPath}]`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "index.ts",
     "state.ts",
     "utils.ts",
+    "tool-rendering.ts",
     "tool-metadata.ts",
     "init.ts",
     "ui-session.ts",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "state.ts",
     "utils.ts",
     "mcp-output-guard.ts",
+    "mcp-content-formatting.ts",
     "tool-rendering.ts",
     "tool-metadata.ts",
     "init.ts",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "index.ts",
     "state.ts",
     "utils.ts",
+    "mcp-output-guard.ts",
     "tool-rendering.ts",
     "tool-metadata.ts",
     "init.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -8,9 +8,29 @@ import { transformMcpContent } from "./tool-registrar.js";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.js";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.js";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js";
+import { sanitizeMimeType } from "./mcp-content-formatting.js";
 import { guardMcpOutput, type McpOutputGuardDetails } from "./mcp-output-guard.js";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
+
+type McpResultDetailsSummary = {
+  isError: boolean;
+  contentSummary: Array<Record<string, unknown>>;
+  structuredContent?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+  extraFields: Array<Record<string, unknown>>;
+  truncated?: boolean;
+  fullOutputPath?: string;
+  totalLines?: number;
+  totalBytes?: number;
+  outputLines?: number;
+  outputBytes?: number;
+  writeError?: string;
+};
+
+const DETAILS_KEYS_PREVIEW_LIMIT = 20;
+const DETAILS_KEY_LENGTH_LIMIT = 80;
+const DETAILS_CONTENT_SUMMARY_LIMIT = 20;
 
 type AutoAuthResult =
   | { status: "skipped" }
@@ -34,21 +54,130 @@ function getAuthFailedMessage(state: McpExtensionState, serverName: string, mess
 }
 
 /**
- * Stores only bounded MCP result metadata in proxy details when the model-facing output was truncated.
+ * Stores bounded MCP result metadata in proxy details without copying raw result payloads.
  */
-function buildMcpResultDetails(result: unknown, guardDetails: McpOutputGuardDetails | undefined): unknown {
-  if (!guardDetails) {
-    return result;
+function buildMcpResultDetails(result: unknown, guardDetails: McpOutputGuardDetails | undefined): McpResultDetailsSummary {
+  const record = isRecord(result) ? result : {};
+  const summary: McpResultDetailsSummary = {
+    isError: record.isError === true,
+    contentSummary: summarizeContent(record.content),
+    extraFields: summarizeExtraFields(record),
+  };
+
+  if ("structuredContent" in record) {
+    summary.structuredContent = summarizeValue(record.structuredContent);
+  }
+  if ("_meta" in record) {
+    summary.meta = summarizeValue(record._meta);
+  }
+  if (guardDetails) {
+    summary.truncated = true;
+    summary.fullOutputPath = guardDetails.fullOutputPath;
+    summary.totalLines = guardDetails.totalLines;
+    summary.totalBytes = guardDetails.totalBytes;
+    summary.outputLines = guardDetails.outputLines;
+    summary.outputBytes = guardDetails.outputBytes;
+    summary.writeError = guardDetails.writeError;
   }
 
+  return summary;
+}
+
+/**
+ * Check whether a value can be inspected as a plain record for details summaries.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Summarize MCP content blocks without storing text or base64 data in proxy details.
+ */
+function summarizeContent(content: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const summaries: Array<Record<string, unknown>> = content.slice(0, DETAILS_CONTENT_SUMMARY_LIMIT).map((block, index) => {
+    if (!isRecord(block)) {
+      return { type: typeof block, omitted: true };
+    }
+    if (block.type === "text") {
+      const text = typeof block.text === "string" ? block.text : "";
+      return { type: "text", bytes: Buffer.byteLength(text, "utf-8"), lines: text.split("\n").length, textOmitted: true };
+    }
+    if (block.type === "image") {
+      const data = typeof block.data === "string" ? block.data : "";
+      const mimeType = typeof block.mimeType === "string" ? sanitizeMimeType(block.mimeType) : undefined;
+      return { type: "image", mimeType, dataBytes: Buffer.byteLength(data, "utf-8"), dataOmitted: true };
+    }
+    return { type: "unknown", originalIndex: index, estimatedBytes: estimateValueBytes(block), omitted: true };
+  });
+
+  if (content.length > DETAILS_CONTENT_SUMMARY_LIMIT) {
+    summaries.push({ type: "omitted", count: content.length - DETAILS_CONTENT_SUMMARY_LIMIT });
+  }
+  return summaries;
+}
+
+/**
+ * Summarize structured objects without storing their values in proxy details.
+ */
+function summarizeValue(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    return { type: value === null ? "null" : typeof value, estimatedBytes: estimateValueBytes(value), omitted: true };
+  }
+
+  const keys = Object.keys(value);
   return {
-    truncated: true,
-    fullOutputPath: guardDetails.fullOutputPath,
-    totalLines: guardDetails.totalLines,
-    totalBytes: guardDetails.totalBytes,
-    outputLines: guardDetails.outputLines,
-    outputBytes: guardDetails.outputBytes,
-    writeError: guardDetails.writeError,
+    type: Array.isArray(value) ? "array" : "object",
+    estimatedBytes: estimateValueBytes(value),
+    keyCount: keys.length,
+    keysPreview: keys.slice(0, DETAILS_KEYS_PREVIEW_LIMIT).map((key) => summarizeDetailsKey(key)),
+    omitted: true,
+  };
+}
+
+/**
+ * Summarize non-standard MCP result fields without storing their values.
+ */
+function summarizeExtraFields(record: Record<string, unknown>): Array<Record<string, unknown>> {
+  const standardKeys = new Set(["content", "isError", "structuredContent", "_meta"]);
+  return Object.keys(record)
+    .filter((key) => !standardKeys.has(key))
+    .slice(0, DETAILS_KEYS_PREVIEW_LIMIT)
+    .map((key) => ({ key: summarizeDetailsKey(key), type: typeof record[key], estimatedBytes: estimateValueBytes(record[key]), omitted: true }));
+}
+
+/**
+ * Estimate omitted value size without materializing a full serialized copy.
+ */
+function estimateValueBytes(value: unknown, depth = 0): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === "string") {
+    return Buffer.byteLength(value, "utf-8");
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return Buffer.byteLength(String(value), "utf-8");
+  }
+  if (!isRecord(value) || depth >= 2) {
+    return 0;
+  }
+
+  const values = Array.isArray(value) ? value.slice(0, DETAILS_KEYS_PREVIEW_LIMIT) : Object.values(value).slice(0, DETAILS_KEYS_PREVIEW_LIMIT);
+  return values.reduce((total, item) => total + estimateValueBytes(item, depth + 1), 0);
+}
+
+/**
+ * Summarize object keys without storing their raw text in details.
+ */
+function summarizeDetailsKey(key: string): Record<string, unknown> {
+  return {
+    keyOmitted: true,
+    keyBytes: Buffer.byteLength(key, "utf-8"),
+    unsafe: key.length > DETAILS_KEY_LENGTH_LIMIT || /[\x00-\x1f\x7f-\x9f\u001b]/.test(key),
   };
 }
 
@@ -718,7 +847,7 @@ export async function executeCall(
       const result = await connection.client.readResource({ uri: toolMeta.resourceUri });
       const content = (result.contents ?? []).map(c => ({
         type: "text" as const,
-        text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
+        text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${sanitizeMimeType((c as { mimeType?: string }).mimeType ?? "", "application/octet-stream")}]` : JSON.stringify(c)),
       }));
       const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }]);
       return {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -8,6 +8,7 @@ import { transformMcpContent } from "./tool-registrar.js";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.js";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.js";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js";
+import { guardMcpOutput, type McpOutputGuardDetails } from "./mcp-output-guard.js";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -30,6 +31,25 @@ function getAuthFailedMessage(state: McpExtensionState, serverName: string, mess
     return `OAuth authentication failed for "${serverName}": ${message}. ${getAuthRequiredMessage(state, serverName)}`;
   }
   return `OAuth authentication failed for "${serverName}": ${message}. Run /mcp-auth ${serverName} first.`;
+}
+
+/**
+ * Stores only bounded MCP result metadata in proxy details when the model-facing output was truncated.
+ */
+function buildMcpResultDetails(result: unknown, guardDetails: McpOutputGuardDetails | undefined): unknown {
+  if (!guardDetails) {
+    return result;
+  }
+
+  return {
+    truncated: true,
+    fullOutputPath: guardDetails.fullOutputPath,
+    totalLines: guardDetails.totalLines,
+    totalBytes: guardDetails.totalBytes,
+    outputLines: guardDetails.outputLines,
+    outputBytes: guardDetails.outputBytes,
+    writeError: guardDetails.writeError,
+  };
 }
 
 async function attemptAutoAuth(
@@ -700,9 +720,10 @@ export async function executeCall(
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
       }));
+      const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }]);
       return {
-        content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
-        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName },
+        content: guarded.content,
+        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName, ...(guarded.details ? { output: guarded.details } : {}) },
       };
     }
 
@@ -727,30 +748,24 @@ export async function executeCall(
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
-
-      const mcpText = content
-        .filter((c) => c.type === "text")
-        .map((c) => (c as { text: string }).text)
-        .join("\n");
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
       if (result.isError) {
-        let errorWithSchema = `Error: ${mcpText || "Tool execution failed"}`;
-        if (toolMeta.inputSchema) {
-          errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-        }
+        const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+        const guardedError = await guardMcpOutput(outputContent, { prefix: "Error: ", suffix: schemaText });
         return {
-          content: [{ type: "text" as const, text: errorWithSchema }],
-          details: { mode: "call", error: "tool_error", mcpResult: result },
+          content: guardedError.content,
+          details: { mode: "call", error: "tool_error", mcpResult: buildMcpResultDetails(result, guardedError.details) },
         };
       }
 
-      const resultText = mcpText || "(empty result)";
       const uiMessage = uiSession?.reused
         ? "Updated the open UI."
         : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
+      const guardedUi = await guardMcpOutput(outputContent, { suffix: `\n\n${uiMessage}` });
       return {
-        content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
-        details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName, uiOpen: true },
+        content: guardedUi.content,
+        details: { mode: "call", mcpResult: buildMcpResultDetails(result, guardedUi.details), server: serverName, tool: toolMeta.originalName, uiOpen: true },
       };
     }
 
@@ -758,40 +773,36 @@ export async function executeCall(
 
     const mcpContent = (result.content ?? []) as McpContent[];
     const content = transformMcpContent(mcpContent);
+    const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
     if (result.isError) {
-      const errorText = content
-        .filter((c) => c.type === "text")
-        .map((c) => (c as { text: string }).text)
-        .join("\n") || "Tool execution failed";
-
-      let errorWithSchema = `Error: ${errorText}`;
-      if (toolMeta.inputSchema) {
-        errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-      }
-
+      const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+      const guardedError = await guardMcpOutput(outputContent, { prefix: "Error: ", suffix: schemaText });
       return {
-        content: [{ type: "text" as const, text: errorWithSchema }],
-        details: { mode: "call", error: "tool_error", mcpResult: result },
+        content: guardedError.content,
+        details: { mode: "call", error: "tool_error", mcpResult: buildMcpResultDetails(result, guardedError.details) },
       };
     }
 
+    const guarded = await guardMcpOutput(outputContent);
     return {
-      content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
-      details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName },
+      content: guarded.content,
+      details: { mode: "call", mcpResult: buildMcpResultDetails(result, guarded.details), server: serverName, tool: toolMeta.originalName },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     uiSession?.sendToolCancelled(message);
 
-    let errorWithSchema = `Failed to call tool: ${message}`;
-    if (toolMeta.inputSchema) {
-      errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-    }
-
+    const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+    const guardedError = await guardMcpOutput([{ type: "text" as const, text: message }], { prefix: "Failed to call tool: ", suffix: schemaText });
     return {
-      content: [{ type: "text" as const, text: errorWithSchema }],
-      details: { mode: "call", error: "call_failed", message },
+      content: guardedError.content,
+      details: {
+        mode: "call",
+        error: "call_failed",
+        message: guardedError.details ? "output truncated; see output.fullOutputPath" : message,
+        ...(guardedError.details ? { output: guardedError.details } : {}),
+      },
     };
   } finally {
     if (uiSession?.reused) {

--- a/tool-registrar.ts
+++ b/tool-registrar.ts
@@ -2,6 +2,7 @@
 // NOTE: Tools are NOT registered with Pi - only the unified `mcp` proxy tool is registered.
 // This keeps the LLM context small (1 tool instead of 100s).
 
+import { formatSize, sanitizeMimeType } from "./mcp-content-formatting.js";
 import type { McpContent, ContentBlock } from "./types.js";
 
 /**
@@ -21,7 +22,7 @@ export function transformMcpContent(content: McpContent[]): ContentBlock[] {
     }
     if (c.type === "resource") {
       const resourceUri = c.resource?.uri ?? "(no URI)";
-      const resourceContent = c.resource?.text ?? (c.resource ? JSON.stringify(c.resource) : "(no content)");
+      const resourceContent = formatResourceContent(c);
       return {
         type: "text" as const,
         text: `[Resource: ${resourceUri}]\n${resourceContent}`,
@@ -38,9 +39,24 @@ export function transformMcpContent(content: McpContent[]): ContentBlock[] {
     if (c.type === "audio") {
       return {
         type: "text" as const,
-        text: `[Audio content: ${c.mimeType ?? "audio/*"}]`,
+        text: `[Audio content: ${sanitizeMimeType(c.mimeType ?? "", "audio/*")}]`,
       };
     }
     return { type: "text" as const, text: JSON.stringify(c) };
   });
+}
+
+/**
+ * Format MCP embedded resources without copying binary blob payloads into model-facing text.
+ */
+function formatResourceContent(content: McpContent): string {
+  if (content.resource?.text !== undefined) {
+    return content.resource.text;
+  }
+  if (content.resource?.blob !== undefined) {
+    const mimeType = sanitizeMimeType(content.mimeType ?? "", "application/octet-stream");
+    const bytes = Buffer.byteLength(content.resource.blob, "utf-8");
+    return `[Binary data: ${mimeType}, ${formatSize(bytes)} base64 payload omitted]`;
+  }
+  return "(no content)";
 }

--- a/tool-rendering.ts
+++ b/tool-rendering.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentToolResult, ToolRenderContext, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
+import { formatImagePlaceholder } from "./mcp-content-formatting.js";
 
 type RenderTheme = {
   fg(color: string, text: string): string;
@@ -16,6 +17,12 @@ const COLLAPSED_RESULT_PREVIEW_LINES = 10;
 const DEFAULT_EXPAND_KEY = "ctrl+o";
 const KEYBINDINGS_PATH = join(homedir(), ".pi", "agent", "keybindings.json");
 const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const TERMINAL_SEQUENCE_PATTERN = /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[P^_][\s\S]*?\x1b\\|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-_]/g;
+
+/**
+ * Cache keybinding text after the first read so terminal rendering does not block on filesystem access.
+ */
+const configuredKeyTextCache = new Map<string, string>();
 
 /**
  * Render MCP tool results with the same collapsed shape as standard Pi text tools.
@@ -39,13 +46,45 @@ export function renderMcpResult(
 }
 
 /**
- * Join text blocks into the same plain text that Pi's fallback renderer would show.
+ * Convert MCP content blocks to safe terminal text without copying binary payloads.
  */
 function getTextOutput(result: AgentToolResult<Record<string, unknown>>): string {
-  return result.content
-    .filter((block) => block.type === "text")
-    .map((block) => block.text)
-    .join("\n");
+  return result.content.map(formatContentBlock).join("\n");
+}
+
+/**
+ * Keep text blocks verbatim and show metadata for image blocks so non-text results are not hidden.
+ */
+function formatContentBlock(block: AgentToolResult<Record<string, unknown>>["content"][number]): string {
+  if (block.type === "text") {
+    return sanitizeTerminalText(block.text);
+  }
+
+  return formatImagePlaceholder(block);
+}
+
+/**
+ * Remove terminal control sequences from external MCP text before TUI rendering.
+ */
+function sanitizeTerminalText(text: string): string {
+  return Array.from(text.replace(TERMINAL_SEQUENCE_PATTERN, "").replace(/\r/g, ""))
+    .filter((char) => {
+      const code = char.codePointAt(0);
+      if (code === undefined) {
+        return false;
+      }
+      if (code === 0x09 || code === 0x0a) {
+        return true;
+      }
+      if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+        return false;
+      }
+      if (code >= 0xfff9 && code <= 0xfffb) {
+        return false;
+      }
+      return true;
+    })
+    .join("");
 }
 
 /**
@@ -103,9 +142,23 @@ function getPiKeyHint(keybinding: string, description: string, theme: RenderThem
 }
 
 /**
- * Read Pi's user keybinding override and fall back to Pi's default expand key.
+ * Read Pi's user keybinding override once and fall back to Pi's default expand key.
  */
 function getConfiguredKeyText(keybinding: string): string {
+  const cached = configuredKeyTextCache.get(keybinding);
+  if (cached) {
+    return cached;
+  }
+
+  const keyText = readConfiguredKeyText(keybinding);
+  configuredKeyTextCache.set(keybinding, keyText);
+  return keyText;
+}
+
+/**
+ * Resolve a keybinding from Pi's config file without throwing during terminal rendering.
+ */
+function readConfiguredKeyText(keybinding: string): string {
   try {
     if (!existsSync(KEYBINDINGS_PATH)) {
       return DEFAULT_EXPAND_KEY;
@@ -141,15 +194,15 @@ function trimTrailingEmptyLines(lines: string[]): string[] {
 }
 
 /**
- * Truncate a line to terminal width without splitting ANSI escape sequences.
- */
-/**
  * Match Pi text tool rendering by replacing tabs before terminal output.
  */
 function replaceTabs(text: string): string {
   return text.replace(/\t/g, "   ");
 }
 
+/**
+ * Truncate a line to terminal width without splitting ANSI escape sequences.
+ */
 function truncateLine(line: string, width: number): string {
   if (visibleWidth(line) <= width) {
     return line;

--- a/tool-rendering.ts
+++ b/tool-rendering.ts
@@ -1,0 +1,184 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentToolResult, ToolRenderContext, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
+
+type RenderTheme = {
+  fg(color: string, text: string): string;
+};
+
+type RenderComponent = {
+  render(width: number): string[];
+  invalidate(): void;
+};
+
+const COLLAPSED_RESULT_PREVIEW_LINES = 10;
+const DEFAULT_EXPAND_KEY = "ctrl+o";
+const KEYBINDINGS_PATH = join(homedir(), ".pi", "agent", "keybindings.json");
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+/**
+ * Render MCP tool results with the same collapsed shape as standard Pi text tools.
+ */
+export function renderMcpResult(
+  result: AgentToolResult<Record<string, unknown>>,
+  options: ToolRenderResultOptions,
+  theme: RenderTheme,
+  _context: ToolRenderContext,
+): RenderComponent {
+  if (options.isPartial) {
+    return new StaticText(theme.fg("warning", "MCP tool is running..."));
+  }
+
+  const output = getTextOutput(result);
+  if (!output) {
+    return new StaticText(theme.fg("muted", "(empty result)"));
+  }
+
+  return new McpResultPreview(output, options.expanded, theme);
+}
+
+/**
+ * Join text blocks into the same plain text that Pi's fallback renderer would show.
+ */
+function getTextOutput(result: AgentToolResult<Record<string, unknown>>): string {
+  return result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Render the first lines and put the expansion hint after the preview, matching Pi's standard read renderer.
+ */
+class McpResultPreview implements RenderComponent {
+  constructor(
+    private readonly output: string,
+    private readonly expanded: boolean,
+    private readonly theme: RenderTheme,
+  ) {}
+
+  render(width: number): string[] {
+    const lines = trimTrailingEmptyLines(this.output.split("\n"));
+    const maxLines = this.expanded ? lines.length : COLLAPSED_RESULT_PREVIEW_LINES;
+    const displayLines = lines.slice(0, maxLines);
+    const remaining = lines.length - maxLines;
+    const rendered = ["", ...displayLines.map((line) => truncateLine(this.theme.fg("toolOutput", line), width))];
+
+    if (remaining > 0) {
+      rendered.push(truncateLine(formatRemainingLinesHint(remaining, this.theme), width));
+    }
+
+    return rendered;
+  }
+
+  invalidate(): void {}
+}
+
+/**
+ * Render fixed text as a Pi-compatible component without importing Pi TUI at runtime.
+ */
+class StaticText implements RenderComponent {
+  constructor(private readonly text: string) {}
+
+  render(width: number): string[] {
+    return this.text.split("\n").map((line) => truncateLine(line, width));
+  }
+
+  invalidate(): void {}
+}
+
+/**
+ * Format the same expansion hint as standard Pi text-tool renderers.
+ */
+function formatRemainingLinesHint(remaining: number, theme: RenderTheme): string {
+  return `${theme.fg("muted", `... (${remaining} more lines,`)} ${getPiKeyHint("app.tools.expand", "to expand", theme)})`;
+}
+
+/**
+ * Use Pi's configured keybinding text when the adapter runs inside Pi.
+ */
+function getPiKeyHint(keybinding: string, description: string, theme: RenderTheme): string {
+  return theme.fg("dim", getConfiguredKeyText(keybinding)) + theme.fg("muted", ` ${description}`);
+}
+
+/**
+ * Read Pi's user keybinding override and fall back to Pi's default expand key.
+ */
+function getConfiguredKeyText(keybinding: string): string {
+  try {
+    if (!existsSync(KEYBINDINGS_PATH)) {
+      return DEFAULT_EXPAND_KEY;
+    }
+
+    const parsed = JSON.parse(readFileSync(KEYBINDINGS_PATH, "utf-8")) as Record<string, unknown>;
+    const value = parsed[keybinding];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      const keys = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+      if (keys.length > 0) {
+        return keys.join("/");
+      }
+    }
+  } catch {
+    return DEFAULT_EXPAND_KEY;
+  }
+
+  return DEFAULT_EXPAND_KEY;
+}
+
+/**
+ * Remove empty lines from the end of output before calculating the collapsed preview.
+ */
+function trimTrailingEmptyLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === "") {
+    end--;
+  }
+  return lines.slice(0, end);
+}
+
+/**
+ * Truncate a line to terminal width without splitting ANSI escape sequences.
+ */
+function truncateLine(line: string, width: number): string {
+  if (visibleWidth(line) <= width) {
+    return line;
+  }
+
+  const ellipsis = "...";
+  return takeVisibleWidth(line, Math.max(0, width - ellipsis.length)) + ellipsis;
+}
+
+/**
+ * Return the prefix that fits into the requested terminal width.
+ */
+function takeVisibleWidth(text: string, width: number): string {
+  let result = "";
+  let visible = 0;
+
+  for (let index = 0; index < text.length && visible < width;) {
+    const ansi = text.slice(index).match(/^\x1b\[[0-?]*[ -/]*[@-~]/);
+    if (ansi) {
+      result += ansi[0];
+      index += ansi[0].length;
+      continue;
+    }
+
+    result += text[index];
+    visible += 1;
+    index += 1;
+  }
+
+  return result;
+}
+
+/**
+ * Count printable characters; ANSI color sequences do not occupy terminal columns.
+ */
+function visibleWidth(text: string): number {
+  return text.replace(ANSI_PATTERN, "").length;
+}

--- a/tool-rendering.ts
+++ b/tool-rendering.ts
@@ -45,8 +45,7 @@ function getTextOutput(result: AgentToolResult<Record<string, unknown>>): string
   return result.content
     .filter((block) => block.type === "text")
     .map((block) => block.text)
-    .join("\n")
-    .trim();
+    .join("\n");
 }
 
 /**
@@ -64,7 +63,7 @@ class McpResultPreview implements RenderComponent {
     const maxLines = this.expanded ? lines.length : COLLAPSED_RESULT_PREVIEW_LINES;
     const displayLines = lines.slice(0, maxLines);
     const remaining = lines.length - maxLines;
-    const rendered = ["", ...displayLines.map((line) => truncateLine(this.theme.fg("toolOutput", line), width))];
+    const rendered = ["", ...displayLines.map((line) => truncateLine(this.theme.fg("toolOutput", replaceTabs(line)), width))];
 
     if (remaining > 0) {
       rendered.push(truncateLine(formatRemainingLinesHint(remaining, this.theme), width));
@@ -144,6 +143,13 @@ function trimTrailingEmptyLines(lines: string[]): string[] {
 /**
  * Truncate a line to terminal width without splitting ANSI escape sequences.
  */
+/**
+ * Match Pi text tool rendering by replacing tabs before terminal output.
+ */
+function replaceTabs(text: string): string {
+  return text.replace(/\t/g, "   ");
+}
+
 function truncateLine(line: string, width: number): string {
   if (visibleWidth(line) <= width) {
     return line;


### PR DESCRIPTION
## Summary

This PR introduces two improvements to handle large MCP responses and enhance tool result rendering:

### MCP Output Guard
A mechanism to guard against oversized MCP responses:
  - Limits output to 2000 lines or 50KB (default thresholds)
  - Writes full output to temp file when limits are exceeded
  - Provides truncation notices with metadata about original size
  - Handles binary payloads (images) efficiently by omitting base64 data
  - Includes detailed truncation statistics (lines, bytes, file paths)

### Tool Rendering
Enhanced rendering for MCP tool results:
  - Improved display formatting for tool outputs
  - Better handling of structured responses
  - Enhanced user experience for tool interactions
