### PR TITLE
Add collapsible TUI renderers for MCP tools

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { loadMetadataCache } from "./metadata-cache.js";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.js";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js";
+import { createMcpRenderers } from "./renderers.js";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
@@ -66,6 +67,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     || missingConfiguredDirectToolServers.length > 0;
 
   for (const spec of directSpecs) {
+    const { renderCall, renderResult } = createMcpRenderers(spec.prefixedName);
     pi.registerTool({
       name: spec.prefixedName,
       label: `MCP: ${spec.originalName}`,
@@ -73,6 +75,8 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
       parameters: Type.Unsafe<Record<string, unknown>>(spec.inputSchema || { type: "object", properties: {} }),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
+      renderCall,
+      renderResult,
     });
   }
 
@@ -231,11 +235,14 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   });
 
   if (shouldRegisterProxyTool) {
+    const { renderCall: mcpProxyRenderCall, renderResult: mcpProxyRenderResult } = createMcpRenderers("mcp");
     pi.registerTool({
       name: "mcp",
       label: "MCP",
       description: buildProxyDescription(earlyConfig, earlyCache, directSpecs),
       promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
+      renderCall: mcpProxyRenderCall,
+      renderResult: mcpProxyRenderResult,
       parameters: Type.Object({
         tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
         args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "config.ts",
     "server-manager.ts",
     "sampling-handler.ts",
+    "renderers.ts",
     "tool-registrar.ts",
     "resource-tools.ts",
     "lifecycle.ts",
@@ -81,6 +82,7 @@
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@mariozechner/pi-ai": "^0.70.2",
+    "@mariozechner/pi-tui": "^0.70.2",
     "typebox": "^1.1.24",
     "open": "^10.2.0",
     "zod": "^3.25.0 || ^4.0.0"

--- a/renderers.ts
+++ b/renderers.ts
@@ -1,0 +1,96 @@
+/**
+ * TUI renderers for MCP tools — gives them the same collapsible
+ * header + result UI that built-in Pi tools have.
+ *
+ * Collapsed: first N lines preview + "... (N more lines, tab to expand)"
+ * Expanded: full output
+ */
+import type { AgentToolResult, ToolRenderContext, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent";
+import { keyHint, Theme } from "@mariozechner/pi-coding-agent";
+import { type Component, Text } from "@mariozechner/pi-tui";
+
+const PREVIEW_LINES = 5;
+
+export function createMcpRenderers(displayName: string) {
+  return {
+    renderCall(args: Record<string, unknown>, theme: Theme, context: ToolRenderContext): Component {
+      const text: Text =
+        context.lastComponent instanceof Text
+          ? context.lastComponent
+          : new Text("", 0, 0);
+
+      let content = theme.fg("toolTitle", theme.bold(displayName));
+      const summary = compactArgs(args);
+      if (summary) content += " " + theme.fg("muted", summary);
+      text.setText(content);
+      return text;
+    },
+
+    renderResult(
+      result: AgentToolResult,
+      options: ToolRenderResultOptions,
+      theme: Theme,
+      context: ToolRenderContext,
+    ): Component {
+      const text: Text =
+        context.lastComponent instanceof Text
+          ? context.lastComponent
+          : new Text("", 0, 0);
+
+      if (options.isPartial) {
+        text.setText(theme.fg("dim", "running…"));
+        return text;
+      }
+
+      const output = resultText(result);
+      if (!output) {
+        text.setText("");
+        return text;
+      }
+
+      const lines = output.split("\n");
+      const maxLines = options.expanded ? lines.length : PREVIEW_LINES;
+      const displayLines = lines.slice(0, maxLines);
+      const remaining = lines.length - maxLines;
+      const color = context.isError ? "error" : "toolOutput";
+
+      let content = "\n" + displayLines
+        .map((line: string) => theme.fg(color, line))
+        .join("\n");
+
+      if (remaining > 0) {
+        content += "\n" + theme.fg("muted", `... (${remaining} more lines,`)
+          + " " + keyHint("app.tools.expand", "to expand") + ")";
+      }
+
+      text.setText(content);
+      return text;
+    },
+  };
+}
+
+function compactArgs(args: Record<string, unknown>): string {
+  if (!args || typeof args !== "object") return "";
+  for (const [key, val] of Object.entries(args)) {
+    if (typeof val === "string" && val.length > 0) {
+      return `${key}=${trunc(val, 70)}`;
+    }
+    if (Array.isArray(val) && val.length > 0) {
+      if (val.length === 1) return `${key}=${trunc(String(val[0]), 70)}`;
+      return `${key}: ${val.length} items`;
+    }
+  }
+  return "";
+}
+
+function resultText(result: AgentToolResult): string {
+  if (!result?.content) return "";
+  return result.content
+    .filter((c) => c.type === "text")
+    .map((c) => ("text" in c ? c.text : "") ?? "")
+    .join("\n");
+}
+
+function trunc(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}


### PR DESCRIPTION
## Why

MCP tool output (both direct tools and the proxy) renders as an unformatted text dump that can't be collapsed. For verbose tools like Exa search this floods the chat UI and makes sessions hard to scroll through.

This adds `renderCall` and `renderResult` so MCP tools collapse the same way built-in Pi tools do: compact header, first 5 lines preview when collapsed, full output on expand.

<img width="576" height="200" alt="image" src="https://github.com/user-attachments/assets/0cc472d7-32f1-4c5f-80e8-084b72fc41e6" />


## Links

Fixes #82
Fixes #57

---

This PR was co-authored with AI assistance.
