### PR TITLE
feat: Add configurable MCP tool timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added global and per-server `toolTimeoutMs` settings to configure MCP tool call request timeouts.
+
 ## [2.6.0] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Pi-specific files are the write targets for imported or shared global servers wh
       "command": "npx",
       "args": ["-y", "some-mcp-server"],
       "lifecycle": "lazy",
-      "idleTimeout": 10
+      "idleTimeout": 10,
+      "toolTimeoutMs": 600000
     }
   }
 }
@@ -129,6 +130,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
+| `toolTimeoutMs` | MCP tool call request timeout in milliseconds (overrides global) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
@@ -146,7 +148,8 @@ Pi-specific files are the write targets for imported or shared global servers wh
 {
   "settings": {
     "toolPrefix": "server",
-    "idleTimeout": 10
+    "idleTimeout": 10,
+    "toolTimeoutMs": 600000
   },
   "mcpServers": { }
 }
@@ -156,13 +159,14 @@ Pi-specific files are the write targets for imported or shared global servers wh
 |---------|-------------|
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
+| `toolTimeoutMs` | Global MCP tool call request timeout in milliseconds (defaults to MCP SDK timeout) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
 | `samplingAutoApprove` | Skip sampling confirmation prompts. Required for sampling in non-UI sessions (default: false). |
 
-Per-server `idleTimeout` overrides the global setting.
+Per-server `idleTimeout` and `toolTimeoutMs` override the global settings.
 
 ### Direct Tools
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -457,6 +457,44 @@ describe("UiServer", () => {
       });
     });
 
