### PR TITLE
feat: support project-level oauthDir in MCP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `settings.oauthDir` to store MCP OAuth credentials in a project-specific directory, with `MCP_OAUTH_DIR` still taking precedence. Thanks @Termina1 for PR #105.
 - Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
   "settings": {
     "toolPrefix": "server",
     "idleTimeout": 10,
-    "requestTimeoutMs": 30000
+    "requestTimeoutMs": 30000,
+    "oauthDir": ".pi/mcp-oauth"
   },
   "mcpServers": { }
 }
@@ -191,6 +192,7 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
+| `oauthDir` | OAuth credential directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -45,7 +45,7 @@ describe("config discovery", () => {
     });
 
     writeJson(join(project, ".mcp.json"), {
-      settings: { toolPrefix: "none" },
+      settings: { toolPrefix: "none", oauthDir: "shared-oauth" },
       mcpServers: {
         shared: { command: "project" },
         projectOnly: { command: "project-only" },
@@ -53,7 +53,7 @@ describe("config discovery", () => {
     });
 
     writeJson(join(project, ".pi", "mcp.json"), {
-      settings: { autoAuth: true },
+      settings: { autoAuth: true, oauthDir: ".pi/oauth" },
       mcpServers: {
         shared: { command: "project-pi" },
         projectPiOnly: { command: "project-pi-only" },
@@ -74,7 +74,20 @@ describe("config discovery", () => {
       toolPrefix: "none",
       directTools: true,
       autoAuth: true,
+      oauthDir: ".pi/oauth",
     });
+  });
+
+  it("resolves configured oauthDir against the active project cwd", async () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-oauthdir-project-"));
+    const absolute = mkdtempSync(join(tmpdir(), "pi-mcp-oauthdir-absolute-"));
+
+    const { resolveConfiguredOAuthDir } = await import("../config.ts");
+
+    expect(resolveConfiguredOAuthDir(".pi/oauth", project)).toBe(resolve(project, ".pi/oauth"));
+    expect(resolveConfiguredOAuthDir(absolute, project)).toBe(resolve(absolute));
+    expect(resolveConfiguredOAuthDir("  ", project)).toBeUndefined();
+    expect(() => resolveConfiguredOAuthDir(123, project)).toThrow(/settings\.oauthDir must be a string/);
   });
 
   it("prefers modern Claude Code config detection over legacy paths", async () => {

--- a/__tests__/init-elicitation.test.ts
+++ b/__tests__/init-elicitation.test.ts
@@ -19,6 +19,7 @@ vi.mock("../config.ts", async importOriginal => ({
 vi.mock("../server-manager.ts", () => ({
   McpServerManager: vi.fn().mockImplementation(function (this: any) {
     this.setDefaultRequestTimeoutMs = vi.fn();
+    this.setAuthStorageOptions = vi.fn();
     this.setSamplingConfig = vi.fn();
     this.setElicitationConfig = vi.fn();
     this.getConnection = vi.fn();
@@ -61,6 +62,18 @@ describe("initializeMcp elicitation config", () => {
     expect(mocks.managers[0].setElicitationConfig).toHaveBeenCalledWith({
       ui: ctx.ui,
       allowUrl: true,
+    });
+  });
+
+  it("binds oauthDir storage to the active context cwd", async () => {
+    mocks.loadMcpConfig.mockReturnValue({ mcpServers: {}, settings: { oauthDir: ".pi/oauth" } });
+    const { initializeMcp } = await import("../init.ts");
+    const ctx = context();
+
+    await initializeMcp(extensionApi(), ctx);
+
+    expect(mocks.managers[0].setAuthStorageOptions).toHaveBeenCalledWith({
+      baseDir: "/tmp/project/.pi/oauth",
     });
   });
 

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -14,6 +14,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config.ts", () => ({
   loadMcpConfig: vi.fn(() => mocks.config),
+  resolveConfiguredOAuthDir: vi.fn((raw, cwd = process.cwd()) => {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== "string") throw new Error("settings.oauthDir must be a string");
+    const trimmed = raw.trim();
+    return trimmed ? join(cwd, trimmed) : undefined;
+  }),
 }));
 
 vi.mock("../metadata-cache.ts", () => ({
@@ -51,6 +57,7 @@ function createManager() {
   let current: typeof connection | undefined;
   const manager = {
     setDefaultRequestTimeoutMs: vi.fn(),
+    setAuthStorageOptions: vi.fn(),
     setSamplingConfig: vi.fn(),
     setElicitationConfig: vi.fn(),
     getConnection: vi.fn(() => current),

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -281,6 +281,47 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("stale")).not.toBe("old-state");
   });
 
+  it("keeps same-name pending OAuth flows isolated by auth storage", async () => {
+    delete process.env.MCP_OAUTH_DIR;
+    const projectA = mkdtempSync(join(tmpdir(), "pi-mcp-auth-flow-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-mcp-auth-flow-b-"));
+    const authStorageOptionsA = { baseDir: join(projectA, ".pi", "oauth") };
+    const authStorageOptionsB = { baseDir: join(projectB, ".pi", "oauth") };
+    let call = 0;
+    mocks.sdkAuth.mockImplementation(async (provider) => {
+      call++;
+      if (call <= 2) {
+        await provider.saveClientInformation({ client_id: `client-${call}` });
+        await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize-${call}`));
+        return "REDIRECT";
+      }
+      await provider.saveTokens({ access_token: "token-b", token_type: "Bearer" });
+      return "AUTHORIZED";
+    });
+    const { startAuth, completeAuthFromInput, shutdownOAuth } = await import("../mcp-auth-flow.ts");
+    const { getAuthForUrl, getOAuthState } = await import("../mcp-auth.ts");
+
+    await startAuth("shared", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    }, { authStorageOptions: authStorageOptionsA });
+    await startAuth("shared", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    }, { authStorageOptions: authStorageOptionsB });
+
+    expect(getOAuthState("shared", authStorageOptionsA)).toBeDefined();
+    expect(getOAuthState("shared", authStorageOptionsB)).toBeDefined();
+
+    await completeAuthFromInput("shared", "code-b", { authStorageOptions: authStorageOptionsB });
+
+    expect(getAuthForUrl("shared", "https://api.example.com/mcp", authStorageOptionsA)?.tokens).toBeUndefined();
+    expect(getAuthForUrl("shared", "https://api.example.com/mcp", authStorageOptionsB)?.tokens?.accessToken).toBe("token-b");
+    await shutdownOAuth();
+    rmSync(projectA, { recursive: true, force: true });
+    rmSync(projectB, { recursive: true, force: true });
+  });
+
   it("preserves stored dynamic client info when tokens exist", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       expect(await provider.clientInformation()).toEqual({ client_id: "stored-client", client_secret: "stored-secret" });

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { isAbsolute, join, relative } from "node:path";
 import { tmpdir } from "node:os";
-import { getAuthEntry, getAuthEntryFilePath, saveAuthEntry } from "../mcp-auth.ts";
+import { getAuthEntry, getAuthEntryFilePath, getAuthStorageOptions, saveAuthEntry } from "../mcp-auth.ts";
 
 describe("mcp-auth storage paths", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
@@ -43,5 +43,46 @@ describe("mcp-auth storage paths", () => {
 
   it("rejects non-string names at the storage boundary", () => {
     expect(() => getAuthEntryFilePath(undefined as unknown as string)).toThrow(/Invalid MCP server name/);
+  });
+
+  it("uses configured oauthDir relative to the active cwd", () => {
+    delete process.env.MCP_OAUTH_DIR;
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-auth-project-"));
+    const options = getAuthStorageOptions(".pi/oauth", project);
+
+    saveAuthEntry("configured", { tokens: { accessToken: "token" } }, "https://example.com/mcp", options);
+
+    const filePath = getAuthEntryFilePath("configured", options);
+    expect(filePath.startsWith(join(project, ".pi", "oauth"))).toBe(true);
+    expect(existsSync(filePath)).toBe(true);
+    rmSync(project, { recursive: true, force: true });
+  });
+
+  it("keeps separate configured oauthDir values isolated in one process", () => {
+    delete process.env.MCP_OAUTH_DIR;
+    const projectA = mkdtempSync(join(tmpdir(), "pi-mcp-auth-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-mcp-auth-project-b-"));
+    const optionsA = getAuthStorageOptions(".pi/oauth", projectA);
+    const optionsB = getAuthStorageOptions(".pi/oauth", projectB);
+
+    saveAuthEntry("same-server", { tokens: { accessToken: "token-a" } }, "https://example.com/mcp", optionsA);
+    saveAuthEntry("same-server", { tokens: { accessToken: "token-b" } }, "https://example.com/mcp", optionsB);
+
+    expect(getAuthEntry("same-server", optionsA)?.tokens?.accessToken).toBe("token-a");
+    expect(getAuthEntry("same-server", optionsB)?.tokens?.accessToken).toBe("token-b");
+    rmSync(projectA, { recursive: true, force: true });
+    rmSync(projectB, { recursive: true, force: true });
+  });
+
+  it("keeps MCP_OAUTH_DIR as the explicit override over settings.oauthDir", () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-auth-project-"));
+    const options = getAuthStorageOptions(".pi/oauth", project);
+
+    saveAuthEntry("env-override", { tokens: { accessToken: "token" } }, "https://example.com/mcp", options);
+
+    const filePath = getAuthEntryFilePath("env-override", options);
+    expect(filePath.startsWith(authDir)).toBe(true);
+    expect(filePath.startsWith(join(project, ".pi", "oauth"))).toBe(false);
+    rmSync(project, { recursive: true, force: true });
   });
 });

--- a/commands.ts
+++ b/commands.ts
@@ -16,7 +16,7 @@ import { lazyConnect, markKeepAliveAfterConnect, updateMetadataCache, updateStat
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
-import { getAuthForUrl } from "./mcp-auth.ts";
+import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath } from "./utils.ts";
 
@@ -174,7 +174,9 @@ export async function authenticateServer(
 
   try {
     ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
+    const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
     const status = await authenticate(serverName, definition.url, definition, {
+      ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
       onAuthorizationUrl: (authorizationUrl) => {
         ctx.ui.notify(
           `Open this URL to authenticate ${serverName}:\n\n${authorizationUrl}\n\n` +
@@ -218,7 +220,7 @@ export async function logoutServer(
     return { ok: false, message };
   }
 
-  await removeAuth(serverName);
+  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions });
   await state.manager.close(serverName);
   updateStatusBar(state);
 
@@ -334,7 +336,7 @@ function buildMcpPanelCallbacks(
         && definition.url
         && definition.oauth !== false
         && definition.oauth?.grantType !== "client_credentials"
-        && !getAuthForUrl(serverName, definition.url)?.tokens
+        && !getAuthForUrl(serverName, definition.url, state.authStorageOptions)?.tokens
       ) {
         return "needs-auth";
       }

--- a/config.ts
+++ b/config.ts
@@ -703,3 +703,34 @@ export function writeDirectToolsConfig(
     writeRawConfigObject(filePath, raw);
   }
 }
+
+// ---- Project-level OAuth directory resolution ----
+
+let cachedOAuthDir: { dir: string | undefined; ts: number } | undefined;
+const OAUTH_DIR_CACHE_TTL = 5_000; // 5 seconds
+
+/**
+ * Get the resolved OAuth token storage directory from the merged MCP config.
+ * Returns undefined when no oauthDir is configured, meaning the default
+ * agent mcp-oauth/ directory should be used.
+ *
+ * Priority: MCP_OAUTH_DIR env var > config oauthDir.
+ * Callers should also check the env var themselves.
+ */
+export function getResolvedOAuthDir(cwd?: string): string | undefined {
+  const now = Date.now();
+  if (cachedOAuthDir && now - cachedOAuthDir.ts < OAUTH_DIR_CACHE_TTL) {
+    return cachedOAuthDir.dir;
+  }
+
+  const config = loadMcpConfig(undefined, cwd);
+  const raw = config.settings?.oauthDir;
+  if (!raw) {
+    cachedOAuthDir = { dir: undefined, ts: now };
+    return undefined;
+  }
+
+  const dir = raw.startsWith('/') ? raw : resolve(cwd ?? process.cwd(), raw);
+  cachedOAuthDir = { dir, ts: now };
+  return dir;
+}

--- a/config.ts
+++ b/config.ts
@@ -704,33 +704,13 @@ export function writeDirectToolsConfig(
   }
 }
 
-// ---- Project-level OAuth directory resolution ----
-
-let cachedOAuthDir: { dir: string | undefined; ts: number } | undefined;
-const OAUTH_DIR_CACHE_TTL = 5_000; // 5 seconds
-
-/**
- * Get the resolved OAuth token storage directory from the merged MCP config.
- * Returns undefined when no oauthDir is configured, meaning the default
- * agent mcp-oauth/ directory should be used.
- *
- * Priority: MCP_OAUTH_DIR env var > config oauthDir.
- * Callers should also check the env var themselves.
- */
-export function getResolvedOAuthDir(cwd?: string): string | undefined {
-  const now = Date.now();
-  if (cachedOAuthDir && now - cachedOAuthDir.ts < OAUTH_DIR_CACHE_TTL) {
-    return cachedOAuthDir.dir;
+export function resolveConfiguredOAuthDir(raw: unknown, cwd = process.cwd()): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "string") {
+    throw new Error("settings.oauthDir must be a string");
   }
 
-  const config = loadMcpConfig(undefined, cwd);
-  const raw = config.settings?.oauthDir;
-  if (!raw) {
-    cachedOAuthDir = { dir: undefined, ts: now };
-    return undefined;
-  }
-
-  const dir = raw.startsWith('/') ? raw : resolve(cwd ?? process.cwd(), raw);
-  cachedOAuthDir = { dir, ts: now };
-  return dir;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return resolve(cwd, trimmed);
 }

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -66,7 +66,11 @@ async function attemptDirectAutoAuth(
   }
 
   try {
-    await authenticate(serverName, definition.url, definition);
+    if (state.authStorageOptions) {
+      await authenticate(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions });
+    } else {
+      await authenticate(serverName, definition.url, definition);
+    }
     return { status: "success" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/init.ts
+++ b/init.ts
@@ -23,6 +23,7 @@ import { openUrl, parallelLimit } from "./utils.ts";
 import { logger } from "./logger.ts";
 import { getMissingConfiguredDirectToolServers } from "./direct-tools.ts";
 import { throwIfAborted } from "./abort.ts";
+import { getAuthStorageOptions } from "./mcp-auth.ts";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
 
@@ -36,9 +37,11 @@ export async function initializeMcp(
 ): Promise<McpExtensionState> {
   const configPath = pi.getFlag("mcp-config") as string | undefined;
   const config = loadMcpConfig(configPath, ctx.cwd);
+  const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
 
   const manager = new McpServerManager(ctx.cwd);
   manager.setDefaultRequestTimeoutMs(config.settings?.requestTimeoutMs);
+  manager.setAuthStorageOptions(authStorageOptions);
   const samplingAutoApprove = config.settings?.samplingAutoApprove === true;
   if (config.settings?.sampling !== false && (ctx.hasUI || samplingAutoApprove)) {
     manager.setSamplingConfig({
@@ -69,6 +72,7 @@ export async function initializeMcp(
     toolMetadata,
     serverInstructions,
     config,
+    authStorageOptions,
     failureTracker,
     uiResourceHandler,
     consentManager,

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -30,6 +30,8 @@ import {
   updateOAuthState,
   getOAuthState,
   clearOAuthState,
+  getAuthBaseDir,
+  type AuthStorageOptions,
   type StoredTokens,
 } from "./mcp-auth.ts"
 import type { ServerEntry } from "./types.ts"
@@ -40,6 +42,7 @@ export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 
 export interface AuthenticateOptions {
   onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
+  authStorageOptions?: AuthStorageOptions
 }
 
 type AuthDiscovery = {
@@ -48,9 +51,11 @@ type AuthDiscovery = {
 }
 
 type PendingAuth = {
+  serverName: string
   authProvider: McpOAuthProvider
   serverUrl: string
   discovery: AuthDiscovery
+  authStorageOptions: AuthStorageOptions
 }
 
 const pendingAuths = new Map<string, PendingAuth>()
@@ -59,6 +64,10 @@ const pendingAuthCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>(
 
 // Deduplicate concurrent authenticate() calls per server.
 const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
+
+function getPendingAuthKey(serverName: string, options: AuthStorageOptions): string {
+  return `${serverName}|${getAuthBaseDir(options)}`
+}
 
 /** Timeout for manual auth completion (5 minutes) */
 const MANUAL_AUTH_TIMEOUT_MS = 5 * 60 * 1000
@@ -194,23 +203,25 @@ function parseOAuthRedirectUri(redirectUri: string): { port: number; callbackHos
 export async function startAuth(
   serverName: string,
   serverUrl: string,
-  definition?: ServerEntry
+  definition?: ServerEntry,
+  options: AuthenticateOptions = {},
 ): Promise<{ authorizationUrl: string }> {
   const config = definition ? extractOAuthConfig(definition) : {}
+  const authStorageOptions = options.authStorageOptions ?? {}
 
   if (config.grantType === "client_credentials") {
-    const storedAuth = await getAuthForUrl(serverName, serverUrl)
+    const storedAuth = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
     if (storedAuth?.clientInfo && !storedAuth.tokens && !config.clientId) {
-      clearClientInfo(serverName)
-      clearCodeVerifier(serverName)
-      await clearOAuthState(serverName)
+      clearClientInfo(serverName, authStorageOptions)
+      clearCodeVerifier(serverName, authStorageOptions)
+      await clearOAuthState(serverName, authStorageOptions)
     }
 
     const authProvider = new McpOAuthProvider(serverName, serverUrl, config, {
       onRedirect: async () => {
         throw new Error("Browser redirect is not used for client_credentials flow")
       },
-    })
+    }, authStorageOptions)
     const discovery = await probeAuthDiscovery(serverUrl, definition)
     const result = await runSdkAuth(authProvider, { serverUrl, ...discovery })
     if (result !== "AUTHORIZED") {
@@ -230,7 +241,7 @@ export async function startAuth(
       ...(redirectCallback ? { port: redirectCallback.port, callbackHost: redirectCallback.callbackHost, callbackPath: redirectCallback.callbackPath } : {}),
     })
   } catch (error) {
-    await clearOAuthState(serverName)
+    await clearOAuthState(serverName, authStorageOptions)
     throw error
   }
 
@@ -239,42 +250,42 @@ export async function startAuth(
     onRedirect: async (url) => {
       capturedUrl = url
     },
-  })
+  }, authStorageOptions)
 
   try {
-    const storedAuth = await getAuthForUrl(serverName, serverUrl)
+    const storedAuth = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
     if (storedAuth?.clientInfo && !config.clientId) {
       if (!storedAuth.tokens) {
-        clearClientInfo(serverName)
-        clearCodeVerifier(serverName)
-        await clearOAuthState(serverName)
+        clearClientInfo(serverName, authStorageOptions)
+        clearCodeVerifier(serverName, authStorageOptions)
+        await clearOAuthState(serverName, authStorageOptions)
       } else {
         const redirectUris = storedAuth.clientInfo.redirectUris
         if (!Array.isArray(redirectUris) || !redirectUris.includes(authProvider.redirectUrl ?? "")) {
-          clearClientInfo(serverName)
-          clearTokens(serverName)
-          clearCodeVerifier(serverName)
-          await clearOAuthState(serverName)
+          clearClientInfo(serverName, authStorageOptions)
+          clearTokens(serverName, authStorageOptions)
+          clearCodeVerifier(serverName, authStorageOptions)
+          await clearOAuthState(serverName, authStorageOptions)
         }
       }
     }
 
-    await updateOAuthState(serverName, oauthState, serverUrl)
+    await updateOAuthState(serverName, oauthState, serverUrl, authStorageOptions)
 
     const discovery = await probeAuthDiscovery(serverUrl, definition)
     const result = await runSdkAuth(authProvider, { serverUrl, ...discovery })
     if (result === "AUTHORIZED") {
       releaseCallbackServer(oauthState)
-      await clearOAuthState(serverName)
+      await clearOAuthState(serverName, authStorageOptions)
       return { authorizationUrl: "" }
     }
     if (!capturedUrl) {
       throw new UnauthorizedError("OAuth authorization URL was not provided")
     }
-    await setPendingAuth(serverName, { authProvider, serverUrl, discovery }, oauthState)
+    await setPendingAuth(serverName, { serverName, authProvider, serverUrl, discovery, authStorageOptions }, oauthState)
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
-    await clearPendingAuth(serverName, oauthState)
+    await clearPendingAuth(serverName, oauthState, authStorageOptions)
     throw error
   }
 }
@@ -284,34 +295,38 @@ async function setPendingAuth(
   pendingAuth: PendingAuth,
   oauthState: string,
 ): Promise<void> {
-  await clearPendingAuth(serverName)
-  pendingAuths.set(serverName, pendingAuth)
-  pendingAuthStates.set(serverName, oauthState)
+  const key = getPendingAuthKey(serverName, pendingAuth.authStorageOptions)
+  await clearPendingAuth(serverName, undefined, pendingAuth.authStorageOptions)
+  pendingAuths.set(key, pendingAuth)
+  pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(serverName, oauthState)
+    void clearPendingAuth(serverName, oauthState, pendingAuth.authStorageOptions)
   }, MANUAL_AUTH_TIMEOUT_MS)
   cleanupTimer.unref?.()
-  pendingAuthCleanupTimers.set(serverName, cleanupTimer)
+  pendingAuthCleanupTimers.set(key, cleanupTimer)
 }
 
-async function clearPendingAuth(serverName: string, oauthState?: string): Promise<void> {
-  const pendingState = pendingAuthStates.get(serverName)
+async function clearPendingAuth(serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}): Promise<void> {
+  const key = getPendingAuthKey(serverName, fallbackStorageOptions)
+  const pendingAuth = pendingAuths.get(key)
+  const authStorageOptions = pendingAuth?.authStorageOptions ?? fallbackStorageOptions
+  const pendingState = pendingAuthStates.get(key)
   if (oauthState && pendingState && pendingState !== oauthState) return
 
-  const timer = pendingAuthCleanupTimers.get(serverName)
+  const timer = pendingAuthCleanupTimers.get(key)
   if (timer) {
     clearTimeout(timer)
-    pendingAuthCleanupTimers.delete(serverName)
+    pendingAuthCleanupTimers.delete(key)
   }
 
-  pendingAuths.delete(serverName)
-  pendingAuthStates.delete(serverName)
+  pendingAuths.delete(key)
+  pendingAuthStates.delete(key)
   const stateToRelease = pendingState ?? oauthState
   if (stateToRelease) {
     releaseCallbackServer(stateToRelease)
-    const storedState = await getOAuthState(serverName)
+    const storedState = await getOAuthState(serverName, authStorageOptions)
     if (storedState === stateToRelease) {
-      await clearOAuthState(serverName)
+      await clearOAuthState(serverName, authStorageOptions)
     }
   }
 }
@@ -378,10 +393,13 @@ export function parseAuthorizationCodeInput(input: string, expectedState?: strin
 export async function completeAuthFromInput(
   serverName: string,
   input: string,
+  options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
-  const oauthState = await getOAuthState(serverName)
+  const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
+  const authStorageOptions = pendingAuths.get(getPendingAuthKey(serverName, fallbackAuthStorageOptions))?.authStorageOptions ?? fallbackAuthStorageOptions
+  const oauthState = await getOAuthState(serverName, authStorageOptions)
   const code = parseAuthorizationCodeInput(input, oauthState)
-  return completeAuth(serverName, code)
+  return completeAuth(serverName, code, options)
 }
 
 /**
@@ -389,14 +407,18 @@ export async function completeAuthFromInput(
  */
 export async function completeAuth(
   serverName: string,
-  authorizationCode: string
+  authorizationCode: string,
+  options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
-  const pendingAuth = pendingAuths.get(serverName)
+  const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
+  const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
+  const pendingAuth = pendingAuths.get(key)
+  const authStorageOptions = pendingAuth?.authStorageOptions ?? fallbackAuthStorageOptions
   if (!pendingAuth) {
     throw new Error(`No pending OAuth flow for server: ${serverName}`)
   }
 
-  const oauthState = await getOAuthState(serverName)
+  const oauthState = await getOAuthState(serverName, authStorageOptions)
 
   try {
     const result = await runSdkAuth(pendingAuth.authProvider, {
@@ -409,7 +431,7 @@ export async function completeAuth(
     }
     return "authenticated"
   } finally {
-    await clearPendingAuth(serverName, oauthState)
+    await clearPendingAuth(serverName, oauthState, authStorageOptions)
   }
 }
 
@@ -427,14 +449,16 @@ export async function authenticate(
   definition?: ServerEntry,
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
-  const inFlight = pendingAuthentications.get(serverName)
+  const authStorageOptions = options.authStorageOptions ?? {}
+  const authKey = `${serverName}|${serverUrl}|${getAuthBaseDir(authStorageOptions)}`
+  const inFlight = pendingAuthentications.get(authKey)
   if (inFlight) {
     return inFlight
   }
 
   const operation = (async (): Promise<AuthStatus> => {
     // Start auth flow
-    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition)
+    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, options)
 
     // If no auth URL needed, already authenticated
     if (!authorizationUrl) {
@@ -442,7 +466,7 @@ export async function authenticate(
     }
 
     // Get the state that was already generated and stored in startAuth()
-    const oauthState = await getOAuthState(serverName)
+    const oauthState = await getOAuthState(serverName, authStorageOptions)
     if (!oauthState) {
       throw new Error("OAuth state not found - this should not happen")
     }
@@ -468,29 +492,29 @@ export async function authenticate(
       const code = await callbackPromise
 
       // Validate state
-      const storedState = await getOAuthState(serverName)
+      const storedState = await getOAuthState(serverName, authStorageOptions)
       if (storedState !== oauthState) {
-        await clearOAuthState(serverName)
+        await clearOAuthState(serverName, authStorageOptions)
         throw new Error("OAuth state mismatch - potential CSRF attack")
       }
-      await clearOAuthState(serverName)
+      await clearOAuthState(serverName, authStorageOptions)
 
       // Complete the auth
-      return await completeAuth(serverName, code)
+      return await completeAuth(serverName, code, options)
     } catch (error) {
       cancelPendingCallback(oauthState)
-      await clearPendingAuth(serverName, oauthState)
+      await clearPendingAuth(serverName, oauthState, authStorageOptions)
       throw error
     }
   })()
 
-  pendingAuthentications.set(serverName, operation)
+  pendingAuthentications.set(authKey, operation)
 
   try {
     return await operation
   } finally {
-    if (pendingAuthentications.get(serverName) === operation) {
-      pendingAuthentications.delete(serverName)
+    if (pendingAuthentications.get(authKey) === operation) {
+      pendingAuthentications.delete(authKey)
     }
   }
 }
@@ -505,15 +529,17 @@ export async function authenticate(
 export async function getValidToken(
   serverName: string,
   serverUrl: string,
+  options: AuthenticateOptions = {},
 ): Promise<StoredTokens | null> {
+  const authStorageOptions = options.authStorageOptions ?? {}
   // Check if we have valid tokens
-  const entry = await getAuthForUrl(serverName, serverUrl)
+  const entry = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
   if (!entry?.tokens) {
     return null
   }
 
   // Check expiration
-  const expired = await isTokenExpired(serverName)
+  const expired = await isTokenExpired(serverName, authStorageOptions)
   if (expired === false) {
     return entry.tokens
   }
@@ -526,7 +552,7 @@ export async function getValidToken(
       // Create auth provider for token refresh
       const authProvider = new McpOAuthProvider(serverName, serverUrl, {}, {
         onRedirect: async () => {},
-      })
+      }, authStorageOptions)
 
       const clientInfo = await authProvider.clientInformation()
       if (!clientInfo) {
@@ -539,7 +565,7 @@ export async function getValidToken(
       if (result !== "AUTHORIZED") {
         return null
       }
-      const refreshed = await getAuthForUrl(serverName, serverUrl)
+      const refreshed = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
       return refreshed?.tokens ?? null
     } catch (error) {
       console.error(`MCP Auth: Token refresh failed for ${serverName}`, { error })
@@ -557,11 +583,12 @@ export async function getValidToken(
  * @param serverName - The name of the MCP server
  * @returns The current auth status
  */
-export async function getAuthStatus(serverName: string): Promise<AuthStatus> {
-  const hasTokens = await hasStoredTokens(serverName)
+export async function getAuthStatus(serverName: string, options: AuthenticateOptions = {}): Promise<AuthStatus> {
+  const authStorageOptions = options.authStorageOptions ?? {}
+  const hasTokens = await hasStoredTokens(serverName, authStorageOptions)
   if (!hasTokens) return "not_authenticated"
 
-  const expired = await isTokenExpired(serverName)
+  const expired = await isTokenExpired(serverName, authStorageOptions)
   return expired ? "expired" : "authenticated"
 }
 
@@ -570,14 +597,15 @@ export async function getAuthStatus(serverName: string): Promise<AuthStatus> {
  * 
  * @param serverName - The name of the MCP server
  */
-export async function removeAuth(serverName: string): Promise<void> {
-  const oauthState = await getOAuthState(serverName)
+export async function removeAuth(serverName: string, options: AuthenticateOptions = {}): Promise<void> {
+  const authStorageOptions = options.authStorageOptions ?? {}
+  const oauthState = await getOAuthState(serverName, authStorageOptions)
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  await clearPendingAuth(serverName, oauthState)
-  clearAllCredentials(serverName)
-  await clearOAuthState(serverName)
+  await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  clearAllCredentials(serverName, authStorageOptions)
+  await clearOAuthState(serverName, authStorageOptions)
   console.log(`MCP Auth: Removed credentials for ${serverName}`)
 }
 
@@ -615,8 +643,8 @@ export async function initializeOAuth(): Promise<void> {}
  * Stops the callback server and cancels pending auths.
  */
 export async function shutdownOAuth(): Promise<void> {
-  for (const serverName of Array.from(pendingAuths.keys())) {
-    await clearPendingAuth(serverName)
+  for (const pendingAuth of Array.from(pendingAuths.values())) {
+    await clearPendingAuth(pendingAuth.serverName, undefined, pendingAuth.authStorageOptions)
   }
   await stopCallbackServer()
 }

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -12,7 +12,7 @@ import { createHash } from 'crypto';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { getAgentPath } from './agent-dir.ts';
-import { getResolvedOAuthDir } from './config.ts';
+import { resolveConfiguredOAuthDir } from './config.ts';
 
 /** OAuth token storage format */
 export interface StoredTokens {
@@ -40,38 +40,44 @@ export interface AuthEntry {
   serverUrl?: string; // Track the URL these credentials are for
 }
 
-// Base directory for auth storage - can be overridden via env var or project config
-export function getAuthBaseDir(): string {
+export interface AuthStorageOptions {
+  baseDir?: string;
+}
+
+export function getAuthStorageOptions(oauthDir: unknown, cwd = process.cwd()): AuthStorageOptions {
+  const baseDir = resolveConfiguredOAuthDir(oauthDir, cwd);
+  return baseDir ? { baseDir } : {};
+}
+
+export function getAuthBaseDir(options: AuthStorageOptions = {}): string {
   const override = process.env.MCP_OAUTH_DIR?.trim();
   if (override) return override;
-  const oauthDir = getResolvedOAuthDir();
-  if (oauthDir) return oauthDir;
-  return getAgentPath('mcp-oauth');
+  return options.baseDir ?? getAgentPath('mcp-oauth');
 }
 
 /**
  * Get the server-specific directory path.
  */
-function getServerDir(serverName: string): string {
+function getServerDir(serverName: string, options?: AuthStorageOptions): string {
   if (typeof serverName !== 'string') {
     throw new Error(`Invalid MCP server name: ${JSON.stringify(serverName)}`);
   }
   const storageKey = createHash('sha256').update(serverName, 'utf8').digest('hex');
-  return join(getAuthBaseDir(), `sha256-${storageKey}`);
+  return join(getAuthBaseDir(options), `sha256-${storageKey}`);
 }
 
 /**
  * Get the tokens file path for a server.
  */
-export function getAuthEntryFilePath(serverName: string): string {
-  return join(getServerDir(serverName), 'tokens.json');
+export function getAuthEntryFilePath(serverName: string, options?: AuthStorageOptions): string {
+  return join(getServerDir(serverName, options), 'tokens.json');
 }
 
 /**
  * Ensure the server directory exists with secure permissions.
  */
-function ensureServerDir(serverName: string): void {
-  const dir = getServerDir(serverName);
+function ensureServerDir(serverName: string, options?: AuthStorageOptions): void {
+  const dir = getServerDir(serverName, options);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
@@ -81,8 +87,8 @@ function ensureServerDir(serverName: string): void {
  * Read the auth entry for a server from disk.
  * Returns undefined if file doesn't exist.
  */
-function readAuthEntry(serverName: string): AuthEntry | undefined {
-  const filePath = getAuthEntryFilePath(serverName);
+function readAuthEntry(serverName: string, options?: AuthStorageOptions): AuthEntry | undefined {
+  const filePath = getAuthEntryFilePath(serverName, options);
   try {
     if (!existsSync(filePath)) {
       return undefined;
@@ -98,25 +104,25 @@ function readAuthEntry(serverName: string): AuthEntry | undefined {
 /**
  * Write the auth entry for a server to disk with secure permissions.
  */
-function writeAuthEntry(serverName: string, entry: AuthEntry): void {
-  ensureServerDir(serverName);
-  const filePath = getAuthEntryFilePath(serverName);
+function writeAuthEntry(serverName: string, entry: AuthEntry, options?: AuthStorageOptions): void {
+  ensureServerDir(serverName, options);
+  const filePath = getAuthEntryFilePath(serverName, options);
   writeFileSync(filePath, JSON.stringify(entry, null, 2), { mode: 0o600 });
 }
 
 /**
  * Get auth entry for a server.
  */
-export function getAuthEntry(serverName: string): AuthEntry | undefined {
-  return readAuthEntry(serverName);
+export function getAuthEntry(serverName: string, options?: AuthStorageOptions): AuthEntry | undefined {
+  return readAuthEntry(serverName, options);
 }
 
 /**
  * Get auth entry and validate it's for the correct URL.
  * Returns undefined if URL has changed (credentials are invalid).
  */
-export function getAuthForUrl(serverName: string, serverUrl: string): AuthEntry | undefined {
-  const entry = getAuthEntry(serverName);
+export function getAuthForUrl(serverName: string, serverUrl: string, options?: AuthStorageOptions): AuthEntry | undefined {
+  const entry = getAuthEntry(serverName, options);
   if (!entry) return undefined;
 
   // If no serverUrl is stored, this is from an old version - consider it invalid
@@ -131,26 +137,26 @@ export function getAuthForUrl(serverName: string, serverUrl: string): AuthEntry 
 /**
  * Save auth entry for a server.
  */
-export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: string): void {
+export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: string, options?: AuthStorageOptions): void {
   // Always update serverUrl if provided
   if (serverUrl) {
     entry.serverUrl = serverUrl;
   }
-  writeAuthEntry(serverName, entry);
+  writeAuthEntry(serverName, entry, options);
 }
 
 /**
  * Remove auth entry for a server.
  * Also removes the server directory if empty.
  */
-export function removeAuthEntry(serverName: string): void {
+export function removeAuthEntry(serverName: string, options?: AuthStorageOptions): void {
   try {
-    const filePath = getAuthEntryFilePath(serverName);
+    const filePath = getAuthEntryFilePath(serverName, options);
     if (existsSync(filePath)) {
       writeFileSync(filePath, '{}', { mode: 0o600 });
     }
     // Try to remove the directory
-    const dir = getServerDir(serverName);
+    const dir = getServerDir(serverName, options);
     if (existsSync(dir)) {
       try {
         rmSync(dir, { recursive: true });
@@ -169,16 +175,17 @@ export function removeAuthEntry(serverName: string): void {
 export function updateTokens(
   serverName: string, 
   tokens: StoredTokens, 
-  serverUrl?: string
+  serverUrl?: string,
+  options?: AuthStorageOptions
 ): void {
-  const entry = getAuthEntry(serverName) ?? {};
+  const entry = getAuthEntry(serverName, options) ?? {};
   if (serverUrl && entry.serverUrl !== serverUrl) {
     delete entry.clientInfo;
     delete entry.codeVerifier;
     delete entry.oauthState;
   }
   entry.tokens = tokens;
-  saveAuthEntry(serverName, entry, serverUrl);
+  saveAuthEntry(serverName, entry, serverUrl, options);
 }
 
 /**
@@ -187,73 +194,74 @@ export function updateTokens(
 export function updateClientInfo(
   serverName: string, 
   clientInfo: StoredClientInfo, 
-  serverUrl?: string
+  serverUrl?: string,
+  options?: AuthStorageOptions
 ): void {
-  const entry = getAuthEntry(serverName) ?? {};
+  const entry = getAuthEntry(serverName, options) ?? {};
   if (serverUrl && entry.serverUrl !== serverUrl) {
     delete entry.tokens;
     delete entry.codeVerifier;
     delete entry.oauthState;
   }
   entry.clientInfo = clientInfo;
-  saveAuthEntry(serverName, entry, serverUrl);
+  saveAuthEntry(serverName, entry, serverUrl, options);
 }
 
 /**
  * Update code verifier for a server.
  */
-export function updateCodeVerifier(serverName: string, codeVerifier: string, serverUrl?: string): void {
-  const entry = getAuthEntry(serverName) ?? {};
+export function updateCodeVerifier(serverName: string, codeVerifier: string, serverUrl?: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options) ?? {};
   if (serverUrl && entry.serverUrl !== serverUrl) {
     delete entry.tokens;
     delete entry.clientInfo;
     delete entry.oauthState;
   }
   entry.codeVerifier = codeVerifier;
-  saveAuthEntry(serverName, entry, serverUrl);
+  saveAuthEntry(serverName, entry, serverUrl, options);
 }
 
 /**
  * Clear code verifier for a server.
  */
-export function clearCodeVerifier(serverName: string): void {
-  const entry = getAuthEntry(serverName);
+export function clearCodeVerifier(serverName: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options);
   if (entry) {
     delete entry.codeVerifier;
-    saveAuthEntry(serverName, entry);
+    saveAuthEntry(serverName, entry, undefined, options);
   }
 }
 
 /**
  * Update OAuth state for a server.
  */
-export function updateOAuthState(serverName: string, state: string, serverUrl?: string): void {
-  const entry = getAuthEntry(serverName) ?? {};
+export function updateOAuthState(serverName: string, state: string, serverUrl?: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options) ?? {};
   if (serverUrl && entry.serverUrl !== serverUrl) {
     delete entry.tokens;
     delete entry.clientInfo;
     delete entry.codeVerifier;
   }
   entry.oauthState = state;
-  saveAuthEntry(serverName, entry, serverUrl);
+  saveAuthEntry(serverName, entry, serverUrl, options);
 }
 
 /**
  * Get OAuth state for a server.
  */
-export function getOAuthState(serverName: string): string | undefined {
-  const entry = getAuthEntry(serverName);
+export function getOAuthState(serverName: string, options?: AuthStorageOptions): string | undefined {
+  const entry = getAuthEntry(serverName, options);
   return entry?.oauthState;
 }
 
 /**
  * Clear OAuth state for a server.
  */
-export function clearOAuthState(serverName: string): void {
-  const entry = getAuthEntry(serverName);
+export function clearOAuthState(serverName: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options);
   if (entry) {
     delete entry.oauthState;
-    saveAuthEntry(serverName, entry);
+    saveAuthEntry(serverName, entry, undefined, options);
   }
 }
 
@@ -261,8 +269,8 @@ export function clearOAuthState(serverName: string): void {
  * Check if stored tokens are expired.
  * Returns null if no tokens exist, false if no expiry or not expired, true if expired.
  */
-export function isTokenExpired(serverName: string): boolean | null {
-  const entry = getAuthEntry(serverName);
+export function isTokenExpired(serverName: string, options?: AuthStorageOptions): boolean | null {
+  const entry = getAuthEntry(serverName, options);
   if (!entry?.tokens) return null;
   if (!entry.tokens.expiresAt) return false;
   return entry.tokens.expiresAt < Date.now() / 1000;
@@ -271,36 +279,36 @@ export function isTokenExpired(serverName: string): boolean | null {
 /**
  * Check if a server has stored tokens.
  */
-export function hasStoredTokens(serverName: string): boolean {
-  const entry = getAuthEntry(serverName);
+export function hasStoredTokens(serverName: string, options?: AuthStorageOptions): boolean {
+  const entry = getAuthEntry(serverName, options);
   return !!entry?.tokens;
 }
 
 /**
  * Clear all credentials for a server.
  */
-export function clearAllCredentials(serverName: string): void {
-  removeAuthEntry(serverName);
+export function clearAllCredentials(serverName: string, options?: AuthStorageOptions): void {
+  removeAuthEntry(serverName, options);
 }
 
 /**
  * Clear only client info for a server.
  */
-export function clearClientInfo(serverName: string): void {
-  const entry = getAuthEntry(serverName);
+export function clearClientInfo(serverName: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options);
   if (entry) {
     delete entry.clientInfo;
-    saveAuthEntry(serverName, entry);
+    saveAuthEntry(serverName, entry, undefined, options);
   }
 }
 
 /**
  * Clear only tokens for a server.
  */
-export function clearTokens(serverName: string): void {
-  const entry = getAuthEntry(serverName);
+export function clearTokens(serverName: string, options?: AuthStorageOptions): void {
+  const entry = getAuthEntry(serverName, options);
   if (entry) {
     delete entry.tokens;
-    saveAuthEntry(serverName, entry);
+    saveAuthEntry(serverName, entry, undefined, options);
   }
 }

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -12,6 +12,7 @@ import { createHash } from 'crypto';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { getAgentPath } from './agent-dir.ts';
+import { getResolvedOAuthDir } from './config.ts';
 
 /** OAuth token storage format */
 export interface StoredTokens {
@@ -39,10 +40,13 @@ export interface AuthEntry {
   serverUrl?: string; // Track the URL these credentials are for
 }
 
-// Base directory for auth storage - can be overridden via env var for testing
-function getAuthBaseDir(): string {
+// Base directory for auth storage - can be overridden via env var or project config
+export function getAuthBaseDir(): string {
   const override = process.env.MCP_OAUTH_DIR?.trim();
-  return override ? override : getAgentPath('mcp-oauth');
+  if (override) return override;
+  const oauthDir = getResolvedOAuthDir();
+  if (oauthDir) return oauthDir;
+  return getAgentPath('mcp-oauth');
 }
 
 /**

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -22,6 +22,7 @@ import {
   clearAllCredentials,
   clearClientInfo,
   clearTokens,
+  type AuthStorageOptions,
   type StoredTokens,
   type StoredClientInfo,
 } from "./mcp-auth.ts"
@@ -90,6 +91,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private serverUrl: string,
     private config: McpOAuthConfig,
     private callbacks: McpOAuthCallbacks,
+    private storageOptions: AuthStorageOptions = {},
   ) {
     this.redirectUrlSnapshot = config.grantType === "client_credentials"
       ? undefined
@@ -154,7 +156,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     // Check stored client info (from dynamic registration)
     // Use getAuthForUrl to validate credentials are for the current server URL
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -182,7 +184,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       clientSecretExpiresAt: info.client_secret_expires_at,
       redirectUris,
     }
-    updateClientInfo(this.serverName, clientInfo, this.serverUrl)
+    updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
   }
 
   /**
@@ -191,7 +193,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   async tokens(): Promise<OAuthTokens | undefined> {
     // Use getAuthForUrl to validate tokens are for the current server URL
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (!entry?.tokens) return undefined
 
     return {
@@ -215,7 +217,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
       scope: tokens.scope,
     }
-    updateTokens(this.serverName, storedTokens, this.serverUrl)
+    updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)
   }
 
   /**
@@ -232,7 +234,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       throw new Error("redirectToAuthorization is not used for client_credentials flow")
     }
     // No saved oauthState means we're on the post-refresh authorize fallback.
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (!entry?.oauthState) {
       throw new UnauthorizedError(
         `Re-authentication required for MCP server: ${this.serverName}`,
@@ -246,7 +248,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Save the PKCE code verifier.
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    updateCodeVerifier(this.serverName, codeVerifier, this.serverUrl)
+    updateCodeVerifier(this.serverName, codeVerifier, this.serverUrl, this.storageOptions)
   }
 
   /**
@@ -257,7 +259,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       throw new Error("codeVerifier is not used for client_credentials flow")
     }
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (!entry?.codeVerifier) {
       throw new Error(`No code verifier saved for MCP server: ${this.serverName}`)
     }
@@ -268,7 +270,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Save the OAuth state parameter for CSRF protection.
    */
   async saveState(state: string): Promise<void> {
-    updateOAuthState(this.serverName, state, this.serverUrl)
+    updateOAuthState(this.serverName, state, this.serverUrl, this.storageOptions)
   }
 
   /**
@@ -279,7 +281,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       throw new Error("state is not used for client_credentials flow")
     }
-    const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+    const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (!entry?.oauthState) {
       throw new UnauthorizedError(
         `Re-authentication required for MCP server: ${this.serverName}`,
@@ -295,13 +297,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
     switch (type) {
       case "all":
-        clearAllCredentials(this.serverName)
+        clearAllCredentials(this.serverName, this.storageOptions)
         break
       case "client":
-        clearClientInfo(this.serverName)
+        clearClientInfo(this.serverName, this.storageOptions)
         break
       case "tokens":
-        clearTokens(this.serverName)
+        clearTokens(this.serverName, this.storageOptions)
         break
     }
   }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -103,7 +103,11 @@ async function attemptAutoAuth(
   }
 
   try {
-    await authenticate(serverName, definition.url, definition);
+    if (state.authStorageOptions) {
+      await authenticate(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions });
+    } else {
+      await authenticate(serverName, definition.url, definition);
+    }
     return { status: "success" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -265,7 +269,9 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
   }
 
   try {
-    const { authorizationUrl } = await startAuth(serverName, definition.url, definition);
+    const { authorizationUrl } = state.authStorageOptions
+      ? await startAuth(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions })
+      : await startAuth(serverName, definition.url, definition);
     if (!authorizationUrl) {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
@@ -295,7 +301,9 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
   }
 
   try {
-    const status = await completeAuthFromInput(serverName, input);
+    const status = state.authStorageOptions
+      ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions })
+      : await completeAuthFromInput(serverName, input);
     if (status !== "authenticated") {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -21,6 +21,7 @@ import { resolveNpxBinary } from "./npx-resolver.ts";
 import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth } from "./mcp-auth-flow.ts";
+import type { AuthStorageOptions } from "./mcp-auth.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
 import {
   handleUrlElicitation,
@@ -51,6 +52,7 @@ export class McpServerManager {
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
   private elicitationConfig: ServerElicitationConfig | undefined;
+  private authStorageOptions: AuthStorageOptions = {};
   private acceptedUrlElicitations = new Map<string, Set<string>>();
   private defaultRequestTimeoutMs: number | undefined;
 
@@ -67,6 +69,10 @@ export class McpServerManager {
 
   setDefaultRequestTimeoutMs(timeoutMs: number | undefined): void {
     this.defaultRequestTimeoutMs = normalizeRequestTimeoutMs(timeoutMs);
+  }
+
+  setAuthStorageOptions(options: AuthStorageOptions): void {
+    this.authStorageOptions = options;
   }
 
   getRequestOptions(name: string, signal?: AbortSignal): RequestOptions | undefined {
@@ -382,7 +388,8 @@ export class McpServerManager {
           onRedirect: async (_authUrl) => {
             // URL is captured by startAuth, no need to log
           },
-        }
+        },
+        this.authStorageOptions
       );
     }
 

--- a/state.ts
+++ b/state.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ConsentManager } from "./consent-manager.ts";
 import type { McpLifecycleManager } from "./lifecycle.ts";
 import type { McpServerManager } from "./server-manager.ts";
+import type { AuthStorageOptions } from "./mcp-auth.ts";
 import type { ToolMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from "./types.ts";
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
 import type { UiServerHandle } from "./ui-server.ts";
@@ -31,6 +32,7 @@ export interface McpExtensionState {
   toolMetadata: Map<string, ToolMetadata[]>;
   serverInstructions: Map<string, string>;
   config: McpConfig;
+  authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;
   uiResourceHandler: UiResourceHandler;
   consentManager: ConsentManager;

--- a/types.ts
+++ b/types.ts
@@ -352,6 +352,15 @@ export interface McpSettings {
    * instruction when unset.
    */
   authRequiredMessage?: string;
+  /**
+   * Override the default OAuth token storage directory.
+   * Relative paths are resolved from the project root (cwd).
+   * Takes precedence over the agent's mcp-oauth/ directory but
+   * can still be overridden by the MCP_OAUTH_DIR env variable.
+   *
+   * Example: ".pi/mcp-oauth" stores tokens in <project>/.pi/mcp-oauth/
+   */
+  oauthDir?: string;
 }
 
 // Root config


### PR DESCRIPTION
Add oauthDir to McpSettings type and resolve it lazily via getResolvedOAuthDir() in config.ts (5s cache). mcp-auth.ts and oauth-handler.ts use it through getAuthBaseDir().
Priority: MCP_OAUTH_DIR env > config oauthDir > agent mcp-oauth/
