### PR TITLE
fix: always register cached MCP direct tools — unbreaks subagent web search

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,14 +51,19 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   const prefix = earlyConfig.settings?.toolPrefix ?? "server";
 
   const envRaw = process.env.MCP_DIRECT_TOOLS;
-  const directSpecs = envRaw === "__none__"
-    ? []
-    : resolveDirectTools(
-        earlyConfig,
-        earlyCache,
-        prefix,
-        envRaw?.split(",").map(s => s.trim()).filter(Boolean),
-      );
+  // Always register cached direct tools. When MCP_DIRECT_TOOLS is set to a
+  // non-__none__ value, use it as an override filter. Otherwise fall back to
+  // per-server directTools / globalDirect from mcp.json config. This fixes
+  // subagents where --tools restricts execution but MCP_DIRECT_TOOLS=__none__
+  // prevented tool registration entirely.
+  const directSpecs = resolveDirectTools(
+    earlyConfig,
+    earlyCache,
+    prefix,
+    envRaw && envRaw !== "__none__"
+      ? envRaw.split(",").map(s => s.trim()).filter(Boolean)
+      : undefined,
+  );
   const missingConfiguredDirectToolServers = getMissingConfiguredDirectToolServers(earlyConfig, earlyCache);
   const shouldRegisterProxyTool =
     earlyConfig.settings?.disableProxyTool !== true


### PR DESCRIPTION
## Problem

Subagents launched by pi-subagents cannot use MCP direct tools (e.g. `parallel_search_web_search`) regardless of how the agent is configured.

**Repro:**
1. Install pi-subagents with a subagent that has `mcp:parallel-search/web_search` in its tools
2. Launch the subagent — task asks it to do a web search
3. The subagent sees `parallel_search_web_search` in its tool descriptions but gets `"Tool not found"` when calling it
4. Similarly, using bare tool names in `--tools` (e.g. `--tools read,write,parallel_search_web_search`) also fails — the tool is in the allowlist but never registered

## Root cause

Two mechanisms deadlock:

**Path A — `mcp:` prefix:**
- pi-subagents sets `MCP_DIRECT_TOOLS=parallel-search/web_search` ✅
- pi-mcp-adapter registers `parallel_search_web_search` ✅  
- pi-core `--tools read,write` allowlist blocks execution ❌

**Path B — bare names in `--tools`:**
- pi-subagents sets `--tools read,write,parallel_search_web_search` ✅
- pi-core allowlist includes the tool name ✅
- pi-subagents sets `MCP_DIRECT_TOOLS=__none__` ❌
- **pi-mcp-adapter sees `__none__` and registers zero direct tools** ❌

The gate in `index.ts`:

```typescript
const directSpecs = envRaw === "__none__"
    ? []  // ← short-circuits, no tools registered at all
    : resolveDirectTools(...);
```

## Fix

Remove the `__none__` short-circuit. When `MCP_DIRECT_TOOLS` is `__none__` or absent, pass `undefined` as `envOverride` to `resolveDirectTools`, which falls back to per-server `directTools` / `globalDirect` from `mcp.json`. Cached tools register normally and pi-core's `--tools` allowlist handles filtering.

When `MCP_DIRECT_TOOLS` has specific values, it still acts as an override filter (existing behavior preserved).

```typescript
const directSpecs = resolveDirectTools(
    earlyConfig, earlyCache, prefix,
    envRaw && envRaw !== "__none__"
      ? envRaw.split(",").map(s => s.trim()).filter(Boolean)
      : undefined,
);
```

## Testing

Tested locally with a subagent using the `parallel_search_web_search` tool, reloaded with the fix applied:

**Path B — bare tool names (FIXED by this PR):**
Agent config: `tools: read, write, parallel_search_web_search`
Subagent task: `parallel_search_web_search({objective:"test", search_queries:["hello"]})`
Result: ✅ returned 7 real search results from the web

**Path A — mcp: prefix (still blocked by pi-core):**
Agent config: `tools: read, write, mcp:parallel-search/web_search`
Subagent task: `parallel_search_web_search({objective:"test mcp prefix", search_queries:["pi coding agent"]})`
Result: ❌ `"Tool parallel_search_web_search not found"` — pi-core's `--tools` allowlist blocks the registered tool despite it being in `MCP_DIRECT_TOOLS`

Path A needs a separate fix in pi-core: when `--tools` is set, extension tools registered via `MCP_DIRECT_TOOLS` should also be allowed. See `agent-session.ts` `_refreshToolRegistry` — the `isAllowedTool` filter currently only checks the `--tools` allowlist and doesn't account for `MCP_DIRECT_TOOLS`-registered tools.

## Behavior changes

- When `MCP_DIRECT_TOOLS` has specific server/tool values → override filter (existing behavior unchanged)
- When `MCP_DIRECT_TOOLS` is `__none__` or absent → tools now register from cache based on mcp.json config (previously registered nothing)