### PR TITLE
fix: resolve bearerToken env interpolation for URL MCP servers

### DIFF
--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -156,6 +156,35 @@ describe("metadata cache hashing", () => {
       computeServerHash({ url: "https://example.test/mcp", auth: "bearer", bearerToken: "token-two", bearerTokenEnv: "MCP_HASH_TOKEN" }),
     );
   });
+
+  it("hashes interpolated bearerToken values", () => {
+    process.env.MCP_HASH_INLINE_TOKEN = "token-one";
+    const first = computeServerHash({
+      url: "https://example.test/mcp",
+      auth: "bearer",
+      bearerToken: "${MCP_HASH_INLINE_TOKEN}",
+    });
+
+    process.env.MCP_HASH_INLINE_TOKEN = "token-two";
+    const second = computeServerHash({
+      url: "https://example.test/mcp",
+      auth: "bearer",
+      bearerToken: "${MCP_HASH_INLINE_TOKEN}",
+    });
+
+    expect(first).not.toBe(second);
+    expect(computeServerHash({
+      url: "https://example.test/mcp",
+      auth: "bearer",
+      bearerToken: "${MCP_HASH_INLINE_TOKEN}",
+    })).toBe(
+      computeServerHash({
+        url: "https://example.test/mcp",
+        auth: "bearer",
+        bearerToken: "token-two",
+      }),
+    );
+  });
 });
 
 describe("excludeTools filtering", () => {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -7,7 +7,7 @@ import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { McpTool, McpResource, ServerEntry, ToolMetadata } from "./types.js";
 import { formatToolName, isToolExcluded } from "./types.js";
 import { resourceNameToToolName } from "./resource-tools.js";
-import { extractToolUiStreamMode, interpolateEnvRecord, resolveConfigPath } from "./utils.js";
+import { extractToolUiStreamMode, interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.js";
 
 const CACHE_VERSION = 1;
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -93,7 +93,7 @@ export function computeServerHash(definition: ServerEntry): string {
     url: definition.url,
     headers: interpolateEnvRecord(definition.headers),
     auth: definition.auth,
-    bearerToken: definition.bearerToken ?? (definition.bearerTokenEnv ? process.env[definition.bearerTokenEnv] : undefined),
+    bearerToken: resolveBearerToken(definition.bearerToken, definition.bearerTokenEnv),
     bearerTokenEnv: definition.bearerTokenEnv,
     exposeResources: definition.exposeResources,
     excludeTools: definition.excludeTools,

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -17,7 +17,7 @@ import { logger } from "./logger.js";
 import { McpOAuthProvider } from "./mcp-oauth-provider.js";
 import { supportsOAuth } from "./mcp-auth-flow.js";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.js";
-import { interpolateEnvRecord, resolveConfigPath } from "./utils.js";
+import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.js";
 
 interface ServerConnection {
   client: Client;
@@ -170,8 +170,7 @@ export class McpServerManager {
     
     // For bearer auth, add the token to headers BEFORE creating requestInit
     if (definition.auth === "bearer") {
-      const token = definition.bearerToken 
-        ?? (definition.bearerTokenEnv ? process.env[definition.bearerTokenEnv] : undefined);
+      const token = resolveBearerToken(definition.bearerToken, definition.bearerTokenEnv);
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
       }

--- a/utils.ts
+++ b/utils.ts
@@ -75,6 +75,20 @@ export function interpolateEnvRecord(values: Record<string, string> | undefined)
   return resolved;
 }
 
+export function resolveBearerToken(
+  bearerToken: string | undefined,
+  bearerTokenEnv: string | undefined,
+): string | undefined {
+  const tokenFromField = bearerToken ? interpolateEnvVars(bearerToken) : undefined;
+  if (tokenFromField) return tokenFromField;
+
+  if (!bearerTokenEnv) return undefined;
+  const envName = interpolateEnvVars(bearerTokenEnv);
+  if (!envName) return undefined;
+
+  return process.env[envName];
+}
+
 export function resolveConfigPath(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
 


### PR DESCRIPTION
## Summary
- resolve env placeholders in `bearerToken` for URL MCP servers
- centralize bearer token resolution in shared utility
- align metadata cache hash with effective resolved bearer token
- add regression test for interpolated `bearerToken`

## Repro
Using config:
```json
{
  "posthog": {
    "url": "https://mcp.posthog.com/mcp",
    "auth": "bearer",
    "bearerToken": "${POSTHOG_BEARER_TOKEN}"
  }
}
```
connection returned 401, while hardcoding token worked.

## Validation
- `npm test -- __tests__/direct-tools.test.ts`
- passes (11/11)

Fixes nicobailon/pi-mcp-adapter#78
