### PR TITLE
feat: add "mcp" toolPrefix mode for mcp__<server>_<tool> naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Avoided MCP renderer crashes without a TUI theme and preserved status-bar updates with plain fallback text. Thanks @fankangsong for PR #183.
 - Abandoned MCP initialization quietly when a session is disposed during eager or keep-alive connection setup. Thanks @luisfontes for PR #192.
+- Added `toolPrefix: "mcp"` support for `mcp__<server>_<tool>` names across direct and proxy MCP tool paths. Thanks @riicodespretty for PR #99.
 - Sanitized dotted MCP tool names before registering them with Pi. Thanks @benjaminrickels for PR #190.
 - Reconnected OAuth MCP servers automatically after successful panel or `/mcp-auth` authorization, and made panel reconnect force a fresh connection like `/mcp reconnect`. Thanks @mightymatth for issue #171.
 - Recovered stale Streamable HTTP MCP sessions that report `-32000 Server not initialized` after a server restart. Thanks @vicary for issue #184.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 
 | Setting | Description |
 |---------|-------------|
-| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
+| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__<server>_`) |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 
 | Setting | Description |
 |---------|-------------|
-| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__<server>_`) |
+| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__`, same normalisation as `"server"` mode) |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You can also pass only the `code` query parameter with `args: { code: "..." }`. 
 
 | Setting | Description |
 |---------|-------------|
-| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
+| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__`, using server-mode normalization) |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `oauthDir` | OAuth credential directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. |

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -548,6 +548,21 @@ describe("config discovery", () => {
     expect(sharedPreview.diffText).toContain('+     "repoprompt": {');
   });
 
+  it("preserves the mcp toolPrefix setting from config files", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-prefix-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-prefix-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), {
+      settings: { toolPrefix: "mcp" },
+      mcpServers: { demo: { command: "demo" } },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().settings?.toolPrefix).toBe("mcp");
+  });
+
   it("writes selected compatibility imports and a starter project config", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-setup-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-setup-project-"));

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -31,6 +31,7 @@ describe("formatToolName", () => {
     expect(formatToolName("namespace.tool", "demo", "server")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo-mcp", "short")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo", "none")).toBe("namespace_tool");
+    expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo_mcp_namespace_tool");
   });
 });
 
