### PR TITLE
feat: add SDK memory MCP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `createMcpAdapter({ configPath, config })` for SDK integrations that need to overlay an in-memory MCP config on top of the existing file-based config.
+
 ## [2.5.4] - 2026-05-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
+- Added `createMcpAdapter({ config, configPath })` for isolated SDK configuration and file-path overrides. Thanks @Cansiny0320 for PR #86.
 
 ### Changed
 - Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ Use the shared MCP files when you want one setup to work across hosts, and Pi-ow
 
 Pi-specific files are the write targets for imported or shared global servers when Pi needs to persist adapter-only settings such as `directTools`.
 
+### SDK in-memory config
+
+The default extension still reads MCP config files exactly as before. SDK users can create an adapter with an in-memory config overlay:
+
+```ts
+import { createMcpAdapter } from "pi-mcp-adapter";
+
+const mcpExtension = createMcpAdapter({
+  configPath: "/path/to/mcp.json",
+  config: {
+    mcpServers: {
+      async_examine_tools: {
+        url: `https://mcp.example.com/mcp?scene=${encodeURIComponent(scene)}`,
+        lifecycle: "eager",
+        directTools: false,
+      },
+    },
+  },
+});
+```
+
+File config is loaded first. The in-memory config is applied last using the same merge rules as existing config precedence, so in-memory servers and settings win on name/key collisions.
+
 ### Server Options
 
 ```json

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ Use the shared MCP files when you want one setup to work across hosts, and Pi-ow
 
 Pi-specific files are the write targets for imported or shared global servers when Pi needs to persist adapter-only settings such as `directTools`.
 
+### SDK configuration
+
+Use `createMcpAdapter` when an SDK or server integration already owns its MCP configuration:
+
+```ts
+import { createMcpAdapter } from "pi-mcp-adapter";
+
+const extension = createMcpAdapter({
+  config: {
+    mcpServers: {
+      docs: {
+        url: "https://mcp.example.com/mcp",
+        lifecycle: "eager",
+      },
+    },
+  },
+});
+
+// Register `extension` with the host SDK.
+```
+
+The package ships TypeScript source for Pi's source-loader and SDK integrations. Use a TypeScript-capable loader/toolchain (for example `node --import tsx`) when importing the package from a standalone Node process; raw Node ESM does not execute the `.ts` entry directly.
+
+A supplied `config` is a complete, isolated snapshot. It is not merged with files, imports, global config, project config, or `--mcp-config`, and it is never mutated. Each adapter factory and session receives its own clone, so separate integrations can use different servers and settings safely. In this mode, server status, reconnect, explicit `/mcp-auth <server>`, proxy calls, and direct tools continue to work; setup and no-argument auth/status panels report the limitation instead of discovering or writing ambient config.
+
+With `configPath` and no `config`, the adapter keeps normal file merge behavior, and that path takes precedence over argv and `--mcp-config`. The default export keeps the normal file-based behavior. OAuth credentials remain persistent and are shared by the configured server name by default; callers requiring strict same-name credential-file isolation should set distinct `settings.oauthDir` values. URL binding prevents credentials from being accepted for a different server URL. CSRF state and PKCE verifiers are flow-local, so concurrent authorization flows do not share transient secrets.
+
 In the configuration examples below, `30000` is illustrative only. If `requestTimeoutMs` is omitted or set to `<= 0`, the MCP SDK default timeout is used.
 
 ### Server Options

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -76,6 +76,51 @@ describe("config discovery", () => {
     });
   });
 
