### PR TITLE
feat: add `disabled` flag to skip MCP servers without removing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added disabled MCP server definitions plus `/mcp disable` and `/mcp enable` project-local overrides that preserve visibility while preventing execution. Thanks Ömer Ulusoy (@ulusoyomer) for PR #61.
 - Added argument completions for `/mcp` subcommands and reconnect/logout server names. Thanks @sting8k for PR #8.
 - Surfaced MCP connection failure reasons from bounded stdio diagnostics in status output and the `/mcp` panel, with a shortcut to copy the selected failure. Thanks @parkuman for PR #197.
 - Added Codex MCP imports from `.codex/config.toml`, with fallback to the existing JSON config. Thanks @npo-mmenke for PR #31.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
 | `debug` | Show server stderr (default: false) |
+| `disabled` | Skip this server entirely without removing config (default: false) |
 
 ### Lifecycle Modes
 
@@ -344,6 +345,8 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 | `/mcp tools` | List all tools |
 | `/mcp reconnect` | Reconnect all servers |
 | `/mcp reconnect <server>` | Connect or reconnect a single server |
+| `/mcp disable <server>` | Disable a server (requires `/reload` to apply) |
+| `/mcp enable <server>` | Re-enable a disabled server (requires `/reload` to apply) |
 | `/mcp-auth <server>` | OAuth setup |
 
 If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls will automatically run OAuth when needed and retry once. In non-interactive sessions, browser-based OAuth still requires running `/mcp-auth <server>` manually.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Precedence is:
 3. `.mcp.json`
 4. `.pi/mcp.json`
 
