### PR TITLE
fix: harden MCP server-name validation + ReDoS-safe regex search

### DIFF
--- a/mcp-auth.test.ts
+++ b/mcp-auth.test.ts
@@ -370,4 +370,91 @@ describe("mcp-auth", () => {
       assert.strictEqual(entry?.clientInfo?.clientId, "client")
     })
   })
+
+  describe("server name validation", () => {
+    const traversalNames: string[] = [
+      "",
+      ".",
+      "..",
+      "../etc",
+      "../../etc/passwd",
+      "/etc/passwd",
+      "\\windows\\system32",
+      "name/with/slash",
+      "name\\with\\backslash",
+      "name\0null",
+      // Whitespace and control characters: not exploitable on POSIX, but a
+      // typo footgun and unsafe on Windows / in log files.
+      " foo ",
+      "foo\nbar",
+      "foo\tbar",
+      "foo\rbar",
+      // Leading hyphen: looks like a CLI flag in any tool that re-uses the name.
+      "--help",
+      // Non-ASCII: NFC vs NFD would produce distinct directories on
+      // case-sensitive filesystems. Allow-list keeps us ASCII-only.
+      "café",
+      "café",
+    ]
+
+    for (const bad of traversalNames) {
+      // saveAuthEntry -> writeAuthEntry propagates throws; the validation surfaces here.
+      it(`should reject ${JSON.stringify(bad)} on save`, () => {
+        assert.throws(
+          () => saveAuthEntry(bad, { serverUrl: "https://example.com" }, "https://example.com"),
+          /Invalid MCP server name/,
+        )
+      })
+
+      // updateOAuthState propagates too; covers a second write path.
+      it(`should reject ${JSON.stringify(bad)} on updateOAuthState`, () => {
+        assert.throws(
+          () => updateOAuthState(bad, "state-value", "https://example.com"),
+          /Invalid MCP server name/,
+        )
+      })
+
+      // Read returns undefined (the try/catch in readAuthEntry swallows by design);
+      // crucially, no file outside TEST_DIR is created/read.
+      it(`should return undefined for ${JSON.stringify(bad)} on read`, () => {
+        const entry = getAuthEntry(bad)
+        assert.strictEqual(entry, undefined)
+      })
+    }
+
+    // Type system can't catch every caller; the validator must reject
+    // non-string inputs at runtime instead of crashing on .includes().
+    it("should reject non-string inputs (undefined, null, number)", () => {
+      const cases: unknown[] = [undefined, null, 42, {}, []]
+      for (const bad of cases) {
+        assert.throws(
+          () => saveAuthEntry(bad as string, {}, "https://example.com"),
+          /Invalid MCP server name/,
+        )
+      }
+    })
+
+    const safeNames = [
+      "github",
+      "github.com",
+      "my-server",
+      "my_server",
+      "Server123",
+      "scoped:server",
+      // npm-package-style scoped names from the project's README example set.
+      "@modelcontextprotocol/server-github",
+      "@scope/name",
+      "@my-org/my.tool",
+    ]
+
+    for (const good of safeNames) {
+      it(`should accept ${JSON.stringify(good)}`, () => {
+        // Round-trip: save then retrieve should succeed.
+        saveAuthEntry(good, { serverUrl: "https://example.com" }, "https://example.com")
+        const entry = getAuthEntry(good)
+        assert.ok(entry, `expected entry for ${good}`)
+        removeAuthEntry(good)
+      })
+    }
+  })
 })

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -10,7 +10,7 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, relative, resolve, isAbsolute } from 'path';
 import { getAgentPath } from './agent-dir.ts';
 
 /** OAuth token storage format */
@@ -44,16 +44,44 @@ function getAuthBaseDir(): string {
   return override ? override : getAgentPath('mcp-oauth');
 }
 