@@ -440,6 +441,39 @@ describe("excludeTools filtering", () => {
     const specs = resolveDirectTools(config, cache, "server");
 
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes"]);
+  });
+
+  it("matches mcp-prefixed exclusions when toolPrefix is mcp", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "mcp" },
+      mcpServers: {
+        "my-server": {
+          command: "npx",
+          args: ["-y", "my-server"],
+          directTools: true,
+          excludeTools: ["mcp__my_server_do_thing"],
+        },
+      },
+    };
+
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": {
+          configHash: computeServerHash(config.mcpServers["my-server"]),
+          cachedAt: Date.now(),
+          tools: [
+            { name: "do_thing", description: "Does a thing" },
+            { name: "other_tool", description: "Another tool" },
+          ],
+          resources: [],
+        },
+      },
+    };
+
+    const specs = resolveDirectTools(config, cache, "mcp");
+
+    expect(specs.map((spec) => spec.prefixedName)).toEqual(["mcp__my_server_other_tool"]);
   });
 
   it("matches prefixed exclusions even when toolPrefix is none", () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -264,6 +264,41 @@ describe("excludeTools filtering", () => {
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes"]);
   });
 
+  it("prefixes tool names with mcp__ when toolPrefix is mcp", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "mcp" },
+      mcpServers: {
+        "my-server": {
+          command: "npx",
+          args: ["-y", "my-server"],
+          directTools: true,
+        },
+      },
+    };
+
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": {
+          configHash: computeServerHash(config.mcpServers["my-server"]),
+          cachedAt: Date.now(),
+          tools: [
+            { name: "do_thing", description: "Does a thing" },
+            { name: "other_tool", description: "Another tool" },
+          ],
+          resources: [],
+        },
+      },
+    };
+
+    const specs = resolveDirectTools(config, cache, "mcp");
+
+    expect(specs.map((spec) => spec.prefixedName)).toEqual([
+      "mcp__my_server_do_thing",
+      "mcp__my_server_other_tool",
+    ]);
+  });
+
   it("matches prefixed exclusions even when toolPrefix is none", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "none" },

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -132,7 +132,7 @@ describe("proxy auto auth", () => {
 
     const state = {
       config: {
-        settings: { autoAuth: true, toolPrefix: "server" },
+        settings: { autoAuth: true, toolPrefix: "mcp" },
         mcpServers: {
           demo: { url: "https://api.example.com/mcp", auth: "oauth" },
         },
@@ -153,6 +153,10 @@ describe("proxy auto auth", () => {
     );
     expect(manager.close).toHaveBeenCalledWith("demo");
     expect(manager.connect).toHaveBeenCalledTimes(2);
+    expect(state.toolMetadata.get("demo")?.[0]).toMatchObject({
+      name: "mcp__demo_search",
+      originalName: "search",
+    });
     expect(result.content[0].text).toContain("demo (1 tools)");
   });
 
@@ -407,7 +411,7 @@ describe("proxy auto auth", () => {
         return false;
       }
       state.toolMetadata.set(serverName, [{
-        name: "demo_search",
+        name: "mcp__demo_search",
         originalName: "search",
         description: "Search",
         inputSchema: { type: "object", properties: {} },
@@ -419,7 +423,7 @@ describe("proxy auto auth", () => {
     manager.setDefaultRequestTimeoutMs(2500);
     const state = {
       config: {
-        settings: { toolPrefix: "server" },
+        settings: { toolPrefix: "mcp" },
         mcpServers: {
           demo: { command: "node", args: ["server.js"], requestTimeoutMs: 5000 },
         },
@@ -431,8 +435,8 @@ describe("proxy auto auth", () => {
     } as any;
 
     const [first, second] = await Promise.all([
-      executeCall(state, "demo_search", { q: "one" }),
-      executeCall(state, "demo_search", { q: "two" }),
+      executeCall(state, "mcp__demo_search", { q: "one" }),
+      executeCall(state, "mcp__demo_search", { q: "two" }),
     ]);
 
     expect(mocks.clients).toHaveLength(1);

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
 import type { McpExtensionState } from "./state.ts";
-import type { DirectToolSpec, McpConfig, McpContent } from "./types.ts";
+import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
 import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
@@ -95,7 +95,7 @@ async function attemptDirectAutoAuth(
 export function resolveDirectTools(
   config: McpConfig,
   cache: MetadataCache | null,
-  prefix: "server" | "none" | "short",
+  prefix: ToolPrefix,
   envOverride?: string[],
 ): DirectToolSpec[] {
   const specs: DirectToolSpec[] = [];

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,7 +1,7 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import { isToolExcluded } from "./types.ts";
-import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.ts";
+import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import type { MetadataCache, ServerCacheEntry, CachedTool } from "./metadata-cache.ts";
 
@@ -152,7 +152,7 @@ interface VisibleItem {
 
 class McpPanel {
   private noticeLines: string[];
-  private prefix: "server" | "none" | "short";
+  private prefix: ToolPrefix;
   private servers: ServerState[] = [];
   private cursorIndex = 0;
   private nameQuery = "";

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -5,7 +5,7 @@ import { getAgentPath } from "./agent-dir.ts";
 import { createHash } from "node:crypto";
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { McpTool, McpResource, ServerEntry, ToolMetadata } from "./types.ts";
-import { formatToolName, isToolExcluded } from "./types.ts";
+import { formatToolName, isToolExcluded, type ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -129,7 +129,7 @@ export function isServerCacheValid(
 export function reconstructToolMetadata(
   serverName: string,
   entry: ServerCacheEntry,
-  prefix: "server" | "none" | "short",
+  prefix: ToolPrefix,
   definition: Pick<ServerEntry, "exposeResources" | "excludeTools">
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,6 +1,6 @@
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { McpExtensionState } from "./state.ts";
-import type { ToolMetadata, McpTool, McpResource, ServerEntry } from "./types.ts";
+import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from "./types.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
@@ -10,7 +10,7 @@ export function buildToolMetadata(
   resources: McpResource[],
   definition: ServerEntry,
   serverName: string,
-  prefix: "server" | "none" | "short"
+  prefix: ToolPrefix
 ): { metadata: ToolMetadata[]; failedTools: string[] } {
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];

--- a/types.ts
+++ b/types.ts
@@ -329,8 +329,10 @@ export interface McpOutputGuardSettings {
 }
 
 // Settings
+export type ToolPrefix = "server" | "none" | "short" | "mcp";
+
 export interface McpSettings {
-  toolPrefix?: "server" | "none" | "short";
+  toolPrefix?: ToolPrefix;
   idleTimeout?: number; // minutes, default 10, 0 to disable
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
@@ -423,7 +425,7 @@ export interface McpPanelResult {
  */
 export function getServerPrefix(
   serverName: string,
-  mode: "server" | "none" | "short"
+  mode: ToolPrefix
 ): string {
   if (mode === "none") return "";
   if (mode === "short") {
@@ -431,6 +433,7 @@ export function getServerPrefix(
     if (!short) short = "mcp";
     return short;
   }
+  if (mode === "mcp") return `mcp__${serverName.replace(/-/g, "_")}`;
   return serverName.replace(/-/g, "_");
 }
 
@@ -440,7 +443,7 @@ export function getServerPrefix(
 export function formatToolName(
   toolName: string,
   serverName: string,
-  prefix: "server" | "none" | "short"
+  prefix: ToolPrefix
 ): string {
   const p = getServerPrefix(serverName, prefix);
   const sanitized = toolName.replace(/\./g, "_");
@@ -454,7 +457,7 @@ function normalizeToolName(value: string): string {
 export function isToolExcluded(
   toolName: string,
   serverName: string,
-  prefix: "server" | "none" | "short",
+  prefix: ToolPrefix,
   excludeTools?: unknown
 ): boolean {
   if (!Array.isArray(excludeTools) || excludeTools.length === 0) return false;
@@ -464,6 +467,7 @@ export function isToolExcluded(
     normalizeToolName(formatToolName(toolName, serverName, prefix)),
     normalizeToolName(formatToolName(toolName, serverName, "server")),
     normalizeToolName(formatToolName(toolName, serverName, "short")),
+    normalizeToolName(formatToolName(toolName, serverName, "mcp")),
   ]);
 
   for (const excluded of excludeTools) {

--- a/types.ts
+++ b/types.ts
@@ -313,7 +313,7 @@ export interface ServerEntry {
 
 // Settings
 export interface McpSettings {
-  toolPrefix?: "server" | "none" | "short";
+  toolPrefix?: "server" | "none" | "short" | "mcp";
   idleTimeout?: number; // minutes, default 10, 0 to disable
   directTools?: boolean;
   disableProxyTool?: boolean;
@@ -388,7 +388,7 @@ export interface McpPanelResult {
  */
 export function getServerPrefix(
   serverName: string,
-  mode: "server" | "none" | "short"
+  mode: "server" | "none" | "short" | "mcp"
 ): string {
   if (mode === "none") return "";
   if (mode === "short") {
@@ -396,6 +396,7 @@ export function getServerPrefix(
     if (!short) short = "mcp";
     return short;
   }
+  if (mode === "mcp") return `mcp__${serverName.replace(/-/g, "_")}`;
   return serverName.replace(/-/g, "_");
 }
 
@@ -405,7 +406,7 @@ export function getServerPrefix(
 export function formatToolName(
   toolName: string,
   serverName: string,
-  prefix: "server" | "none" | "short"
+  prefix: "server" | "none" | "short" | "mcp"
 ): string {
   const p = getServerPrefix(serverName, prefix);
   return p ? `${p}_${toolName}` : toolName;
@@ -418,7 +419,7 @@ function normalizeToolName(value: string): string {
 export function isToolExcluded(
   toolName: string,
   serverName: string,
-  prefix: "server" | "none" | "short",
+  prefix: "server" | "none" | "short" | "mcp",
   excludeTools?: unknown
 ): boolean {
   if (!Array.isArray(excludeTools) || excludeTools.length === 0) return false;


### PR DESCRIPTION
## Problem

When `directTools` are enabled, pi-mcp-adapter registers tools in Pi's tool list using the global `settings.toolPrefix` mode. The three existing modes produce these name patterns:

| Mode | Example result |
|------|---------------|
| `"server"` (default) | `myserver-mcp_do_thing` |
| `"short"` | `myserver_do_thing` |
| `"none"` | `do_thing` |

None of these produce names beginning with `mcp__`.

Some tool-filter middleware checks whether a tool name starts with `mcp__` before forwarding it to the model. With any of the existing prefix modes, **all directTools are silently dropped** from the model's tool list when such a filter is active — the tools are registered in Pi but the model never sees them and cannot call them.

## Solution

Add a fourth prefix mode: `"mcp"`.

`getServerPrefix(serverName, "mcp")` returns `mcp__<serverName>` (hyphens replaced with underscores, same normalisation as `"server"` mode). Combined with the tool name, the result is `mcp__<server>_<tool>`, e.g. `mcp__my_server_do_thing`.

Tools registered this way pass through `mcp__`-aware filters unchanged. No alias layer or workaround is needed.

## Changes

- **`types.ts`** — add `"mcp"` to the `toolPrefix` union in `McpSettings`, and thread the updated union through `getServerPrefix`, `formatToolName`, and `isToolExcluded`
- **`__tests__/direct-tools.test.ts`** — add a test asserting that `resolveDirectTools` with `"mcp"` prefix produces `mcp__<server>_<tool>` names
- **`README.md`** — document the new option in the Settings table

## Usage

```json
{
  "settings": { "toolPrefix": "mcp" },
  "mcpServers": {
    "my-server": {
      "command": "my-server",
      "directTools": true
    }
  }
}
```

Registers tools as `mcp__my_server_<tool_name>`.

## Test output

```
✓ direct-tools > excludeTools filtering > prefixes tool names with mcp__ when toolPrefix is mcp
```

All 13 tests in `direct-tools.test.ts` pass. The 2 failures in the full suite are pre-existing ENOENT errors for `examples/interactive-visualizer/dist/` build artifacts unrelated to this change.
