### PR TITLE
fix: validate cached OAuth client redirect URI

### DIFF
--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -161,7 +161,10 @@ describe("mcp-auth-flow explicit auth", () => {
     const { authenticate } = await import("../mcp-auth-flow.ts");
     const { getOAuthState, updateClientInfo, updateTokens } = await import("../mcp-auth.ts");
 
-    updateClientInfo("expired", { clientId: "client" }, "https://api.example.com/mcp");
+    updateClientInfo("expired", {
+      clientId: "client",
+      redirectUris: ["http://localhost:19876/callback"],
+    }, "https://api.example.com/mcp");
     updateTokens("expired", {
       accessToken: "old-access",
       refreshToken: "old-refresh",
@@ -179,6 +182,47 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("expired")).toBeUndefined();
   });
 
+  it("re-registers instead of reusing stale dynamic client info during browser auth", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await expect(provider.clientInformation()).resolves.toBeUndefined();
+      await expect(provider.tokens()).resolves.toBeUndefined();
+      await provider.saveClientInformation({
+        client_id: "fresh-client",
+        client_secret: "fresh-secret",
+        redirect_uris: [provider.redirectUrl],
+      });
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+      return "REDIRECT";
+    });
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+    const { getAuthForUrl, getOAuthState, updateClientInfo, updateCodeVerifier, updateOAuthState, updateTokens } = await import("../mcp-auth.ts");
+
+    updateClientInfo("expired-stale-redirect", {
+      clientId: "old-client",
+      redirectUris: ["http://localhost:19877/callback"],
+    }, "https://api.example.com/mcp");
+    updateTokens("expired-stale-redirect", {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() / 1000 - 60,
+    }, "https://api.example.com/mcp");
+    updateCodeVerifier("expired-stale-redirect", "old-verifier", "https://api.example.com/mcp");
+    updateOAuthState("expired-stale-redirect", "old-state", "https://api.example.com/mcp");
+
+    const result = await startAuth("expired-stale-redirect", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    });
+
+    const stored = getAuthForUrl("expired-stale-redirect", "https://api.example.com/mcp");
+    expect(result.authorizationUrl).toBe("https://auth.example.com/authorize");
+    expect(stored?.clientInfo?.clientId).toBe("fresh-client");
+    expect(stored?.clientInfo?.redirectUris).toEqual(["http://localhost:19876/callback"]);
+    expect(stored?.tokens).toBeUndefined();
+    expect(stored?.codeVerifier).toBeUndefined();
+    expect(getOAuthState("expired-stale-redirect")).not.toBe("old-state");
+  });
+
   it("refreshes expired tokens through SDK auth before returning them", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.saveTokens({
@@ -192,7 +236,10 @@ describe("mcp-auth-flow explicit auth", () => {
     const { getValidToken } = await import("../mcp-auth-flow.ts");
     const { updateClientInfo, updateTokens } = await import("../mcp-auth.ts");
 
-    updateClientInfo("refresh", { clientId: "client" }, "https://api.example.com/mcp");
+    updateClientInfo("refresh", {
+      clientId: "client",
+      redirectUris: ["http://localhost:19876/callback"],
+    }, "https://api.example.com/mcp");
     updateTokens("refresh", {
       accessToken: "old-access",
       refreshToken: "old-refresh",
@@ -200,6 +247,39 @@ describe("mcp-auth-flow explicit auth", () => {
     }, "https://api.example.com/mcp");
 
     const token = await getValidToken("refresh", "https://api.example.com/mcp");
+
+    expect(token?.accessToken).toBe("new-access");
+    expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes expired tokens when the cached dynamic client has a stale redirect URI", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await expect(provider.clientInformation()).resolves.toEqual({
+        client_id: "client",
+        client_secret: undefined,
+      });
+      await provider.saveTokens({
+        access_token: "new-access",
+        token_type: "Bearer",
+        refresh_token: "new-refresh",
+        expires_in: 3600,
+      });
+      return "AUTHORIZED";
+    });
+    const { getValidToken } = await import("../mcp-auth-flow.ts");
+    const { updateClientInfo, updateTokens } = await import("../mcp-auth.ts");
+
+    updateClientInfo("refresh-stale-redirect", {
+      clientId: "client",
+      redirectUris: ["http://localhost:19877/callback"],
+    }, "https://api.example.com/mcp");
+    updateTokens("refresh-stale-redirect", {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() / 1000 - 60,
+    }, "https://api.example.com/mcp");
+
+    const token = await getValidToken("refresh-stale-redirect", "https://api.example.com/mcp");
 
     expect(token?.accessToken).toBe("new-access");
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
@@ -243,7 +323,11 @@ describe("mcp-auth-flow explicit auth", () => {
     const { startAuth } = await import("../mcp-auth-flow.ts");
     const { getAuthForUrl, updateClientInfo, updateTokens } = await import("../mcp-auth.ts");
 
-    updateClientInfo("tokened", { clientId: "stored-client", clientSecret: "stored-secret" }, "https://api.example.com/mcp");
+    updateClientInfo("tokened", {
+      clientId: "stored-client",
+      clientSecret: "stored-secret",
+      redirectUris: ["http://localhost:19876/callback"],
+    }, "https://api.example.com/mcp");
     updateTokens("tokened", { accessToken: "access", refreshToken: "refresh" }, "https://api.example.com/mcp");
 
     await startAuth("tokened", "https://api.example.com/mcp", {

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
-import { saveAuthEntry, updateOAuthState } from "../mcp-auth.ts";
+import { getAuthForUrl, saveAuthEntry, updateOAuthState } from "../mcp-auth.ts";
 
 describe("McpOAuthProvider authorization fallback", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
@@ -75,5 +75,41 @@ describe("McpOAuthProvider authorization fallback", () => {
     await expect(provider.redirectToAuthorization(new URL("https://auth.example.com/authorize")))
       .rejects.toBeInstanceOf(UnauthorizedError);
     expect(redirected).toBe(false);
+  });
+
+  it("returns stored dynamic client information even when redirect URI metadata is stale", async () => {
+    const provider = new McpOAuthProvider("client-redirect-stale", serverUrl, {}, {
+      onRedirect: async () => {},
+    });
+    saveAuthEntry("client-redirect-stale", {
+      clientInfo: {
+        clientId: "registered-client",
+        redirectUris: ["http://localhost:19877/callback"],
+      },
+      serverUrl,
+    }, serverUrl);
+
+    await expect(provider.clientInformation()).resolves.toEqual({
+      client_id: "registered-client",
+      client_secret: undefined,
+    });
+  });
+
+  it("stores redirect URIs with dynamic client information", async () => {
+    const provider = new McpOAuthProvider("client-redirect-store", serverUrl, {}, {
+      onRedirect: async () => {},
+    });
+
+    await provider.saveClientInformation({
+      client_id: "registered-client",
+      redirect_uris: [provider.redirectUrl!],
+    });
+
+    expect(getAuthForUrl("client-redirect-store", serverUrl)?.clientInfo?.redirectUris)
+      .toEqual([provider.redirectUrl]);
+    await expect(provider.clientInformation()).resolves.toEqual({
+      client_id: "registered-client",
+      client_secret: undefined,
+    });
   });
 });

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -24,6 +24,7 @@ import {
   clearAllCredentials,
   clearClientInfo,
   clearCodeVerifier,
+  clearTokens,
   updateOAuthState,
   getOAuthState,
   clearOAuthState,
@@ -100,15 +101,25 @@ export async function startAuth(
   // Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
   await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
 
-  const oauthState = generateState()
-  await updateOAuthState(serverName, oauthState, serverUrl)
-
   let capturedUrl: URL | undefined
   const authProvider = new McpOAuthProvider(serverName, serverUrl, config, {
     onRedirect: async (url) => {
       capturedUrl = url
     },
   })
+
+  const currentAuth = await getAuthForUrl(serverName, serverUrl)
+  const currentRedirectUrl = authProvider.redirectUrl
+  if (!config.clientId && currentAuth?.clientInfo &&
+    (!currentRedirectUrl || !currentAuth.clientInfo.redirectUris?.includes(currentRedirectUrl))) {
+    clearClientInfo(serverName)
+    clearTokens(serverName)
+    clearCodeVerifier(serverName)
+    await clearOAuthState(serverName)
+  }
+
+  const oauthState = generateState()
+  await updateOAuthState(serverName, oauthState, serverUrl)
 
   try {
     const result = await runSdkAuth(authProvider, { serverUrl })

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -27,6 +27,8 @@ export interface StoredClientInfo {
   clientSecret?: string;
   clientIdIssuedAt?: number;
   clientSecretExpiresAt?: number;
+  /** Redirect URIs used when this dynamic client was registered. */
+  redirectUris?: string[];
 }
 
 /** Complete auth entry for a server */

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -105,6 +105,7 @@ describe("McpOAuthProvider", () => {
           clientSecret: "stored-secret",
           clientIdIssuedAt: Math.floor(Date.now() / 1000),
           clientSecretExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+          redirectUris: [provider.redirectUrl!],
         },
         serverUrl,
       }, serverUrl)
@@ -139,12 +140,46 @@ describe("McpOAuthProvider", () => {
           clientId: "stored-client",
           clientSecret: "stored-secret",
           clientSecretExpiresAt: 1, // Expired in 1970
+          redirectUris: [provider.redirectUrl!],
         },
         serverUrl,
       }, serverUrl)
 
       const info = await provider.clientInformation()
       assert.strictEqual(info, undefined)
+    })
+
+    it("should return stored client info even when redirect URI metadata is stale", async () => {
+      const provider = createProvider()
+
+      saveAuthEntry(serverName, {
+        clientInfo: {
+          clientId: "stored-client",
+          clientSecret: "stored-secret",
+          redirectUris: ["http://localhost:19877/callback"],
+        },
+        serverUrl,
+      }, serverUrl)
+
+      const info = await provider.clientInformation()
+      assert.strictEqual(info?.client_id, "stored-client")
+      assert.strictEqual(info?.client_secret, "stored-secret")
+    })
+
+    it("should return stored client info without redirect URI metadata", async () => {
+      const provider = createProvider()
+
+      saveAuthEntry(serverName, {
+        clientInfo: {
+          clientId: "stored-client",
+          clientSecret: "stored-secret",
+        },
+        serverUrl,
+      }, serverUrl)
+
+      const info = await provider.clientInformation()
+      assert.strictEqual(info?.client_id, "stored-client")
+      assert.strictEqual(info?.client_secret, "stored-secret")
     })
 
     it("should prefer config over stored", async () => {
@@ -171,12 +206,15 @@ describe("McpOAuthProvider", () => {
       const info: OAuthClientInformationFull = {
         client_id: "new-client",
         client_secret: "new-secret",
-        redirect_uris: ["http://localhost:3118/callback"],
+        redirect_uris: [provider.redirectUrl!],
         client_id_issued_at: Math.floor(Date.now() / 1000),
         client_secret_expires_at: futureTime,
       }
 
       await provider.saveClientInformation(info)
+
+      const storedEntry = getAuthForUrl(serverName, serverUrl)
+      assert.deepStrictEqual(storedEntry?.clientInfo?.redirectUris, [provider.redirectUrl])
 
       const storedInfo = await provider.clientInformation()
       assert.strictEqual(storedInfo?.client_id, "new-client")
@@ -372,7 +410,7 @@ describe("McpOAuthProvider", () => {
       await provider.saveClientInformation({
         client_id: "client",
         client_secret: "secret",
-        redirect_uris: ["http://localhost/callback"],
+        redirect_uris: [provider.redirectUrl!],
       })
 
       await provider.invalidateCredentials("all")
@@ -392,7 +430,7 @@ describe("McpOAuthProvider", () => {
       await provider.saveClientInformation({
         client_id: "client",
         client_secret: "secret",
-        redirect_uris: ["http://localhost/callback"],
+        redirect_uris: [provider.redirectUrl!],
         client_id_issued_at: Math.floor(Date.now() / 1000),
         client_secret_expires_at: futureTime,
       })
@@ -415,7 +453,7 @@ describe("McpOAuthProvider", () => {
       await provider.saveClientInformation({
         client_id: "client",
         client_secret: "secret",
-        redirect_uris: ["http://localhost/callback"],
+        redirect_uris: [provider.redirectUrl!],
         client_id_issued_at: Math.floor(Date.now() / 1000),
         client_secret_expires_at: futureTime,
       })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -160,6 +160,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
       clientSecret: info.client_secret,
       clientIdIssuedAt: info.client_id_issued_at,
       clientSecretExpiresAt: info.client_secret_expires_at,
+      redirectUris: info.redirect_uris?.map((uri) => String(uri)) ??
+        (this.redirectUrl ? [this.redirectUrl] : undefined),
     }
     updateClientInfo(this.serverName, clientInfo, this.serverUrl)
   }


### PR DESCRIPTION
## Summary

When the local OAuth callback port changed between dynamic client registration and a later browser reauth attempt, some providers rejected the reused cached client with `Unregistered redirect_uri`; this PR stores registered redirect URIs and discards stale dynamic OAuth cache before starting that browser auth flow.

## Reproduction

1. Authenticate with an OAuth MCP server using dynamic client registration.
2. The adapter registers a dynamic OAuth client for the current callback URL, e.g. `http://localhost:19876/callback`.
3. Later, start OAuth auth again while that port is unavailable.
4. The callback server falls back to another port, e.g. `http://localhost:19877/callback`.
5. Before this PR, the adapter reused the cached dynamic `client_id` because cached client info was only scoped to `serverUrl`.
6. The authorization request then used the old `client_id` with the new `redirect_uri`.
7. OAuth providers that enforce registered redirect URIs reject that request with `invalid_request` / `Unregistered redirect_uri`.

## What changed

- Store the redirect URIs associated with dynamically registered OAuth clients.
- Before starting an interactive browser auth flow, compare the current callback URL with the cached dynamic client's redirect URIs.
- If the cached dynamic client was registered for a different or unknown callback URL:
  - clear cached client info
  - clear cached tokens
  - clear stale PKCE verifier
  - clear stale OAuth state
- Then continue with the normal SDK auth flow, which dynamically registers a fresh client for the current callback URL.

Refresh-token behavior is intentionally unchanged: cached client info is still returned normally from `clientInformation()`, because refresh grants do not use `redirect_uri`.

## Tests

- `npm test`
- `npm run test:oauth-provider`
- `npx tsc --noEmit`
