### PR TITLE
Support OAuth client metadata overrides

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -73,6 +73,8 @@ You can optionally provide a pre-registered client:
 - `oauth.clientId` - Pre-registered client ID (optional, SDK tries dynamic registration if not provided)
 - `oauth.clientSecret` - Client secret for confidential clients (optional)
 - `oauth.scope` - Requested OAuth scopes (optional)
+- `oauth.clientName` - Override dynamic registration `client_name` metadata (optional)
+- `oauth.clientUri` - Override dynamic registration `client_uri` metadata (optional)
 
 ### Non-Interactive `client_credentials`
 
@@ -168,15 +170,17 @@ If no `clientId` is provided, the SDK:
 
 1. Discovers the registration endpoint from OAuth metadata
 2. Registers a new client with:
-   - `client_name`: "Pi Coding Agent"
-   - `redirect_uris`: `["http://localhost:<active-callback-port>/callback"]`
+   - `client_name`: `oauth.clientName` or "Pi Coding Agent"
+   - `client_uri`: `oauth.clientUri` or the pi-mcp-adapter repository URL
+   - `redirect_uris`: `["http://127.0.0.1:<active-callback-port>/callback"]` by default
    - `grant_types`: `["authorization_code", "refresh_token"]`
 3. Stores the registered client credentials
 
 ### Callback Server
 
-A Node.js HTTP server runs on `localhost` at path `/callback`:
+A Node.js HTTP server runs on `127.0.0.1` at path `/callback` by default:
 
+- Preferred callback host is `127.0.0.1` (or `MCP_OAUTH_CALLBACK_HOST` if set)
 - Preferred callback port is `19876` (or `MCP_OAUTH_CALLBACK_PORT` if set)
 - For dynamic registration, if the preferred port is busy, the adapter scans forward for a free local port
 - For pre-registered clients (`oauth.clientId`), the adapter requires the exact configured callback port
@@ -269,7 +273,7 @@ Some servers require pre-registered clients. Obtain a client ID from your OAuth 
 
 For dynamic registration, if the preferred callback port is busy, the adapter scans for the next available local port.
 
-For pre-registered OAuth clients (`oauth.clientId`), the callback redirect URI must match exactly. In that case, free the configured port or set `MCP_OAUTH_CALLBACK_PORT` to the registered port. For clients registered like Slack MCP's Claude-compatible `http://localhost:3118/callback`, set `MCP_OAUTH_CALLBACK_PORT=3118`.
+For pre-registered OAuth clients (`oauth.clientId`), the callback redirect URI must match exactly. In that case, free the configured host/port or set `MCP_OAUTH_CALLBACK_HOST` and `MCP_OAUTH_CALLBACK_PORT` to the registered callback. For clients registered like Slack MCP's Claude-compatible `http://localhost:3118/callback`, set `MCP_OAUTH_CALLBACK_HOST=localhost` and `MCP_OAUTH_CALLBACK_PORT=3118`.
 
 ### Browser doesn't open
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `url` | HTTP endpoint (StreamableHTTP with SSE fallback) |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
+| `oauth.clientName` / `oauth.clientUri` | Override OAuth dynamic client registration metadata when a server requires a specific registered client identity |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
@@ -347,6 +348,8 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 | `/mcp-auth <server>` | OAuth setup |
 
 If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls will automatically run OAuth when needed and retry once. In non-interactive sessions, browser-based OAuth still requires running `/mcp-auth <server>` manually.