+    it("passes configured tool timeout to MCP calls", async () => {
+      const mockClient = {
+        callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "tool result" }] }),
+      };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
+      });
+      handle = await startUiServer(createServerOptions({
+        manager,
+        config: {
+          settings: { toolTimeoutMs: 120000 },
+          mcpServers: {
+            "test-server": {
+              toolTimeoutMs: 600000,
+            },
+          },
+        },
+      }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "some_tool", arguments: { arg1: "value1" } },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        {
+          name: "some_tool",
+          arguments: { arg1: "value1" },
+        },
+        undefined,
+        { timeout: 600000 },
+      );
+    });
+
     it("checks consent before calling tool", async () => {
       const consentManager = createMockConsentManager({
         ensureApproved: vi.fn().mockImplementation(() => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -10,7 +10,7 @@ import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage } from "./utils.ts";
+import { formatAuthRequiredMessage, getToolRequestTimeoutMs } from "./utils.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 
@@ -367,11 +367,16 @@ export function createDirectToolExecutor(
           })
         : null;
 
-      const resultPromise = connection.client.callTool({
+      const callParams = {
         name: spec.originalName,
         arguments: params ?? {},
         _meta: uiSession?.requestMeta,
-      });
+      };
+      const requestTimeoutMs = getToolRequestTimeoutMs(state.config, spec.serverName);
+      const resultPromise =
+        requestTimeoutMs === undefined
+          ? connection.client.callTool(callParams)
+          : connection.client.callTool(callParams, undefined, { timeout: requestTimeoutMs });
 
       const result = await resultPromise;
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -6,7 +6,7 @@ import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSe
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
-import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, getToolRequestTimeoutMs, truncateAtWord } from "./utils.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
@@ -716,11 +716,16 @@ export async function executeCall(
         })
       : null;
 
-    const resultPromise = connection.client.callTool({
+    const callParams = {
       name: toolMeta.originalName,
       arguments: args ?? {},
       _meta: uiSession?.requestMeta,
-    });
+    };
+    const requestTimeoutMs = getToolRequestTimeoutMs(state.config, serverName);
+    const resultPromise =
+      requestTimeoutMs === undefined
+        ? connection.client.callTool(callParams)
+        : connection.client.callTool(callParams, undefined, { timeout: requestTimeoutMs });
 
     if (toolMeta.uiResourceUri) {
       const result = await resultPromise;

--- a/types.ts
+++ b/types.ts
@@ -301,6 +301,7 @@ export interface ServerEntry {
   oauth?: OAuthConfig | false;
   lifecycle?: "keep-alive" | "lazy" | "eager";
   idleTimeout?: number; // minutes, overrides global setting
+  toolTimeoutMs?: number; // MCP request timeout in milliseconds, overrides global setting
   // Resource handling
   exposeResources?: boolean;
   // Direct tool registration
@@ -315,6 +316,7 @@ export interface ServerEntry {
 export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
   idleTimeout?: number; // minutes, default 10, 0 to disable
+  toolTimeoutMs?: number; // MCP request timeout in milliseconds, default SDK timeout
   directTools?: boolean;
   disableProxyTool?: boolean;
   autoAuth?: boolean;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -28,6 +28,8 @@ import {
   type UiSessionMessages,
   type UiStreamSummary,
 } from "./types.ts";
+import type { McpConfig } from "./types.ts";
+import { getToolRequestTimeoutMs } from "./utils.ts";
 
 const MAX_BODY_SIZE = 2 * 1024 * 1024;
 const ABANDONED_GRACE_MS = 60_000;
@@ -41,6 +43,7 @@ export interface UiServerOptions {
   resource: UiResourceContent;
   manager: McpServerManager;
   consentManager: ConsentManager;
+  config?: McpConfig;
   hostContext?: UiHostContext;
   initialResultPromise?: Promise<CallToolResult>;
   sessionToken?: string;
@@ -340,13 +343,18 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         try {
           options.manager.touch(options.serverName);
           options.manager.incrementInFlight(options.serverName);
-          const result = await connection.client.callTool({
+          const mcpCallParams = {
             name: callParams.name,
             arguments:
               callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
                 ? callParams.arguments
                 : {},
-          });
+          };
+          const requestTimeoutMs = getToolRequestTimeoutMs(options.config, options.serverName);
+          const result =
+            requestTimeoutMs === undefined
+              ? await connection.client.callTool(mcpCallParams)
+              : await connection.client.callTool(mcpCallParams, undefined, { timeout: requestTimeoutMs });
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -212,6 +212,7 @@ export async function maybeStartUiSession(
       resource,
       manager: state.manager,
       consentManager: state.consentManager,
+      config: state.config,
       hostContext,
 
       onMessage: (params: UiMessageParams) => {

--- a/utils.ts
+++ b/utils.ts
@@ -115,6 +115,14 @@ export function formatAuthRequiredMessage(
   return template ? template.replaceAll("${server}", serverName) : defaultMessage;
 }
 
+export function getToolRequestTimeoutMs(config: McpConfig | undefined, serverName: string): number | undefined {
+  const serverTimeout = config?.mcpServers[serverName]?.toolTimeoutMs;
+  if (typeof serverTimeout === "number") return serverTimeout;
+
+  const globalTimeout = config?.settings?.toolTimeoutMs;
+  return typeof globalTimeout === "number" ? globalTimeout : undefined;
+}
+
 /**
  * Extract the adapter-owned UI stream mode from tool metadata.
  */


### PR DESCRIPTION
## Summary
- add global and per-server `toolTimeoutMs` configuration support
- pass the resolved timeout through direct-tool, proxy-tool, and UI-initiated MCP tool calls
- document the new setting and add a regression test for the UI server path

## Why
Some MCP tools legitimately run longer than the SDK default timeout. The adapter did not expose a way to tune request timeouts, so those tools could fail even when the server was behaving correctly.

## Impact
Users can now configure `toolTimeoutMs` globally under `settings` or override it per server under `mcpServers.<name>`. Per-server values take precedence over the global default.

## Root Cause
The adapter always called `client.callTool(...)` without a timeout override, so every tool execution path was locked to the SDK default request timeout.

## Validation
- `npx vitest run __tests__/ui-server.test.ts __tests__/proxy-modes-auto-auth.test.ts __tests__/direct-tools-auto-auth.test.ts`