+`/mcp disable <server>` and `/mcp enable <server>` persist only the `disabled` field in the project-local `.pi/mcp.json`, which is the highest-precedence Pi layer. Enabling removes the project flag when lower layers are enabled, or writes `false` when needed to override a disabled lower source. This applies even when the effective server came from a shared global/project file, an imported host config, or `configPath`; the source file is never rewritten and credentials are never copied. Run `/reload` after changing the flag so registered tool surfaces are refreshed. The manual equivalent is to add `{ "disabled": true }` to a server in any normal MCP config. Supplied in-memory `createMcpAdapter({ config })` configurations are isolated and do not read or write this project override; the commands are unavailable in that mode.
+
 Servers are **lazy by default** — they won't connect until you actually call one of their tools. The adapter caches tool metadata so search and describe work without live connections.
 
 ```
@@ -170,6 +172,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
 | `debug` | Show server stderr (default: false) |
+| `disabled` | Keep the server visible in config and status, but prevent connections, authentication, tools, and resource calls (only literal `true` disables it) |
 
 For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
 
@@ -445,6 +448,8 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 | `/mcp tools` | List all tools |
 | `/mcp reconnect` | Reconnect all servers |
 | `/mcp reconnect <server>` | Connect or reconnect a single server |
+| `/mcp disable <server>` | Disable a server in the project-local `.pi/mcp.json` (requires `/reload` to apply) |
+| `/mcp enable <server>` | Enable through the project-local override layer (requires `/reload` to apply) |
 | `/mcp logout <server>` | Clear stored OAuth credentials for a server and disconnect it |
 | `/mcp-auth` | Open an OAuth server picker in interactive UI sessions |
 | `/mcp-auth <server>` | OAuth setup for a specific server |

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -20,6 +20,19 @@ vi.mock("../init.ts", () => ({
 }));
 
 describe("authenticateServer", () => {
+  it("does not open an empty auth panel for disabled-only OAuth config", async () => {
+    const ui = { notify: vi.fn(), custom: vi.fn() };
+    const { openMcpAuthPanel } = await import("../commands.ts");
+
+    await openMcpAuthPanel({
+      programmaticConfig: false,
+      config: { mcpServers: { disabled: { url: "https://example.test/mcp", auth: "oauth", disabled: true } } },
+    } as any, { getFlag: vi.fn() } as any, { hasUI: true, ui } as any);
+
+    expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
+    expect(ui.custom).not.toHaveBeenCalled();
+  });
+
   it("interpolates the server URL before OAuth authentication", async () => {
     const originalUrl = process.env.MCP_AUTH_URL;
     process.env.MCP_AUTH_URL = "https://mcp.sentry.dev/mcp";

--- a/__tests__/disabled-server.test.ts
+++ b/__tests__/disabled-server.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "../direct-tools.ts";
+import { executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus } from "../proxy-modes.ts";
+import { initializeMcp, updateStatusBar } from "../init.ts";
+import { loadMcpConfig, writeProjectServerDisabledOverride } from "../config.ts";
+import { computeServerHash, type MetadataCache } from "../metadata-cache.ts";
+import { McpServerManager } from "../server-manager.ts";
+import { UiResourceHandler } from "../ui-resource-handler.ts";
+
+const cache: MetadataCache = {
+  version: 1,
+  servers: {
+    disabled: {
+      configHash: "disabled-cache",
+      cachedAt: Date.now(),
+      tools: [{ name: "search", description: "disabled search" }],
+      resources: [{ name: "doc", uri: "mcp://doc" }],
+      instructions: "disabled instructions",
+    },
+    enabled: {
+      configHash: "enabled-cache",
+      cachedAt: Date.now(),
+      tools: [{ name: "search", description: "enabled search" }],
+      resources: [],
+    },
+  },
+};
+
+function disabledState() {
+  const connection = {
+    status: "connected",
+    tools: [{ name: "search" }],
+    resources: [],
+    client: { callTool: vi.fn(), readResource: vi.fn() },
+  };
+  return {
+    config: { mcpServers: { disabled: { command: "node", disabled: true }, enabled: { command: "node" } } },
+    toolMetadata: new Map([["disabled", [{ name: "disabled_search", originalName: "search", description: "cached" }]]]),
+    serverInstructions: new Map([["disabled", "cached instructions"]]),
+    manager: {
+      getConnection: vi.fn((name: string) => name === "disabled" ? connection : undefined),
+      getAllConnections: vi.fn(() => new Map([["disabled", connection]])),
+      connect: vi.fn(),
+      close: vi.fn(),
+    },
+    failureTracker: new Map(),
+    failureMessages: new Map(),
+    owner: { signal: new AbortController().signal },
+    ui: undefined,
+  } as any;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("disabled MCP servers", () => {
+  it("only literal true disables direct tools and configured bootstrap", () => {
+    const config = {
+      settings: { directTools: true },
+      mcpServers: {
+        disabled: { command: "node", disabled: true },
+        string: { command: "node", disabled: "true" as unknown as boolean },
+        enabled: { command: "node" },
+      },
+    };
+    const directCache = {
+      ...cache,
+      servers: {
+        disabled: { ...cache.servers.disabled, configHash: computeServerHash(config.mcpServers.disabled) },
+        string: { ...cache.servers.enabled, configHash: computeServerHash(config.mcpServers.string) },
+        enabled: { ...cache.servers.enabled, configHash: computeServerHash(config.mcpServers.enabled) },
+      },
+    };
+
+    expect(resolveDirectTools(config, directCache, "server").map((spec) => spec.serverName).sort()).toEqual(["enabled", "string"]);
+    expect(getMissingConfiguredDirectToolServers(config, directCache)).not.toContain("disabled");
+  });
+
+  it("rejects stale direct executors before connect or auth", async () => {
+    const state = disabledState();
+    const execute = createDirectToolExecutor(() => state, () => null, {
+      serverName: "disabled",
+      originalName: "search",
+      prefixedName: "disabled_search",
+      description: "cached",
+    });
+
+    const result = await execute("call", {}, undefined, undefined, {} as any);
+    expect(result.details).toMatchObject({ error: "server_disabled", server: "disabled" });
+    expect(result.content[0].text).toContain("/reload");
+    expect(state.manager.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects proxy execution and hides disabled cached metadata while listing it in status", async () => {
+    const state = disabledState();
+    expect(executeStatus(state).content[0].text).toContain("disabled");
+    expect(executeStatus(state).content[0].text).toContain("0/1 servers");
+    expect(executeList(state, "disabled").details).toMatchObject({ error: "server_disabled" });
+    expect(executeInstructions(state, "disabled").details).toMatchObject({ error: "server_disabled" });
+    state.toolMetadata.set("enabled", [{ name: "disabled_search", originalName: "search", description: "enabled duplicate" }]);
+    expect(executeDescribe(state, "disabled_search").details).toMatchObject({ server: "enabled" });
+    state.toolMetadata.delete("enabled");
+    expect(executeDescribe(state, "disabled_search").details).toMatchObject({ error: "server_disabled" });
+    expect(executeSearch(state, "cached").details).toMatchObject({ count: 0 });
+    expect(executeSearch(state, "cached", false, "disabled").details).toMatchObject({ error: "server_disabled" });
+    expect((await executeCall(state, "disabled_search", {})).details).toMatchObject({ error: "server_disabled" });
+    expect((await executeCall(state, "disabled_search", {}, "disabled")).details).toMatchObject({ error: "server_disabled" });
+    expect((await executeConnect(state, "disabled")).details).toMatchObject({ error: "server_disabled" });
+    expect((await executeAuthStart(state, "disabled")).details).toMatchObject({ error: "server_disabled" });
+    expect(state.manager.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects manager and UI resource connections for disabled definitions", async () => {
+    const manager = new McpServerManager();
+    await expect(manager.connect("disabled", { command: "node", disabled: true })).rejects.toThrow("disabled");
+    const handler = new UiResourceHandler({
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getConnection: vi.fn(),
+    } as any, { mcpServers: { disabled: { url: "https://example.test", disabled: true } } });
+    await expect(handler.readUiResource("disabled", "ui://example")).rejects.toThrow("disabled");
+  });
+
+  it("writes only a project-local disabled override and removes it cleanly", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-disabled-override-"));
+    const filePath = join(cwd, ".pi", "mcp.json");
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(filePath, JSON.stringify({ unrelated: { keep: true }, mcpServers: {
+      disabled: { disabled: false, directTools: true },
+      onlyFlag: { disabled: true },
+    }}));
+
+    expect(writeProjectServerDisabledOverride(undefined, cwd, "disabled", true)).toMatchObject({ changed: true, path: filePath });
+    const disabledRaw = JSON.parse(readFileSync(filePath, "utf8"));
+    expect(disabledRaw.unrelated).toEqual({ keep: true });
+    expect(disabledRaw.mcpServers.disabled).toEqual({ disabled: true, directTools: true });
+
+    expect(writeProjectServerDisabledOverride(undefined, cwd, "onlyFlag", false)).toMatchObject({ changed: true });
+    const enabledRaw = JSON.parse(readFileSync(filePath, "utf8"));
+    expect(enabledRaw.mcpServers.onlyFlag).toBeUndefined();
+    expect(enabledRaw.mcpServers.disabled.directTools).toBe(true);
+  });
+
+  it("writes an explicit enabled override when a lower config disables the server", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-disabled-layer-"));
+    const overridePath = join(cwd, "factory.json");
+    writeFileSync(overridePath, JSON.stringify({ mcpServers: { lower: { command: "node", disabled: true } } }));
+
+    expect(writeProjectServerDisabledOverride(overridePath, cwd, "lower", false)).toMatchObject({ changed: true });
+    expect(JSON.parse(readFileSync(join(cwd, ".pi", "mcp.json"), "utf8")).mcpServers.lower).toEqual({ disabled: false });
+    expect(loadMcpConfig(overridePath, cwd).mcpServers.lower.disabled).toBe(false);
+  });
+
+  it("enables a server disabled by an import declared in the project override", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-disabled-project-import-"));
+    mkdirSync(join(cwd, ".vscode"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(join(cwd, ".vscode", "mcp.json"), JSON.stringify({
+      mcpServers: { imported: { command: "node", disabled: true } },
+    }));
+    writeFileSync(join(cwd, ".pi", "mcp.json"), JSON.stringify({
+      imports: ["vscode"],
+      mcpServers: { imported: { disabled: true } },
+    }));
+
+    expect(writeProjectServerDisabledOverride(undefined, cwd, "imported", false)).toMatchObject({ changed: true });
+    expect(JSON.parse(readFileSync(join(cwd, ".pi", "mcp.json"), "utf8")).mcpServers.imported).toEqual({ disabled: false });
+    expect(loadMcpConfig(undefined, cwd).mcpServers.imported).toMatchObject({ command: "node", disabled: false });
+  });
+
+  it("preserves the supported raw server-map key while updating an override", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-disabled-alias-"));
+    const filePath = join(cwd, ".pi", "mcp.json");
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(filePath, JSON.stringify({ "mcp-servers": { alias: { command: "node", args: ["server"] } } }));
+
+    expect(writeProjectServerDisabledOverride(undefined, cwd, "alias", true)).toMatchObject({ changed: true });
+    const raw = JSON.parse(readFileSync(filePath, "utf8"));
+    expect(raw.mcpServers).toBeUndefined();
+    expect(raw["mcp-servers"].alias).toEqual({ command: "node", args: ["server"], disabled: true });
+    expect(loadMcpConfig(undefined, cwd).mcpServers.alias).toMatchObject({ command: "node", args: ["server"], disabled: true });
+  });
+
+  it("preserves malformed project overrides instead of replacing them", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-disabled-malformed-"));
+    const filePath = join(cwd, ".pi", "mcp.json");
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(filePath, "{ malformed");
+
+    expect(() => writeProjectServerDisabledOverride(undefined, cwd, "server", true)).toThrow("Failed to read project MCP override");
+    expect(readFileSync(filePath, "utf8")).toBe("{ malformed");
+  });
+
+  it("initializes all-disabled config without attempting connections or cache bootstrap", async () => {
+    const notify = vi.fn();
+    const state = await initializeMcp({ getFlag: vi.fn() } as any, {
+      cwd: mkdtempSync(join(tmpdir(), "pi-mcp-disabled-init-")),
+      hasUI: true,
+      mode: "tui",
+      ui: { notify, setStatus: vi.fn() },
+      signal: new AbortController().signal,
+    } as any, undefined, { config: { mcpServers: { one: { command: "node", disabled: true } } } });
+
+    expect(notify).toHaveBeenCalledWith("MCP: All 1 server(s) are disabled", "info");
+    expect(state.manager.getAllConnections().size).toBe(0);
+  });
+
+  it("connects only enabled servers during mixed eager initialization", async () => {
+    const connect = vi.spyOn(McpServerManager.prototype, "connect").mockResolvedValue({
+      status: "connected",
+      tools: [],
+      resources: [],
+    } as any);
+    await initializeMcp({ getFlag: vi.fn() } as any, {
+      cwd: mkdtempSync(join(tmpdir(), "pi-mcp-disabled-mixed-")),
+      hasUI: false,
+      mode: "json",
+      signal: new AbortController().signal,
+    } as any, undefined, { config: { mcpServers: {
+      disabled: { command: "node", lifecycle: "eager", disabled: true },
+      enabled: { command: "node", lifecycle: "eager" },
+    } } });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith("enabled", expect.objectContaining({ lifecycle: "eager" }), expect.any(AbortSignal));
+  });
+
+  it("keeps no-theme status usable and reports disabled count", () => {
+    const setStatus = vi.fn();
+    updateStatusBar({
+      ...disabledState(),
+      ui: { setStatus, theme: undefined },
+    });
+    expect(setStatus).toHaveBeenCalledWith("mcp", "MCP: 0/1 servers (1 disabled)");
+  });
+});

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   openMcpAuthPanel: vi.fn(),
   openMcpPanel: vi.fn(),
   openMcpSetup: vi.fn(),
+  writeProjectServerDisabledOverride: vi.fn(() => ({ path: "/tmp/project/.pi/mcp.json", changed: true })),
   executeAuthComplete: vi.fn(),
   executeAuthStart: vi.fn(),
   executeCall: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock("../mcp-auth-flow.ts", () => ({
 vi.mock("../config.ts", () => ({
   loadMcpConfig: mocks.loadMcpConfig,
   cloneMcpConfig: mocks.cloneMcpConfig,
+  writeProjectServerDisabledOverride: mocks.writeProjectServerDisabledOverride,
 }));
 
 vi.mock("../metadata-cache.ts", () => ({
@@ -519,6 +521,7 @@ describe("mcpAdapter session lifecycle", () => {
 
     const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp")?.[1];
     await commandDef.handler("setup", { hasUI: true, ui });
+    await commandDef.handler("disable memory", { hasUI: true, ui });
     await commandDef.handler("status", { hasUI: true, ui });
     const authDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp-auth")?.[1];
     await authDef.handler("", { hasUI: true, ui });
@@ -526,6 +529,7 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.openMcpSetup).not.toHaveBeenCalled();
     expect(mocks.openMcpPanel).not.toHaveBeenCalled();
     expect(mocks.openMcpAuthPanel).not.toHaveBeenCalled();
+    expect(mocks.writeProjectServerDisabledOverride).not.toHaveBeenCalled();
     expect(mocks.showStatus).toHaveBeenCalled();
     expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("in-memory"), "info");
   });
@@ -619,6 +623,8 @@ describe("mcpAdapter session lifecycle", () => {
       "tools",
       "setup",
       "logout",
+      "disable",
+      "enable",
       "status",
     ]);
     expect(commandDef.getArgumentCompletions("st")).toEqual([
@@ -632,6 +638,13 @@ describe("mcpAdapter session lifecycle", () => {
     expect(commandDef.getArgumentCompletions("  logout git")).toEqual([
       { value: "logout github", label: "github" },
       { value: "logout gitlab", label: "gitlab" },
+    ]);
+    expect(commandDef.getArgumentCompletions("disable git")).toEqual([
+      { value: "disable github", label: "github" },
+      { value: "disable gitlab", label: "gitlab" },
+    ]);
+    expect(commandDef.getArgumentCompletions("enable not")).toEqual([
+      { value: "enable notion", label: "notion" },
     ]);
     expect(commandDef.getArgumentCompletions("tools anything")).toBeNull();
     expect(api.registerCommand.mock.calls.some((call: any[]) => call[0] === "mcp-reconnect")).toBe(false);
@@ -676,6 +689,26 @@ describe("mcpAdapter session lifecycle", () => {
     await commandDef.handler("logout oauth-server", { hasUI: true, ui });
 
     expect(mocks.logoutServer).toHaveBeenCalledWith("oauth-server", state, expect.any(Object));
+  });
+
+  it("writes project-local disabled overrides and rejects unknown servers", async () => {
+    const state = createState();
+    state.config.mcpServers = { global: { url: "https://example.test/mcp" } };
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, { hasUI: true, cwd: "/tmp/project", ui: { notify: vi.fn() } });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp")?.[1];
+    const ui = { notify: vi.fn() };
+    await commandDef.handler("disable global", { hasUI: true, cwd: "/tmp/project", ui });
+    expect(mocks.writeProjectServerDisabledOverride).toHaveBeenCalledWith(undefined, "/tmp/project", "global", true);
+    await commandDef.handler("disable missing", { hasUI: true, cwd: "/tmp/project", ui });
+    expect(ui.notify).toHaveBeenCalledWith("Server \"missing\" not found in effective config", "error");
   });
 
   it("shows usage for `/mcp logout` without a server", async () => {

--- a/__tests__/init-status.test.ts
+++ b/__tests__/init-status.test.ts
@@ -19,6 +19,16 @@ describe("updateStatusBar", () => {
     expect(setStatus).toHaveBeenCalledWith("mcp", "MCP: 0/1 servers");
   });
 
+  it("does not count a needs-auth connection as connected", () => {
+    const setStatus = vi.fn();
+    const state = createState({ setStatus, theme: undefined });
+    state.manager.getAllConnections.mockReturnValue(new Map([["demo", { status: "needs-auth" }]]));
+
+    updateStatusBar(state);
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", "MCP: 0/1 servers");
+  });
+
   it("keeps themed status text when a theme is available", () => {
     const setStatus = vi.fn();
     const state = createState({

--- a/__tests__/mcp-panel-auth.test.ts
+++ b/__tests__/mcp-panel-auth.test.ts
@@ -21,7 +21,7 @@ function createCache(config: McpConfig): MetadataCache {
   };
 }
 
-function createCallbacks(status: "connected" | "idle" | "failed" | "needs-auth" = "needs-auth") {
+function createCallbacks(status: "connected" | "idle" | "failed" | "needs-auth" | "disabled" = "needs-auth") {
   let currentStatus = status;
   const callbacks: McpPanelCallbacks = {
     reconnect: vi.fn(async () => {
@@ -80,6 +80,22 @@ describe("mcp-panel auth actions", () => {
     await Promise.resolve();
 
     expect(callbacks.authenticate).toHaveBeenCalledWith("github");
+    panel.dispose();
+  });
+
+  it("ignores the auth shortcut for a disabled server", async () => {
+    const config: McpConfig = {
+      mcpServers: {
+        github: { url: "https://api.githubcopilot.com/mcp", auth: "oauth", disabled: true },
+      },
+    };
+    const callbacks = createCallbacks("disabled");
+    const panel = createMcpPanel(config, createCache(config), new Map(), callbacks, { requestRender: () => {} }, () => {});
+
+    panel.handleInput("\x01");
+    await Promise.resolve();
+
+    expect(callbacks.authenticate).not.toHaveBeenCalled();
     panel.dispose();
   });
 

--- a/commands.ts
+++ b/commands.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import type { McpAuthResult, McpConfig, McpPanelCallbacks, McpPanelResult, ImportKind } from "./types.ts";
+import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCallbacks, type McpPanelResult, type ImportKind } from "./types.ts";
 import {
   ensureCompatibilityImports,
   getMcpDiscoverySummary,
@@ -9,6 +9,7 @@ import {
   previewSharedServerEntry,
   previewStarterProjectConfig,
   writeDirectToolsConfig,
+  writeProjectServerDisabledOverride,
   writeSharedServerEntry,
   writeStarterProjectConfig,
 } from "./config.ts";
@@ -27,6 +28,11 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
   const lines: string[] = ["MCP Server Status:", ""];
 
   for (const name of Object.keys(state.config.mcpServers)) {
+    const definition = state.config.mcpServers[name];
+    if (isServerDisabled(definition)) {
+      lines.push(`⊘ ${name}: disabled (run /mcp enable ${name}, then /reload)`);
+      continue;
+    }
     const connection = state.manager.getConnection(name);
     const metadata = state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
@@ -65,7 +71,9 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
 export async function showTools(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
 
-  const allTools = [...state.toolMetadata.values()].flat().map(m => m.name);
+  const allTools = [...state.toolMetadata.entries()]
+    .filter(([serverName]) => !isServerDisabled(state.config.mcpServers[serverName]))
+    .flatMap(([, metadata]) => metadata.map(m => m.name));
 
   if (allTools.length === 0) {
     ctx.ui.notify("No MCP tools available", "info");
@@ -95,6 +103,10 @@ export async function reconnectServer(
     if (ui) {
       ui.notify(`Server "${name}" not found in config`, "error");
     }
+    return false;
+  }
+  if (isServerDisabled(definition)) {
+    if (ui) ui.notify(`MCP: ${name} is disabled. Run /mcp enable ${name}, then /reload.`, "warning");
     return false;
   }
 
@@ -184,6 +196,11 @@ export async function authenticateServer(
   if (!definition) {
     const message = `Server "${serverName}" not found in config`;
     ui.notify(message, "error");
+    return { ok: false, message };
+  }
+  if (isServerDisabled(definition)) {
+    const message = `Server "${serverName}" is disabled. Run /mcp enable ${serverName}, then /reload.`;
+    ui.notify(message, "warning");
     return { ok: false, message };
   }
 
@@ -361,11 +378,12 @@ function buildMcpPanelCallbacks(
     reconnect: (serverName: string) => reconnectServer(state, ctx, serverName),
     canAuthenticate: (serverName: string) => {
       const definition = config.mcpServers[serverName];
-      return definition ? supportsOAuth(definition) : false;
+      return definition ? !isServerDisabled(definition) && supportsOAuth(definition) : false;
     },
     authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
     getConnectionStatus: (serverName: string) => {
       const definition = config.mcpServers[serverName];
+      if (isServerDisabled(definition)) return "disabled";
       const connection = state.manager.getConnection(serverName);
       if (connection?.status === "needs-auth") {
         return "needs-auth";
@@ -462,7 +480,9 @@ export async function openMcpAuthPanel(
   }
 
   const config = state.config;
-  const oauthServers = Object.entries(config.mcpServers).filter(([, definition]) => supportsOAuth(definition));
+  const oauthServers = Object.entries(config.mcpServers).filter(
+    ([, definition]) => !isServerDisabled(definition) && supportsOAuth(definition),
+  );
   if (oauthServers.length === 0) {
     ctx.ui.notify("No OAuth-capable MCP servers are configured.", "warning");
     return { configChanged: false };

--- a/config.ts
+++ b/config.ts
@@ -591,6 +591,22 @@ export function writeSharedServerEntry(filePath: string, serverName: string, ent
   return filePath;
 }
 
+export function setServerDisabled(overridePath: string | undefined, serverName: string, disabled: boolean): string | null {
+  const userPath = getPiGlobalConfigPath(overridePath);
+  const raw = readRawConfigObject(userPath);
+  const servers = getServersObject(raw);
+  if (!servers[serverName]) return null;
+  if (disabled) {
+    servers[serverName] = { ...servers[serverName], disabled: true };
+  } else {
+    const { disabled: _, ...rest } = servers[serverName];
+    servers[serverName] = rest;
+  }
+  setServersObject(raw, servers);
+  writeRawConfigObject(userPath, raw);
+  return userPath;
+}
+
 export function getServerProvenance(overridePath?: string): Map<string, ServerProvenance> {
   const provenance = new Map<string, ServerProvenance>();
   const userPath = getPiGlobalConfigPath(overridePath);

--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { parse as parseToml } from "smol-toml";
 import { getAgentPath } from "./agent-dir.ts";
-import type { McpConfig, ServerEntry, McpSettings, ImportKind, ServerProvenance } from "./types.ts";
+import { isServerDisabled, type McpConfig, type ServerEntry, type McpSettings, type ImportKind, type ServerProvenance } from "./types.ts";
 import { toStringRecord } from "./utils.ts";
 
 const GENERIC_GLOBAL_CONFIG_PATH = join(homedir(), ".config", "mcp", "mcp.json");
@@ -692,6 +692,79 @@ function getServersObject(raw: Record<string, unknown>): Record<string, ServerEn
 function setServersObject(raw: Record<string, unknown>, servers: Record<string, ServerEntry>): void {
   delete raw["mcp-servers"];
   raw.mcpServers = servers;
+}
+
+export interface ServerDisabledOverrideResult {
+  path: string;
+  changed: boolean;
+}
+
+/**
+ * Persist only the disabled field in the project Pi layer. Enabling writes an
+ * explicit false only when a lower-precedence source is itself disabled; this
+ * writer never copies a server definition or its credentials into the file.
+ */
+export function writeProjectServerDisabledOverride(
+  overridePath: string | undefined,
+  cwd: string,
+  serverName: string,
+  disabled: boolean,
+): ServerDisabledOverrideResult {
+  const filePath = getProjectPiConfigPath(cwd);
+  let raw: Record<string, unknown> = {};
+  if (existsSync(filePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("root value must be an object");
+      }
+      raw = parsed as Record<string, unknown>;
+    } catch (error) {
+      throw new Error(`Failed to read project MCP override at ${filePath}: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
+  }
+
+  const serverKey = raw.mcpServers !== undefined ? "mcpServers" : raw["mcp-servers"] !== undefined ? "mcp-servers" : "mcpServers";
+  const rawServers = raw[serverKey];
+  if (rawServers !== undefined && (!rawServers || typeof rawServers !== "object" || Array.isArray(rawServers))) {
+    throw new Error(`Failed to update project MCP override at ${filePath}: ${serverKey} must be an object`);
+  }
+  const servers = (rawServers ?? {}) as Record<string, unknown>;
+  const previous = servers[serverName];
+  if (previous !== undefined && (!previous || typeof previous !== "object" || Array.isArray(previous))) {
+    throw new Error(`Failed to update project MCP override at ${filePath}: server "${serverName}" must be an object`);
+  }
+  const existing = previous as Record<string, unknown> | undefined;
+
+  let next: Record<string, unknown>;
+  if (disabled) {
+    next = { ...existing, disabled: true };
+  } else {
+    next = Object.fromEntries(Object.entries(existing ?? {}).filter(([key]) => key !== "disabled"));
+    let lowerConfig: McpConfig = { mcpServers: {} };
+    for (const source of getConfigSources(overridePath, cwd)) {
+      if (source.readPath === filePath) continue;
+      const loaded = readValidatedConfig(source.readPath, `MCP config from ${source.readPath}`);
+      if (loaded) lowerConfig = mergeConfigs(lowerConfig, expandImports(loaded, cwd));
+    }
+    if (raw.imports !== undefined) {
+      if (!Array.isArray(raw.imports) || raw.imports.some((kind) => typeof kind !== "string" || !Object.hasOwn(IMPORT_PATHS, kind))) {
+        throw new Error(`Failed to update project MCP override at ${filePath}: imports contains an unsupported config kind`);
+      }
+      lowerConfig = mergeConfigs(lowerConfig, expandImports({ mcpServers: {}, imports: raw.imports as ImportKind[] }, cwd));
+    }
+    if (isServerDisabled(lowerConfig.mcpServers[serverName])) next.disabled = false;
+  }
+
+  if ((!existing && Object.keys(next).length === 0) || JSON.stringify(existing) === JSON.stringify(next)) {
+    return { path: filePath, changed: false };
+  }
+  if (Object.keys(next).length === 0) delete servers[serverName];
+  else servers[serverName] = next;
+
+  raw[serverKey] = servers;
+  writeRawConfigObject(filePath, raw);
+  return { path: filePath, changed: true };
 }
 
 function isRepoPromptServer(name: string, entry: ServerEntry): boolean {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -10,7 +10,7 @@ import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatToolName, isToolExcluded } from "./types.ts";