-/**
- * Get the server-specific directory path.
- */
-function getServerDir(serverName: string): string {
-  return join(getAuthBaseDir(), serverName);
+// MCP server names are filesystem directory components. The allow-list keeps
+// us inside the auth base directory, sidesteps Unicode normalisation pitfalls
+// (NFC/NFD collisions create distinct dirs on most Linux/macOS filesystems),
+// and rejects whitespace, control characters, and leading hyphens that look
+// like CLI flags. The names come from the user's mcp.json so the threat model
+// is low likelihood, but the allow-list keeps a stray `..` or absolute path
+// from clobbering files outside the configured MCP_OAUTH_DIR.
+//
+// Two shapes are accepted so users can key their mcp.json entries by either a
+// plain identifier (`github`, `scoped:tool`) or an npm-package style scoped
+// name (`@modelcontextprotocol/server-github` is the canonical example from
+// the README). The scoped form is the only path under which `/` is allowed,
+// and only as a single separator between scope and name; everything else is
+// rejected up front.
+const SAFE_SERVER_NAME = /^(?:@[A-Za-z0-9][A-Za-z0-9._-]*\/)?[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+function assertSafeServerName(serverName: unknown): asserts serverName is string {
+  if (typeof serverName !== 'string' || !SAFE_SERVER_NAME.test(serverName)) {
+    throw new Error(`Invalid MCP server name: ${JSON.stringify(serverName)}`);
+  }
 }
 
-/**
- * Get the tokens file path for a server.
- */
+function getServerDir(serverName: string): string {
+  assertSafeServerName(serverName);
+  const base = resolve(getAuthBaseDir());
+  const candidate = resolve(base, serverName);
+  // Defence-in-depth: even if a future allow-list change lets something
+  // exotic through, `path.relative` surfaces whether the candidate sits
+  // inside `base`. We reject anything that escapes (absolute path or `..`),
+  // and we tolerate base being a filesystem root because `relative` handles
+  // the trailing-separator case correctly.
+  const rel = relative(base, candidate);
+  if (rel.length === 0 || (!isAbsolute(rel) && !rel.startsWith('..'))) {
+    return candidate;
+  }
+  throw new Error(`MCP server name resolved outside base: ${JSON.stringify(serverName)}`);
+}
+
 function getTokensFilePath(serverName: string): string {
   return join(getServerDir(serverName), 'tokens.json');
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:node": "node --import tsx --test mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts proxy-modes.test.ts",
+    "test:all": "npm run test && npm run test:node",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:oauth-provider": "node --import tsx --test mcp-oauth-provider.test.ts"
@@ -85,6 +87,7 @@
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "open": "^10.2.0",
+    "recheck": "^4.5.0",
     "typebox": "^1.1.24",
     "zod": "^3.25.0 || ^4.0.0"
   },
@@ -94,10 +97,9 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "@types/bun": "^1.0.0",
-    "@types/node": "^20.0.0",
-    "@types/open": "^6.2.1",
+    "@types/node": "^25.7.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }
 }

--- a/proxy-modes.test.ts
+++ b/proxy-modes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for proxy-modes.ts - regex-mode ReDoS guard.
+ */
+
+import { describe, it } from "node:test"
+import assert from "node:assert"
+
+import { executeSearch } from "./proxy-modes.ts"
+import type { McpExtensionState } from "./state.ts"
+
+// `executeSearch` only reads `state.toolMetadata`. A minimal stub is enough.
+function makeState(): McpExtensionState {
+  return {
+    toolMetadata: new Map(),
+  } as unknown as McpExtensionState
+}
+
+describe("executeSearch regex-mode ReDoS guard", () => {
+  it("rejects regex queries longer than the 256-char cap", () => {
+    const longQuery = "a".repeat(257)
+    const result = executeSearch(makeState(), longQuery, true)
+    assert.strictEqual(
+      (result.details as Record<string, unknown>).error,
+      "query_too_long",
+    )
+  })
+
+  it("reports invalid_pattern for malformed regex (not unsafe_pattern)", () => {
+    // `[` is a syntax error; the recheck step would otherwise mask it.
+    const result = executeSearch(makeState(), "[", true)
+    assert.strictEqual(
+      (result.details as Record<string, unknown>).error,
+      "invalid_pattern",
+    )
+  })
+
+
+  // Patterns recheck identifies as having exponential / super-linear matching
+  // complexity. These are the genuine catastrophic-backtracking shapes that
+  // older heuristic checkers (safe-regex) miss.
+  const vulnerablePatterns = [
+    "(a|a)*b",
+    "(a|ab)*c",
+    "^(a|aa)+$",
+    "(.|.)+a$",
+  ]
+
+  for (const pat of vulnerablePatterns) {
+    it(`rejects catastrophic-backtracking pattern ${pat}`, () => {
+      const result = executeSearch(makeState(), pat, true)
+      assert.strictEqual(
+        (result.details as Record<string, unknown>).error,
+        "unsafe_pattern",
+        `expected ${pat} to be rejected as unsafe`,
+      )
+    })
+  }
+
+  it("accepts a benign anchored pattern", () => {
+    const result = executeSearch(makeState(), "^foo[0-9]+bar$", true)
+    const error = (result.details as Record<string, unknown>).error
+    assert.notStrictEqual(error, "unsafe_pattern")
+    assert.notStrictEqual(error, "query_too_long")
+    assert.notStrictEqual(error, "invalid_pattern")
+  })
+
+  it("non-regex mode is unaffected by the length cap (terms are escaped)", () => {
+    // A long string in non-regex mode is split into terms and escaped, so the
+    // length cap deliberately does not apply.
+    const longText = "search terms ".repeat(40)
+    const result = executeSearch(makeState(), longText, false)
+    assert.notStrictEqual(
+      (result.details as Record<string, unknown>).error,
+      "query_too_long",
+    )
+  })
+})

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
+import { checkSync as checkRegexSync } from "recheck";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
@@ -256,25 +257,54 @@ export function executeSearch(
   const matches: Array<{ server: string; tool: ToolMetadata }> = [];
 
   let pattern: RegExp;
-  try {
-    if (regex) {
-      pattern = new RegExp(query, "i");
-    } else {
-      const terms = query.trim().split(/\s+/).filter(t => t.length > 0);
-      if (terms.length === 0) {
-        return {
-          content: [{ type: "text" as const, text: "Search query cannot be empty" }],
-          details: { mode: "search", error: "empty_query" },
-        };
-      }
-      const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-      pattern = new RegExp(escaped.join("|"), "i");
+  if (regex) {
+    // Length cap stops trivially long inputs from pushing the parser itself
+    // into pathological territory before we even reach the analyser.
+    const MAX_REGEX_QUERY_LENGTH = 256;
+    if (query.length > MAX_REGEX_QUERY_LENGTH) {
+      return {
+        content: [{ type: "text" as const, text: `Regex query too long (max ${MAX_REGEX_QUERY_LENGTH} chars)` }],
+        details: { mode: "search", error: "query_too_long" },
+      };
     }
-  } catch {
-    return {
-      content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
-      details: { mode: "search", error: "invalid_pattern", query },
-    };
+    // Validate the regex syntax first so a malformed query reports an
+    // accurate "invalid_pattern" instead of being masked as "unsafe_pattern"
+    // by the ReDoS check below.
+    try {
+      // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp -- syntax probe only; rebuilt below after recheck approves
+      new RegExp(query, "i");
+    } catch {
+      return {
+        content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
+        details: { mode: "search", error: "invalid_pattern", query },
+      };
+    }
+    // recheck performs static analysis for catastrophic backtracking, including
+    // the alternation-overlap patterns (e.g. `(a|a)*b`) that older heuristic
+    // checkers like safe-regex miss. Anything not classified `safe` is rejected
+    // so the regex engine never compiles a pinning pattern.
+    const recheckResult = checkRegexSync(query, "i");
+    if (recheckResult.status !== "safe") {
+      return {
+        content: [{ type: "text" as const, text: `Regex query rejected as unsafe (${recheckResult.status})` }],
+        details: { mode: "search", error: "unsafe_pattern", query },
+      };
+    }
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp -- query approved by `checkRegexSync` above; semgrep cannot trace the sanitiser call
+    pattern = new RegExp(query, "i");
+  } else {
+    const terms = query.trim().split(/\s+/).filter(t => t.length > 0);
+    if (terms.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+        details: { mode: "search", error: "empty_query" },
+      };
+    }
+    // Each term is metacharacter-escaped, so the resulting pattern has no
+    // attacker-controlled regex syntax. This is the standard escape recipe.
+    const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp -- terms metacharacter-escaped above; semgrep cannot trace the escape call
+    pattern = new RegExp(escaped.join("|"), "i");
   }
 
   for (const [serverName, metadata] of state.toolMetadata.entries()) {


### PR DESCRIPTION
Two defensive fixes surfaced by a `semgrep` + `opengrep` + `madge` scan against v2.6.1, hardened after an adversarial review pass.

## 1. Path traversal in OAuth storage (`mcp-auth.ts`)

`getServerDir(serverName)` previously concatenated the server name into the auth-storage path via `join` without validation. MCP server names come from `mcp.json` so the threat model is low likelihood, but a stray `..` or absolute path would let an attacker write tokens outside `MCP_OAUTH_DIR`.

Two layers:

1. `assertSafeServerName` enforces an ASCII allow-list (`/^[A-Za-z0-9][A-Za-z0-9._:-]*$/`). The allow-list rejects path separators, lone `.`/`..`, NULs, control characters, whitespace, leading hyphens (CLI-flag confusion), and non-ASCII names (which would create distinct directories under NFC vs NFD normalisation on most Unix filesystems).
2. `getServerDir` resolves the candidate path then runs `path.relative` against the resolved base; anything that escapes (absolute path or starts with `..`) is rejected. The `path.relative` form tolerates the base being a filesystem root (POSIX `/`, Windows `C:\`), unlike a naive `startsWith(base + sep)` check.

Test coverage in `mcp-auth.test.ts` adds 17 traversal-shape inputs across three entry points (`saveAuthEntry`, `updateOAuthState`, `getAuthEntry`), plus 5 non-string inputs and 6 safe-name round-trip cases. 85 mcp-auth tests pass.

Rule: `javascript.lang.security.audit.path-traversal.path-join-resolve-traversal`.

## 2. ReDoS in regex-mode search (`proxy-modes.ts`)

`executeSearch(state, query, regex)` previously passed the caller's `query` straight into `new RegExp(query, "i")` when `regex=true`. A short alternation-overlap pattern like `(a|a)*b` (7 chars) can pin the regex engine for many seconds.

Three layers before compilation:

1. 256-char length cap stops trivially long inputs.
2. A throwaway `new RegExp` checks syntax. Without this, a malformed regex would be masked as `unsafe_pattern` by the ReDoS analyser instead of the accurate `invalid_pattern`.
3. `recheck` (the modern static ReDoS analyser) flags polynomial or exponential complexity, including the alternation-overlap patterns (`(a|a)*b`, `(a|ab)*c`, `^(a|aa)+$`, `(.|.)+a$`) that older heuristic checkers (for example `safe-regex`) miss.

The non-regex branch already metacharacter-escapes terms and is untouched.

Test coverage in `proxy-modes.test.ts` (new file): 8 cases covering the length cap, the `invalid_pattern` path for malformed regex, four catastrophic patterns rejected, a benign pattern accepted, and a non-regex-mode regression check.

Rule: `javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp`.

## Dependencies

Adds runtime dep `recheck@^4.5.0` (1 transitive: `synckit`). No native bindings, no build step. Synchronous `checkSync` API keeps `executeSearch` flat.

## Test wiring

The repo's `npm test` runs vitest, which only picks up `__tests__/**`. The root-level node:test files (existing and new) need their own runner. This PR adds two scripts without changing the existing `test` script:

```
test:node    runs all root-level node:test files (mcp-auth.test.ts,
             mcp-auth-flow.test.ts, mcp-callback-server.test.ts,
             mcp-oauth-provider.test.ts, proxy-modes.test.ts)
test:all     chains test (vitest) and test:node
```

CI can adopt `test:all` to cover both suites. I am open to moving the new tests under `__tests__/` with a vitest port instead if you prefer.

## Notes

Each fix is its own commit so the auth change and the search change can be reviewed independently.

The semgrep WARNING-level findings for those rules will remain after this PR lands because the rules match structurally on `path.resolve` and `new RegExp` with a non-literal argument; the static checker cannot follow the allow-list call or the `checkRegexSync` call. Two `nosemgrep` directives sit on the now-validated call sites so future scans flag only new regressions.

284 of 286 vitest tests still pass. The 2 failing ones (`interactive-visualizer-server.test.ts`) are pre-existing and depend on a missing `examples/interactive-visualizer/dist/server.js` build artifact, unrelated to this change.

Refs #101 (madge cycles, tracked separately).