### PR TITLE
Add per-server OAuth callback port

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
+| `oauth.callbackPort` | Callback port for pre-registered OAuth clients that require an exact redirect URI; overrides `MCP_OAUTH_CALLBACK_PORT` for this server |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -60,6 +60,7 @@ function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     clientId: definition.oauth?.clientId,
     clientSecret: definition.oauth?.clientSecret,
     scope: definition.oauth?.scope,
+    callbackPort: definition.oauth?.callbackPort,
   }
 }
 
@@ -89,7 +90,10 @@ export async function startAuth(
 
   // Start the callback server.
   // Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
-  await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
+  await ensureCallbackServer({
+    strictPort: Boolean(config.clientId),
+    preferredPort: config.callbackPort,
+  })
 
   const oauthState = generateState()
   await updateOAuthState(serverName, oauthState)

--- a/mcp-callback-server.test.ts
+++ b/mcp-callback-server.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert"
+import { createServer } from "node:http"
 import {
   ensureCallbackServer,
   waitForCallback,
@@ -13,6 +14,22 @@ import {
   getPendingAuthCount,
 } from "./mcp-callback-server.js"
 import { getOAuthCallbackPort } from "./mcp-oauth-provider.js"
+
+async function getAvailablePort(): Promise<number> {
+  const server = createServer()
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "localhost", () => resolve())
+  })
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const port = address.port
+
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  return port
+}
 
 describe("mcp-callback-server", () => {
   beforeEach(async () => {
@@ -36,6 +53,15 @@ describe("mcp-callback-server", () => {
       await ensureCallbackServer()
       await ensureCallbackServer()
       assert.strictEqual(isCallbackServerRunning(), true)
+    })
+
+    it("should use a configured preferred port", async () => {
+      const preferredPort = await getAvailablePort()
+
+      await ensureCallbackServer({ strictPort: true, preferredPort })
+
+      assert.strictEqual(isCallbackServerRunning(), true)
+      assert.strictEqual(getOAuthCallbackPort(), preferredPort)
     })
   })
 

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -73,6 +73,7 @@ const MAX_PORT_SCAN_ATTEMPTS = 25
 
 interface EnsureCallbackServerOptions {
   strictPort?: boolean
+  preferredPort?: number
 }
 
 /**
@@ -149,7 +150,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
  * If strictPort is false, scans forward for an available local port.
  */
 export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
-  const configuredPort = getConfiguredOAuthCallbackPort()
+  const configuredPort = options.preferredPort ?? getConfiguredOAuthCallbackPort()
   const strictPort = options.strictPort === true
 
   if (server) {

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -60,6 +60,7 @@ export interface McpOAuthConfig {
   clientId?: string
   clientSecret?: string
   scope?: string
+  callbackPort?: number
 }
 
 /** Callbacks for OAuth flow interactions */

--- a/types.ts
+++ b/types.ts
@@ -272,6 +272,8 @@ export interface OAuthConfig {
   clientSecret?: string;
   /** Requested OAuth scopes */
   scope?: string;
+  /** Callback port for pre-registered OAuth clients that require an exact redirect URI */
+  callbackPort?: number;
 }
 
 // Server configuration


### PR DESCRIPTION
## Summary

Adds an optional per-server `oauth.callbackPort` setting for OAuth MCP servers.

This lets pre-registered OAuth clients use the exact localhost callback port registered with their OAuth provider without changing `MCP_OAUTH_CALLBACK_PORT` for every MCP server in the Pi process.

Example:

```json
{
  "mcpServers": {
    "slack": {
      "url": "https://mcp.slack.com/mcp",
      "auth": "oauth",
      "oauth": {
        "clientId": "1601185624273.8899143856786",
        "callbackPort": 3118
      }
    }
  }
}
```

## Motivation

Some OAuth servers use pre-registered public clients and require an exact redirect URI. Today the adapter only supports a process-wide callback port via `MCP_OAUTH_CALLBACK_PORT`, so one server that requires a specific port forces all OAuth servers in the same Pi process to use that port.

A per-server option avoids breaking other OAuth flows while still supporting exact-redirect providers.

## Changes

- Adds `oauth.callbackPort` to config types.
- Passes the configured port into OAuth callback server startup.
- Keeps existing default behavior when `callbackPort` is omitted.
- Documents the new option in README.
- Adds callback server coverage for preferred port binding.

## Test plan

- `node --import tsx --test mcp-callback-server.test.ts mcp-auth-flow.test.ts mcp-oauth-provider.test.ts`

Also ran `npm test`; unrelated existing failures occurred due missing generated interactive visualizer dist files and missing `@mariozechner/pi-tui` package in a fresh clone.
