### PR TITLE
Localize MCP status empty-state copy

### DIFF
--- a/commands.ts
+++ b/commands.ts
@@ -19,42 +19,48 @@ import { supportsOAuth, authenticate } from "./mcp-auth-flow.js";
 import { hasStoredTokens } from "./mcp-auth.js";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.js";
 import { openPath } from "./utils.js";
+import { t } from "./i18n.js";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
 
-  const lines: string[] = ["MCP Server Status:", ""];
+  const lines: string[] = [t("mcp.status.title", "MCP Server Status:"), ""];
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const connection = state.manager.getConnection(name);
     const metadata = state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
     const failedAgo = getFailureAgeSeconds(state, name);
-    let status = "not connected";
+    let status = t("mcp.status.notConnected", "not connected");
     let statusIcon = "○";
     let failed = false;
 
     if (connection?.status === "connected") {
-      status = "connected";
+      status = t("mcp.status.connected", "connected");
       statusIcon = "✓";
     } else if (connection?.status === "needs-auth") {
-      status = "needs auth";
+      status = t("mcp.status.needsAuth", "needs auth");
       statusIcon = "⚠";
     } else if (failedAgo !== null) {
-      status = `failed ${failedAgo}s ago`;
+      status = t("mcp.status.failedAgo", "failed {seconds}s ago", { seconds: failedAgo });
       statusIcon = "✗";
       failed = true;
     } else if (metadata !== undefined) {
-      status = "cached";
+      status = t("mcp.status.cached", "cached");
     }
 
-    const toolSuffix = failed ? "" : ` (${toolCount} tools${status === "cached" ? ", cached" : ""})`;
+    const cachedStatus = t("mcp.status.cached", "cached");
+    const toolSuffix = failed
+      ? ""
+      : ` (${status === cachedStatus
+        ? t("mcp.status.toolsCached", "{count} tools, cached", { count: toolCount })
+        : t("mcp.status.tools", "{count} tools", { count: toolCount })})`;
     lines.push(`${statusIcon} ${name}: ${status}${toolSuffix}`);
   }
 
   if (Object.keys(state.config.mcpServers).length === 0) {
-    lines.push("No MCP servers configured");
-    lines.push("Run /mcp setup to adopt imports or scaffold a starter .mcp.json");
+    lines.push(t("mcp.status.noneConfigured", "No MCP servers configured"));
+    lines.push(t("mcp.status.setupHint", "Run /mcp setup to adopt imports or scaffold a starter .mcp.json"));
   }
 
   ctx.ui.notify(lines.join("\n"), "info");

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,72 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+  es: {
+    "mcp.status.title": "Estado de servidores MCP:",
+    "mcp.status.notConnected": "no conectado",
+    "mcp.status.connected": "conectado",
+    "mcp.status.needsAuth": "requiere autenticación",
+    "mcp.status.failedAgo": "falló hace {seconds}s",
+    "mcp.status.cached": "en caché",
+    "mcp.status.tools": "{count} herramientas",
+    "mcp.status.toolsCached": "{count} herramientas, en caché",
+    "mcp.status.noneConfigured": "No hay servidores MCP configurados",
+    "mcp.status.setupHint": "Ejecuta /mcp setup para adoptar importaciones o crear un .mcp.json inicial",
+  },
+  fr: {
+    "mcp.status.title": "État des serveurs MCP :",
+    "mcp.status.notConnected": "non connecté",
+    "mcp.status.connected": "connecté",
+    "mcp.status.needsAuth": "authentification requise",
+    "mcp.status.failedAgo": "échec il y a {seconds}s",
+    "mcp.status.cached": "en cache",
+    "mcp.status.tools": "{count} outils",
+    "mcp.status.toolsCached": "{count} outils, en cache",
+    "mcp.status.noneConfigured": "Aucun serveur MCP configuré",
+    "mcp.status.setupHint": "Exécutez /mcp setup pour adopter des imports ou créer un .mcp.json de départ",
+  },
+  "pt-BR": {
+    "mcp.status.title": "Status dos servidores MCP:",
+    "mcp.status.notConnected": "não conectado",
+    "mcp.status.connected": "conectado",
+    "mcp.status.needsAuth": "requer autenticação",
+    "mcp.status.failedAgo": "falhou há {seconds}s",
+    "mcp.status.cached": "em cache",
+    "mcp.status.tools": "{count} ferramentas",
+    "mcp.status.toolsCached": "{count} ferramentas, em cache",
+    "mcp.status.noneConfigured": "Nenhum servidor MCP configurado",
+    "mcp.status.setupHint": "Execute /mcp setup para adotar importações ou criar um .mcp.json inicial",
+  },
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: ExtensionAPI): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", {
+    namespace: "pi-mcp-adapter",
+    defaultLocale: "en",
+    locales: translations,
+  });
+
+  pi.events?.emit?.("pi-core/i18n/requestApi", {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const next = api.getLocale?.();
+      if (isLocale(next)) currentLocale = next;
+      api.onLocaleChange?.((locale) => {
+        if (isLocale(locale)) currentLocale = locale;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/index.ts
+++ b/index.ts
@@ -9,8 +9,10 @@ import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
+import { initI18n } from "./i18n.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
+  initI18n(pi);
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
   let lifecycleGeneration = 0;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "state.ts",
     "utils.ts",
     "tool-metadata.ts",
+    "i18n.ts",
     "init.ts",
     "ui-session.ts",
     "proxy-modes.ts",


### PR DESCRIPTION
Reposting this as a much smaller follow-up after retracting the earlier over-broad PR.

The `/mcp` status empty-state is a setup decision point: users need to know whether servers are connected, cached, failed, need auth, or are not configured yet. I kept this PR limited to that status/empty-state path instead of wrapping the setup panel or broader MCP copy.

What changed:
- added a tiny optional i18n bridge in `i18n.ts`
- registered `es`, `fr`, and `pt-BR` strings
- wrapped only `/mcp` server status labels and the no-server setup hint
- added `i18n.ts` to package files so the extension still packs correctly

What did not change:
- no required dependency
- no behavior change without a Pi i18n provider
- English fallback strings stay in the call sites
- no README, setup panel, auth flow, or tool behavior changed
- easy to revert by deleting `i18n.ts` and the small wrappers

Validation:
- `npx esbuild index.ts --bundle --platform=node --format=esm --outfile=... --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-tui` passed
- `npm pack --dry-run` passed and includes `i18n.ts`
- `npm test` ran: 224 passed / 15 failed; failures appear pre-existing/environmental around Windows path/home config, missing interactive-visualizer dist artifacts, and onboarding state leakage, not these status string wrappers

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.
