### PR TITLE
Localize MCP setup and auth status strings

### DIFF
--- a/commands.ts
+++ b/commands.ts
@@ -19,42 +19,45 @@ import { supportsOAuth, authenticate } from "./mcp-auth-flow.js";
 import { hasStoredTokens } from "./mcp-auth.js";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.js";
 import { openPath } from "./utils.js";
+import { t } from "./i18n.js";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
 
-  const lines: string[] = ["MCP Server Status:", ""];
+  const lines: string[] = [t("status.header", "MCP Server Status:"), ""];
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const connection = state.manager.getConnection(name);
     const metadata = state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
     const failedAgo = getFailureAgeSeconds(state, name);
-    let status = "not connected";
+    let status = t("status.notConnected", "not connected");
     let statusIcon = "○";
     let failed = false;
+    let cached = false;
 
     if (connection?.status === "connected") {
-      status = "connected";
+      status = t("status.connected", "connected");
       statusIcon = "✓";
     } else if (connection?.status === "needs-auth") {
-      status = "needs auth";
+      status = t("status.needsAuth", "needs auth");
       statusIcon = "⚠";
     } else if (failedAgo !== null) {
-      status = `failed ${failedAgo}s ago`;
+      status = t("status.failedAgo", "failed {seconds}s ago", { seconds: failedAgo });
       statusIcon = "✗";
       failed = true;
     } else if (metadata !== undefined) {
-      status = "cached";
+      status = t("status.cached", "cached");
+      cached = true;
     }
 
-    const toolSuffix = failed ? "" : ` (${toolCount} tools${status === "cached" ? ", cached" : ""})`;
+    const toolSuffix = failed ? "" : ` (${toolCount} tools${cached ? ", cached" : ""})`;
     lines.push(`${statusIcon} ${name}: ${status}${toolSuffix}`);
   }
 
   if (Object.keys(state.config.mcpServers).length === 0) {
-    lines.push("No MCP servers configured");
-    lines.push("Run /mcp setup to adopt imports or scaffold a starter .mcp.json");
+    lines.push(t("status.noServers", "No MCP servers configured"));
+    lines.push(t("status.setupHint", "Run /mcp setup to adopt imports or scaffold a starter .mcp.json"));
   }
 
   ctx.ui.notify(lines.join("\n"), "info");
@@ -66,7 +69,7 @@ export async function showTools(state: McpExtensionState, ctx: ExtensionContext)
   const allTools = [...state.toolMetadata.values()].flat().map(m => m.name);
 
   if (allTools.length === 0) {
-    ctx.ui.notify("No MCP tools available", "info");
+    ctx.ui.notify(t("tools.none", "No MCP tools available"), "info");
     return;
   }
 
