### PR TITLE
fix(mcp-ui): Fix CSP construction to match the fields used in the MCP Apps spec

### DIFF
--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -158,16 +158,55 @@ describe("buildHostHtmlTemplate", () => {
   });
 
   describe("CSP handling", () => {
-    it("buildCspMetaContent generates correct CSP directives", async () => {
+    it("buildCspMetaContent generates restrictive default CSP when csp is omitted", async () => {
+      const { buildCspMetaContent } = await import("../host-html-template.js");
+      const csp = buildCspMetaContent(undefined);
+
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+      expect(csp).toContain("img-src 'self' data:");
+      expect(csp).toContain("media-src 'self' data:");
+      expect(csp).toContain("connect-src 'none'");
+      expect(csp).toContain("object-src 'none'");
+    });
+
+    it("buildCspMetaContent maps resourceDomains to all static-asset directives", async () => {
       const { buildCspMetaContent } = await import("../host-html-template.js");
       const csp = buildCspMetaContent({
-        scriptDomains: ["'self'", "cdn.example.com"],
-        styleDomains: ["'self'"],
+        resourceDomains: ["cdn.example.com"],
+        connectDomains: ["https://api.example.com"],
       });
 
-      expect(csp).toContain("script-src 'self' cdn.example.com");
-      expect(csp).toContain("style-src 'self'");
       expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("script-src 'self' 'unsafe-inline' cdn.example.com");
+      expect(csp).toContain("style-src 'self' 'unsafe-inline' cdn.example.com");
+      expect(csp).toContain("img-src 'self' data: cdn.example.com");
+      expect(csp).toContain("font-src 'self' cdn.example.com");
+      expect(csp).toContain("media-src 'self' data: cdn.example.com");
+      expect(csp).toContain("connect-src 'self' https://api.example.com");
+      expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("frame-src 'none'");
+      expect(csp).toContain("base-uri 'self'");
+    });
+
+    it("buildCspMetaContent respects frameDomains and baseUriDomains", async () => {
+      const { buildCspMetaContent } = await import("../host-html-template.js");
+      const csp = buildCspMetaContent({
+        frameDomains: ["https://embed.example.com"],
+        baseUriDomains: ["https://base.example.com"],
+      });
+
+      expect(csp).toContain("frame-src https://embed.example.com");
+      expect(csp).toContain("base-uri https://base.example.com");
+    });
+
+    it("buildCspMetaContent uses safe defaults for frame-src and base-uri when omitted", async () => {
+      const { buildCspMetaContent } = await import("../host-html-template.js");
+      const csp = buildCspMetaContent({});
+
+      expect(csp).toContain("frame-src 'none'");
+      expect(csp).toContain("base-uri 'self'");
     });
 
     it("applyCspMeta injects CSP meta into HTML head", async () => {

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -192,8 +192,8 @@ describe("UiResourceHandler", () => {
               _meta: {
                 ui: {
                   csp: {
-                    scriptDomains: ["'self'", "cdn.example.com"],
-                    styleDomains: ["'self'"],
+                    resourceDomains: ["cdn.example.com"],
+                    connectDomains: ["https://api.example.com"],
                   },
                 },
               },
@@ -206,8 +206,8 @@ describe("UiResourceHandler", () => {
       const result = await handler.readUiResource("server", "ui://test/widget");
 
       expect(result.meta.csp).toEqual({
-        scriptDomains: ["'self'", "cdn.example.com"],
-        styleDomains: ["'self'"],
+        resourceDomains: ["cdn.example.com"],
+        connectDomains: ["https://api.example.com"],
       });
     });
 

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -356,42 +356,48 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
 </html>`;
 }
 
-export function buildCspMetaContent(csp: UiResourceCsp | undefined): string | undefined {
-  if (!csp) return undefined;
+/**
+ * Build a CSP string from resource metadata following the MCP Apps spec
+ * (specification/2026-01-26/apps.mdx § "Content Security Policy Enforcement").
+ *
+ * When `csp` is omitted the host MUST apply the spec-mandated restrictive default.
+ * When `csp` is provided the host builds a full directive list using `resourceDomains`
+ * for static assets and `connectDomains` for network access.
+ */
+export function buildCspMetaContent(csp: UiResourceCsp | undefined): string {
+  // Spec: "If ui.csp is omitted, Host MUST use" this restrictive default.
+  if (!csp) {
+    return [
+      "default-src 'none'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "media-src 'self' data:",
+      "connect-src 'none'",
+      "object-src 'none'",
+    ].join("; ");
+  }
 
-  const directives: string[] = [];
-  directives.push("default-src 'none'");
-
-  const scriptSrc = toDirective("script-src", csp.scriptDomains);
-  const styleSrc = toDirective("style-src", csp.styleDomains);
-  const fontSrc = toDirective("font-src", csp.fontDomains);
-  const imgSrc = toDirective("img-src", csp.imgDomains);
-  const mediaSrc = toDirective("media-src", csp.mediaDomains);
-  const connectSrc = toDirective("connect-src", csp.connectDomains);
-  const frameSrc = toDirective("frame-src", csp.frameDomains);
-  const workerSrc = toDirective("worker-src", csp.workerDomains);
-  const baseUri = toDirective("base-uri", csp.baseUriDomains);
-
-  if (scriptSrc) directives.push(scriptSrc);
-  if (styleSrc) directives.push(styleSrc);
-  if (fontSrc) directives.push(fontSrc);
-  if (imgSrc) directives.push(imgSrc);
-  if (mediaSrc) directives.push(mediaSrc);
-  if (connectSrc) directives.push(connectSrc);
-  if (frameSrc) directives.push(frameSrc);
-  if (workerSrc) directives.push(workerSrc);
-  if (baseUri) directives.push(baseUri);
-
-  return directives.join("; ");
+  // Spec CSP construction from declared domains.
+  const res = csp.resourceDomains?.join(" ") ?? "";
+  const connect = csp.connectDomains?.join(" ") ?? "";
+  const frame = csp.frameDomains?.join(" ") || "'none'";
+  const base = csp.baseUriDomains?.join(" ") || "'self'";
+  return [
+    "default-src 'none'",
+    `script-src 'self' 'unsafe-inline'${res ? " " + res : ""}`,
+    `style-src 'self' 'unsafe-inline'${res ? " " + res : ""}`,
+    `connect-src 'self'${connect ? " " + connect : ""}`,
+    `img-src 'self' data:${res ? " " + res : ""}`,
+    `font-src 'self'${res ? " " + res : ""}`,
+    `media-src 'self' data:${res ? " " + res : ""}`,
+    `frame-src ${frame}`,
+    "object-src 'none'",
+    `base-uri ${base}`,
+  ].join("; ");
 }
 
-function toDirective(name: string, domains: string[] | undefined): string | null {
-  if (!domains || domains.length === 0) return null;
-  return `${name} ${domains.join(" ")}`;
-}
-
-export function applyCspMeta(html: string, cspContent: string | undefined): string {
-  if (!cspContent) return html;
+export function applyCspMeta(html: string, cspContent: string): string {
   if (/http-equiv=["']Content-Security-Policy["']/i.test(html)) return html;
   const metaTag = `<meta http-equiv="Content-Security-Policy" content="${escapeHtmlAttribute(cspContent)}">`;
   if (/<head[^>]*>/i.test(html)) {

--- a/types.ts
+++ b/types.ts
@@ -64,14 +64,13 @@ export interface UiProxyResult<T = Record<string, unknown>> {
 }
 
 export interface UiResourceCsp {
+  /** Origins for network requests (fetch/XHR/WebSocket) → connect-src */
   connectDomains?: string[];
-  scriptDomains?: string[];
-  styleDomains?: string[];
-  fontDomains?: string[];
-  imgDomains?: string[];
-  mediaDomains?: string[];
+  /** Origins for static resources (scripts, images, styles, fonts, media) → script-src, style-src, img-src, font-src, media-src */
+  resourceDomains?: string[];
+  /** Origins for nested iframes → frame-src */
   frameDomains?: string[];
-  workerDomains?: string[];
+  /** Allowed base URIs → base-uri */
   baseUriDomains?: string[];
 }
 


### PR DESCRIPTION
## Summary

There was a mismatch between the pi internal `UiResourceCsp` type and the [MCP Apps spec](https://raw.githubusercontent.com/modelcontextprotocol/ext-apps/refs/heads/main/specification/2026-01-26/apps.mdx) (see the Content Security Policy Enforcement section). 

This meant CSP metadata from a spec-compliant server was being silently ignored. As a result, some MCP apps that was working in [Cursor](https://cursor.com/blog/new-plugins#infrastructure) did not load in Pi-mcp-adapter because the resourceDomains field was not being checked.

## Changes

1. The `UiResourceCsp` type had granular fields (`scriptDomains`, `styleDomains`, `fontDomains`, `imgDomains`, `mediaDomains`, `workerDomains`) that don't exist in the current version of the [spec](https://raw.githubusercontent.com/modelcontextprotocol/ext-apps/refs/heads/main/specification/2026-01-26/apps.mdx) (maybe these were from previous versions?)

The spec uses a single `resourceDomains` field that maps to all static-asset directives, so those have been replaced.

2. `buildCspMetaContent` was also missing some required base values from each directive (`'self' 'unsafe-inline'` on script/style, `data:` on img/media, `object-src 'none'`), and `frame-src` and `base-uri` were only emitted when extra domains were provided. The spec requires them unconditionally with safe fallbacks.

2. Finally, when `csp` was omitted entirely, the function returned `undefined` so nothing got injected. The spec mandates a restrictive default in that case, so the function now always returns a string.

Files changed:

- `types.ts`: replace the granular domain fields with spec-defined `resourceDomains`, `connectDomains`, `frameDomains`, `baseUriDomains`
- `host-html-template.ts`: rewrite `buildCspMetaContent` to always return a string with correct base values; tighten `applyCspMeta` signature to match
- tests updated to use the new field names and verify the spec-correct directive output

## Testing

Existing vitest suite covers the updated field names and the new directive assertions. Run with `npm test`.

With this change in place, when interacting with the Datadog MCP [server](https://docs.datadoghq.com/bits_ai/mcp_server/), you'll be able to see graphs (instead of a blank screen). This is using fixture data inside the Glimpse viewer.

https://github.com/user-attachments/assets/875b0b68-adee-4c9b-a2e4-2ea11daa1615

## Notes

- If there are some other apps that are dependent on those other paths, this change might break them. However, I couldn't find any examples in this repo. Given that mcp-ui is now aligned with mcp-apps, I figured this change could be helpful to share with the community rather than forking. 