+
+OAuth callbacks bind to `127.0.0.1:19876` by default. Set `MCP_OAUTH_CALLBACK_HOST` or `MCP_OAUTH_CALLBACK_PORT` before starting Pi if your OAuth client registration requires a different loopback redirect URI.
 
 ## How It Works
 

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -50,6 +50,7 @@ const mocks = vi.hoisted(() => {
     runtime,
     createServer,
     getConfiguredOAuthCallbackPort: vi.fn(() => state.configuredPort),
+    getOAuthCallbackHost: vi.fn(() => "127.0.0.1"),
     getOAuthCallbackPort: vi.fn(() => state.activePort),
     setOAuthCallbackPort: vi.fn((port: number) => {
       state.activePort = port;
@@ -64,6 +65,7 @@ vi.mock("http", () => ({
 vi.mock("../mcp-oauth-provider.js", () => ({
   OAUTH_CALLBACK_PATH: "/callback",
   getConfiguredOAuthCallbackPort: mocks.getConfiguredOAuthCallbackPort,
+  getOAuthCallbackHost: mocks.getOAuthCallbackHost,
   getOAuthCallbackPort: mocks.getOAuthCallbackPort,
   setOAuthCallbackPort: mocks.setOAuthCallbackPort,
 }));
@@ -79,16 +81,17 @@ describe("mcp-callback-server", () => {
     };
     mocks.createServer.mockClear();
     mocks.getConfiguredOAuthCallbackPort.mockClear();
+    mocks.getOAuthCallbackHost.mockClear();
     mocks.getOAuthCallbackPort.mockClear();
     mocks.setOAuthCallbackPort.mockClear();
   });
 
-  it("binds localhost and unrefs the callback server after a successful bind", async () => {
+  it("binds the configured callback host and unrefs the callback server after a successful bind", async () => {
     const { ensureCallbackServer } = await import("../mcp-callback-server.ts");
 
     await ensureCallbackServer();
 
-    expect(mocks.runtime.servers[0]?.listen).toHaveBeenCalledWith(4337, "localhost", expect.any(Function));
+    expect(mocks.runtime.servers[0]?.listen).toHaveBeenCalledWith(4337, "127.0.0.1", expect.any(Function));
     expect(mocks.runtime.servers[0]?.unref).toHaveBeenCalledTimes(1);
   });
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -60,6 +60,8 @@ function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     clientId: definition.oauth?.clientId,
     clientSecret: definition.oauth?.clientSecret,
     scope: definition.oauth?.scope,
+    clientName: definition.oauth?.clientName,
+    clientUri: definition.oauth?.clientUri,
   }
 }
 

--- a/mcp-callback-server.test.ts
+++ b/mcp-callback-server.test.ts
@@ -52,7 +52,7 @@ describe("mcp-callback-server", () => {
       // Simulate callback by making HTTP request
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/callback?code=${expectedCode}&state=${state}`
+        `http://127.0.0.1:${callbackPort}/callback?code=${expectedCode}&state=${state}`
       )
 
       // Should get HTML success response
@@ -76,7 +76,7 @@ describe("mcp-callback-server", () => {
       // Simulate error callback
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/callback?error=${errorMsg}&state=${state}`
+        `http://127.0.0.1:${callbackPort}/callback?error=${errorMsg}&state=${state}`
       )
 
       assert.strictEqual(response.status, 200)
@@ -92,7 +92,7 @@ describe("mcp-callback-server", () => {
 
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/callback?code=abc123`
+        `http://127.0.0.1:${callbackPort}/callback?code=abc123`
       )
 
       assert.strictEqual(response.status, 400)
@@ -108,7 +108,7 @@ describe("mcp-callback-server", () => {
 
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/callback?code=abc123&state=invalid-state`
+        `http://127.0.0.1:${callbackPort}/callback?code=abc123&state=invalid-state`
       )
 
       assert.strictEqual(response.status, 400)
@@ -127,7 +127,7 @@ describe("mcp-callback-server", () => {
 
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/callback?state=${state}`
+        `http://127.0.0.1:${callbackPort}/callback?state=${state}`
       )
 
       assert.strictEqual(response.status, 400)
@@ -143,7 +143,7 @@ describe("mcp-callback-server", () => {
 
       const callbackPort = getOAuthCallbackPort()
       const response = await fetch(
-        `http://localhost:${callbackPort}/wrong/path`
+        `http://127.0.0.1:${callbackPort}/wrong/path`
       )
 
       assert.strictEqual(response.status, 404)

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -9,6 +9,7 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
 import {
   OAUTH_CALLBACK_PATH,
   getConfiguredOAuthCallbackPort,
+  getOAuthCallbackHost,
   getOAuthCallbackPort,
   setOAuthCallbackPort,
 } from "./mcp-oauth-provider.js"
@@ -178,7 +179,7 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
           reject(err)
         })
 
-        candidateServer.listen(candidatePort, "localhost", () => {
+        candidateServer.listen(candidatePort, getOAuthCallbackHost(), () => {
           resolve()
         })
       })
@@ -203,13 +204,13 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
 
   if (strictPort) {
     throw new Error(
-      `OAuth callback port ${preferredPort} is already in use. Pre-registered OAuth clients require an exact redirect URI; set MCP_OAUTH_CALLBACK_PORT to your registered port or free port ${preferredPort}`,
+      `OAuth callback ${getOAuthCallbackHost()}:${preferredPort} is already in use. Pre-registered OAuth clients require an exact redirect URI; set MCP_OAUTH_CALLBACK_PORT to your registered port or free port ${preferredPort}`,
       { cause: lastError }
     )
   }
 
   throw new Error(
-    `OAuth callback port ${preferredPort} is already in use and no free port was found in range ${preferredPort}-${preferredPort + MAX_PORT_SCAN_ATTEMPTS - 1}`,
+    `OAuth callback ${getOAuthCallbackHost()}:${preferredPort} is already in use and no free port was found in range ${preferredPort}-${preferredPort + MAX_PORT_SCAN_ATTEMPTS - 1}`,
     { cause: lastError }
   )
 }

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -13,7 +13,7 @@ import { randomBytes } from "crypto"
 const TEST_DIR = join(tmpdir(), `mcp-oauth-test-${randomBytes(4).toString('hex')}`)
 process.env.MCP_OAUTH_DIR = TEST_DIR
 
-import { McpOAuthProvider } from "./mcp-oauth-provider.js"
+import { McpOAuthProvider, type McpOAuthConfig } from "./mcp-oauth-provider.js"
 import { saveAuthEntry, updateOAuthState } from "./mcp-auth.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
@@ -47,7 +47,7 @@ describe("McpOAuthProvider", () => {
     redirectCaptured = undefined
   })
 
-  function createProvider(config: { clientId?: string; clientSecret?: string; scope?: string } = {}) {
+  function createProvider(config: McpOAuthConfig = {}) {
     return new McpOAuthProvider(serverName, serverUrl, config, {
       onRedirect: async (url) => {
         redirectCaptured = url
@@ -60,7 +60,7 @@ describe("McpOAuthProvider", () => {
       const provider = createProvider()
       assert.strictEqual(
         provider.redirectUrl,
-        "http://localhost:19876/callback"
+        "http://127.0.0.1:19876/callback"
       )
     })
   })
@@ -70,7 +70,7 @@ describe("McpOAuthProvider", () => {
       const provider = createProvider()
       const metadata = provider.clientMetadata
 
-      assert.deepStrictEqual(metadata.redirect_uris, ["http://localhost:19876/callback"])
+      assert.deepStrictEqual(metadata.redirect_uris, ["http://127.0.0.1:19876/callback"])
       assert.strictEqual(metadata.client_name, "Pi Coding Agent")
       assert.strictEqual(metadata.client_uri, "https://github.com/nicobailon/pi-mcp-adapter")
       assert.deepStrictEqual(metadata.grant_types, ["authorization_code", "refresh_token"])
@@ -83,6 +83,28 @@ describe("McpOAuthProvider", () => {
       const metadata = provider.clientMetadata
 
       assert.strictEqual(metadata.token_endpoint_auth_method, "client_secret_post")
+    })
+
+    it("should support custom dynamic registration metadata", () => {
+      const provider = createProvider({
+        clientName: "Custom Client",
+        clientUri: "https://example.com/custom-client",
+      })
+      const metadata = provider.clientMetadata
+
+      assert.strictEqual(metadata.client_name, "Custom Client")
+      assert.strictEqual(metadata.client_uri, "https://example.com/custom-client")
+    })
+
+    it("should use custom client name for client credentials metadata", () => {
+      const provider = createProvider({
+        grantType: "client_credentials",
+        clientName: "Machine Client",
+      })
+      const metadata = provider.clientMetadata
+
+      assert.strictEqual(metadata.client_name, "Machine Client")
+      assert.deepStrictEqual(metadata.redirect_uris, [])
     })
   })
 
@@ -171,6 +193,7 @@ describe("McpOAuthProvider", () => {
       const info: OAuthClientInformationFull = {
         client_id: "new-client",
         client_secret: "new-secret",
+        redirect_uris: ["http://127.0.0.1:19876/callback"],
         client_id_issued_at: Math.floor(Date.now() / 1000),
         client_secret_expires_at: futureTime,
       }

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -29,7 +29,10 @@ import {
 
 // Callback server configuration
 const DEFAULT_OAUTH_CALLBACK_PORT = 19876
+const DEFAULT_OAUTH_CALLBACK_HOST = "127.0.0.1"
 const OAUTH_CALLBACK_PATH = "/callback"
+
+const configuredOAuthCallbackHost = process.env.MCP_OAUTH_CALLBACK_HOST?.trim() || DEFAULT_OAUTH_CALLBACK_HOST
 
 let configuredOAuthCallbackPort = DEFAULT_OAUTH_CALLBACK_PORT
 
@@ -46,6 +49,10 @@ export function getConfiguredOAuthCallbackPort(): number {
   return configuredOAuthCallbackPort
 }
 
+export function getOAuthCallbackHost(): string {
+  return configuredOAuthCallbackHost
+}
+
 export function getOAuthCallbackPort(): number {
   return oauthCallbackPort
 }
@@ -60,6 +67,10 @@ export interface McpOAuthConfig {
   clientId?: string
   clientSecret?: string
   scope?: string
+  /** Override dynamic OAuth registration client_name. */
+  clientName?: string
+  /** Override dynamic OAuth registration client_uri. */
+  clientUri?: string
 }
 
 /** Callbacks for OAuth flow interactions */
@@ -83,13 +94,21 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return this.config.grantType === "client_credentials"
   }
 
+  private get clientName(): string {
+    return this.config.clientName ?? "Pi Coding Agent"
+  }
+
+  private get clientUri(): string {
+    return this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter"
+  }
+
   /**
    * The redirect URL for OAuth callbacks.
    * This must match the redirect_uri in client metadata.
    */
   get redirectUrl(): string | undefined {
     if (this.usesClientCredentials) return undefined
-    return `http://localhost:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+    return `http://${getOAuthCallbackHost()}:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
   }
 
   /**
@@ -99,7 +118,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   get clientMetadata(): OAuthClientMetadata {
     if (this.usesClientCredentials) {
       return {
-        client_name: "Pi Coding Agent",
+        client_name: this.clientName,
         redirect_uris: [],
         grant_types: ["client_credentials"],
         token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -113,8 +132,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     return {
       redirect_uris: [redirectUrl],
-      client_name: "Pi Coding Agent",
-      client_uri: "https://github.com/nicobailon/pi-mcp-adapter",
+      client_name: this.clientName,
+      client_uri: this.clientUri,
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -300,4 +319,4 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 }
 
-export { DEFAULT_OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }
+export { DEFAULT_OAUTH_CALLBACK_PORT, DEFAULT_OAUTH_CALLBACK_HOST, OAUTH_CALLBACK_PATH }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -188,6 +188,8 @@ export class McpServerManager {
         clientId: definition.oauth?.clientId,
         clientSecret: definition.oauth?.clientSecret,
         scope: definition.oauth?.scope,
+        clientName: definition.oauth?.clientName,
+        clientUri: definition.oauth?.clientUri,
       };
       authProvider = new McpOAuthProvider(
         serverName,

--- a/types.ts
+++ b/types.ts
@@ -272,6 +272,10 @@ export interface OAuthConfig {
   clientSecret?: string;
   /** Requested OAuth scopes */
   scope?: string;
+  /** Override dynamic OAuth registration client_name */
+  clientName?: string;
+  /** Override dynamic OAuth registration client_uri */
+  clientUri?: string;
 }
 
 // Server configuration


### PR DESCRIPTION
## Summary

Adds configurable OAuth dynamic client registration metadata and a configurable OAuth callback host.

This helps with OAuth MCP servers that validate or allowlist dynamic client registration metadata, and avoids callback ambiguity when `localhost` resolves to a different loopback listener than the one started for the active auth flow.

Related to #49.

## Changes

- Add `oauth.clientName` and `oauth.clientUri` config fields.
- Pass those OAuth metadata overrides through:
  - `mcp-auth-flow.ts`
  - `server-manager.ts`
  - `mcp-oauth-provider.ts`
  - `types.ts`
- Change the default OAuth callback host from `localhost` to `127.0.0.1`.
- Add `MCP_OAUTH_CALLBACK_HOST` env override.
- Update README/OAuth docs.
- Update OAuth/callback tests.

## Motivation

Some remote MCP OAuth providers enforce client identity during dynamic client registration. For example, Figma’s remote MCP currently rejects the default dynamic registration metadata with `403 Forbidden`, as discussed in #49.

This PR does not hardcode any provider-specific behavior. It makes the OAuth client metadata configurable so users can work with providers that require specific registered metadata.

The callback host change also fixes a redirect issue observed when older Pi sessions had callback servers bound on `localhost`/IPv6 loopback while the active auth flow expected a different callback state.

## Example

```json
{
  "mcpServers": {
    "figma": {
      "url": "https://mcp.figma.com/mcp",
      "auth": "oauth",
      "oauth": {
        "clientName": "Claude Code",
        "clientUri": "https://www.anthropic.com/claude-code"
      }
    }
  }
}
```