@@ -88,7 +91,7 @@ export async function reconnectServers(
 ): Promise<void> {
   if (targetServer && !state.config.mcpServers[targetServer]) {
     if (ctx.hasUI) {
-      ctx.ui.notify(`Server "${targetServer}" not found in config`, "error");
+      ctx.ui.notify(t("reconnect.serverNotFound", `Server "${targetServer}" not found in config`, { server: targetServer }), "error");
     }
     return;
   }
@@ -104,7 +107,7 @@ export async function reconnectServers(
       const connection = await state.manager.connect(name, definition);
       if (connection.status === "needs-auth") {
         if (ctx.hasUI) {
-          ctx.ui.notify(`MCP: ${name} requires OAuth. Run /mcp-auth ${name} first.`, "warning");
+          ctx.ui.notify(t("reconnect.requiresOAuth", `MCP: ${name} requires OAuth. Run /mcp-auth ${name} first.`, { server: name }), "warning");
         }
         continue;
       }
@@ -117,18 +120,18 @@ export async function reconnectServers(
 
       if (ctx.hasUI) {
         ctx.ui.notify(
-          `MCP: Reconnected to ${name} (${connection.tools.length} tools, ${connection.resources.length} resources)`,
+          t("reconnect.success", `MCP: Reconnected to ${name} (${connection.tools.length} tools, ${connection.resources.length} resources)`, { server: name, tools: connection.tools.length, resources: connection.resources.length }),
           "info"
         );
         if (failedTools.length > 0) {
-          ctx.ui.notify(`MCP: ${name} - ${failedTools.length} tools skipped`, "warning");
+          ctx.ui.notify(t("reconnect.toolsSkipped", `MCP: ${name} - ${failedTools.length} tools skipped`, { server: name, count: failedTools.length }), "warning");
         }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       state.failureTracker.set(name, Date.now());
       if (ctx.hasUI) {
-        ctx.ui.notify(`MCP: Failed to reconnect to ${name}: ${message}`, "error");
+        ctx.ui.notify(t("reconnect.failed", `MCP: Failed to reconnect to ${name}: ${message}`, { server: name, message }), "error");
       }
     }
   }
@@ -145,14 +148,13 @@ export async function authenticateServer(
 
   const definition = config.mcpServers[serverName];
   if (!definition) {
-    ctx.ui.notify(`Server "${serverName}" not found in config`, "error");
+    ctx.ui.notify(t("reconnect.serverNotFound", `Server "${serverName}" not found in config`, { server: serverName }), "error");
     return;
   }
 
   if (!supportsOAuth(definition)) {
     ctx.ui.notify(
-      `Server "${serverName}" does not use OAuth authentication.\n` +
-      `Set "auth": "oauth" or omit auth for auto-detection.`,
+      t("auth.notOAuth", `Server "${serverName}" does not use OAuth authentication.\nSet "auth": "oauth" or omit auth for auto-detection.`, { server: serverName }),
       "error"
     );
     return;
@@ -160,31 +162,30 @@ export async function authenticateServer(
 
   if (!definition.url) {
     ctx.ui.notify(
-      `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`,
+      t("auth.noUrl", `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`, { server: serverName }),
       "error"
     );
     return;
   }
 
   try {
-    ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
+    ctx.ui.setStatus("mcp-auth", t("auth.status", `Authenticating ${serverName}...`, { server: serverName }));
     const status = await authenticate(serverName, definition.url, definition);
 
     if (status === "authenticated") {
       ctx.ui.notify(
-        `OAuth authentication successful for "${serverName}"!\n` +
-        `Run /mcp reconnect ${serverName} to connect with the new token.`,
+        t("auth.success", `OAuth authentication successful for "${serverName}"!\nRun /mcp reconnect ${serverName} to connect with the new token.`, { server: serverName }),
         "success"
       );
     } else {
       ctx.ui.notify(
-        `OAuth authentication failed for "${serverName}".`,
+        t("auth.failed", `OAuth authentication failed for "${serverName}".`, { server: serverName }),
         "error"
       );
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    ctx.ui.notify(`Failed to authenticate "${serverName}": ${message}`, "error");
+    ctx.ui.notify(t("auth.failedWithMessage", `Failed to authenticate "${serverName}": ${message}`, { server: serverName, message }), "error");
   } finally {
     ctx.ui.setStatus("mcp-auth", undefined);
   }

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,164 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const namespace = "pi-mcp-adapter";
+type Params = Record<string, string | number>;
+type I18nApi = { t?: (key: string, params?: Params) => string };
+
+let api: I18nApi | null = null;
+
+export function initI18n(pi: ExtensionAPI): void {
+  const events = pi.events;
+  if (!events) return;
+
+  events.emit("pi-core/i18n/registerBundle", jaBundle);
+  events.emit("pi-core/i18n/registerBundle", zhCnBundle);
+  events.emit("pi-core/i18n/registerBundle", deBundle);
+  events.emit("pi-core/i18n/requestApi", {
+    reply(candidate: I18nApi) {
+      api = candidate;
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+  const fullKey = `${namespace}.${key}`;
+  const value = api?.t?.(fullKey, params);
+  return value && value !== fullKey ? value : format(fallback, params);
+}
+
+function format(template: string, params?: Params): string {
+  if (!params) return template;
+  return template.replace(/\{(\w+)\}/g, (_m, name) => String(params[name] ?? `{${name}}`));
+}
+
+const jaBundle = {
+  schemaVersion: 1,
+  namespace,
+  locale: "ja",
+  messages: {
+    "status.header": "MCP サーバーの状態:",
+    "status.notConnected": "未接続",
+    "status.connected": "接続済み",
+    "status.needsAuth": "認証が必要",
+    "status.failedAgo": "{seconds} 秒前に失敗",
+    "status.cached": "キャッシュ済み",
+    "status.noServers": "MCP サーバーが設定されていません",
+    "status.setupHint": "/mcp setup を実行してインポートを採用するか、スターター .mcp.json を作成してください",
+    "tools.none": "利用可能な MCP ツールはありません",
+    "reconnect.serverNotFound": "サーバー \"{server}\" は設定にありません",
+    "reconnect.requiresOAuth": "MCP: {server} は OAuth が必要です。先に /mcp-auth {server} を実行してください。",
+    "reconnect.success": "MCP: {server} に再接続しました（{tools} ツール、{resources} リソース）",
+    "reconnect.toolsSkipped": "MCP: {server} - {count} 個のツールをスキップしました",
+    "reconnect.failed": "MCP: {server} への再接続に失敗しました: {message}",
+    "auth.notOAuth": "サーバー \"{server}\" は OAuth 認証を使用していません。\n\"auth\": \"oauth\" を設定するか、自動検出のため auth を省略してください。",
+    "auth.noUrl": "サーバー \"{server}\" には URL が設定されていません（OAuth には HTTP transport が必要です）",
+    "auth.status": "{server} を認証中...",
+    "auth.success": "\"{server}\" の OAuth 認証に成功しました！\n新しいトークンで接続するには /mcp reconnect {server} を実行してください。",
+    "auth.failed": "\"{server}\" の OAuth 認証に失敗しました。",
+    "auth.failedWithMessage": "\"{server}\" の認証に失敗しました: {message}",
+    "setup.run.label": "セットアップを実行",
+    "setup.run.description": "検出された設定を確認し、インポートを採用し、最小限の `.mcp.json` を作成します。",
+    "setup.adopt.label": "検出された互換インポートを採用",
+    "setup.adopt.description": "Pi が独自の override ファイルに取り込むホスト別 MCP 設定を選択します。{count} 件のソースが見つかりました。",
+    "setup.example.label": "`.mcp.json` の例を見る",
+    "setup.example.description": "貼り付けまたは調整できる共有 MCP 設定の例をプレビューします。",
+    "setup.scaffold.label": "プロジェクト `.mcp.json` を作成",
+    "setup.scaffold.description": "標準の共有 MCP ファイルパスを使って最小限のプロジェクト設定を書き込み、Pi をリロードします。",
+    "setup.precedence.label": "設定の優先順位を説明",
+    "setup.precedence.description": "読み込み順と Pi が互換設定を書き込む場所を表示します。",
+    "setup.paths.label": "検出された設定パスを開く",
+    "setup.paths.description": "このマシンで Pi が検出した実際の設定ファイルを参照します。",
+    "setup.repoprompt.label": "RepoPrompt を共有 MCP 設定に追加",
+    "setup.repoprompt.description": "推奨される共有ターゲットに RepoPrompt の標準 MCP エントリを書き込み、セッション内で MCP をリロードします。",
+    "setup.close.label": "閉じる",
+    "setup.close.description": "オンボーディングを終了します。"
+  }
+};
+
+const zhCnBundle = {
+  schemaVersion: 1,
+  namespace,
+  locale: "zh-CN",
+  messages: {
+    "status.header": "MCP 服务器状态：",
+    "status.notConnected": "未连接",
+    "status.connected": "已连接",
+    "status.needsAuth": "需要认证",
+    "status.failedAgo": "{seconds} 秒前失败",
+    "status.cached": "已缓存",
+    "status.noServers": "尚未配置 MCP 服务器",
+    "status.setupHint": "运行 /mcp setup 以采用导入配置，或生成 starter .mcp.json",
+    "tools.none": "没有可用的 MCP 工具",
+    "reconnect.serverNotFound": "配置中找不到服务器 \"{server}\"",
+    "reconnect.requiresOAuth": "MCP：{server} 需要 OAuth。请先运行 /mcp-auth {server}。",
+    "reconnect.success": "MCP：已重新连接到 {server}（{tools} 个工具，{resources} 个资源）",
+    "reconnect.toolsSkipped": "MCP：{server} - 已跳过 {count} 个工具",
+    "reconnect.failed": "MCP：重新连接到 {server} 失败：{message}",
+    "auth.notOAuth": "服务器 \"{server}\" 未使用 OAuth 认证。\n请设置 \"auth\": \"oauth\"，或省略 auth 以自动检测。",
+    "auth.noUrl": "服务器 \"{server}\" 没有配置 URL（OAuth 需要 HTTP transport）",
+    "auth.status": "正在认证 {server}...",
+    "auth.success": "\"{server}\" 的 OAuth 认证成功！\n运行 /mcp reconnect {server} 以使用新 token 连接。",
+    "auth.failed": "\"{server}\" 的 OAuth 认证失败。",
+    "auth.failedWithMessage": "认证 \"{server}\" 失败：{message}",
+    "setup.run.label": "运行设置",
+    "setup.run.description": "检查检测到的配置，采用导入项，并生成最小 `.mcp.json`。",
+    "setup.adopt.label": "采用检测到的兼容导入",
+    "setup.adopt.description": "选择 Pi 应导入到自身 override 文件的主机专用 MCP 配置。发现 {count} 个来源。",
+    "setup.example.label": "查看 `.mcp.json` 示例",
+    "setup.example.description": "预览可粘贴或调整的共享 MCP 配置示例。",
+    "setup.scaffold.label": "生成项目 `.mcp.json`",
+    "setup.scaffold.description": "使用标准共享 MCP 文件路径写入最小项目配置，然后重新加载 Pi。",
+    "setup.precedence.label": "说明配置优先级",
+    "setup.precedence.description": "显示读取顺序以及 Pi 写入兼容设置的位置。",
+    "setup.paths.label": "打开检测到的配置路径",
+    "setup.paths.description": "浏览 Pi 在本机发现的实际配置文件。",
+    "setup.repoprompt.label": "将 RepoPrompt 添加到共享 MCP 配置",
+    "setup.repoprompt.description": "将 RepoPrompt 的标准 MCP 条目写入推荐的共享目标，然后在会话中重新加载 MCP。",
+    "setup.close.label": "关闭",
+    "setup.close.description": "退出引导流程。"
+  }
+};
+
+const deBundle = {
+  schemaVersion: 1,
+  namespace,
+  locale: "de",
+  messages: {
+    "status.header": "MCP-Serverstatus:",
+    "status.notConnected": "nicht verbunden",
+    "status.connected": "verbunden",
+    "status.needsAuth": "Authentifizierung erforderlich",
+    "status.failedAgo": "vor {seconds}s fehlgeschlagen",
+    "status.cached": "zwischengespeichert",
+    "status.noServers": "Keine MCP-Server konfiguriert",
+    "status.setupHint": "Führe /mcp setup aus, um Imports zu übernehmen oder eine Starter-.mcp.json zu erzeugen",
+    "tools.none": "Keine MCP-Tools verfügbar",
+    "reconnect.serverNotFound": "Server \"{server}\" wurde in der Konfiguration nicht gefunden",
+    "reconnect.requiresOAuth": "MCP: {server} benötigt OAuth. Führe zuerst /mcp-auth {server} aus.",
+    "reconnect.success": "MCP: Wieder mit {server} verbunden ({tools} Tools, {resources} Ressourcen)",
+    "reconnect.toolsSkipped": "MCP: {server} - {count} Tools übersprungen",
+    "reconnect.failed": "MCP: Wiederverbindung zu {server} fehlgeschlagen: {message}",
+    "auth.notOAuth": "Server \"{server}\" verwendet keine OAuth-Authentifizierung.\nSetze \"auth\": \"oauth\" oder lasse auth für automatische Erkennung weg.",
+    "auth.noUrl": "Server \"{server}\" hat keine URL konfiguriert (OAuth benötigt HTTP-Transport)",
+    "auth.status": "Authentifiziere {server}...",
+    "auth.success": "OAuth-Authentifizierung für \"{server}\" erfolgreich!\nFühre /mcp reconnect {server} aus, um mit dem neuen Token zu verbinden.",
+    "auth.failed": "OAuth-Authentifizierung für \"{server}\" fehlgeschlagen.",
+    "auth.failedWithMessage": "Authentifizierung für \"{server}\" fehlgeschlagen: {message}",
+    "setup.run.label": "Setup ausführen",
+    "setup.run.description": "Erkannte Konfigurationen prüfen, Imports übernehmen und eine minimale `.mcp.json` erstellen.",
+    "setup.adopt.label": "Erkannte Kompatibilitäts-Imports übernehmen",
+    "setup.adopt.description": "Auswählen, welche host-spezifischen MCP-Konfigurationen Pi in die eigene Override-Datei importieren soll. {count} Quellen gefunden.",
+    "setup.example.label": "Beispiel-`.mcp.json` anzeigen",
+    "setup.example.description": "Eine funktionierende gemeinsame MCP-Konfiguration zum Einfügen oder Anpassen vorab ansehen.",
+    "setup.scaffold.label": "Projekt-`.mcp.json` erzeugen",
+    "setup.scaffold.description": "Eine minimale Projektkonfiguration mit dem Standardpfad für gemeinsame MCP-Dateien schreiben und Pi neu laden.",
+    "setup.precedence.label": "Konfigurationsreihenfolge erklären",
+    "setup.precedence.description": "Lesereihenfolge und Speicherort der Pi-Kompatibilitätseinstellungen anzeigen.",
+    "setup.paths.label": "Erkannte Konfigurationspfade öffnen",
+    "setup.paths.description": "Die tatsächlichen Konfigurationsdateien durchsuchen, die Pi auf diesem Rechner gefunden hat.",
+    "setup.repoprompt.label": "RepoPrompt zur gemeinsamen MCP-Konfiguration hinzufügen",
+    "setup.repoprompt.description": "Einen Standard-MCP-Eintrag für RepoPrompt in das empfohlene gemeinsame Ziel schreiben und MCP in der Sitzung neu laden.",
+    "setup.close.label": "Schließen",
+    "setup.close.description": "Onboarding beenden."
+  }
+};

--- a/index.ts
+++ b/index.ts
@@ -9,8 +9,11 @@ import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
+import { initI18n } from "./i18n.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
+  initI18n(pi);
+
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
   let lifecycleGeneration = 0;

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -2,6 +2,7 @@ import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui"
 import type { ImportKind } from "./types.js";
 import type { ConfigWritePreview, McpDiscoverySummary } from "./config.js";
 import type { McpOnboardingState } from "./onboarding-state.js";
+import { t } from "./i18n.js";
 
 interface SetupTheme {
   border: string;
@@ -125,23 +126,23 @@ export class McpSetupPanel {
   private getActions(): Action[] {
     const actions: Action[] = [];
     if (this.screen === "empty") {
-      actions.push({ id: "run-setup", label: "Run setup", description: "Inspect detected configs, adopt imports, and scaffold a minimal `.mcp.json`." });
+      actions.push({ id: "run-setup", label: t("setup.run.label", "Run setup"), description: t("setup.run.description", "Inspect detected configs, adopt imports, and scaffold a minimal `.mcp.json`.") });
     }
     if (this.discovery.imports.length > 0) {
-      actions.push({ id: "adopt-imports", label: "Adopt detected compatibility imports", description: `Choose which host-specific MCP configs Pi should import into its own override file. ${this.discovery.imports.length} source${this.discovery.imports.length === 1 ? "" : "s"} found.` });
+      actions.push({ id: "adopt-imports", label: t("setup.adopt.label", "Adopt detected compatibility imports"), description: t("setup.adopt.description", `Choose which host-specific MCP configs Pi should import into its own override file. ${this.discovery.imports.length} source${this.discovery.imports.length === 1 ? "" : "s"} found.`, { count: this.discovery.imports.length }) });
     }
-    actions.push({ id: "view-example", label: "View example `.mcp.json`", description: "Preview a working shared MCP config you can paste or adapt." });
+    actions.push({ id: "view-example", label: t("setup.example.label", "View example `.mcp.json`"), description: t("setup.example.description", "Preview a working shared MCP config you can paste or adapt.") });
     if (!this.discovery.sources.some((source) => source.id === "shared-project" && source.exists)) {
-      actions.push({ id: "scaffold-project", label: "Scaffold project `.mcp.json`", description: "Write a minimal project config using the standard shared MCP file path, then reload Pi." });
+      actions.push({ id: "scaffold-project", label: t("setup.scaffold.label", "Scaffold project `.mcp.json`"), description: t("setup.scaffold.description", "Write a minimal project config using the standard shared MCP file path, then reload Pi.") });
     }
-    actions.push({ id: "show-precedence", label: "Explain config precedence", description: "Show the read order and where Pi writes compatibility settings." });
+    actions.push({ id: "show-precedence", label: t("setup.precedence.label", "Explain config precedence"), description: t("setup.precedence.description", "Show the read order and where Pi writes compatibility settings.") });
     if (this.getDetectedPaths().length > 0) {
-      actions.push({ id: "open-paths", label: "Open detected config paths", description: "Browse the actual config files that Pi discovered on this machine." });
+      actions.push({ id: "open-paths", label: t("setup.paths.label", "Open detected config paths"), description: t("setup.paths.description", "Browse the actual config files that Pi discovered on this machine.") });
     }
     if (!this.discovery.repoPrompt.configured && this.discovery.repoPrompt.executablePath && this.discovery.repoPrompt.targetPath && this.discovery.repoPrompt.entry && this.discovery.repoPrompt.serverName) {
-      actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to shared MCP config", description: "Write a standard MCP entry for RepoPrompt to the recommended shared target, then reload MCP in-session." });
+      actions.push({ id: "add-repoprompt", label: t("setup.repoprompt.label", "Add RepoPrompt to shared MCP config"), description: t("setup.repoprompt.description", "Write a standard MCP entry for RepoPrompt to the recommended shared target, then reload MCP in-session.") });
     }
-    actions.push({ id: "close", label: "Close", description: "Exit the onboarding flow." });
+    actions.push({ id: "close", label: t("setup.close.label", "Close"), description: t("setup.close.description", "Exit the onboarding flow.") });
     return actions;
   }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "proxy-modes.ts",
     "direct-tools.ts",
     "commands.ts",
+    "i18n.ts",
     "onboarding-state.ts",
     "mcp-setup-panel.ts",
     "types.ts",


### PR DESCRIPTION
I found one small UX issue: the setup/auth path has dense status strings exactly where users are deciding which MCP configs to import, when to authenticate, and when to reconnect. If those messages are misread, Pi can stay disconnected or load the wrong MCP tools into context.

This PR makes that path optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, de — large developer markets for dense setup/error copy
- Small diff; easy to revert

Validation:
- npm pack --dry-run
- npx vitest run __tests__/index-lifecycle.test.ts __tests__/package-manifest.test.ts

Note: full npm test has existing environment-related failures in config/fixture tests on this Windows machine, plus a missing optional @mariozechner/pi-tui package for one panel test. The targeted lifecycle/package checks pass.