### PR TITLE
feat: respect modelPreferences.hints in MCP sampling

### DIFF
--- a/__tests__/sampling-handler.test.ts
+++ b/__tests__/sampling-handler.test.ts
@@ -130,6 +130,74 @@ describe("sampling handler", () => {
     expect(ui.confirm.mock.calls[1][1]).toContain("Bonjour");
   });
 
+  it("respects modelPreferences.hints to select a matching model", async () => {
+    const { handleSamplingRequest } = await import("../sampling-handler.ts");
+    const flashModel = {
+      provider: "google",
+      id: "gemini-2.5-flash",
+      api: "google-genai",
+      name: "Gemini 2.5 Flash",
+      input: ["text"],
+      reasoning: false,
+      cost: usage.cost,
+      contextWindow: 1000000,
+      maxTokens: 8192,
+    };
+    const options = createOptions({
+      getCurrentModel: vi.fn(() => model),
+      modelRegistry: {
+        getAvailable: vi.fn(() => [model, flashModel]),
+        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "gkey", headers: {} })),
+      },
+    });
+
+    await handleSamplingRequest(options, {
+      method: "sampling/createMessage",
+      params: {
+        messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+        maxTokens: 50,
+        modelPreferences: {
+          hints: [{ name: "flash" }],
+        },
+      },
+    } as any);
+
+    // Should have called complete with the flash model, not the current model
+    expect(mocks.complete).toHaveBeenCalledWith(
+      flashModel,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to current model when hints don't match", async () => {
+    const { handleSamplingRequest } = await import("../sampling-handler.ts");
+    const options = createOptions({
+      getCurrentModel: vi.fn(() => model),
+      modelRegistry: {
+        getAvailable: vi.fn(() => [model]),
+        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key", headers: {} })),
+      },
+    });
+
+    await handleSamplingRequest(options, {
+      method: "sampling/createMessage",
+      params: {
+        messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+        maxTokens: 50,
+        modelPreferences: {
+          hints: [{ name: "nonexistent-model" }],
+        },
+      },
+    } as any);
+
+    expect(mocks.complete).toHaveBeenCalledWith(
+      model,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("rejects unsupported sampling features loudly", async () => {
     const { handleSamplingRequest } = await import("../sampling-handler.ts");
 

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -6,6 +6,7 @@ import {
   CreateMessageRequestSchema,
   type CreateMessageRequest,
   type CreateMessageResult,
+  type ModelHint,
   type SamplingMessage,
   type SamplingMessageContentBlock,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -50,7 +51,7 @@ export async function handleSamplingRequest(
   }
 
   const messages = params.messages.map(convertSamplingMessage);
-  const { model, apiKey, headers } = await resolveSamplingModel(options);
+  const { model, apiKey, headers } = await resolveSamplingModel(options, params.modelPreferences?.hints);
   await confirmSampling(
     options,
     "Approve MCP sampling request",
@@ -114,16 +115,40 @@ function messageText(message: Message): string {
   }).join("\n");
 }
 
-async function resolveSamplingModel(options: SamplingHandlerOptions): Promise<{
+async function resolveSamplingModel(
+  options: SamplingHandlerOptions,
+  hints?: ModelHint[],
+): Promise<{
   model: Model<any>;
   apiKey?: string;
   headers?: Record<string, string>;
 }> {
+  const available = options.modelRegistry.getAvailable();
+
+  // If the server provided model hints, try to match them first.
+  // Per the MCP spec, hints are treated as substrings of model names.
+  if (hints?.length) {
+    for (const hint of hints) {
+      if (!hint.name) continue;
+      const needle = hint.name.toLowerCase();
+      for (const model of available) {
+        const haystack = `${model.provider}/${model.id}`.toLowerCase();
+        if (haystack.includes(needle) || model.name.toLowerCase().includes(needle)) {
+          const auth = await options.modelRegistry.getApiKeyAndHeaders(model);
+          if (auth.ok) {
+            return { model, apiKey: auth.apiKey, headers: auth.headers };
+          }
+        }
+      }
+    }
+  }
+
+  // Fall back to current model, then any available model.
   const candidates: Model<any>[] = [];
   const currentModel = options.getCurrentModel();
   if (currentModel) candidates.push(currentModel);
 
-  for (const model of options.modelRegistry.getAvailable()) {
+  for (const model of available) {
     if (!candidates.some((candidate) => candidate.provider === model.provider && candidate.id === model.id)) {
       candidates.push(model);
     }


### PR DESCRIPTION
Closes #80

## What

When an MCP server sends `sampling/createMessage` with `modelPreferences.hints`, the adapter now tries to match those hints against available Pi models before falling back to the current conversation model.

## Why

MCP servers like [the-i18n-mcp](https://github.com/fabkho/the-i18n-kit) use sampling for bulk operations (translating to 16+ locales). They send hints like `["flash", "haiku", "gpt-4o-mini"]` requesting fast/cheap models, but the adapter was ignoring them — always using the conversation model (e.g. Claude Opus), which is slow, expensive, and hits rate limits.

## How

In `resolveSamplingModel()`:
1. If `params.modelPreferences.hints` exists, iterate through hints
2. For each hint, fuzzy-match `hint.name` (case-insensitive substring) against `provider/id` and `model.name` of all available models
3. First match with valid auth is used
4. If no hint matches, fall back to existing behavior (current model → any available)

This follows the [MCP spec](https://modelcontextprotocol.io/docs/concepts/sampling#model-preferences) which says hints should be treated as substrings of model names.

## Tests

Added 2 tests:
- ✅ `respects modelPreferences.hints to select a matching model` — verifies flash model is selected when hint matches
- ✅ `falls back to current model when hints don't match` — verifies graceful fallback

All existing tests continue to pass.