+  it("merges in-memory config after file config with in-memory precedence", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-memory-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-memory-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(project, ".mcp.json"), {
+      imports: ["cursor"],
+      settings: { toolPrefix: "short", idleTimeout: 5 },
+      mcpServers: {
+        shared: { command: "file-command", directTools: true },
+        fileOnly: { command: "file-only" },
+      },
+    });
+    writeJson(join(home, ".cursor", "mcp.json"), {
+      mcpServers: {
+        importedOnly: { command: "cursor" },
+      },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig(undefined, {
+      imports: ["vscode"],
+      settings: { idleTimeout: 30, sampling: false },
+      mcpServers: {
+        shared: { url: "https://memory.example.com/mcp", lifecycle: "eager" },
+        memoryOnly: { url: "https://memory-only.example.com/mcp" },
+      },
+    });
+
+    expect(config.imports).toEqual(["cursor", "vscode"]);
+    expect(config.settings).toEqual({
+      toolPrefix: "short",
+      idleTimeout: 30,
+      sampling: false,
+    });
+    expect(config.mcpServers.fileOnly).toEqual({ command: "file-only" });
+    expect(config.mcpServers.importedOnly).toEqual({ command: "cursor" });
+    expect(config.mcpServers.memoryOnly).toEqual({ url: "https://memory-only.example.com/mcp" });
+    expect(config.mcpServers.shared).toEqual({
+      url: "https://memory.example.com/mcp",
+      lifecycle: "eager",
+    });
+  });
+
   it("prefers modern Claude Code config detection over legacy paths", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-import-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-import-project-"));

--- a/__tests__/direct-tool-schema.test.ts
+++ b/__tests__/direct-tool-schema.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { normalizeDirectToolInputSchema } from "../utils.ts";
+import { computeServerHash, type MetadataCache } from "../metadata-cache.ts";
+import { resolveDirectTools } from "../direct-tools.ts";
 
 describe("normalizeDirectToolInputSchema", () => {
   it("removes top-level draft metadata and strict additional properties", () => {
@@ -32,5 +34,23 @@ describe("normalizeDirectToolInputSchema", () => {
 
   it("uses an empty object schema when the MCP tool omits inputSchema", () => {
     expect(normalizeDirectToolInputSchema(undefined)).toEqual({ type: "object", properties: {} });
+  });
+
+  it("does not reuse ambient cache metadata for a different programmatic server identity", () => {
+    const ambientDefinition = { url: "https://ambient.example.com/mcp" };
+    const programmaticDefinition = { url: "https://programmatic.example.com/mcp", directTools: true as const };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        shared: {
+          configHash: computeServerHash(ambientDefinition),
+          tools: [{ name: "ambient_tool", inputSchema: { type: "object" } }],
+          resources: [],
+          cachedAt: Date.now(),
+        },
+      },
+    };
+
+    expect(resolveDirectTools({ mcpServers: { shared: programmaticDefinition } }, cache, "server")).toEqual([]);
   });
 });

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -199,6 +199,38 @@ describe("mcpAdapter session lifecycle", () => {
     expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
   });
 
+  it("creates an SDK adapter that merges file config with in-memory config", async () => {
+    const memoryConfig = {
+      mcpServers: {
+        memory: { url: "https://memory.example.com/mcp", lifecycle: "eager" },
+      },
+    };
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.loadMcpConfig.mockReturnValue(memoryConfig);
+
+    const { createMcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    createMcpAdapter({
+      configPath: "/tmp/sdk-mcp.json",
+      config: memoryConfig,
+    })(api);
+
+    expect(mocks.loadMcpConfig).toHaveBeenCalledWith("/tmp/sdk-mcp.json", memoryConfig);
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, {});
+
+    expect(mocks.initializeMcp).toHaveBeenCalledWith(
+      api,
+      expect.any(Object),
+      {
+        configPath: "/tmp/sdk-mcp.json",
+        config: memoryConfig,
+      },
+    );
+  });
+
   it("starts a replacement init immediately and shuts down stale init results", async () => {
     const first = createDeferred<any>();
     const second = createDeferred<any>();

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -5,8 +5,10 @@ const mocks = vi.hoisted(() => ({
   updateStatusBar: vi.fn(),
   flushMetadataCache: vi.fn(),
   initializeOAuth: vi.fn().mockResolvedValue(undefined),
+  createOAuthRuntime: vi.fn((signal: AbortSignal) => ({ signal })),
   shutdownOAuth: vi.fn().mockResolvedValue(undefined),
   loadMcpConfig: vi.fn(() => ({ mcpServers: {} })),
+  cloneMcpConfig: vi.fn((config: unknown) => structuredClone(config)),
   loadMetadataCache: vi.fn(() => null),
   buildProxyDescription: vi.fn(() => "MCP gateway"),
   createDirectToolExecutor: vi.fn(() => vi.fn()),
@@ -45,11 +47,13 @@ vi.mock("../init.ts", () => ({
 
 vi.mock("../mcp-auth-flow.ts", () => ({
   initializeOAuth: mocks.initializeOAuth,
+  createOAuthRuntime: mocks.createOAuthRuntime,
   shutdownOAuth: mocks.shutdownOAuth,
 }));
 
 vi.mock("../config.ts", () => ({
   loadMcpConfig: mocks.loadMcpConfig,
+  cloneMcpConfig: mocks.cloneMcpConfig,
 }));
 
 vi.mock("../metadata-cache.ts", () => ({
@@ -109,6 +113,7 @@ function createState() {
     lifecycle: { gracefulShutdown: vi.fn().mockResolvedValue(undefined) },
     toolMetadata: new Map(),
     config: { mcpServers: {} },
+    oauthRuntime: { signal: new AbortController().signal },
     failureTracker: new Map(),
     uiResourceHandler: {},
     consentManager: {},
@@ -148,8 +153,10 @@ describe("mcpAdapter session lifecycle", () => {
     }
 
     mocks.initializeOAuth.mockResolvedValue(undefined);
+    mocks.createOAuthRuntime.mockImplementation((signal: AbortSignal) => ({ signal }));
     mocks.shutdownOAuth.mockResolvedValue(undefined);
     mocks.loadMcpConfig.mockReturnValue({ mcpServers: {} });
+    mocks.cloneMcpConfig.mockImplementation((config: unknown) => structuredClone(config));
     mocks.loadMetadataCache.mockReturnValue(null);
     mocks.buildProxyDescription.mockReturnValue("MCP gateway");
     mocks.createDirectToolExecutor.mockReturnValue(vi.fn());
@@ -413,6 +420,116 @@ describe("mcpAdapter session lifecycle", () => {
     );
   });
 
+  it("exports createMcpAdapter while retaining the default adapter export", async () => {
+    const adapterModule = await import("../index.ts");
+    expect(adapterModule.createMcpAdapter).toBeTypeOf("function");
+    expect(adapterModule.default).toBeTypeOf("function");
+
+    const { api } = createPi();
+    adapterModule.default(api);
+    expect(mocks.loadMcpConfig).toHaveBeenCalledWith(undefined);
+  });
+
+  it("uses only the supplied config for early registration and session initialization", async () => {
+    const config = {
+      mcpServers: {
+        memory: { url: "https://memory.example.com/mcp", directTools: true },
+      },
+      settings: { disableProxyTool: true as const },
+    };
+    mocks.getConfigPathFromArgv.mockReturnValue("/ambient/argv.json");
+    mocks.resolveDirectTools.mockReturnValue([{
+      serverName: "memory",
+      originalName: "search",
+      prefixedName: "memory_search",
+      description: "Search",
+    }]);
+    const state = createState();
+    state.config = structuredClone(config);
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { createMcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    createMcpAdapter({ config })(api);
+
+    expect(mocks.loadMcpConfig).not.toHaveBeenCalled();
+    expect(mocks.getConfigPathFromArgv).not.toHaveBeenCalled();
+    expect(mocks.resolveDirectTools).toHaveBeenCalledWith(
+      expect.objectContaining({ mcpServers: { memory: config.mcpServers.memory } }),
+      null,
+      "server",
+      undefined,
+    );
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "memory_search" }));
+    expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    expect(mocks.initializeMcp).toHaveBeenCalledWith(
+      api,
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({ config: expect.objectContaining({ mcpServers: config.mcpServers }) }),
+    );
+    expect(mocks.initializeMcp.mock.calls[0][3].config).not.toBe(config);
+  });
+
+  it("snapshots caller config and isolates separate factories", async () => {
+    const firstConfig = { mcpServers: { first: { url: "https://first.example.com/mcp" } } };
+    const secondConfig = { mcpServers: { second: { url: "https://second.example.com/mcp" } } };
+    const firstAdapter = (await import("../index.ts")).createMcpAdapter({ config: firstConfig });
+    const secondAdapter = (await import("../index.ts")).createMcpAdapter({ config: secondConfig });
+    firstConfig.mcpServers.first.url = "https://mutated.example.com/mcp";
+
+    const firstPi = createPi();
+    const secondPi = createPi();
+    firstAdapter(firstPi.api);
+    secondAdapter(secondPi.api);
+
+    expect(mocks.resolveDirectTools.mock.calls.at(-2)?.[0]).toEqual({
+      mcpServers: { first: { url: "https://first.example.com/mcp" } },
+    });
+    expect(mocks.resolveDirectTools.mock.calls.at(-1)?.[0]).toEqual(secondConfig);
+  });
+
+  it("gives configPath precedence without changing the default argv path", async () => {
+    mocks.getConfigPathFromArgv.mockReturnValue("/argv.json");
+    const { createMcpAdapter, default: defaultAdapter } = await import("../index.ts");
+    const configured = createMcpAdapter({ configPath: "/factory.json" });
+    configured(createPi().api);
+    expect(mocks.loadMcpConfig).toHaveBeenCalledWith("/factory.json");
+    expect(mocks.getConfigPathFromArgv).not.toHaveBeenCalled();
+
+    mocks.loadMcpConfig.mockClear();
+    mocks.getConfigPathFromArgv.mockClear();
+    defaultAdapter(createPi().api);
+    expect(mocks.getConfigPathFromArgv).toHaveBeenCalledTimes(1);
+    expect(mocks.loadMcpConfig).toHaveBeenCalledWith("/argv.json");
+  });
+
+  it("uses status notifications instead of ambient panels in memory-config mode", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { createMcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    createMcpAdapter({ config: { mcpServers: { memory: { url: "https://memory.example.com/mcp" } } } })(api);
+    const ui = { notify: vi.fn() };
+    await handlers.get("session_start")?.({}, { hasUI: true, ui });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp")?.[1];
+    await commandDef.handler("setup", { hasUI: true, ui });
+    await commandDef.handler("status", { hasUI: true, ui });
+    const authDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp-auth")?.[1];
+    await authDef.handler("", { hasUI: true, ui });
+
+    expect(mocks.openMcpSetup).not.toHaveBeenCalled();
+    expect(mocks.openMcpPanel).not.toHaveBeenCalled();
+    expect(mocks.openMcpAuthPanel).not.toHaveBeenCalled();
+    expect(mocks.showStatus).toHaveBeenCalled();
+    expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("in-memory"), "info");
+  });
+
   it("starts a replacement init immediately and shuts down stale init results", async () => {
     const first = createDeferred<any>();
     const second = createDeferred<any>();
@@ -429,11 +546,13 @@ describe("mcpAdapter session lifecycle", () => {
 
     await sessionStart?.({}, {});
     expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
-    expect(mocks.shutdownOAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.shutdownOAuth).not.toHaveBeenCalled();
+    const firstRuntime = mocks.createOAuthRuntime.mock.results[0].value;
 
     await sessionStart?.({}, {});
     expect(mocks.initializeMcp).toHaveBeenCalledTimes(2);
-    expect(mocks.shutdownOAuth).toHaveBeenCalledTimes(2);
+    expect(mocks.shutdownOAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.shutdownOAuth).toHaveBeenCalledWith(firstRuntime);
 
     const activeState = createState();
     second.resolve(activeState);
@@ -643,7 +762,13 @@ describe("mcpAdapter session lifecycle", () => {
     const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp-auth")?.[1];
     await commandDef.handler("github", { hasUI: true, ui });
 
-    expect(mocks.authenticateServer).toHaveBeenCalledWith("github", state.config, expect.any(Object));
+    expect(mocks.authenticateServer).toHaveBeenCalledWith(
+      "github",
+      state.config,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.reconnectServer).toHaveBeenCalledWith(state, expect.any(Object), "github");
     expect(mocks.openMcpAuthPanel).not.toHaveBeenCalled();
   });
@@ -666,7 +791,13 @@ describe("mcpAdapter session lifecycle", () => {
     const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp-auth")?.[1];
     await commandDef.handler("github", { hasUI: true, ui });
 
-    expect(mocks.authenticateServer).toHaveBeenCalledWith("github", state.config, expect.any(Object));
+    expect(mocks.authenticateServer).toHaveBeenCalledWith(
+      "github",
+      state.config,
+      expect.any(Object),
+      expect.any(AbortSignal),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.reconnectServer).not.toHaveBeenCalled();
     expect(mocks.openMcpAuthPanel).not.toHaveBeenCalled();
   });

--- a/__tests__/init-elicitation.test.ts
+++ b/__tests__/init-elicitation.test.ts
@@ -51,6 +51,23 @@ describe("initializeMcp elicitation config", () => {
     mocks.loadMcpConfig.mockReturnValue({ mcpServers: {}, settings: {} });
   });
 
+  it("uses an isolated programmatic config without reading flags or files", async () => {
+    const config = {
+      mcpServers: {},
+      settings: { sampling: false as const },
+    };
+    const api = extensionApi();
+    const { initializeMcp } = await import("../init.ts");
+    const { createMcpRuntimeOwner } = await import("../runtime-owner.ts");
+    const state = await initializeMcp(api, context({ hasUI: false }), createMcpRuntimeOwner(), { config });
+
+    expect(api.getFlag).not.toHaveBeenCalled();
+    expect(mocks.loadMcpConfig).not.toHaveBeenCalled();
+    expect(state.config).toEqual(config);
+    expect(state.config).not.toBe(config);
+    expect(state.programmaticConfig).toBe(true);
+  });
+
   it("enables form and URL elicitation in TUI mode", async () => {
     const { initializeMcp } = await import("../init.ts");
     const { McpServerManager } = await import("../server-manager.ts");

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -298,26 +298,29 @@ describe("mcp-auth-flow explicit auth", () => {
       await provider.saveTokens({ access_token: "token-b", token_type: "Bearer" });
       return "AUTHORIZED";
     });
-    const { startAuth, completeAuthFromInput, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const { createOAuthRuntime, startAuth, completeAuthFromInput, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const runtimeA = createOAuthRuntime();
+    const runtimeB = createOAuthRuntime();
     const { getAuthForUrl, getOAuthState } = await import("../mcp-auth.ts");
 
     await startAuth("shared", "https://api.example.com/mcp", {
       url: "https://api.example.com/mcp",
       auth: "oauth",
-    }, { authStorageOptions: authStorageOptionsA });
+    }, { authStorageOptions: authStorageOptionsA, runtime: runtimeA });
     await startAuth("shared", "https://api.example.com/mcp", {
       url: "https://api.example.com/mcp",
       auth: "oauth",
-    }, { authStorageOptions: authStorageOptionsB });
+    }, { authStorageOptions: authStorageOptionsB, runtime: runtimeB });
 
-    expect(getOAuthState("shared", authStorageOptionsA)).toBeDefined();
-    expect(getOAuthState("shared", authStorageOptionsB)).toBeDefined();
+    expect(getOAuthState("shared", authStorageOptionsA)).toBeUndefined();
+    expect(getOAuthState("shared", authStorageOptionsB)).toBeUndefined();
 
-    await completeAuthFromInput("shared", "code-b", { authStorageOptions: authStorageOptionsB });
+    await completeAuthFromInput("shared", "code-b", { authStorageOptions: authStorageOptionsB, runtime: runtimeB });
 
     expect(getAuthForUrl("shared", "https://api.example.com/mcp", authStorageOptionsA)?.tokens).toBeUndefined();
     expect(getAuthForUrl("shared", "https://api.example.com/mcp", authStorageOptionsB)?.tokens?.accessToken).toBe("token-b");
-    await shutdownOAuth();
+    await shutdownOAuth(runtimeA);
+    await shutdownOAuth(runtimeB);
     rmSync(projectA, { recursive: true, force: true });
     rmSync(projectB, { recursive: true, force: true });
   });
@@ -545,7 +548,7 @@ describe("mcp-auth-flow explicit auth", () => {
       serverUrl: "https://api.example.com/mcp",
       authorizationCode: "manual-code",
     });
-    expect(mocks.cancelPendingCallback).not.toHaveBeenCalled();
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(mocks.waitForCallback.mock.calls[0][0]);
     expect(getOAuthState("browser-fail")).toBeUndefined();
   });
 
@@ -659,12 +662,94 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
   });
 
+  it("isolates concurrent OAuth runtimes with the same server name and auth directory", async () => {
+    const states: string[] = [];
+    const verifiers: string[] = [];
+    mocks.sdkAuth.mockImplementation(async (provider, options) => {
+      if (options.authorizationCode) {
+        verifiers.push(await provider.codeVerifier());
+        return "AUTHORIZED";
+      }
+      const state = await provider.state();
+      states.push(state);
+      await provider.saveCodeVerifier(`verifier-${states.length}`);
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${state}`));
+      return "REDIRECT";
+    });
+    const { completeAuthFromInput, createOAuthRuntime, hasPendingAuth, startAuth, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const runtimeA = createOAuthRuntime();
+    const runtimeB = createOAuthRuntime();
+    const definition = { auth: "oauth" as const };
+
+    await startAuth("shared", "https://a.example.com/mcp", definition, { runtime: runtimeA });
+    await startAuth("shared", "https://b.example.com/mcp", definition, { runtime: runtimeB });
+
+    expect(states).toHaveLength(2);
+    expect(states[0]).not.toBe(states[1]);
+    expect(hasPendingAuth("shared", undefined, runtimeA)).toBe(true);
+    expect(hasPendingAuth("shared", undefined, runtimeB)).toBe(true);
+
+    await expect(completeAuthFromInput("shared", `code=code-a&state=${states[0]}`, { runtime: runtimeA })).resolves.toBe("authenticated");
+    await expect(completeAuthFromInput("shared", `code=code-b&state=${states[1]}`, { runtime: runtimeB })).resolves.toBe("authenticated");
+    expect(verifiers).toEqual(["verifier-1", "verifier-2"]);
+
+    await shutdownOAuth(runtimeA);
+    await shutdownOAuth(runtimeA);
+    expect(hasPendingAuth("shared", undefined, runtimeA)).toBe(false);
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
+
+    await shutdownOAuth(runtimeB);
+    expect(hasPendingAuth("shared", undefined, runtimeB)).toBe(false);
+    expect(mocks.stopCallbackServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels only the stopped runtime's callback while another flow remains active", async () => {
+    const states: string[] = [];
+    mocks.sdkAuth.mockImplementation(async (provider, options) => {
+      if (options.authorizationCode) return "AUTHORIZED";
+      const state = await provider.state();
+      states.push(state);
+      await provider.saveCodeVerifier(`verifier-${states.length}`);
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${state}`));
+      return "REDIRECT";
+    });
+    const { completeAuthFromInput, createOAuthRuntime, hasPendingAuth, startAuth, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const runtimeA = createOAuthRuntime();
+    const runtimeB = createOAuthRuntime();
+    const definition = { auth: "oauth" as const };
+
+    await startAuth("shared", "https://a.example.com/mcp", definition, { runtime: runtimeA });
+    await startAuth("shared", "https://b.example.com/mcp", definition, { runtime: runtimeB });
+    await shutdownOAuth(runtimeA);
+
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(states[0]);
+    expect(hasPendingAuth("shared", undefined, runtimeB)).toBe(true);
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
+    await expect(completeAuthFromInput("shared", `code=code-b&state=${states[1]}`, { runtime: runtimeB })).resolves.toBe("authenticated");
+    await shutdownOAuth(runtimeB);
+  });
+
+  it("does not reactivate a stopped runtime after a stale auth call", async () => {
+    const { createOAuthRuntime, getAuthStatus, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const staleRuntime = createOAuthRuntime();
+    await shutdownOAuth(staleRuntime);
+    mocks.stopCallbackServer.mockClear();
+
+    await expect(getAuthStatus("stale", { runtime: staleRuntime })).rejects.toThrow("OAuth runtime stopped");
+
+    const liveRuntime = createOAuthRuntime();
+    await shutdownOAuth(liveRuntime);
+    expect(mocks.stopCallbackServer).toHaveBeenCalledTimes(1);
+  });
+
   it("releases reserved callback state after direct completeAuth", async () => {
     const resourceMetadataUrl = "https://api.example.com/.well-known/oauth-protected-resource";
     mocks.fetch.mockResolvedValueOnce(new Response(null, {
       headers: { "www-authenticate": `Bearer resource_metadata="${resourceMetadataUrl}", scope="mcp:read"` },
     }));
+    let oauthState: string | undefined;
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      oauthState = await provider.state();
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
       return "REDIRECT";
     });
@@ -676,7 +761,8 @@ describe("mcp-auth-flow explicit auth", () => {
       auth: "oauth",
       headers: { "X-Tenant": "tenant-a" },
     });
-    const oauthState = getOAuthState("direct-complete");
+    expect(oauthState).toBeDefined();
+    expect(getOAuthState("direct-complete")).toBeUndefined();
 
     await expect(completeAuth("direct-complete", "auth-code")).resolves.toBe("authenticated");
 
@@ -694,7 +780,7 @@ describe("mcp-auth-flow explicit auth", () => {
       resourceMetadataUrl: new URL(resourceMetadataUrl),
       scope: "mcp:read",
     });
-    expect(mocks.releaseCallbackServer).toHaveBeenCalledWith(oauthState);
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(oauthState);
     expect(getOAuthState("direct-complete")).toBeUndefined();
   });
 

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
-import { saveAuthEntry, updateOAuthState } from "../mcp-auth.ts";
+import { saveAuthEntry } from "../mcp-auth.ts";
 
 describe("McpOAuthProvider clientMetadata scope", () => {
   it("includes configured scope in authorization_code client metadata", () => {
@@ -199,15 +199,14 @@ describe("McpOAuthProvider authorization fallback", () => {
     expect(redirected).toBe(false);
   });
 
-  it("still redirects when startAuth has seeded OAuth state", async () => {
+  it("redirects when the active provider owns OAuth state", async () => {
     const authUrl = new URL("https://auth.example.com/authorize");
     let redirected: URL | undefined;
-    updateOAuthState("redirect-active", "state-abc", serverUrl);
     const provider = new McpOAuthProvider("redirect-active", serverUrl, {}, {
       onRedirect: async (url) => {
         redirected = url;
       },
-    });
+    }, {}, undefined, "state-abc");
 
     await provider.redirectToAuthorization(authUrl);
 

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -10,6 +10,8 @@ const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf
   files?: string[];
   peerDependencies?: Record<string, string>;
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  exports?: Record<string, unknown>;
+  types?: string;
 };
 
 const hostPeerPackages = {
@@ -19,6 +21,22 @@ const hostPeerPackages = {
 };
 
 describe("package.json files", () => {
+  it("exports the TypeScript source entry for SDK consumers", () => {
+    expect(packageJson.types).toBe("./index.ts");
+    expect(packageJson.exports).toMatchObject({
+      ".": {
+        types: "./index.ts",
+        import: "./index.ts",
+        default: "./index.ts",
+      },
+      "./types": {
+        types: "./types.ts",
+        import: "./types.ts",
+        default: "./types.ts",
+      },
+    });
+  });
+
   it("publishes every root runtime TypeScript module", () => {
     const publishedFiles = new Set(packageJson.files ?? []);
     const runtimeModules = readdirSync(repoRoot)

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -144,6 +144,7 @@ describe("proxy auto auth", () => {
         },
       },
       manager,
+      oauthRuntime: { signal: new AbortController().signal },
       toolMetadata: new Map(),
       serverInstructions: new Map(),
       failureTracker: new Map(),
@@ -156,6 +157,7 @@ describe("proxy auto auth", () => {
       "demo",
       "https://api.example.com/mcp",
       state.config.mcpServers.demo,
+      { runtime: state.oauthRuntime },
     );
     expect(manager.close).toHaveBeenCalledWith("demo");
     expect(manager.connect).toHaveBeenCalledTimes(2);

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -40,6 +40,7 @@ function createState(overrides: Record<string, unknown> = {}) {
       },
     },
     manager: { close: vi.fn(async () => {}) },
+    oauthRuntime: { signal: new AbortController().signal },
     toolMetadata: new Map(),
     failureTracker: new Map([["demo", Date.now()]]),
     failureMessages: new Map([["demo", "stale failure"]]),
@@ -68,7 +69,12 @@ describe("manual OAuth proxy actions", () => {
 
     const result = await executeAuthStart(state, "demo");
 
-    expect(mocks.startAuth).toHaveBeenCalledWith("demo", "https://api.example.com/mcp", state.config.mcpServers.demo);
+    expect(mocks.startAuth).toHaveBeenCalledWith(
+      "demo",
+      "https://api.example.com/mcp",
+      state.config.mcpServers.demo,
+      { runtime: state.oauthRuntime },
+    );
     expect(result.content[0].text).toContain("Open this URL in your local browser");
     expect(result.content[0].text).toContain("https://auth.example.com/authorize");
     expect(result.content[0].text).toContain("auth-complete");
@@ -94,7 +100,11 @@ describe("manual OAuth proxy actions", () => {
 
     const result = await executeAuthComplete(state, "demo", "http://localhost:19876/callback?code=abc&state=state");
 
-    expect(mocks.completeAuthFromInput).toHaveBeenCalledWith("demo", "http://localhost:19876/callback?code=abc&state=state");
+    expect(mocks.completeAuthFromInput).toHaveBeenCalledWith(
+      "demo",
+      "http://localhost:19876/callback?code=abc&state=state",
+      { runtime: state.oauthRuntime },
+    );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
     expect(state.failureTracker.has("demo")).toBe(false);
     expect(mocks.updateStatusBar).toHaveBeenCalledWith(state);

--- a/commands.ts
+++ b/commands.ts
@@ -15,7 +15,7 @@ import {
 import { markKeepAliveAfterConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds, getFailureMessage, clearFailure, recordFailure } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
-import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
+import { supportsOAuth, authenticate, removeAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
@@ -173,6 +173,7 @@ export async function authenticateServer(
   config: McpConfig,
   ctx: ExtensionContext,
   signal?: AbortSignal,
+  runtime?: McpOAuthRuntime,
 ): Promise<McpAuthResult> {
   const ui = ctx.hasUI ? ctx.ui : undefined;
   const cwd = ctx.cwd;
@@ -216,6 +217,7 @@ export async function authenticateServer(
         );
       },
       signal,
+      runtime,
     });
     if (signal?.aborted) signal.throwIfAborted();
 
@@ -251,7 +253,7 @@ export async function logoutServer(
     return { ok: false, message };
   }
 
-  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions, signal: state.owner?.signal });
+  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions, signal: state.owner?.signal, runtime: state.oauthRuntime });
   state.owner?.throwIfInactive();
   await state.manager.close(serverName);
   state.owner?.throwIfInactive();
@@ -285,13 +287,17 @@ function buildSharedConfigNoticeLines(configOverridePath: string | undefined, cw
 }
 
 export async function openMcpSetup(
-  _state: McpExtensionState,
+  state: McpExtensionState,
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   configOverridePath?: string,
   mode: "empty" | "setup" = "setup",
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (state.programmaticConfig) {
+    ctx.ui.notify("MCP setup is unavailable when config is supplied by createMcpAdapter().", "info");
+    return { configChanged: false };
+  }
 
   const discovery = getMcpDiscoverySummary(configOverridePath, ctx.cwd);
   const onboardingState = loadOnboardingState();
@@ -357,7 +363,7 @@ function buildMcpPanelCallbacks(
       const definition = config.mcpServers[serverName];
       return definition ? supportsOAuth(definition) : false;
     },
-    authenticate: (serverName: string) => authenticateServer(serverName, config, ctx),
+    authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
     getConnectionStatus: (serverName: string) => {
       const definition = config.mcpServers[serverName];
       const connection = state.manager.getConnection(serverName);
@@ -397,6 +403,13 @@ export async function openMcpPanel(
   ctx: ExtensionContext,
   configOverridePath?: string,
 ): Promise<PanelFlowResult> {
+  if (state.programmaticConfig) {
+    if (ctx.hasUI) {
+      ctx.ui.notify("MCP status is shown from the in-memory SDK config; configuration discovery is unavailable.", "info");
+      await showStatus(state, ctx);
+    }
+    return { configChanged: false };
+  }
   if (Object.keys(state.config.mcpServers).length === 0) {
     return openMcpSetup(state, pi, ctx, configOverridePath, "empty");
   }
@@ -443,6 +456,10 @@ export async function openMcpAuthPanel(
   configOverridePath?: string,
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (state.programmaticConfig) {
+    ctx.ui.notify("Use /mcp-auth <server> to authenticate a server from the in-memory SDK config.", "info");
+    return { configChanged: false };
+  }
 
   const config = state.config;
   const oauthServers = Object.entries(config.mcpServers).filter(([, definition]) => supportsOAuth(definition));

--- a/config.ts
+++ b/config.ts
@@ -180,16 +180,16 @@ export function getMcpDiscoverySummary(overridePath?: string, cwd = process.cwd(
   };
 }
 
-export function loadMcpConfig(overridePath?: string): McpConfig {
+export function loadMcpConfig(overridePath?: string, memoryConfig?: McpConfig): McpConfig {
   let config: McpConfig = { mcpServers: {} };
 
   for (const source of getConfigSources(overridePath)) {
     const loaded = readValidatedConfig(source.readPath, `MCP config from ${source.readPath}`);
     if (!loaded) continue;
-    config = mergeConfigs(config, expandImports(loaded));
+    config = mergeMcpConfigs(config, expandImports(loaded));
   }
 
-  return config;
+  return memoryConfig ? mergeMcpConfigs(config, memoryConfig) : config;
 }
 
 function getConfigSources(overridePath?: string, cwd = process.cwd()): ConfigSourceSpec[] {
@@ -248,7 +248,7 @@ function getConfigSources(overridePath?: string, cwd = process.cwd()): ConfigSou
   return sources;
 }
 
-function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
+export function mergeMcpConfigs(base: McpConfig, next: McpConfig): McpConfig {
   return {
     mcpServers: { ...base.mcpServers, ...next.mcpServers },
     imports: mergeImports(base.imports, next.imports),

--- a/config.ts
+++ b/config.ts
@@ -189,6 +189,10 @@ export function getMcpDiscoverySummary(overridePath?: string, cwd = process.cwd(
   };
 }
 
+export function cloneMcpConfig(config: McpConfig): McpConfig {
+  return structuredClone(config);
+}
+
 export function loadMcpConfig(overridePath?: string, cwd = process.cwd()): McpConfig {
   let config: McpConfig = { mcpServers: {} };
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -84,10 +84,12 @@ async function attemptDirectAutoAuth(
         serverName,
         serverUrl,
         definition,
-        signal ? { authStorageOptions: state.authStorageOptions, signal } : { authStorageOptions: state.authStorageOptions },
+        signal
+          ? { authStorageOptions: state.authStorageOptions, signal, runtime: state.oauthRuntime }
+          : { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime },
       );
     } else {
-      await authenticate(serverName, serverUrl, definition, signal ? { signal } : {});
+      await authenticate(serverName, serverUrl, definition, { signal, runtime: state.oauthRuntime });
     }
     return { status: "success" };
   } catch (error) {

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
 import type { McpExtensionState } from "./state.js";
+import type { McpAdapterOptions } from "./types.js";
 import { Type } from "typebox";
 import { showStatus, showTools, reconnectServers, authenticateServer, openMcpPanel, openMcpSetup } from "./commands.js";
 import { loadMcpConfig } from "./config.js";
@@ -10,7 +11,7 @@ import { executeCall, executeConnect, executeDescribe, executeList, executeSearc
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
 
-export default function mcpAdapter(pi: ExtensionAPI) {
+function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
   let lifecycleGeneration = 0;
@@ -45,8 +46,8 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     }
   }
 
-  const earlyConfigPath = getConfigPathFromArgv();
-  const earlyConfig = loadMcpConfig(earlyConfigPath);
+  const earlyConfigPath = options.configPath ?? getConfigPathFromArgv();
+  const earlyConfig = loadMcpConfig(earlyConfigPath, options.config);
   const earlyCache = loadMetadataCache();
   const prefix = earlyConfig.settings?.toolPrefix ?? "server";
 
@@ -106,7 +107,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       console.error("MCP OAuth initialization failed:", err);
     });
 
-    const promise = initializeMcp(pi, ctx);
+    const promise = initializeMcp(pi, ctx, {
+      configPath: earlyConfigPath,
+      config: options.config,
+    });
     initPromise = promise;
 
     promise.then(async (nextState) => {
@@ -315,3 +319,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     });
   }
 }
+
+export function createMcpAdapter(options: McpAdapterOptions = {}) {
+  return function mcpAdapter(pi: ExtensionAPI) {
+    installMcpAdapter(pi, options);
+  };
+}
+
+export default createMcpAdapter();

--- a/index.ts
+++ b/index.ts
@@ -1,22 +1,29 @@
 import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
+import type { McpAdapterOptions } from "./types.ts";
+import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
 import { showStatus, showTools, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
-import { loadMcpConfig } from "./config.ts";
+import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { formatTerminalError, getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
-import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
+import { createOAuthRuntime, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
 import { toolErrorOverride } from "./error-signal.ts";
 import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 
-export default function mcpAdapter(pi: ExtensionAPI) {
+export type { McpAdapterOptions } from "./types.ts";
+
+function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
+  const sessionConfig = options.config !== undefined ? cloneMcpConfig(options.config) : undefined;
+  const programmaticConfig = sessionConfig !== undefined;
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
   let currentOwner: McpRuntimeOwner | null = null;
+  let currentOAuthRuntime: McpOAuthRuntime | null = null;
   let lifecycleGeneration = 0;
 
   async function shutdownState(currentState: McpExtensionState | null, reason: string): Promise<void> {
@@ -53,8 +60,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     }
   }
 
-  const earlyConfigPath = getConfigPathFromArgv();
-  const earlyConfig = loadMcpConfig(earlyConfigPath);
+  const earlyConfigPath = programmaticConfig
+    ? undefined
+    : options.configPath ?? getConfigPathFromArgv();
+  const earlyConfig = programmaticConfig
+    ? cloneMcpConfig(sessionConfig)
+    : loadMcpConfig(earlyConfigPath);
   const earlyCache = loadMetadataCache();
   const prefix = earlyConfig.settings?.toolPrefix ?? "server";
 
@@ -106,8 +117,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     const generation = ++lifecycleGeneration;
     const previousState = state;
     const previousOwner = currentOwner;
+    const previousOAuthRuntime = currentOAuthRuntime;
     const owner = createMcpRuntimeOwner();
+    const oauthRuntime = createOAuthRuntime(owner.signal);
     currentOwner = owner;
+    currentOAuthRuntime = oauthRuntime;
     state = null;
     initPromise = null;
 
@@ -118,7 +132,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       await Promise.all([
         stopPrevious,
         shutdownState(previousState, "session_restart"),
-        shutdownOAuth(),
+        previousOAuthRuntime ? shutdownOAuth(previousOAuthRuntime) : Promise.resolve(),
       ]);
     } catch (error) {
       console.error(`MCP: failed to shut down previous session state: ${formatTerminalError(error)}`);
@@ -128,13 +142,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       return;
     }
 
-    await initializeOAuth(owner.signal).catch(err => {
-      console.error(`MCP OAuth initialization failed: ${formatTerminalError(err)}`);
-    });
-
     if (generation !== lifecycleGeneration || !owner.isActive()) return;
 
-    const promise = initializeMcp(pi, ctx, owner);
+    const initOptions = {
+      ...(programmaticConfig || options.configPath !== undefined
+        ? { configPath: earlyConfigPath, config: sessionConfig }
+        : {}),
+      oauthRuntime,
+    };
+    const promise = initializeMcp(pi, ctx, owner, initOptions);
     initPromise = promise;
 
     promise.then(async (nextState) => {
@@ -166,7 +182,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     ++lifecycleGeneration;
     const currentState = state;
     const owner = currentOwner;
+    const oauthRuntime = currentOAuthRuntime;
     currentOwner = null;
+    currentOAuthRuntime = null;
     state = null;
     initPromise = null;
 
@@ -177,7 +195,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       await Promise.all([
         stopOwner,
         shutdownState(currentState, "session_shutdown"),
-        shutdownOAuth(),
+        oauthRuntime ? shutdownOAuth(oauthRuntime) : Promise.resolve(),
       ]);
     } catch (error) {
       console.error(`MCP: session shutdown cleanup failed: ${formatTerminalError(error)}`);
@@ -255,6 +273,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           break;
         case "setup": {
           commandOwner?.throwIfInactive();
+          if (programmaticConfig) {
+            commandCtx.ui?.notify("MCP setup is unavailable when config is supplied by createMcpAdapter().", "info");
+            break;
+          }
           const result = await openMcpSetup(state, pi, commandCtx, earlyConfigPath, "setup");
           if (result?.configChanged) {
             commandOwner?.throwIfInactive();
@@ -278,6 +300,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         default:
           if (commandCtx.hasUI) {
             commandOwner?.throwIfInactive();
+            if (programmaticConfig) {
+              commandCtx.ui?.notify("MCP status is shown from the in-memory SDK config; configuration discovery is unavailable.", "info");
+              await showStatus(state, commandCtx);
+              break;
+            }
             const result = await openMcpPanel(state, pi, commandCtx, earlyConfigPath);
             if (result?.configChanged) {
               commandOwner?.throwIfInactive();
@@ -328,11 +355,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       }
 
       if (!serverName) {
+        if (programmaticConfig) {
+          commandCtx.ui?.notify("Use /mcp-auth <server> to authenticate a server from the in-memory SDK config.", "info");
+          return;
+        }
         await openMcpAuthPanel(state, pi, commandCtx, earlyConfigPath);
         return;
       }
 
-      const result = await authenticateServer(serverName, state.config, commandCtx);
+      const result = await authenticateServer(serverName, state.config, commandCtx, commandCtx.signal, state.oauthRuntime);
       if (result.ok) {
         commandOwner?.throwIfInactive();
         await reconnectServer(state, commandCtx, serverName);
@@ -479,3 +510,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     });
   }
 }
+
+export function createMcpAdapter(options: McpAdapterOptions = {}) {
+  const factoryConfig = options.config !== undefined ? cloneMcpConfig(options.config) : undefined;
+  return function mcpAdapter(pi: ExtensionAPI) {
+    installMcpAdapter(pi, {
+      configPath: options.configPath,
+      config: factoryConfig !== undefined ? cloneMcpConfig(factoryConfig) : undefined,
+    });
+  };
+}
+
+export default createMcpAdapter();

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { McpExtensionState } from "./state.js";
-import type { ToolMetadata } from "./types.js";
+import type { McpAdapterOptions, ToolMetadata } from "./types.js";
 import { existsSync } from "node:fs";
 import { loadMcpConfig } from "./config.js";
 import { ConsentManager } from "./consent-manager.js";
@@ -27,10 +27,12 @@ const FAILURE_BACKOFF_MS = 60 * 1000;
 
 export async function initializeMcp(
   pi: ExtensionAPI,
-  ctx: ExtensionContext
+  ctx: ExtensionContext,
+  options: McpAdapterOptions = {},
 ): Promise<McpExtensionState> {
-  const configPath = pi.getFlag("mcp-config") as string | undefined;
-  const config = loadMcpConfig(configPath);
+  const flagConfigPath = pi.getFlag("mcp-config");
+  const configPath = options.configPath ?? (typeof flagConfigPath === "string" ? flagConfigPath : undefined);
+  const config = loadMcpConfig(configPath, options.config);
 
   const manager = new McpServerManager();
   const samplingAutoApprove = config.settings?.samplingAutoApprove === true;

--- a/init.ts
+++ b/init.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import type { ToolMetadata } from "./types.ts";
+import type { McpAdapterOptions, ToolMetadata } from "./types.ts";
 import { existsSync } from "node:fs";
-import { loadMcpConfig } from "./config.ts";
+import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
 import { McpLifecycleManager } from "./lifecycle.ts";
 import {
@@ -24,6 +24,7 @@ import { logger } from "./logger.ts";
 import { getMissingConfiguredDirectToolServers } from "./direct-tools.ts";
 import { throwIfAborted } from "./abort.ts";
 import { getAuthStorageOptions } from "./mcp-auth.ts";
+import { createOAuthRuntime, hasPendingAuth, shutdownOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import {
   combineAbortSignals,
   createMcpRuntimeOwner,
@@ -74,14 +75,19 @@ export function isTuiMode(ctx: Pick<ExtensionContext, "hasUI" | "mode">): boolea
   return ctx.hasUI && ctx.mode === "tui";
 }
 
+type McpInitializationOptions = McpAdapterOptions & { oauthRuntime?: McpOAuthRuntime };
+
 export async function initializeMcp(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   owner: McpRuntimeOwner = createMcpRuntimeOwner(),
+  options: McpInitializationOptions = {},
 ): Promise<McpExtensionState> {
   // Pi guards ExtensionContext getters after reload. Snapshot all values that
   // can be used by asynchronous work before the first await.
-  const configPath = pi.getFlag("mcp-config") as string | undefined;
+  const configPath = options.config !== undefined
+    ? undefined
+    : options.configPath ?? (pi.getFlag("mcp-config") as string | undefined);
   const cwd = ctx.cwd;
   const hasUI = ctx.hasUI;
   const mode = ctx.mode;
@@ -90,11 +96,16 @@ export async function initializeMcp(
   const initialSignal = ctx.signal;
   const ui = rawUi ? createOwnedUi(rawUi, owner) : undefined;
   const runtimeSignal = combineAbortSignals(owner.signal, initialSignal);
-  const config = loadMcpConfig(configPath, cwd);
+  const config = options.config !== undefined
+    ? cloneMcpConfig(options.config)
+    : loadMcpConfig(configPath, cwd);
   const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
 
+  const ownsOAuthRuntime = options.oauthRuntime === undefined;
+  const oauthRuntime = options.oauthRuntime ?? createOAuthRuntime(owner.signal);
   const manager = new McpServerManager(cwd);
   manager.setRuntimeSignal?.(owner.signal);
+  manager.setOAuthRuntime?.(oauthRuntime);
   manager.setDefaultRequestTimeoutMs(config.settings?.requestTimeoutMs);
   manager.setAuthStorageOptions(authStorageOptions);
   const samplingAutoApprove = config.settings?.samplingAutoApprove === true;
@@ -116,7 +127,7 @@ export async function initializeMcp(
       allowUrl: mode === "tui",
     });
   }
-  const lifecycle = new McpLifecycleManager(manager);
+  const lifecycle = new McpLifecycleManager(manager, (serverName) => hasPendingAuth(serverName, undefined, oauthRuntime));
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
@@ -130,6 +141,8 @@ export async function initializeMcp(
     toolMetadata,
     serverInstructions,
     config,
+    programmaticConfig: options.config !== undefined,
+    oauthRuntime,
     authStorageOptions,
     failureTracker,
     failureMessages,
@@ -148,6 +161,7 @@ export async function initializeMcp(
       pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options);
     },
   };
+  if (ownsOAuthRuntime) owner.addCleanup(() => shutdownOAuth(oauthRuntime));
   owner.addCleanup(() => lifecycle.gracefulShutdown());
   owner.addCleanup(() => {
     if (state.uiServer) {

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -27,7 +27,6 @@ import {
   clearClientInfo,
   clearTokens,
   clearCodeVerifier,
-  updateOAuthState,
   getOAuthState,
   clearOAuthState,
   getAuthBaseDir,
@@ -42,10 +41,15 @@ import { combineAbortSignals, isAbortError } from "./runtime-owner.ts"
 /** Auth status for a server */
 export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 
+export interface McpOAuthRuntime {
+  readonly signal: AbortSignal
+}
+
 export interface AuthenticateOptions {
   onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
   authStorageOptions?: AuthStorageOptions
   signal?: AbortSignal
+  runtime?: McpOAuthRuntime
 }
 
 type AuthDiscovery = {
@@ -62,24 +66,63 @@ type PendingAuth = {
   authStorageOptions: AuthStorageOptions
 }
 
-const pendingAuths = new Map<string, PendingAuth>()
-const pendingAuthStates = new Map<string, string>()
-const pendingAuthCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>()
+type RuntimeState = {
+  controller: AbortController
+  generation: number
+  pendingAuths: Map<string, PendingAuth>
+  pendingAuthStates: Map<string, string>
+  pendingAuthCleanupTimers: Map<string, ReturnType<typeof setTimeout>>
+  pendingAuthentications: Map<string, Promise<AuthStatus>>
+}
 
-// Deduplicate concurrent authenticate() calls per server.
-const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
-let oauthRuntimeSignal: AbortSignal | undefined
-let oauthGeneration = 0
+const runtimeStates = new WeakMap<McpOAuthRuntime, RuntimeState>()
+const activeRuntimes = new Set<McpOAuthRuntime>()
+
+export function createOAuthRuntime(signal?: AbortSignal): McpOAuthRuntime {
+  const controller = new AbortController()
+  const runtime = { signal: combineAbortSignals(signal, controller.signal)! } satisfies McpOAuthRuntime
+  runtimeStates.set(runtime, {
+    controller,
+    generation: 0,
+    pendingAuths: new Map(),
+    pendingAuthStates: new Map(),
+    pendingAuthCleanupTimers: new Map(),
+    pendingAuthentications: new Map(),
+  })
+  activeRuntimes.add(runtime)
+  return runtime
+}
+
+let legacyRuntime = createOAuthRuntime()
+activeRuntimes.delete(legacyRuntime)
+
+function getRuntime(options?: AuthenticateOptions): McpOAuthRuntime {
+  if (options?.runtime) {
+    options.runtime.signal.throwIfAborted()
+    activeRuntimes.add(options.runtime)
+    return options.runtime
+  }
+  if (legacyRuntime.signal.aborted) legacyRuntime = createOAuthRuntime()
+  activeRuntimes.add(legacyRuntime)
+  return legacyRuntime
+}
+
+function getRuntimeState(runtime: McpOAuthRuntime): RuntimeState {
+  const state = runtimeStates.get(runtime)
+  if (!state) throw new Error("Unknown OAuth runtime")
+  return state
+}
 
 function getPendingAuthKey(serverName: string, options: AuthStorageOptions): string {
   return `${serverName}|${getAuthBaseDir(options)}`
 }
 
-export function hasPendingAuth(serverName: string, options?: AuthStorageOptions): boolean {
+export function hasPendingAuth(serverName: string, options?: AuthStorageOptions, runtime?: McpOAuthRuntime): boolean {
+  const state = getRuntimeState(runtime ?? legacyRuntime)
   if (options) {
-    return pendingAuths.has(getPendingAuthKey(serverName, options))
+    return state.pendingAuths.has(getPendingAuthKey(serverName, options))
   }
-  return Array.from(pendingAuths.values()).some(pendingAuth => pendingAuth.serverName === serverName)
+  return Array.from(state.pendingAuths.values()).some(pendingAuth => pendingAuth.serverName === serverName)
 }
 
 /** Timeout for manual auth completion (5 minutes) */
@@ -178,7 +221,7 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
     await response.body?.cancel().catch(() => {})
     return { ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}), ...(scope ? { scope } : {}) }
   } catch (error) {
-    if (signal?.aborted || oauthRuntimeSignal?.aborted) throwIfAborted(combineAbortSignals(signal, oauthRuntimeSignal))
+    if (signal?.aborted) throwIfAborted(signal)
     return {}
   } finally {
     clearTimeout(timer)
@@ -230,10 +273,12 @@ export async function startAuth(
   definition?: ServerEntry,
   options: AuthenticateOptions = {},
 ): Promise<{ authorizationUrl: string }> {
+  const runtime = getRuntime(options)
+  const runtimeState = getRuntimeState(runtime)
   const config = definition ? extractOAuthConfig(definition) : {}
   const authStorageOptions = options.authStorageOptions ?? {}
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
-  const generation = oauthGeneration
+  const signal = combineAbortSignals(runtime.signal, options.signal)
+  const generation = runtimeState.generation
   throwIfAborted(signal)
 
   if (config.grantType === "client_credentials") {
@@ -248,7 +293,7 @@ export async function startAuth(
       onRedirect: async () => {
         throw new Error("Browser redirect is not used for client_credentials flow")
       },
-    }, authStorageOptions)
+    }, authStorageOptions, runtime.signal)
     try {
       const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
       throwIfAborted(signal)
@@ -263,7 +308,7 @@ export async function startAuth(
     }
   }
 
-  const existingPendingAuth = pendingAuths.get(getPendingAuthKey(serverName, authStorageOptions))
+  const existingPendingAuth = runtimeState.pendingAuths.get(getPendingAuthKey(serverName, authStorageOptions))
   if (existingPendingAuth?.serverUrl === serverUrl) {
     return { authorizationUrl: existingPendingAuth.authorizationUrl }
   }
@@ -294,7 +339,7 @@ export async function startAuth(
     onRedirect: async (url) => {
       capturedUrl = url
     },
-  }, authStorageOptions)
+  }, authStorageOptions, runtime.signal, oauthState)
 
   try {
     const storedAuth = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
@@ -314,7 +359,6 @@ export async function startAuth(
       }
     }
 
-    await updateOAuthState(serverName, oauthState, serverUrl, authStorageOptions)
     throwIfAborted(signal)
 
     const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
@@ -330,12 +374,12 @@ export async function startAuth(
     if (!capturedUrl) {
       throw new UnauthorizedError("OAuth authorization URL was not provided")
     }
-    await setPendingAuth(serverName, { serverName, authProvider, serverUrl, authorizationUrl: capturedUrl.toString(), discovery, authStorageOptions }, oauthState, signal, generation)
+    await setPendingAuth(runtime, serverName, { serverName, authProvider, serverUrl, authorizationUrl: capturedUrl.toString(), discovery, authStorageOptions }, oauthState, signal, generation)
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
     authProvider.deactivate()
     try {
-      await clearPendingAuth(serverName, oauthState, authStorageOptions)
+      await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -344,46 +388,49 @@ export async function startAuth(
 }
 
 async function setPendingAuth(
+  runtime: McpOAuthRuntime,
   serverName: string,
   pendingAuth: PendingAuth,
   oauthState: string,
   signal?: AbortSignal,
-  generation = oauthGeneration,
+  generation = getRuntimeState(runtime).generation,
 ): Promise<void> {
+  const state = getRuntimeState(runtime)
   const key = getPendingAuthKey(serverName, pendingAuth.authStorageOptions)
-  await clearPendingAuth(serverName, undefined, pendingAuth.authStorageOptions)
+  await clearPendingAuth(runtime, serverName, undefined, pendingAuth.authStorageOptions)
   throwIfAborted(signal)
-  if (generation !== oauthGeneration) throw new Error("OAuth runtime stopped")
-  pendingAuths.set(key, pendingAuth)
-  pendingAuthStates.set(key, oauthState)
+  if (generation !== state.generation) throw new Error("OAuth runtime stopped")
+  state.pendingAuths.set(key, pendingAuth)
+  state.pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+    void clearPendingAuth(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
       console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
     })
   }, MANUAL_AUTH_TIMEOUT_MS)
   cleanupTimer.unref?.()
-  pendingAuthCleanupTimers.set(key, cleanupTimer)
+  state.pendingAuthCleanupTimers.set(key, cleanupTimer)
 }
 
-async function clearPendingAuth(serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}): Promise<void> {
+async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}): Promise<void> {
+  const state = getRuntimeState(runtime)
   const key = getPendingAuthKey(serverName, fallbackStorageOptions)
-  const pendingAuth = pendingAuths.get(key)
+  const pendingAuth = state.pendingAuths.get(key)
   const authStorageOptions = pendingAuth?.authStorageOptions ?? fallbackStorageOptions
-  const pendingState = pendingAuthStates.get(key)
+  const pendingState = state.pendingAuthStates.get(key)
   if (oauthState && pendingState && pendingState !== oauthState) return
 
-  const timer = pendingAuthCleanupTimers.get(key)
+  const timer = state.pendingAuthCleanupTimers.get(key)
   if (timer) {
     clearTimeout(timer)
-    pendingAuthCleanupTimers.delete(key)
+    state.pendingAuthCleanupTimers.delete(key)
   }
 
   pendingAuth?.authProvider.deactivate()
-  pendingAuths.delete(key)
-  pendingAuthStates.delete(key)
+  state.pendingAuths.delete(key)
+  state.pendingAuthStates.delete(key)
   const stateToRelease = pendingState ?? oauthState
   if (stateToRelease) {
-    releaseCallbackServer(stateToRelease)
+    cancelPendingCallback(stateToRelease)
     const storedState = await getOAuthState(serverName, authStorageOptions)
     if (storedState === stateToRelease) {
       await clearOAuthState(serverName, authStorageOptions)
@@ -455,11 +502,14 @@ export async function completeAuthFromInput(
   input: string,
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
+  const runtime = getRuntime(options)
+  const runtimeState = getRuntimeState(runtime)
   const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
-  const authStorageOptions = pendingAuths.get(getPendingAuthKey(serverName, fallbackAuthStorageOptions))?.authStorageOptions ?? fallbackAuthStorageOptions
-  const oauthState = await getOAuthState(serverName, authStorageOptions)
+  const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
+  const authStorageOptions = runtimeState.pendingAuths.get(key)?.authStorageOptions ?? fallbackAuthStorageOptions
+  const oauthState = runtimeState.pendingAuthStates.get(key)
   throwIfAborted(signal)
   const code = parseAuthorizationCodeInput(input, oauthState)
   return completeAuth(serverName, code, options)
@@ -473,17 +523,19 @@ export async function completeAuth(
   authorizationCode: string,
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
+  const runtime = getRuntime(options)
+  const runtimeState = getRuntimeState(runtime)
   const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
   const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
-  const pendingAuth = pendingAuths.get(key)
+  const pendingAuth = runtimeState.pendingAuths.get(key)
   const authStorageOptions = pendingAuth?.authStorageOptions ?? fallbackAuthStorageOptions
   if (!pendingAuth) {
     throw new Error(`No pending OAuth flow for server: ${serverName}`)
   }
 
-  const oauthState = await getOAuthState(serverName, authStorageOptions)
+  const oauthState = runtimeState.pendingAuthStates.get(key)
   throwIfAborted(signal)
 
   try {
@@ -498,14 +550,14 @@ export async function completeAuth(
     }
   } catch (error) {
     try {
-      await clearPendingAuth(serverName, oauthState, authStorageOptions)
+      await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth completion cleanup failed")
     }
     throw error
   }
 
-  await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
   return "authenticated"
 }
 
@@ -523,18 +575,20 @@ export async function authenticate(
   definition?: ServerEntry,
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
+  const runtime = getRuntime(options)
+  const runtimeState = getRuntimeState(runtime)
   const authStorageOptions = options.authStorageOptions ?? {}
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
   const authKey = `${serverName}|${serverUrl}|${getAuthBaseDir(authStorageOptions)}`
-  const inFlight = pendingAuthentications.get(authKey)
+  const inFlight = runtimeState.pendingAuthentications.get(authKey)
   if (inFlight) {
     return inFlight
   }
 
   const operation = (async (): Promise<AuthStatus> => {
     // Start auth flow
-    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, { ...options, signal })
+    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, { ...options, signal, runtime })
 
     // If no auth URL needed, already authenticated
     if (!authorizationUrl) {
@@ -546,7 +600,7 @@ export async function authenticate(
       // Get the state that was already generated and stored in startAuth().
       // Keep this lookup and its abort check inside the cleanup boundary because
       // startAuth has already reserved callback state at this point.
-      oauthState = await getOAuthState(serverName, authStorageOptions)
+      oauthState = runtimeState.pendingAuthStates.get(getPendingAuthKey(serverName, authStorageOptions))
       throwIfAborted(signal)
       if (!oauthState) {
         throw new Error("OAuth state not found - this should not happen")
@@ -573,25 +627,15 @@ export async function authenticate(
       // Wait for callback
       const code = await abortable(callbackPromise, signal)
 
-      // Validate state
-      const storedState = await getOAuthState(serverName, authStorageOptions)
-      if (storedState !== oauthState) {
-        const mismatchError = new Error("OAuth state mismatch - potential CSRF attack")
-        try {
-          await clearOAuthState(serverName, authStorageOptions)
-        } catch (cleanupError) {
-          throw new AggregateError([mismatchError, cleanupError], "OAuth state mismatch cleanup failed")
-        }
-        throw mismatchError
-      }
-      await clearOAuthState(serverName, authStorageOptions)
+      // The callback server accepted only the flow-local reserved state.
+      throwIfAborted(signal)
 
       // Complete the auth
-      return await completeAuth(serverName, code, { ...options, signal })
+      return await completeAuth(serverName, code, { ...options, signal, runtime })
     } catch (error) {
       if (oauthState) cancelPendingCallback(oauthState)
       try {
-        await clearPendingAuth(serverName, oauthState, authStorageOptions)
+        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         throw new AggregateError([error, cleanupError], "OAuth cancellation cleanup failed")
       }
@@ -599,13 +643,13 @@ export async function authenticate(
     }
   })()
 
-  pendingAuthentications.set(authKey, operation)
+  runtimeState.pendingAuthentications.set(authKey, operation)
 
   try {
     return await operation
   } finally {
-    if (pendingAuthentications.get(authKey) === operation) {
-      pendingAuthentications.delete(authKey)
+    if (runtimeState.pendingAuthentications.get(authKey) === operation) {
+      runtimeState.pendingAuthentications.delete(authKey)
     }
   }
 }
@@ -622,8 +666,9 @@ export async function getValidToken(
   serverUrl: string,
   options: AuthenticateOptions = {},
 ): Promise<StoredTokens | null> {
+  const runtime = getRuntime(options)
   const authStorageOptions = options.authStorageOptions ?? {}
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
   // Check if we have valid tokens
   const entry = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
@@ -646,7 +691,7 @@ export async function getValidToken(
       // Create auth provider for token refresh
       const authProvider = new McpOAuthProvider(serverName, serverUrl, {}, {
         onRedirect: async () => {},
-      }, authStorageOptions)
+      }, authStorageOptions, runtime.signal)
 
       try {
         const clientInfo = await authProvider.clientInformation()
@@ -687,6 +732,7 @@ export async function getValidToken(
  * @returns The current auth status
  */
 export async function getAuthStatus(serverName: string, options: AuthenticateOptions = {}): Promise<AuthStatus> {
+  const runtime = getRuntime(options)
   const authStorageOptions = options.authStorageOptions ?? {}
   const hasTokens = await hasStoredTokens(serverName, authStorageOptions)
   if (!hasTokens) return "not_authenticated"
@@ -701,7 +747,8 @@ export async function getAuthStatus(serverName: string, options: AuthenticateOpt
  * @param serverName - The name of the MCP server
  */
 export async function removeAuth(serverName: string, options: AuthenticateOptions = {}): Promise<void> {
-  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const runtime = getRuntime(options)
+  const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
   const authStorageOptions = options.authStorageOptions ?? {}
   const oauthState = await getOAuthState(serverName, authStorageOptions)
@@ -709,7 +756,7 @@ export async function removeAuth(serverName: string, options: AuthenticateOption
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
   throwIfAborted(signal)
   clearAllCredentials(serverName, authStorageOptions)
   await clearOAuthState(serverName, authStorageOptions)
@@ -744,21 +791,37 @@ export function supportsOAuth(definition: ServerEntry): boolean {
  * Initialize the OAuth system on startup.
  * OAuth callback binding is lazy and starts from startAuth() only.
  */
-export async function initializeOAuth(signal?: AbortSignal): Promise<void> {
-  oauthRuntimeSignal = signal
-  oauthGeneration += 1
+export async function initializeOAuth(
+  runtimeOrSignal?: McpOAuthRuntime | AbortSignal,
+): Promise<McpOAuthRuntime> {
+  if (runtimeOrSignal && "signal" in runtimeOrSignal) {
+    runtimeOrSignal.signal.throwIfAborted()
+    activeRuntimes.add(runtimeOrSignal)
+    return runtimeOrSignal
+  }
+
+  await shutdownOAuth(legacyRuntime)
+  legacyRuntime = createOAuthRuntime(runtimeOrSignal as AbortSignal | undefined)
+  return legacyRuntime
 }
 
 /**
- * Shutdown the OAuth system.
- * Stops the callback server and cancels pending auths.
+ * Shutdown one OAuth runtime. The callback server remains process-shared while
+ * another runtime has pending/reserved callback state or is still active.
  */
-export async function shutdownOAuth(): Promise<void> {
-  oauthGeneration += 1
-  oauthRuntimeSignal = undefined
-  for (const pendingAuth of Array.from(pendingAuths.values())) {
-    await clearPendingAuth(pendingAuth.serverName, undefined, pendingAuth.authStorageOptions)
+export async function shutdownOAuth(runtime: McpOAuthRuntime = legacyRuntime): Promise<void> {
+  const state = getRuntimeState(runtime)
+  if (state.controller.signal.aborted) return
+  state.generation += 1
+  state.controller.abort(new Error("OAuth runtime stopped"))
+  for (const callbackState of Array.from(state.pendingAuthStates.values())) cancelPendingCallback(callbackState)
+  for (const pendingAuth of Array.from(state.pendingAuths.values())) {
+    await clearPendingAuth(runtime, pendingAuth.serverName, undefined, pendingAuth.authStorageOptions)
   }
-  for (const state of Array.from(pendingAuthStates.values())) cancelPendingCallback(state)
-  await stopCallbackServer()
+  state.pendingAuthentications.clear()
+  activeRuntimes.delete(runtime)
+
+  if (activeRuntimes.size === 0) {
+    await stopCallbackServer()
+  }
 }

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -21,7 +21,7 @@ import {
   setOAuthCallbackPort,
   type McpOAuthConfig,
 } from "./mcp-oauth-provider.ts"
-import { getAuthForUrl, saveAuthEntry, updateOAuthState } from "./mcp-auth.ts"
+import { getAuthForUrl, saveAuthEntry } from "./mcp-auth.ts"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
 
@@ -329,8 +329,7 @@ describe("McpOAuthProvider", () => {
         onRedirect: async (url) => {
           redirectCaptured = url
         },
-      })
-      await updateOAuthState("redirect-with-state", "state-abc", serverUrl)
+      }, {}, undefined, "state-abc")
       const testUrl = new URL("https://example.com/auth")
 
       await provider.redirectToAuthorization(testUrl)
@@ -379,7 +378,7 @@ describe("McpOAuthProvider", () => {
 
       const verifier = await provider.codeVerifier()
       assert.strictEqual(verifier, "verifier-abc-123")
-      assert.strictEqual(getAuthForUrl("code-verifier-test", serverUrl)?.codeVerifier, "verifier-abc-123")
+      assert.strictEqual(getAuthForUrl("code-verifier-test", serverUrl), undefined)
     })
 
     it("should throw when no code verifier", async () => {
@@ -419,7 +418,7 @@ describe("McpOAuthProvider", () => {
 
       const state = await provider.state()
       assert.strictEqual(state, "state-xyz-789")
-      assert.strictEqual(getAuthForUrl("state-test-save", serverUrl)?.oauthState, "state-xyz-789")
+      assert.strictEqual(getAuthForUrl("state-test-save", serverUrl), undefined)
     })
 
     it("should throw UnauthorizedError when no state is saved", async () => {

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -17,8 +17,6 @@ import {
   getAuthForUrl,
   updateTokens,
   updateClientInfo,
-  updateCodeVerifier,
-  updateOAuthState,
   clearAllCredentials,
   clearClientInfo,
   clearTokens,
@@ -86,6 +84,9 @@ export interface McpOAuthCallbacks {
 export class McpOAuthProvider implements OAuthClientProvider {
   private readonly redirectUrlSnapshot: string | undefined
   private active = true
+  private flowClientInfo: StoredClientInfo | undefined
+  private flowCodeVerifier: string | undefined
+  private flowState: string | undefined
 
   constructor(
     private serverName: string,
@@ -93,7 +94,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private config: McpOAuthConfig,
     private callbacks: McpOAuthCallbacks,
     private storageOptions: AuthStorageOptions = {},
+    private runtimeSignal?: AbortSignal,
+    initialState?: string,
   ) {
+    this.flowState = initialState
     this.redirectUrlSnapshot = config.grantType === "client_credentials"
       ? undefined
       : config.redirectUri ?? `http://localhost:${getOAuthCallbackPort()}${getOAuthCallbackPath()}`
@@ -109,6 +113,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   private throwIfInactive(): void {
     if (!this.active) throw new Error("OAuth flow is no longer active")
+    this.runtimeSignal?.throwIfAborted()
   }
 
   /**
@@ -163,17 +168,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
       }
     }
 
-    // Check stored client info (from dynamic registration)
-    // Use getAuthForUrl to validate credentials are for the current server URL
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
-    if (entry?.clientInfo) {
+    // Keep client registration associated with this in-flight flow even if
+    // another runtime writes the shared persistent entry for the same name.
+    const clientInfo = this.flowClientInfo ?? (await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions))?.clientInfo
+    if (clientInfo) {
       // Check if client secret has expired
-      if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
+      if (clientInfo.clientSecretExpiresAt && clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
         return undefined
       }
       return {
-        client_id: entry.clientInfo.clientId,
-        client_secret: entry.clientInfo.clientSecret,
+        client_id: clientInfo.clientId,
+        client_secret: clientInfo.clientSecret,
       }
     }
 
@@ -194,6 +199,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       redirectUris,
     }
     this.throwIfInactive()
+    this.flowClientInfo = clientInfo
     updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
   }
 
@@ -244,10 +250,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       throw new Error("redirectToAuthorization is not used for client_credentials flow")
     }
-    // No saved oauthState means we're on the post-refresh authorize fallback.
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
+    // No flow-local state means we're on the post-refresh authorize fallback.
     this.throwIfInactive()
-    if (!entry?.oauthState) {
+    if (!this.flowState) {
       throw new UnauthorizedError(
         `Re-authentication required for MCP server: ${this.serverName}`,
       )
@@ -261,7 +266,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
     this.throwIfInactive()
-    updateCodeVerifier(this.serverName, codeVerifier, this.serverUrl, this.storageOptions)
+    this.flowCodeVerifier = codeVerifier
   }
 
   /**
@@ -272,11 +277,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       throw new Error("codeVerifier is not used for client_credentials flow")
     }
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
-    if (!entry?.codeVerifier) {
+    this.throwIfInactive()
+    if (!this.flowCodeVerifier) {
       throw new Error(`No code verifier saved for MCP server: ${this.serverName}`)
     }
-    return entry.codeVerifier
+    return this.flowCodeVerifier
   }
 
   /**
@@ -284,7 +289,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   async saveState(state: string): Promise<void> {
     this.throwIfInactive()
-    updateOAuthState(this.serverName, state, this.serverUrl, this.storageOptions)
+    this.flowState = state
   }
 
   /**
@@ -295,13 +300,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       throw new Error("state is not used for client_credentials flow")
     }
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
-    if (!entry?.oauthState) {
+    this.throwIfInactive()
+    if (!this.flowState) {
       throw new UnauthorizedError(
         `Re-authentication required for MCP server: ${this.serverName}`,
       )
     }
-    return entry.oauthState
+    return this.flowState
   }
 
   /**
@@ -312,9 +317,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
     this.throwIfInactive()
     switch (type) {
       case "all":
+        this.flowClientInfo = undefined
+        this.flowCodeVerifier = undefined
+        this.flowState = undefined
         clearAllCredentials(this.serverName, this.storageOptions)
         break
       case "client":
+        this.flowClientInfo = undefined
         clearClientInfo(this.serverName, this.storageOptions)
         break
       case "tokens":

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@mariozechner/pi-ai": "^0.70.2",
+    "@mariozechner/pi-tui": "^0.73.0",
     "typebox": "^1.1.24",
     "open": "^10.2.0",
     "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,19 @@
   "version": "2.11.0",
   "description": "MCP (Model Context Protocol) adapter extension for Pi coding agent",
   "type": "module",
+  "types": "./index.ts",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "import": "./index.ts",
+      "default": "./index.ts"
+    },
+    "./types": {
+      "types": "./types.ts",
+      "import": "./types.ts",
+      "default": "./types.ts"
+    }
+  },
   "license": "MIT",
   "author": "Nico Bailon",
   "bin": {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -122,13 +122,15 @@ async function attemptAutoAuth(
         serverName,
         serverUrl,
         definition,
-        signal ? { authStorageOptions: state.authStorageOptions, signal } : { authStorageOptions: state.authStorageOptions },
+        signal
+          ? { authStorageOptions: state.authStorageOptions, signal, runtime: state.oauthRuntime }
+          : { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime },
       );
     } else {
       if (signal) {
-        await authenticate(serverName, serverUrl, definition, { signal });
+        await authenticate(serverName, serverUrl, definition, { signal, runtime: state.oauthRuntime });
       } else {
-        await authenticate(serverName, serverUrl, definition);
+        await authenticate(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
       }
     }
     return { status: "success" };
@@ -298,11 +300,11 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
 
     const { authorizationUrl } = state.authStorageOptions
       ? ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, signal: ownedSignal })
-        : await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions })
+        ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
+        : await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
       : ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, { signal: ownedSignal })
-        : await startAuth(serverName, serverUrl, definition);
+        ? await startAuth(serverName, serverUrl, definition, { signal: ownedSignal, runtime: state.oauthRuntime })
+        : await startAuth(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
     if (!authorizationUrl) {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
@@ -336,11 +338,11 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
   try {
     const status = state.authStorageOptions
       ? ownedSignal
-        ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, signal: ownedSignal })
-        : await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions })
+        ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
+        : await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
       : ownedSignal
-        ? await completeAuthFromInput(serverName, input, { signal: ownedSignal })
-        : await completeAuthFromInput(serverName, input);
+        ? await completeAuthFromInput(serverName, input, { signal: ownedSignal, runtime: state.oauthRuntime })
+        : await completeAuthFromInput(serverName, input, { runtime: state.oauthRuntime });
     if (status !== "authenticated") {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -20,7 +20,7 @@ import { serverStreamResultPatchNotificationSchema } from "./types.ts";
 import { resolveNpxBinary } from "./npx-resolver.ts";
 import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
-import { extractOAuthConfig, supportsOAuth } from "./mcp-auth-flow.ts";
+import { extractOAuthConfig, supportsOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import type { AuthStorageOptions } from "./mcp-auth.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
 import {
@@ -85,6 +85,7 @@ export class McpServerManager {
   private samplingConfig: ServerSamplingConfig | undefined;
   private elicitationConfig: ServerElicitationConfig | undefined;
   private authStorageOptions: AuthStorageOptions = {};
+  private oauthRuntime: McpOAuthRuntime | undefined;
   private acceptedUrlElicitations = new Map<string, Set<string>>();
   private defaultRequestTimeoutMs: number | undefined;
   private runtimeSignal: AbortSignal | undefined;
@@ -114,6 +115,10 @@ export class McpServerManager {
 
   setAuthStorageOptions(options: AuthStorageOptions): void {
     this.authStorageOptions = options;
+  }
+
+  setOAuthRuntime(runtime: McpOAuthRuntime): void {
+    this.oauthRuntime = runtime;
   }
 
   getRequestOptions(name: string, signal?: AbortSignal): RequestOptions | undefined {
@@ -515,7 +520,8 @@ export class McpServerManager {
             // URL is captured by startAuth, no need to log
           },
         },
-        this.authStorageOptions
+        this.authStorageOptions,
+        this.oauthRuntime?.signal,
       );
     }
 

--- a/state.ts
+++ b/state.ts
@@ -7,6 +7,7 @@ import type { ToolMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
 import type { UiServerHandle } from "./ui-server.ts";
 import type { McpRuntimeOwner } from "./runtime-owner.ts";
+import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 
 export interface CompletedUiSession {
   serverName: string;
@@ -34,6 +35,8 @@ export interface McpExtensionState {
   toolMetadata: Map<string, ToolMetadata[]>;
   serverInstructions: Map<string, string>;
   config: McpConfig;
+  programmaticConfig?: boolean;
+  oauthRuntime: McpOAuthRuntime;
   authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;
   failureMessages: Map<string, string>;

--- a/types.ts
+++ b/types.ts
@@ -335,6 +335,11 @@ export interface McpConfig {
   settings?: McpSettings;
 }
 
+export interface McpAdapterOptions {
+  configPath?: string;
+  config?: McpConfig;
+}
+
 // Alias for clarity
 export type ServerDefinition = ServerEntry;
 

--- a/types.ts
+++ b/types.ts
@@ -368,6 +368,11 @@ export interface McpConfig {
   settings?: McpSettings;
 }
 
+export interface McpAdapterOptions {
+  config?: McpConfig;
+  configPath?: string;
+}
+
 // Alias for clarity
 export type ServerDefinition = ServerEntry;
 


### PR DESCRIPTION
## Summary
- add createMcpAdapter({ configPath, config }) for SDK integrations that need an in-memory MCP config overlay
- merge in-memory config after existing file/import config so in-memory definitions have highest precedence
- keep the default adapter export and file-based config behavior unchanged
- declare the existing @mariozechner/pi-tui runtime import as a direct dependency

Closes #85

## Verification
- npm --prefix examples/interactive-visualizer install
- npm --prefix examples/interactive-visualizer run build
- npm test
- npm run test:oauth-provider
- npm pack --dry-run