### PR TITLE
feat: show MCP tool call input in TUI

### DIFF
--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -1,6 +1,11 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { formatMcpToolResultLines, renderMcpToolResult } from "../tool-result-renderer.ts";
+import {
+  formatMcpDirectToolCallLines,
+  formatMcpProxyToolCallLines,
+  formatMcpToolResultLines,
+  renderMcpToolResult,
+} from "../tool-result-renderer.ts";
 
 type TestDetails = Record<string, unknown> & { error?: unknown };
 type TestResult = AgentToolResult<TestDetails>;
@@ -11,6 +16,46 @@ const plainTheme = { fg: (_name: string, text: string) => text };
 function result(content: TestResult["content"], details: TestDetails = {}): TestResult {
   return { content, details };
 }
+
+describe("MCP tool call renderer", () => {
+  it("shows proxy tool calls with parsed JSON arguments", () => {
+    const display = formatMcpProxyToolCallLines({
+      tool: "cf-portal_list_worker_tail_events",
+      server: "cf-portal",
+      args: JSON.stringify({ accountId: "abc", scriptName: "worker" }),
+    });
+
+    expect(display).toEqual([
+      "mcp call cf-portal_list_worker_tail_events @ cf-portal",
+      '{\n  "accountId": "abc",\n  "scriptName": "worker"\n}',
+    ]);
+  });
+
+  it("shows proxy discovery operations", () => {
+    expect(formatMcpProxyToolCallLines({ search: "tail events", server: "cf-portal", regex: true })).toEqual([
+      "mcp search tail events @ cf-portal (regex)",
+    ]);
+    expect(formatMcpProxyToolCallLines({ connect: "cf-portal" })).toEqual(["mcp connect cf-portal"]);
+    expect(formatMcpProxyToolCallLines({ server: "cf-portal" })).toEqual(["mcp list cf-portal"]);
+    expect(formatMcpProxyToolCallLines({})).toEqual(["mcp status"]);
+  });
+
+  it("shows direct tool calls with JSON arguments", () => {
+    const display = formatMcpDirectToolCallLines("cf-portal_list_worker_tail_events", {
+      accountId: "abc",
+      scriptName: "worker",
+    });
+
+    expect(display).toEqual([
+      "cf-portal_list_worker_tail_events",
+      '{\n  "accountId": "abc",\n  "scriptName": "worker"\n}',
+    ]);
+  });
+
+  it("omits empty direct tool arguments", () => {
+    expect(formatMcpDirectToolCallLines("cf-portal_status", {})).toEqual(["cf-portal_status"]);
+  });
+});
 
 describe("MCP tool result renderer", () => {
   it("shows the first three lines and an ellipsis for collapsed long text", () => {

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { loadMetadataCache } from "./metadata-cache.ts";
 import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
-import { renderMcpToolResult } from "./tool-result-renderer.ts";
+import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
@@ -74,6 +74,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
       parameters: Type.Unsafe((spec.inputSchema || { type: "object", properties: {} }) as never),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
+      renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
       renderResult: renderMcpToolResult,
     });
   }
@@ -252,6 +253,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       label: "MCP",
       description: buildProxyDescription(earlyConfig, earlyCache, directSpecs),
       promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
+      renderCall: renderMcpProxyToolCall,
       parameters: Type.Object({
         tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
         args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -6,6 +6,19 @@ type McpToolContentBlock = AgentToolResult<McpToolResultDetails>["content"][numb
 
 interface RenderTheme {
   fg: (name: string, text: string) => string;
+  bold?: (text: string) => string;
+}
+
+export interface McpProxyToolCallInput {
+  tool?: string;
+  args?: string;
+  connect?: string;
+  describe?: string;
+  search?: string;
+  regex?: boolean;
+  includeSchemas?: boolean;
+  server?: string;
+  action?: string;
 }
 
 interface McpToolRenderContext {
@@ -15,6 +28,87 @@ interface McpToolRenderContext {
 export interface McpToolResultDisplay {
   lines: string[];
   truncated: boolean;
+}
+
+const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function formatJsonish(value: unknown, maxChars: number): string {
+  if (typeof value === "string") {
+    try {
+      return truncateText(JSON.stringify(JSON.parse(value), null, 2), maxChars);
+    } catch {
+      return truncateText(value, maxChars);
+    }
+  }
+
+  try {
+    return truncateText(JSON.stringify(value, null, 2), maxChars);
+  } catch {
+    return truncateText(String(value), maxChars);
+  }
+}
+
+function hasUsefulObjectContent(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length > 0;
+}
+
+export function formatMcpProxyToolCallLines(
+  args: McpProxyToolCallInput,
+  maxInputChars = DEFAULT_MAX_CALL_INPUT_CHARS,
+): string[] {
+  if (args.tool) {
+    const target = args.server ? `${args.tool} @ ${args.server}` : args.tool;
+    const lines = [`mcp call ${target}`];
+    if (args.args) lines.push(formatJsonish(args.args, maxInputChars));
+    return lines;
+  }
+
+  if (args.connect) return [`mcp connect ${args.connect}`];
+  if (args.describe) return [`mcp describe ${args.describe}`];
+
+  if (args.search) {
+    let line = `mcp search ${args.search}`;
+    if (args.server) line += ` @ ${args.server}`;
+    if (args.regex === true) line += " (regex)";
+    if (args.includeSchemas === false) line += " (schemas hidden)";
+    return [line];
+  }
+
+  if (args.server) return [`mcp list ${args.server}`];
+  if (args.action) return [`mcp ${args.action}`];
+
+  return ["mcp status"];
+}
+
+export function formatMcpDirectToolCallLines(
+  displayName: string,
+  args: Record<string, unknown>,
+  maxInputChars = DEFAULT_MAX_CALL_INPUT_CHARS,
+): string[] {
+  if (!hasUsefulObjectContent(args)) return [displayName];
+  return [displayName, formatJsonish(args, maxInputChars)];
+}
+
+function renderToolCallLines(lines: string[], theme: RenderTheme) {
+  const [title = "mcp", ...rest] = lines;
+  const styledTitle = theme.fg("toolTitle", theme.bold ? theme.bold(title) : title);
+  const styledRest = rest.map(line => theme.fg("muted", line));
+  return new Text([styledTitle, ...styledRest].join("\n"), 0, 0);
+}
+
+export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme: RenderTheme) {
+  return renderToolCallLines(formatMcpProxyToolCallLines(args), theme);
+}
+
+export function createMcpDirectToolCallRenderer(displayName: string) {
+  return (args: Record<string, unknown>, theme: RenderTheme) => {
+    return renderToolCallLines(formatMcpDirectToolCallLines(displayName, args), theme);
+  };
 }
 
 function blockToLines(block: McpToolContentBlock): string[] {


### PR DESCRIPTION
## Summary

Adds `renderCall` handlers for MCP tools so Pi's TUI shows the input for MCP calls instead of only showing `mcp`.

- Proxy `mcp` calls now show the operation (`call`, `search`, `connect`, `describe`, `list`, etc.)
- Proxy calls with `args` show parsed/pretty-printed JSON arguments
- Direct MCP tools show their tool name plus JSON arguments when present
- Existing compact `renderResult` behavior is unchanged

Example proxy call render:

```text
mcp call cf-portal_list_worker_tail_events @ cf-portal
{
  "accountId": "...",
  "scriptName": "..."
}
```

This is meant to make MCP calls easier to audit/debug in the TUI, especially for calls that mutate state or query scoped resources.

This overlaps with the rendering direction in #88, but is a smaller/focused patch for making call inputs visible. Happy to rebase/close if #88 lands first with equivalent proxy arg rendering.

## Tests

- `npm test -- --run __tests__/tool-result-renderer.test.ts` ✅
- `npx tsc --noEmit` ✅
- `npm test` runs with 288 passing / 2 failing due the existing missing `examples/interactive-visualizer/dist/*` artifacts (`app.html`, `server.js`), unrelated to this change.

Written by Pi; reviewed and approved by Dillon Mulroy <dillon@cloudflare.com>.
