### PR TITLE
Add /mcp logout command

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -132,6 +132,12 @@ The SDK automatically:
 - Refreshes expired tokens automatically
 - Re-authenticates if tokens are invalid
 
+To clear stored OAuth credentials and force a fresh authorization:
+
+```
+/mcp logout my-oauth-server
+```
+
 ## How It Works
 
 ### Authentication Flow

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 | `/mcp tools` | List all tools |
 | `/mcp reconnect` | Reconnect all servers |
 | `/mcp reconnect <server>` | Connect or reconnect a single server |
+| `/mcp logout <server>` | Clear stored OAuth credentials for a server and disconnect it |
 | `/mcp-auth` | Open an OAuth server picker in interactive UI sessions |
 | `/mcp-auth <server>` | OAuth setup for a specific server |
 

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -102,6 +102,28 @@ describe("commands onboarding", () => {
     expect(loadOnboardingState().sharedConfigHintShown).toBe(true);
   });
 
+  it("clears OAuth credentials and closes the server on logout", async () => {
+    process.env.MCP_OAUTH_DIR = mkdtempSync(join(tmpdir(), "pi-mcp-commands-logout-"));
+    const ui = createUi();
+    const close = vi.fn();
+    const { getAuthEntry, updateTokens } = await import("../mcp-auth.ts");
+    const { logoutServer } = await import("../commands.ts");
+
+    updateTokens("oauth-server", { accessToken: "token", refreshToken: "refresh" }, "https://example.com/mcp");
+
+    const result = await logoutServer("oauth-server", {
+      config: { mcpServers: { "oauth-server": { url: "https://example.com/mcp", auth: "oauth" } } },
+      manager: { close },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+    } as any, { hasUI: true, ui } as any);
+
+    expect(result.ok).toBe(true);
+    expect(getAuthEntry("oauth-server")).toBeUndefined();
+    expect(close).toHaveBeenCalledWith("oauth-server");
+    expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("OAuth credentials cleared"), "info");
+  });
+
   it("marks explicit OAuth servers as needs-auth when only stale URL tokens exist", async () => {
     process.env.MCP_OAUTH_DIR = mkdtempSync(join(tmpdir(), "pi-mcp-commands-oauth-"));
     const ui = createUi();

--- a/commands.ts
+++ b/commands.ts
@@ -16,7 +16,7 @@ import { lazyConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate } from "./mcp-auth-flow.ts";
-import { getAuthForUrl } from "./mcp-auth.ts";
+import { clearAllCredentials, getAuthForUrl } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath } from "./utils.ts";
 
@@ -190,6 +190,27 @@ export async function authenticateServer(
   } finally {
     ctx.ui.setStatus("mcp-auth", undefined);
   }
+}
+
+export async function logoutServer(
+  serverName: string,
+  state: McpExtensionState,
+  ctx: ExtensionContext
+): Promise<{ ok: boolean; message: string }> {
+  const definition = state.config.mcpServers[serverName];
+  if (!definition) {
+    const message = `Server "${serverName}" not found in config`;
+    if (ctx.hasUI) ctx.ui.notify(message, "error");
+    return { ok: false, message };
+  }
+
+  clearAllCredentials(serverName);
+  await state.manager.close(serverName);
+  updateStatusBar(state);
+
+  const message = `OAuth credentials cleared for "${serverName}". Run /mcp-auth ${serverName} to authenticate again.`;
+  if (ctx.hasUI) ctx.ui.notify(message, "info");
+  return { ok: true, message };
 }
 
 export interface PanelFlowResult {

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
 import { Type } from "typebox";
-import { showStatus, showTools, reconnectServers, authenticateServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
+import { showStatus, showTools, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { loadMcpConfig } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
@@ -172,6 +172,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       const parts = args?.trim()?.split(/\s+/) ?? [];
       const subcommand = parts[0] ?? "";
       const targetServer = parts[1];
+      const rest = parts.slice(1).join(" ");
 
       switch (subcommand) {
         case "reconnect":
@@ -186,6 +187,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
             await ctx.reload();
             return;
           }
+          break;
+        }
+        case "logout": {
+          const serverName = rest;
+          if (!serverName) {
+            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp logout <server>", "error");
+            return;
+          }
+          await logoutServer(serverName, state, ctx);
           break;
         }
         case "status":


### PR DESCRIPTION
## Summary

- Add `/mcp logout <server>` to clear stored OAuth credentials for an MCP server.
- Disconnect the server after credentials are cleared so the next auth/connect uses fresh tokens.
- Document the command in README and OAuth docs.
- Add coverage for clearing credentials and closing the server.

## Test plan

- `npx tsc --noEmit`
- `npm test -- __tests__/commands-onboarding.test.ts __tests__/mcp-auth.test.ts`

Note: full `npm test` currently fails on main because `examples/interactive-visualizer/dist/app.html` and `dist/server.js` are not built/present locally.

Generated with Clanker.