+import { formatToolName, isServerDisabled, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
@@ -51,7 +51,7 @@ async function attemptDirectAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition || !supportsOAuth(definition)) {
+  if (!definition || isServerDisabled(definition) || !supportsOAuth(definition)) {
     return { status: "skipped" };
   }
 
@@ -135,6 +135,7 @@ export function resolveDirectTools(
   const globalDirect = config.settings?.directTools;
 
   for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
     const serverCache = cache.servers[serverName];
     if (!serverCache || !isServerCacheValid(serverCache, definition)) continue;
 
@@ -217,6 +218,7 @@ export function getMissingConfiguredDirectToolServers(
   const globalDirect = config.settings?.directTools;
 
   for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
     const hasDirectTools = definition.directTools !== undefined
       ? !!definition.directTools
       : !!globalDirect;
@@ -253,8 +255,9 @@ export function buildProxyDescription(
 
   const serverSummaries: string[] = [];
   for (const serverName of Object.keys(config.mcpServers)) {
-    const entry = cache?.servers?.[serverName];
     const definition = config.mcpServers[serverName];
+    if (isServerDisabled(definition)) continue;
+    const entry = cache?.servers?.[serverName];
     const toolCount = (entry?.tools ?? []).filter(
       (tool) => !isToolExcluded(tool.name, serverName, prefix, definition.excludeTools),
     ).length;
@@ -277,8 +280,16 @@ export function buildProxyDescription(
     desc += `\nServers: ${serverSummaries.join(", ")}\n`;
   }
 
+  const disabledServers = Object.entries(config.mcpServers)
+    .filter(([, definition]) => isServerDisabled(definition))
+    .map(([serverName]) => serverName);
+  if (disabledServers.length > 0) {
+    desc += `\nDisabled servers (enable with /mcp enable <server> and /reload): ${disabledServers.join(", ")}\n`;
+  }
+
   const instructionSummaries: string[] = [];
   for (const serverName of Object.keys(config.mcpServers)) {
+    if (isServerDisabled(config.mcpServers[serverName])) continue;
     const instructions = cache?.servers?.[serverName]?.instructions;
     if (!instructions) continue;
     const snippet = truncateAtWord(instructions.replace(/\s+/g, " ").trim(), INSTRUCTIONS_SNIPPET_LENGTH);
@@ -337,6 +348,15 @@ export function createDirectToolExecutor(
       return {
         content: [{ type: "text" as const, text: "MCP not initialized" }],
         details: { error: "not_initialized" },
+      };
+    }
+
+    const definition = state.config.mcpServers[spec.serverName];
+    if (isServerDisabled(definition)) {
+      const message = `MCP server "${spec.serverName}" is disabled. Run /mcp enable ${spec.serverName} and /reload to enable it.`;
+      return {
+        content: [{ type: "text" as const, text: message }],
+        details: { error: "server_disabled", server: spec.serverName, message },
       };
     }
 

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
 import type { McpExtensionState } from "./state.js";
 import { Type } from "typebox";
 import { showStatus, showTools, reconnectServers, authenticateServer, openMcpPanel, openMcpSetup } from "./commands.js";
-import { loadMcpConfig } from "./config.js";
+import { loadMcpConfig, setServerDisabled } from "./config.js";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.js";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js";
 import { loadMetadataCache } from "./metadata-cache.js";
@@ -178,6 +178,32 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         case "tools":
           await showTools(state, ctx);
           break;
+        case "disable": {
+          if (!targetServer) {
+            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp disable <server-name>", "error");
+            break;
+          }
+          const disablePath = setServerDisabled(earlyConfigPath, targetServer, true);
+          if (!disablePath) {
+            if (ctx.hasUI) ctx.ui.notify(`Server "${targetServer}" not found in config`, "error");
+          } else {
+            if (ctx.hasUI) ctx.ui.notify(`Disabled server "${targetServer}" — reload to apply`, "info");
+          }
+          break;
+        }
+        case "enable": {
+          if (!targetServer) {
+            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp enable <server-name>", "error");
+            break;
+          }
+          const enablePath = setServerDisabled(earlyConfigPath, targetServer, false);
+          if (!enablePath) {
+            if (ctx.hasUI) ctx.ui.notify(`Server "${targetServer}" not found in config`, "error");
+          } else {
+            if (ctx.hasUI) ctx.ui.notify(`Enabled server "${targetServer}" — reload to apply`, "info");
+          }
+          break;
+        }
         case "setup": {
           const result = await openMcpSetup(state, pi, ctx, earlyConfigPath, "setup");
           if (result?.configChanged) {

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import type { McpAdapterOptions } from "./types.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
 import { showStatus, showTools, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
-import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
+import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
@@ -216,13 +216,15 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           { value: "tools", label: "tools — List all tools" },
           { value: "setup", label: "setup — Configure MCP servers" },
           { value: "logout", label: "logout — Clear server credentials" },
+          { value: "disable", label: "disable — Disable a server" },
+          { value: "enable", label: "enable — Enable a server" },
           { value: "status", label: "status — Show server status" },
         ].filter(({ value }) => value.startsWith(normalized));
         return subcommands.length > 0 ? subcommands : null;
       }
 
       const [, subcommand, argumentPrefix] = argumentMatch;
-      if ((subcommand !== "reconnect" && subcommand !== "logout") || !state) return null;
+      if ((subcommand !== "reconnect" && subcommand !== "logout" && subcommand !== "disable" && subcommand !== "enable") || !state) return null;
 
       const servers = Object.keys(state.config.mcpServers)
         .filter((serverName) => serverName.startsWith(argumentPrefix.trimStart()))
@@ -293,6 +295,30 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           }
           commandOwner?.throwIfInactive();
           await logoutServer(serverName, state, commandCtx);
+          break;
+        }
+        case "disable":
+        case "enable": {
+          const serverName = rest;
+          if (programmaticConfig) {
+            commandCtx.ui?.notify(`/mcp ${subcommand} is unavailable when config is supplied by createMcpAdapter().`, "info");
+            break;
+          }
+          if (!serverName) {
+            commandCtx.ui?.notify(`Usage: /mcp ${subcommand} <server>`, "error");
+            break;
+          }
+          if (!state.config.mcpServers[serverName]) {
+            commandCtx.ui?.notify(`Server "${serverName}" not found in effective config`, "error");
+            break;
+          }
+          commandOwner?.throwIfInactive();
+          const result = writeProjectServerDisabledOverride(earlyConfigPath, commandCtx.cwd, serverName, subcommand === "disable");
+          if (result.changed) {
+            commandCtx.ui?.notify(`${subcommand === "disable" ? "Disabled" : "Enabled"} server "${serverName}" in ${result.path} — run /reload to apply`, "info");
+          } else {
+            commandCtx.ui?.notify(`Server "${serverName}" is already ${subcommand === "disable" ? "disabled" : "enabled"}`, "info");
+          }
           break;
         }
         case "status":

--- a/init.ts
+++ b/init.ts
@@ -64,8 +64,14 @@ export async function initializeMcp(
     sendMessage: (message, options) => pi.sendMessage(message, options),
   };
 
-  const serverEntries = Object.entries(config.mcpServers);
+  const serverEntries = Object.entries(config.mcpServers).filter(
+    ([, definition]) => !definition.disabled
+  );
   if (serverEntries.length === 0) {
+    const totalServers = Object.keys(config.mcpServers).length;
+    if (totalServers > 0 && ctx.hasUI) {
+      ctx.ui.notify(`MCP: All ${totalServers} server(s) are disabled`, "info");
+    }
     return state;
   }
 
@@ -269,13 +275,20 @@ export function flushMetadataCache(state: McpExtensionState): void {
 export function updateStatusBar(state: McpExtensionState): void {
   const ui = state.ui;
   if (!ui) return;
-  const total = Object.keys(state.config.mcpServers).length;
+  const allServers = Object.entries(state.config.mcpServers);
+  const total = allServers.length;
   if (total === 0) {
     ui.setStatus("mcp", undefined);
     return;
   }
+  const disabledCount = allServers.filter(([, def]) => def.disabled).length;
   const connectedCount = state.manager.getAllConnections().size;
-  ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`));
+  const activeTotal = total - disabledCount;
+  let status = `MCP: ${connectedCount}/${activeTotal} servers`;
+  if (disabledCount > 0) {
+    status += ` (${disabledCount} disabled)`;
+  }
+  ui.setStatus("mcp", ui.theme.fg("accent", status));
 }
 
 export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import type { McpAdapterOptions, ToolMetadata } from "./types.ts";
+import { isServerDisabled, type McpAdapterOptions, type ToolMetadata } from "./types.ts";
 import { existsSync } from "node:fs";
 import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
@@ -170,8 +170,12 @@ export async function initializeMcp(
     }
   });
 
-  const serverEntries = Object.entries(config.mcpServers);
+  const allServerEntries = Object.entries(config.mcpServers);
+  const serverEntries = allServerEntries.filter(([, definition]) => !isServerDisabled(definition));
   if (serverEntries.length === 0) {
+    if (allServerEntries.length > 0 && hasUI) {
+      ui?.notify(`MCP: All ${allServerEntries.length} server(s) are disabled`, "info");
+    }
     return state;
   }
 
@@ -359,6 +363,7 @@ export async function initializeMcp(
 
 export function markKeepAliveAfterConnect(state: McpExtensionState, serverName: string): void {
   const definition = state.config.mcpServers[serverName];
+  if (isServerDisabled(definition)) return;
   if ((definition?.lifecycle ?? "lazy") === "lazy-keep-alive") {
     state.lifecycle.markKeepAlive(serverName, definition);
   }
@@ -370,6 +375,11 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
 
   const definition = state.config.mcpServers[serverName];
   if (!definition) return;
+  if (isServerDisabled(definition)) {
+    state.toolMetadata.delete(serverName);
+    state.serverInstructions.delete(serverName);
+    return;
+  }
 
   const prefix = state.config.settings?.toolPrefix ?? "server";
 
@@ -387,7 +397,7 @@ export function updateMetadataCache(state: McpExtensionState, serverName: string
   if (!connection || connection.status !== "connected") return;
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition) return;
+  if (!definition || isServerDisabled(definition)) return;
 
   const configHash = computeServerHash(definition);
   const existing = loadMetadataCache();
@@ -427,13 +437,19 @@ export function flushMetadataCache(state: McpExtensionState): void {
 export function updateStatusBar(state: McpExtensionState): void {
   const ui = state.ui;
   if (!ui) return;
-  const total = Object.keys(state.config.mcpServers).length;
-  if (total === 0) {
+  const entries = Object.entries(state.config.mcpServers);
+  const disabledCount = entries.filter(([, definition]) => isServerDisabled(definition)).length;
+  const enabledCount = entries.length - disabledCount;
+  if (entries.length === 0) {
     ui.setStatus("mcp", undefined);
     return;
   }
-  const connectedCount = state.manager.getAllConnections().size;
-  const status = `MCP: ${connectedCount}/${total} servers`;
+  const connectedCount = [...state.manager.getAllConnections()].filter(([name, connection]) => {
+    const definition = state.config.mcpServers[name];
+    return connection.status === "connected" && definition !== undefined && !isServerDisabled(definition);
+  }).length;
+  let status = `MCP: ${connectedCount}/${enabledCount} servers`;
+  if (disabledCount > 0) status += ` (${disabledCount} disabled)`;
   ui.setStatus("mcp", ui.theme ? ui.theme.fg("accent", status) : status);
 }
 
@@ -467,7 +483,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
   if (failedAgo !== null) return false;
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition) return false;
+  if (!definition || isServerDisabled(definition)) return false;
 
   try {
     if (state.ui) {

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -1,4 +1,4 @@
-import type { ServerDefinition } from "./types.ts";
+import { isServerDisabled, type ServerDefinition } from "./types.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import { hasPendingAuth } from "./mcp-auth-flow.ts";
 import { logger } from "./logger.ts";
@@ -36,10 +36,12 @@ export class McpLifecycleManager {
   }
 
   markKeepAlive(name: string, definition: ServerDefinition): void {
+    if (isServerDisabled(definition)) return;
     this.keepAliveServers.set(name, definition);
   }
 
   registerServer(name: string, definition: ServerDefinition, settings?: { idleTimeout?: number }): void {
+    if (isServerDisabled(definition)) return;
     this.allServers.set(name, definition);
     if (settings?.idleTimeout !== undefined) this.serverSettings.set(name, settings);
   }
@@ -86,6 +88,7 @@ export class McpLifecycleManager {
   private async checkConnections(signal?: AbortSignal): Promise<void> {
     if (this.stopped || signal?.aborted) return;
     for (const [name, definition] of this.keepAliveServers) {
+      if (isServerDisabled(definition)) continue;
       const connection = this.manager.getConnection(name);
       if (!connection || connection.status !== "connected") {
         if (this.hasPendingAuthForServer(name)) {

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -33,7 +33,7 @@ import {
   type AuthStorageOptions,
   type StoredTokens,
 } from "./mcp-auth.ts"
-import type { ServerEntry } from "./types.ts"
+import { isServerDisabled, type ServerEntry } from "./types.ts"
 import { formatTerminalError, interpolateEnvRecord, interpolateEnvVars } from "./utils.ts"
 import { abortable, throwIfAborted } from "./abort.ts"
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts"
@@ -273,6 +273,7 @@ export async function startAuth(
   definition?: ServerEntry,
   options: AuthenticateOptions = {},
 ): Promise<{ authorizationUrl: string }> {
+  if (isServerDisabled(definition)) throw new Error(`MCP server "${serverName}" is disabled`)
   const runtime = getRuntime(options)
   const runtimeState = getRuntimeState(runtime)
   const config = definition ? extractOAuthConfig(definition) : {}
@@ -575,6 +576,7 @@ export async function authenticate(
   definition?: ServerEntry,
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
+  if (isServerDisabled(definition)) throw new Error(`MCP server "${serverName}" is disabled`)
   const runtime = getRuntime(options)
   const runtimeState = getRuntimeState(runtime)
   const authStorageOptions = options.authStorageOptions ?? {}

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,7 +1,7 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { copyToClipboard } from "@earendil-works/pi-coding-agent";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
-import { isToolExcluded } from "./types.ts";
+import { isServerDisabled, isToolExcluded } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { sanitizeTerminalText, stripOscSequences } from "./utils.ts";
@@ -114,7 +114,7 @@ function estimateTokens(tool: CachedTool): number {
   return Math.ceil((tool.name.length + descLen + schemaLen) / 4) + 10;
 }
 
-type ConnectionStatus = "connected" | "idle" | "failed" | "needs-auth" | "connecting";
+type ConnectionStatus = "connected" | "idle" | "failed" | "needs-auth" | "connecting" | "disabled";
 
 interface ToolState {
   name: string;
@@ -196,7 +196,7 @@ class McpPanel {
       }
 
       const tools: ToolState[] = [];
-      if (serverCache && !this.authOnly) {
+      if (serverCache && !this.authOnly && !isServerDisabled(definition)) {
         for (const tool of serverCache.tools ?? []) {
           if (isToolExcluded(tool.name, serverName, this.prefix, definition.excludeTools)) {
             continue;
@@ -421,6 +421,7 @@ class McpPanel {
       if (!item) return;
       const server = this.servers[item.serverIndex];
       if (item.type === "server") {
+        if (server.connectionStatus === "disabled") return;
         if (this.authOnly || server.connectionStatus === "needs-auth") {
           this.authenticateServer(server);
           return;
@@ -504,7 +505,7 @@ class McpPanel {
 
   private authenticateServer(server: ServerState): void {
     if (this.authInFlight) return;
-    if (server.connectionStatus === "connecting") return;
+    if (server.connectionStatus === "connecting" || server.connectionStatus === "disabled") return;
     const serverName = sanitizeDisplayText(server.name);
     if (!this.callbacks.canAuthenticate(server.name)) {
       this.authNotice = `${serverName} does not use OAuth authentication.`;
@@ -539,7 +540,7 @@ class McpPanel {
   }
 
   private reconnectServer(server: ServerState, options: { afterAuth?: boolean } = {}): void {
-    if (server.connectionStatus === "connecting") return;
+    if (server.connectionStatus === "connecting" || server.connectionStatus === "disabled") return;
     const serverName = sanitizeDisplayText(server.name);
     server.connectionStatus = "connecting";
     this.tui.requestRender();
@@ -908,6 +909,7 @@ class McpPanel {
   private renderConnectionStatus(server: ServerState): string {
     const t = this.t;
     if (this.authInFlight === server.name) return `  ${fg(t.needsAuth, "authenticating")}`;
+    if (server.connectionStatus === "disabled") return `  ${fg(t.description, "disabled")}`;
     if (server.connectionStatus === "needs-auth") return `  ${fg(t.needsAuth, "needs auth")}`;
     if (server.connectionStatus === "connecting") return `  ${fg(t.needsAuth, "connecting")}`;
     if (server.connectionStatus === "failed") return `  ${fg(t.cancel, "failed")}`;

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -3,7 +3,7 @@ import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js"
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
-import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
+import { getServerPrefix, isServerDisabled, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, markKeepAliveAfterConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
@@ -30,6 +30,14 @@ type AutoAuthResult =
   | { status: "skipped" }
   | { status: "success" }
   | { status: "failed"; message: string };
+
+function disabledResult(mode: string, serverName: string): ProxyToolResult {
+  const message = `Server "${serverName}" is disabled. Run /mcp enable ${serverName} and /reload to enable it.`;
+  return {
+    content: [{ type: "text" as const, text: message }],
+    details: { mode, error: "server_disabled", server: serverName, message },
+  };
+}
 
 function getAuthRequiredMessage(
   state: McpExtensionState,
@@ -89,7 +97,7 @@ async function attemptAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition || !supportsOAuth(definition)) {
+  if (!definition || isServerDisabled(definition) || !supportsOAuth(definition)) {
     return { status: "skipped" };
   }
 
@@ -223,32 +231,42 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 }
 
 export function executeStatus(state: McpExtensionState): ProxyToolResult {
-  const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null }> = [];
+  const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null; disabled?: boolean }> = [];
 
   for (const name of Object.keys(state.config.mcpServers)) {
-    const connection = state.manager.getConnection(name);
-    const metadata = state.toolMetadata.get(name);
+    const definition = state.config.mcpServers[name];
+    const disabled = isServerDisabled(definition);
+    const connection = disabled ? undefined : state.manager.getConnection(name);
+    const metadata = disabled ? undefined : state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
-    const failedAgo = getFailureAgeSeconds(state, name);
-    let status = "not connected";
-    if (connection?.status === "connected") {
+    const failedAgo = disabled ? null : getFailureAgeSeconds(state, name);
+    let status = disabled ? "disabled" : "not connected";
+    if (!disabled && connection?.status === "connected") {
       status = "connected";
-    } else if (connection?.status === "needs-auth") {
+    } else if (!disabled && connection?.status === "needs-auth") {
       status = "needs-auth";
-    } else if (failedAgo !== null) {
+    } else if (!disabled && failedAgo !== null) {
       status = "failed";
-    } else if (metadata !== undefined) {
+    } else if (!disabled && metadata !== undefined) {
       status = "cached";
     }
 
-    servers.push({ name, status, toolCount, failedAgo });
+    servers.push({ name, status, toolCount, failedAgo, ...(disabled ? { disabled: true } : {}) });
   }
 
-  const totalTools = servers.reduce((sum, s) => sum + s.toolCount, 0);
-  const connectedCount = servers.filter(s => s.status === "connected").length;
+  const disabledCount = servers.filter(s => s.disabled).length;
+  const enabledServers = servers.filter(s => !s.disabled);
+  const totalTools = enabledServers.reduce((sum, s) => sum + s.toolCount, 0);
+  const connectedCount = enabledServers.filter(s => s.status === "connected").length;
 
-  let text = `MCP: ${connectedCount}/${servers.length} servers, ${totalTools} tools\n\n`;
+  let text = `MCP: ${connectedCount}/${enabledServers.length} servers, ${totalTools} tools`;
+  if (disabledCount > 0) text += ` (${disabledCount} disabled)`;
+  text += "\n\n";
   for (const server of servers) {
+    if (server.disabled) {
+      text += `⊘ ${server.name} (disabled)\n`;
+      continue;
+    }
     if (server.status === "connected") {
       text += `✓ ${server.name} (${server.toolCount} tools)\n`;
       continue;
@@ -274,7 +292,7 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "status", servers, totalTools, connectedCount },
+    details: { mode: "status", servers, totalTools, connectedCount, disabledCount },
   };
 }
 
@@ -288,6 +306,7 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
       details: { mode: "auth-start", error: "not_found", server: serverName },
     };
   }
+  if (isServerDisabled(definition)) return disabledResult("auth-start", serverName);
 
   try {
     const serverUrl = resolveServerUrl(definition);
@@ -328,12 +347,14 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
 export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string, signal?: AbortSignal): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
-  if (!state.config.mcpServers[serverName]) {
+  const definition = state.config.mcpServers[serverName];
+  if (!definition) {
     return {
       content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "auth-complete", error: "not_found", server: serverName },
     };
   }
+  if (isServerDisabled(definition)) return disabledResult("auth-complete", serverName);
 
   try {
     const status = state.authStorageOptions
@@ -369,17 +390,22 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
 export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
   let serverName: string | undefined;
   let toolMeta: ToolMetadata | undefined;
+  let disabledMatch: string | undefined;
 
   for (const [server, metadata] of state.toolMetadata.entries()) {
     const found = findToolByName(metadata, toolName);
-    if (found) {
-      serverName = server;
-      toolMeta = found;
-      break;
+    if (!found) continue;
+    if (isServerDisabled(state.config.mcpServers[server])) {
+      disabledMatch ??= server;
+      continue;
     }
+    serverName = server;
+    toolMeta = found;
+    break;
   }
 
   if (!serverName || !toolMeta) {
+    if (disabledMatch) return disabledResult("describe", disabledMatch);
     return {
       content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.` }],
       details: { mode: "describe", error: "tool_not_found", requestedTool: toolName },
@@ -415,6 +441,7 @@ export function executeSearch(
   includeSchemas?: boolean,
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
+  if (server && isServerDisabled(state.config.mcpServers[server])) return disabledResult("search", server);
 
   const matches: Array<{ server: string; tool: ToolMetadata }> = [];
 
@@ -465,6 +492,7 @@ export function executeSearch(
   }
 
   for (const [serverName, metadata] of state.toolMetadata.entries()) {
+    if (isServerDisabled(state.config.mcpServers[serverName])) continue;
     if (server && serverName !== server) continue;
     for (const tool of metadata) {
       if (pattern.test(tool.name) || pattern.test(tool.description)) {
@@ -521,12 +549,14 @@ export function executeSearch(
 }
 
 export function executeList(state: McpExtensionState, server: string): ProxyToolResult {
-  if (!state.config.mcpServers[server]) {
+  const definition = state.config.mcpServers[server];
+  if (!definition) {
     return {
       content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "list", server, tools: [], count: 0, error: "not_found" },
     };
   }
+  if (isServerDisabled(definition)) return disabledResult("list", server);
 
   const metadata = state.toolMetadata.get(server);
   const toolNames = metadata?.map(m => m.name) ?? [];
@@ -587,12 +617,14 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
 }
 
 export function executeInstructions(state: McpExtensionState, server: string): ProxyToolResult {
-  if (!state.config.mcpServers[server]) {
+  const definition = state.config.mcpServers[server];
+  if (!definition) {
     return {
       content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "instructions", server, error: "not_found" },
     };
   }
+  if (isServerDisabled(definition)) return disabledResult("instructions", server);
 
   const instructions = state.serverInstructions.get(server);
   if (instructions) {
@@ -626,6 +658,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       details: { mode: "connect", error: "not_found", server: serverName },
     };
   }
+  if (isServerDisabled(definition)) return disabledResult("connect", serverName);
 
   try {
     if (state.ui) {
@@ -702,18 +735,26 @@ export async function executeCall(
       details: { mode: "call", error: "server_not_found", server: serverName },
     };
   }
+  if (serverName && isServerDisabled(state.config.mcpServers[serverName])) {
+    return disabledResult("call", serverName);
+  }
 
   if (serverName) {
     toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
   } else {
+    let disabledMatch: string | undefined;
     for (const [server, metadata] of state.toolMetadata.entries()) {
       const found = findToolByName(metadata, toolName);
-      if (found) {
-        serverName = server;
-        toolMeta = found;
-        break;
+      if (!found) continue;
+      if (isServerDisabled(state.config.mcpServers[server])) {
+        disabledMatch ??= server;
+        continue;
       }
+      serverName = server;
+      toolMeta = found;
+      break;
     }
+    if (!toolMeta && disabledMatch) return disabledResult("call", disabledMatch);
   }
 
   if (serverName && !toolMeta) {
@@ -773,6 +814,7 @@ export async function executeCall(
 
   if (!serverName && !toolMeta && prefixMode !== "none") {
     const candidates = Object.keys(state.config.mcpServers)
+      .filter(name => !isServerDisabled(state.config.mcpServers[name]))
       .map(name => ({ name, prefix: getServerPrefix(name, prefixMode) }))
       .filter(c => c.prefix && toolName.startsWith(c.prefix + "_"))
       .sort((a, b) => b.prefix.length - a.prefix.length);
@@ -932,6 +974,10 @@ export async function executeCall(
         details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", message },
       };
     }
+  }
+
+  if (isServerDisabled(state.config.mcpServers[serverName])) {
+    return disabledResult("call", serverName);
   }
 
   let uiSession: UiSessionRuntime | null = null;

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -9,14 +9,15 @@ import {
   type ReadResourceResult,
   type UrlElicitationRequiredError,
 } from "@modelcontextprotocol/sdk/types.js";
-import type {
-  McpTool,
-  McpResource,
-  ServerDefinition,
-  ServerStreamResultPatchNotification,
-  Transport,
+import {
+  isServerDisabled,
+  type McpTool,
+  type McpResource,
+  type ServerDefinition,
+  type ServerStreamResultPatchNotification,
+  type Transport,
+  serverStreamResultPatchNotificationSchema,
 } from "./types.ts";
-import { serverStreamResultPatchNotificationSchema } from "./types.ts";
 import { resolveNpxBinary } from "./npx-resolver.ts";
 import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
@@ -151,6 +152,7 @@ export class McpServerManager {
   }
 
   async connect(name: string, definition: ServerDefinition, signal?: AbortSignal): Promise<ServerConnection> {
+    if (isServerDisabled(definition)) throw new Error(`MCP server "${name}" is disabled`);
     if (this.stopped) throw new Error("MCP server manager is closed");
     const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
     throwIfAborted(ownedSignal);
@@ -206,6 +208,7 @@ export class McpServerManager {
     staleConnection: ServerConnection,
     signal?: AbortSignal,
   ): Promise<ServerConnection> {
+    if (isServerDisabled(definition)) throw new Error(`MCP server "${name}" is disabled`);
     if (this.stopped) throw new Error("MCP server manager is closed");
     const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
     throwIfAborted(ownedSignal);
@@ -636,6 +639,9 @@ export class McpServerManager {
   }
 
   async readResource(name: string, uri: string, signal?: AbortSignal): Promise<ReadResourceResult> {
+    if (isServerDisabled(this.connections.get(name)?.definition)) {
+      throw new Error(`MCP server "${name}" is disabled`);
+    }
     const connection = this.connections.get(name);
     if (!connection || connection.status !== "connected") {
       throw new Error(`Server "${name}" is not connected`);

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -24,7 +24,7 @@ import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamable
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "./logger.ts";
 import { throwIfAborted } from "./abort.ts";
-import type { McpConfig } from "./types.ts";
+import { isServerDisabled, type McpConfig } from "./types.ts";
 import type { McpServerManager, ServerConnection } from "./server-manager.ts";
 
 /**
@@ -95,6 +95,9 @@ export async function withSessionRecovery<T>(
   serverName: string,
   fn: (conn: ServerConnection) => Promise<T>,
 ): Promise<T> {
+  if (isServerDisabled(deps.config.mcpServers[serverName])) {
+    throw new Error(`MCP server "${serverName}" is disabled`);
+  }
   const connection = deps.manager.getConnection(serverName);
   if (!connection) {
     throw new Error(`Server "${serverName}" is not connected`);

--- a/types.ts
+++ b/types.ts
@@ -309,6 +309,8 @@ export interface ServerEntry {
   excludeTools?: string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
+  // Disable server without removing config
+  disabled?: boolean;
 }
 
 // Settings

--- a/types.ts
+++ b/types.ts
@@ -312,6 +312,13 @@ export interface ServerEntry {
   excludeTools?: string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
+  // Keep configuration visible without allowing connections or execution.
+  disabled?: boolean;
+}
+
+/** Only the literal boolean `true` disables a server. */
+export function isServerDisabled(definition: ServerEntry | undefined): boolean {
+  return definition?.disabled === true;
 }
 
 // Output guard tuning (settings.outputGuard object form)
@@ -412,7 +419,7 @@ export interface McpPanelCallbacks {
   reconnect: (serverName: string) => Promise<boolean>;
   canAuthenticate: (serverName: string) => boolean;
   authenticate: (serverName: string) => Promise<McpAuthResult>;
-  getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth";
+  getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth" | "disabled";
   getFailureMessage?: (serverName: string) => string | null;
   refreshCacheAfterReconnect: (serverName: string) => import("./metadata-cache.ts").ServerCacheEntry | null;
 }

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -4,7 +4,7 @@ import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import type { McpServerManager } from "./server-manager.ts";
-import type { McpConfig, UiResourceContent, UiResourceCsp, UiResourceMeta } from "./types.ts";
+import { isServerDisabled, type McpConfig, type UiResourceContent, type UiResourceCsp, type UiResourceMeta } from "./types.ts";
 
 interface ResourceContentRecord {
   uri?: string;
@@ -37,6 +37,9 @@ export class UiResourceHandler {
     let result: ReadResourceResult;
     try {
       const config = options.config ?? this.config;
+      if (config && isServerDisabled(config.mcpServers[serverName])) {
+        throw new Error(`MCP server "${serverName}" is disabled`);
+      }
       if (config) {
         this.manager.touch(serverName);
         this.manager.incrementInFlight(serverName);

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -17,6 +17,7 @@ import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionReco
 import {
   extractUiPromptText,
   getVisualizationStreamEnvelope,
+  isServerDisabled,
   type McpConfig,
   type UiDisplayMode,
   type UiDisplayModeRequest,
@@ -347,6 +348,10 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         const connection = options.manager.getConnection(options.serverName);
         if (!connection || connection.status !== "connected") {
           sendJson(res, 503, { ok: false, error: `Server "${options.serverName}" is not connected` });
+          return;
+        }
+        if (isServerDisabled(options.config?.mcpServers[options.serverName]) || isServerDisabled(connection.definition)) {
+          sendJson(res, 503, { ok: false, error: `Server "${options.serverName}" is disabled` });
           return;
         }
 


### PR DESCRIPTION
## Problem

Currently, there is no way to temporarily disable an MCP server without completely removing it from `mcp.json`. Users who want to temporarily turn off servers (e.g., to save resources or debug) must manually edit JSON, remove entries, and re-add them later.

## Solution

Add a `disabled?: boolean` field to the `ServerEntry` type. When `disabled: true`, the server is skipped during initialization but its configuration is preserved.

### Changes

1. **`types.ts`** — Added `disabled?: boolean` to `ServerEntry`
2. **`init.ts`** — Filter out disabled servers during `initializeMcp()`; show notification when all servers are disabled; show disabled count in status bar
3. **`config.ts`** — Added `setServerDisabled()` function to toggle the flag in `mcp.json`
4. **`index.ts`** — Added `/mcp disable <server>` and `/mcp enable <server>` subcommands
5. **`README.md`** — Documented the new config option and commands

### Usage

**Via commands:**
```
/mcp disable godot     # Disable server, /reload to apply
/mcp enable godot      # Re-enable server, /reload to apply
```

**Via config (mcp.json):**
```json
{
  "mcpServers": {
    "godot": {
      "command": "node",
      "args": ["..."],
      "disabled": true
    }
  }
}
```

### Status bar

When servers are disabled, the status bar shows: `MCP: 2/3 servers (1 disabled)`

### Tests

- All 25/27 existing test suites pass (2 pre-existing failures unrelated to this change)
- 229/231 tests pass