### PR TITLE
feat: add Pi session id to MCP tool call metadata

### DIFF
--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -66,6 +66,7 @@ describe("direct tools auto auth", () => {
       failureTracker: new Map(),
       ui: { setStatus: vi.fn() },
       completedUiSessions: [],
+      sessionId: "pi-session-direct",
     } as any;
 
     const executor = createDirectToolExecutor(
@@ -87,6 +88,11 @@ describe("direct tools auto auth", () => {
       state.config.mcpServers.demo,
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
+    expect(connected.client.callTool).toHaveBeenCalledWith({
+      name: "search",
+      arguments: { q: "hello" },
+      _meta: { "pi/session_id": "pi-session-direct" },
+    });
     expect(result.content[0].text).toContain("ok");
   });
 

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -199,6 +199,7 @@ describe("proxy auto auth", () => {
       failureTracker: new Map(),
       ui: { setStatus: vi.fn() },
       completedUiSessions: [],
+      sessionId: "pi-session-proxy",
     } as any;
 
     const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
@@ -209,6 +210,11 @@ describe("proxy auto auth", () => {
       state.config.mcpServers.demo,
     );
     expect(manager.connect).toHaveBeenCalledTimes(1);
+    expect(connected.client.callTool).toHaveBeenCalledWith({
+      name: "search",
+      arguments: { q: "hello" },
+      _meta: { "pi/session_id": "pi-session-proxy" },
+    });
     expect(result.content[0].text).toContain("ok");
   });
 });

--- a/__tests__/state.test.ts
+++ b/__tests__/state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildMcpRequestMeta } from "../state.ts";
+
+describe("buildMcpRequestMeta", () => {
+  it("adds Pi session id to request metadata", () => {
+    expect(buildMcpRequestMeta("pi-session-123")).toEqual({
+      "pi/session_id": "pi-session-123",
+    });
+  });
+
+  it("preserves existing request metadata and owns the Pi session id", () => {
+    expect(buildMcpRequestMeta("pi-session-123", {
+      "pi-mcp-adapter/stream-token": "stream-token",
+      "pi/session_id": "caller-supplied",
+    })).toEqual({
+      "pi-mcp-adapter/stream-token": "stream-token",
+      "pi/session_id": "pi-session-123",
+    });
+  });
+});

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -436,13 +436,17 @@ describe("UiServer", () => {
       const manager = createMockManager({
         getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
       });
-      handle = await startUiServer(createServerOptions({ manager }));
+      handle = await startUiServer(createServerOptions({ manager, piSessionId: "pi-session-ui" }));
 
       const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
         method: "POST",
         body: {
           token: handle.sessionToken,
-          params: { name: "some_tool", arguments: { arg1: "value1" } },
+          params: {
+            name: "some_tool",
+            arguments: { arg1: "value1" },
+            _meta: { "ui/call": "from-widget" },
+          },
         },
       });
 
@@ -454,6 +458,7 @@ describe("UiServer", () => {
       expect(mockClient.callTool).toHaveBeenCalledWith({
         name: "some_tool",
         arguments: { arg1: "value1" },
+        _meta: { "ui/call": "from-widget", "pi/session_id": "pi-session-ui" },
       });
     });
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,5 +1,5 @@
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
-import type { McpExtensionState } from "./state.js";
+import { buildMcpRequestMeta, type McpExtensionState } from "./state.js";
 import type { DirectToolSpec, McpConfig, McpContent } from "./types.js";
 import type { MetadataCache } from "./metadata-cache.js";
 import { lazyConnect, getFailureAgeSeconds } from "./init.js";
@@ -364,7 +364,7 @@ export function createDirectToolExecutor(
       const resultPromise = connection.client.callTool({
         name: spec.originalName,
         arguments: params ?? {},
-        _meta: uiSession?.requestMeta,
+        _meta: buildMcpRequestMeta(state.sessionId, uiSession?.requestMeta),
       });
 
       const result = await resultPromise;

--- a/init.ts
+++ b/init.ts
@@ -59,6 +59,7 @@ export async function initializeMcp(
     consentManager,
     uiServer: null,
     completedUiSessions: [],
+    sessionId: ctx.sessionManager.getSessionId(),
     openBrowser: (url: string) => openUrl(pi, url, process.env.BROWSER),
     ui,
     sendMessage: (message, options) => pi.sendMessage(message, options),

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@mariozechner/pi-coding-agent";
-import type { McpExtensionState } from "./state.js";
+import { buildMcpRequestMeta, type McpExtensionState } from "./state.js";
 import type { ToolMetadata, McpContent } from "./types.js";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.js";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.js";
@@ -719,7 +719,7 @@ export async function executeCall(
     const resultPromise = connection.client.callTool({
       name: toolMeta.originalName,
       arguments: args ?? {},
-      _meta: uiSession?.requestMeta,
+      _meta: buildMcpRequestMeta(state.sessionId, uiSession?.requestMeta),
     });
 
     if (toolMeta.uiResourceUri) {

--- a/state.ts
+++ b/state.ts
@@ -35,7 +35,19 @@ export interface McpExtensionState {
   consentManager: ConsentManager;
   uiServer: UiServerHandle | null;
   completedUiSessions: CompletedUiSession[];
+  sessionId: string;
   openBrowser: (url: string) => Promise<void>;
   ui?: ExtensionContext["ui"];
   sendMessage?: SendMessageFn;
+}
+
+export function buildMcpRequestMeta(
+  sessionId: string | undefined,
+  requestMeta?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!sessionId) return requestMeta;
+  return {
+    ...requestMeta,
+    "pi/session_id": sessionId,
+  };
 }

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -12,6 +12,7 @@ import { ServerError, wrapError } from "./errors.js";
 import { buildHostHtmlTemplate, buildCspMetaContent, applyCspMeta } from "./host-html-template.js";
 import { logger } from "./logger.js";
 import type { McpServerManager } from "./server-manager.js";
+import { buildMcpRequestMeta } from "./state.js";
 import {
   extractUiPromptText,
   getVisualizationStreamEnvelope,
@@ -42,6 +43,7 @@ export interface UiServerOptions {
   manager: McpServerManager;
   consentManager: ConsentManager;
   hostContext?: UiHostContext;
+  piSessionId?: string;
   initialResultPromise?: Promise<CallToolResult>;
   sessionToken?: string;
   port?: number;
@@ -346,6 +348,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
                 ? callParams.arguments
                 : {},
+            _meta: buildMcpRequestMeta(options.piSessionId, callParams._meta),
           });
           sendJson(res, 200, { ok: true, result });
         } finally {

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -213,6 +213,7 @@ export async function maybeStartUiSession(
       manager: state.manager,
       consentManager: state.consentManager,
       hostContext,
+      piSessionId: state.sessionId,
 
       onMessage: (params: UiMessageParams) => {
         const prompt = extractUiPromptText(params);


### PR DESCRIPTION
## Summary
- Add `pi/session_id` to downstream MCP `tools/call` request metadata
- Preserve existing request `_meta` values while ensuring Pi owns the session id field
- Propagate the same metadata through proxy, direct tool, and MCP UI bridge tool-call paths

## Why
Stateful MCP servers need a stable per-Pi-session identity to route per-conversation state without relying on environment-variable hacks. Pi already has a persistent session id via `ctx.sessionManager.getSessionId()`, so this exposes it per call under Pi's own `_meta` namespace.

## Tests
- `bunx vitest run __tests__/state.test.ts __tests__/direct-tools-auto-auth.test.ts __tests__/proxy-modes-auto-auth.test.ts __tests__/ui-server.test.ts`
