### PR TITLE
feat: emit MCP lifecycle events on pi.events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   envelope as a stable, additive integration contract. Each transition is also
   mirrored durably via `pi.appendEntry("mcp:state", …)` so consumers attaching
   mid-session can reconstruct state by replaying entries. Emission is
-  fire-and-forget and changes no existing tool/command/UI behaviour. See the
-  new "Events" section in the README.
+  fire-and-forget and changes no existing tool/command/UI behaviour. The
+  durable `mcp:state` write is coalesced (appended only when the
+  reconstructable state changes, not per transition) to avoid session-JSONL
+  write amplification, and the last observed transport kind is retained across
+  disconnect so `reconnecting` events are not mislabelled for SSE servers. See
+  the new "Events" section in the README.
 
 ## [2.6.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Emit MCP lifecycle events on the shared `pi.events` bus under the reserved
+  `mcp:` namespace (`mcp:server`, `mcp:tools`, `mcp:auth`), with a versioned
+  envelope as a stable, additive integration contract. Each transition is also
+  mirrored durably via `pi.appendEntry("mcp:state", …)` so consumers attaching
+  mid-session can reconstruct state by replaying entries. Emission is
+  fire-and-forget and changes no existing tool/command/UI behaviour. See the
+  new "Events" section in the README.
+
 ## [2.6.1] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -404,12 +404,21 @@ export default function myExtension(pi) {
 }
 ```
 
-For consumers that attach mid-session (or after a reload), each transition is
-also mirrored durably to the session log via `pi.appendEntry("mcp:state", …)`.
+For consumers that attach mid-session (or after a reload), state is also
+mirrored durably to the session log via `pi.appendEntry("mcp:state", …)`.
 Replaying `mcp:state` entries reconstructs current per-server state
 (`{ serverId, transport, status, toolCount }`, `status` one of `connected`,
 `disconnected`, `needs-auth`, `failed`, `cached`) without racing a live
-`mcp({ ... })` status pull. These entries are persisted state, not LLM context.
+`mcp({ ... })` status pull. Writes are coalesced — an entry is appended only
+when the reconstructable state actually changes, not on every transition, so a
+churny multi-server config doesn't amplify session-JSONL writes.
+
+`pi.appendEntry` is PI's documented mechanism for persisted session state that
+is *not* sent to the model ("not sent to LLM" per the `ExtensionAPI` contract):
+in the pinned PI version, `type:"custom"` session entries are excluded from
+both the live context and the compaction-kept replay. That exclusion is a
+PI-internal guarantee this adapter depends on — if PI ever surfaces custom
+entries to the model, these snapshots would need an explicit opt-out.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,51 @@ In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or 
 - Keep-alive servers get health checks and auto-reconnect
 - Specific tools can be promoted from the proxy to first-class Pi tools via `directTools` config, so the LLM sees them directly instead of having to search
 
+## Events
+
+The adapter announces every MCP server state transition on PI's shared event
+bus (`pi.events`) under the reserved `mcp:` channel namespace. This is a stable,
+additive contract: subscribing is optional, emission is fire-and-forget, and a
+faulty subscriber can never wedge a connection. Any extension, dashboard, or
+embedder can react without adapter-specific glue.
+
+Every event shares a versioned envelope. Branch on `v`; additive fields within a
+version are allowed, semantic changes bump `v`. No secrets are ever emitted —
+`authorizationUrl` is the only auth-adjacent field and only on the interactive
+`auth_required` phase.
+
+| Channel | Payload | Phases / fields |
+|---|---|---|
+| `mcp:server` | `{ v, serverId, transport, at, phase, error? }` | `connecting`, `connected`, `disconnected`, `reconnecting`, `reconnected`, `idle_shutdown`, `errored` |
+| `mcp:tools` | `{ v, serverId, transport, at, toolCount, toolNames?, source }` | `source`: `connect` \| `refresh` \| `cache`; `toolNames` omitted past 100 tools |
+| `mcp:auth` | `{ v, serverId, transport, at, phase, authorizationUrl?, error? }` | `auth_required`, `auth_succeeded`, `auth_failed` |
+
+`transport` is `"stdio" | "http" | "sse"`; `at` is epoch ms; `serverId` is the
+configured server key.
+
+Subscribe from any extension:
+
+```ts
+export default function myExtension(pi) {
+  pi.events.on("mcp:server", (e) => {
+    console.log(`[mcp] ${e.serverId} (${e.transport}) → ${e.phase}`);
+  });
+  pi.events.on("mcp:tools", (e) => {
+    console.log(`[mcp] ${e.serverId} exposes ${e.toolCount} tools`);
+  });
+  pi.events.on("mcp:auth", (e) => {
+    if (e.phase === "auth_required") console.log(`[mcp] authorize: ${e.authorizationUrl}`);
+  });
+}
+```
+
+For consumers that attach mid-session (or after a reload), each transition is
+also mirrored durably to the session log via `pi.appendEntry("mcp:state", …)`.
+Replaying `mcp:state` entries reconstructs current per-server state
+(`{ serverId, transport, status, toolCount }`, `status` one of `connected`,
+`disconnected`, `needs-auth`, `failed`, `cached`) without racing a live
+`mcp({ ... })` status pull. These entries are persisted state, not LLM context.
+
 ## Limitations
 
 - Cross-session server sharing not yet implemented (each Pi session runs its own server processes)

--- a/__tests__/mcp-events.test.ts
+++ b/__tests__/mcp-events.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  McpEventBus,
+  MCP_EVENT_CHANNELS,
+  MCP_STATE_ENTRY_TYPE,
+  MCP_TOOL_NAMES_LIMIT,
+  NOOP_EVENT_BUS,
+  toEventError,
+  type McpEventSink,
+} from "../mcp-events.ts";
+
+type Emitted = { channel: string; data: any };
+
+function createSpySink() {
+  const emitted: Emitted[] = [];
+  const entries: Array<{ customType: string; data: any }> = [];
+  const sink: McpEventSink & { emitted: Emitted[]; entries: typeof entries } = {
+    emitted,
+    entries,
+    emit(channel, data) {
+      emitted.push({ channel, data });
+    },
+    appendEntry(customType, data) {
+      entries.push({ customType, data });
+    },
+  };
+  return sink;
+}
+
+describe("McpEventBus", () => {
+  it("emits a versioned envelope on mcp:server", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 1234);
+
+    bus.emitServer("github", "stdio", "connecting");
+
+    expect(sink.emitted).toEqual([
+      {
+        channel: MCP_EVENT_CHANNELS.server,
+        data: { v: 1, serverId: "github", transport: "stdio", at: 1234, phase: "connecting" },
+      },
+    ]);
+  });
+
+  it("attaches error only when provided", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 1);
+
+    bus.emitServer("s", "http", "errored", { message: "boom", code: "ECONN" });
+
+    expect(sink.emitted[0].data).toMatchObject({
+      phase: "errored",
+      error: { message: "boom", code: "ECONN" },
+    });
+  });
+
+  it("bounds mcp:tools.toolNames and keeps the count", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 0);
+
+    bus.emitTools("s", "http", 3, "connect", ["a", "b", "c"]);
+    expect(sink.emitted[0].data).toMatchObject({
+      toolCount: 3,
+      source: "connect",
+      toolNames: ["a", "b", "c"],
+    });
+
+    const many = Array.from({ length: MCP_TOOL_NAMES_LIMIT + 1 }, (_, i) => `t${i}`);
+    bus.emitTools("s", "http", many.length, "refresh", many);
+    expect(sink.emitted[1].data.toolCount).toBe(many.length);
+    expect(sink.emitted[1].data.toolNames).toBeUndefined();
+  });
+
+  it("carries authorizationUrl only on the interactive auth_required phase", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 0);
+
+    bus.emitAuth("s", "http", "auth_required", { authorizationUrl: "https://idp/authorize" });
+    bus.emitAuth("s", "http", "auth_succeeded", { authorizationUrl: "https://idp/authorize" });
+    bus.emitAuth("s", "http", "auth_failed", { error: { message: "denied" } });
+
+    expect(sink.emitted[0].data.authorizationUrl).toBe("https://idp/authorize");
+    expect(sink.emitted[1].data.authorizationUrl).toBeUndefined();
+    expect(sink.emitted[2].data).toMatchObject({ phase: "auth_failed", error: { message: "denied" } });
+  });
+
+  it("is a no-op without a sink (the default the manager holds)", () => {
+    expect(() => NOOP_EVENT_BUS.emitServer("s", "stdio", "connected")).not.toThrow();
+  });
+
+  it("never lets a faulty sink wedge the caller", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const bus = new McpEventBus({
+        emit() {
+          throw new Error("subscriber blew up");
+        },
+      });
+      expect(() => bus.emitServer("s", "stdio", "connected")).not.toThrow();
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("mirrors a durable mcp:state snapshot on each transition when a provider is set", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 7);
+    bus.setSnapshotProvider(() => [
+      { serverId: "s", transport: "stdio", status: "connected", toolCount: 2 },
+    ]);
+
+    bus.emitServer("s", "stdio", "connected");
+
+    expect(sink.entries).toEqual([
+      {
+        customType: MCP_STATE_ENTRY_TYPE,
+        data: {
+          v: 1,
+          at: 7,
+          servers: [{ serverId: "s", transport: "stdio", status: "connected", toolCount: 2 }],
+        },
+      },
+    ]);
+  });
+
+  it("does not mirror when the sink cannot append entries", () => {
+    const emitted: Emitted[] = [];
+    const bus = new McpEventBus({ emit: (channel, data) => emitted.push({ channel, data }) });
+    bus.setSnapshotProvider(() => []);
+    expect(() => bus.emitServer("s", "stdio", "connected")).not.toThrow();
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("normalizes thrown values via toEventError", () => {
+    const withCode = Object.assign(new Error("nope"), { code: "EBADF" });
+    expect(toEventError(withCode)).toEqual({ message: "nope", code: "EBADF" });
+    expect(toEventError(new Error("plain"))).toEqual({ message: "plain" });
+    expect(toEventError("string error")).toEqual({ message: "string error" });
+  });
+});

--- a/__tests__/mcp-events.test.ts
+++ b/__tests__/mcp-events.test.ts
@@ -125,6 +125,26 @@ describe("McpEventBus", () => {
     ]);
   });
 
+  it("coalesces snapshots: appends only when reconstructable state changes", () => {
+    const sink = createSpySink();
+    const bus = new McpEventBus(sink, () => 1);
+    let status = "connecting";
+    bus.setSnapshotProvider(() => [
+      { serverId: "s", transport: "stdio", status: status as any, toolCount: 0 },
+    ]);
+
+    bus.emitServer("s", "stdio", "connecting");
+    bus.emitServer("s", "stdio", "connecting"); // no state change → no extra append
+    expect(sink.entries).toHaveLength(1);
+
+    status = "connected";
+    bus.emitServer("s", "stdio", "connected");
+    expect(sink.entries).toHaveLength(2);
+
+    bus.emitServer("s", "stdio", "connected"); // unchanged again
+    expect(sink.entries).toHaveLength(2);
+  });
+
   it("does not mirror when the sink cannot append entries", () => {
     const emitted: Emitted[] = [];
     const bus = new McpEventBus({ emit: (channel, data) => emitted.push({ channel, data }) });

--- a/__tests__/server-manager-events.test.ts
+++ b/__tests__/server-manager-events.test.ts
@@ -110,25 +110,44 @@ describe("McpServerManager lifecycle events", () => {
 });
 
 describe("McpLifecycleManager lifecycle events", () => {
-  it("emits reconnecting → reconnected for a forced reconnect", async () => {
+  it("emits reconnecting → reconnected and labels reconnecting with the last known transport", async () => {
     const { bus, emitted } = spyBus();
 
+    // A URL server previously observed as SSE: the manager retains that kind
+    // across disconnect, so `reconnecting` must not fall back to http.
     const fakeManager = {
       getConnection: vi.fn(() => undefined),
       connect: vi.fn(async () => ({ status: "connected" })),
-      getTransportKind: vi.fn(() => "stdio" as const),
+      getTransportKind: vi.fn(() => "sse" as const),
       isIdle: vi.fn(() => false),
       close: vi.fn(async () => undefined),
     };
 
     const lifecycle = new McpLifecycleManager(fakeManager as any);
     lifecycle.setEventBus(bus);
-    lifecycle.markKeepAlive("keep", { command: "demo" });
+    lifecycle.markKeepAlive("keep", { url: "https://example.test/mcp" });
 
     await (lifecycle as any).checkConnections();
 
     expect(phases(emitted)).toEqual(["mcp:server:reconnecting", "mcp:server:reconnected"]);
-    expect(fakeManager.connect).toHaveBeenCalledWith("keep", { command: "demo" });
+    expect(emitted.map((e) => e.data.transport)).toEqual(["sse", "sse"]);
+    expect(fakeManager.connect).toHaveBeenCalledWith("keep", { url: "https://example.test/mcp" });
+  });
+
+  it("retains the last observed transport kind across disconnect", async () => {
+    const { bus } = spyBus();
+    const manager = new McpServerManager();
+    manager.setEventBus(bus);
+
+    expect(manager.getTransportKind("local")).toBeUndefined();
+
+    await manager.connect("local", { command: "demo-server" });
+    expect(manager.getTransportKind("local")).toBe("stdio");
+
+    await manager.close("local");
+    // No live connection, but the kind is still known for a precise
+    // `reconnecting` label instead of a config-derived guess.
+    expect(manager.getTransportKind("local")).toBe("stdio");
   });
 
   it("closes idle servers with the idle reason so close() emits idle_shutdown", async () => {

--- a/__tests__/server-manager-events.test.ts
+++ b/__tests__/server-manager-events.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { McpEventBus, type McpEventSink } from "../mcp-events.ts";
+import { McpServerManager } from "../server-manager.ts";
+import { McpLifecycleManager } from "../lifecycle.ts";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(async () => undefined),
+  listTools: vi.fn(async () => ({ tools: [{ name: "alpha" }, { name: "beta" }] })),
+  listResources: vi.fn(async () => ({ resources: [] })),
+  close: vi.fn(async () => undefined),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    setRequestHandler: vi.fn(),
+    setNotificationHandler: vi.fn(),
+    connect: mocks.connect,
+    listTools: mocks.listTools,
+    listResources: mocks.listResources,
+    close: mocks.close,
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(() => ({ close: vi.fn(async () => undefined) })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
+type Emitted = { channel: string; data: any };
+
+function spyBus() {
+  const emitted: Emitted[] = [];
+  const sink: McpEventSink = { emit: (channel, data) => emitted.push({ channel, data }) };
+  return { bus: new McpEventBus(sink), emitted };
+}
+
+function phases(emitted: Emitted[]): string[] {
+  return emitted.map((e) => `${e.channel}:${e.data.phase ?? e.data.source ?? ""}`);
+}
+
+describe("McpServerManager lifecycle events", () => {
+  beforeEach(() => {
+    mocks.connect.mockReset().mockResolvedValue(undefined);
+    mocks.listTools.mockReset().mockResolvedValue({ tools: [{ name: "alpha" }, { name: "beta" }] });
+    mocks.listResources.mockReset().mockResolvedValue({ resources: [] });
+    mocks.close.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("emits connecting → connected → tools for connect → tools-load", async () => {
+    const { bus, emitted } = spyBus();
+    const manager = new McpServerManager();
+    manager.setEventBus(bus);
+
+    await manager.connect("local", { command: "demo-server" });
+
+    expect(phases(emitted)).toEqual([
+      "mcp:server:connecting",
+      "mcp:server:connected",
+      "mcp:tools:connect",
+    ]);
+    const toolsEvent = emitted[2].data;
+    expect(toolsEvent).toMatchObject({
+      serverId: "local",
+      transport: "stdio",
+      toolCount: 2,
+      toolNames: ["alpha", "beta"],
+      source: "connect",
+    });
+  });
+
+  it("emits disconnected on close and idle_shutdown on idle close", async () => {
+    const { bus, emitted } = spyBus();
+    const manager = new McpServerManager();
+    manager.setEventBus(bus);
+
+    await manager.connect("local", { command: "demo-server" });
+    await manager.close("local");
+
+    expect(phases(emitted).at(-1)).toBe("mcp:server:disconnected");
+
+    await manager.connect("local", { command: "demo-server" });
+    await manager.close("local", { reason: "idle" });
+
+    expect(phases(emitted).at(-1)).toBe("mcp:server:idle_shutdown");
+  });
+
+  it("emits connecting then errored when the transport fails", async () => {
+    mocks.connect.mockRejectedValueOnce(new Error("spawn failed"));
+    const { bus, emitted } = spyBus();
+    const manager = new McpServerManager();
+    manager.setEventBus(bus);
+
+    await expect(manager.connect("local", { command: "demo-server" })).rejects.toThrow("spawn failed");
+
+    expect(phases(emitted)).toEqual(["mcp:server:connecting", "mcp:server:errored"]);
+    expect(emitted[1].data.error).toMatchObject({ message: "spawn failed" });
+  });
+});
+
+describe("McpLifecycleManager lifecycle events", () => {
+  it("emits reconnecting → reconnected for a forced reconnect", async () => {
+    const { bus, emitted } = spyBus();
+
+    const fakeManager = {
+      getConnection: vi.fn(() => undefined),
+      connect: vi.fn(async () => ({ status: "connected" })),
+      getTransportKind: vi.fn(() => "stdio" as const),
+      isIdle: vi.fn(() => false),
+      close: vi.fn(async () => undefined),
+    };
+
+    const lifecycle = new McpLifecycleManager(fakeManager as any);
+    lifecycle.setEventBus(bus);
+    lifecycle.markKeepAlive("keep", { command: "demo" });
+
+    await (lifecycle as any).checkConnections();
+
+    expect(phases(emitted)).toEqual(["mcp:server:reconnecting", "mcp:server:reconnected"]);
+    expect(fakeManager.connect).toHaveBeenCalledWith("keep", { command: "demo" });
+  });
+
+  it("closes idle servers with the idle reason so close() emits idle_shutdown", async () => {
+    const { bus } = spyBus();
+
+    const fakeManager = {
+      getConnection: vi.fn(() => ({ status: "connected" })),
+      connect: vi.fn(async () => ({ status: "connected" })),
+      getTransportKind: vi.fn(() => "stdio" as const),
+      isIdle: vi.fn(() => true),
+      close: vi.fn(async () => undefined),
+    };
+
+    const lifecycle = new McpLifecycleManager(fakeManager as any);
+    lifecycle.setEventBus(bus);
+    lifecycle.registerServer("idle", { command: "demo" });
+    lifecycle.setGlobalIdleTimeout(1);
+
+    await (lifecycle as any).checkConnections();
+
+    expect(fakeManager.close).toHaveBeenCalledWith("idle", { reason: "idle" });
+  });
+});

--- a/__tests__/state-snapshot.test.ts
+++ b/__tests__/state-snapshot.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { buildStateSnapshot } from "../init.ts";
+
+function makeState(overrides: {
+  connections: Record<string, { status: string } | undefined>;
+  kinds: Record<string, "stdio" | "http" | "sse">;
+  tools: Record<string, number>;
+  failures?: Record<string, number>;
+}) {
+  return {
+    config: {
+      mcpServers: {
+        local: { command: "demo" },
+        remote: { url: "https://example.test/mcp" },
+        cachedOnly: { command: "cached" },
+        broken: { command: "broken" },
+      },
+    },
+    manager: {
+      getConnection: (name: string) => overrides.connections[name],
+      getTransportKind: (name: string) => overrides.kinds[name],
+    },
+    toolMetadata: new Map(
+      Object.entries(overrides.tools).map(([k, n]) => [k, Array.from({ length: n })]),
+    ),
+    failureTracker: new Map(Object.entries(overrides.failures ?? {})),
+  } as any;
+}
+
+describe("buildStateSnapshot", () => {
+  it("classifies each server after a multi-server connect", () => {
+    const state = makeState({
+      connections: {
+        local: { status: "connected" },
+        remote: { status: "needs-auth" },
+        cachedOnly: undefined,
+        broken: undefined,
+      },
+      kinds: { local: "stdio", remote: "http" },
+      tools: { local: 4, cachedOnly: 9 },
+      failures: { broken: Date.now() },
+    });
+
+    expect(buildStateSnapshot(state)).toEqual([
+      { serverId: "local", transport: "stdio", status: "connected", toolCount: 4 },
+      { serverId: "remote", transport: "http", status: "needs-auth", toolCount: 0 },
+      { serverId: "cachedOnly", transport: "stdio", status: "cached", toolCount: 9 },
+      { serverId: "broken", transport: "stdio", status: "failed", toolCount: 0 },
+    ]);
+  });
+
+  it("falls back to disconnected with config-derived transport", () => {
+    const state = makeState({
+      connections: { local: undefined, remote: undefined, cachedOnly: undefined, broken: undefined },
+      kinds: {},
+      tools: {},
+    });
+
+    const snapshot = buildStateSnapshot(state);
+    expect(snapshot.find((s) => s.serverId === "remote")).toEqual({
+      serverId: "remote",
+      transport: "http",
+      status: "disconnected",
+      toolCount: 0,
+    });
+    expect(snapshot.every((s) => s.status === "disconnected")).toBe(true);
+  });
+});

--- a/init.ts
+++ b/init.ts
@@ -17,6 +17,8 @@ import {
   type ServerCacheEntry,
 } from "./metadata-cache.ts";
 import { McpServerManager } from "./server-manager.ts";
+import { McpEventBus, type McpStateSnapshotServer, type McpStateStatus, type McpTransportKind } from "./mcp-events.ts";
+import { setAuthEventBus } from "./mcp-auth-flow.ts";
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.ts";
 import { UiResourceHandler } from "./ui-resource-handler.ts";
 import { openUrl, parallelLimit } from "./utils.ts";
@@ -63,6 +65,17 @@ export async function initializeMcp(
     ui,
     sendMessage: (message, options) => pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options),
   };
+
+  // Wire the lifecycle event bus to PI's shared bus + durable session log.
+  // Additive and fire-and-forget: emission can never wedge a connection.
+  const eventBus = new McpEventBus({
+    emit: (channel, data) => pi.events.emit(channel, data),
+    appendEntry: (customType, data) => pi.appendEntry(customType, data),
+  });
+  eventBus.setSnapshotProvider(() => buildStateSnapshot(state));
+  manager.setEventBus(eventBus);
+  lifecycle.setEventBus(eventBus);
+  setAuthEventBus(eventBus);
 
   const serverEntries = Object.entries(config.mcpServers);
   if (serverEntries.length === 0) {
@@ -284,6 +297,37 @@ export function getFailureAgeSeconds(state: McpExtensionState, serverName: strin
   const ageMs = Date.now() - failedAt;
   if (ageMs > FAILURE_BACKOFF_MS) return null;
   return Math.round(ageMs / 1000);
+}
+
+/**
+ * Build the per-server snapshot mirrored durably via `pi.appendEntry`. Lets a
+ * consumer attaching mid-session reconstruct current state by replaying
+ * entries instead of racing a live `status` pull.
+ */
+export function buildStateSnapshot(state: McpExtensionState): McpStateSnapshotServer[] {
+  const servers: McpStateSnapshotServer[] = [];
+  for (const [name, definition] of Object.entries(state.config.mcpServers)) {
+    const connection = state.manager.getConnection(name);
+    const transport: McpTransportKind =
+      state.manager.getTransportKind(name) ?? (definition.command ? "stdio" : "http");
+    const toolCount = state.toolMetadata.get(name)?.length ?? 0;
+
+    let status: McpStateStatus;
+    if (connection?.status === "connected") {
+      status = "connected";
+    } else if (connection?.status === "needs-auth") {
+      status = "needs-auth";
+    } else if (getFailureAgeSeconds(state, name) !== null) {
+      status = "failed";
+    } else if (toolCount > 0) {
+      status = "cached";
+    } else {
+      status = "disconnected";
+    }
+
+    servers.push({ serverId: name, transport, status, toolCount });
+  }
+  return servers;
 }
 
 export async function lazyConnect(state: McpExtensionState, serverName: string): Promise<boolean> {

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -73,7 +73,11 @@ export class McpLifecycleManager {
       const connection = this.manager.getConnection(name);
       
       if (!connection || connection.status !== "connected") {
-        this.events.emitServer(name, definitionTransportKind(definition), "reconnecting");
+        this.events.emitServer(
+          name,
+          this.manager.getTransportKind(name) ?? definitionTransportKind(definition),
+          "reconnecting",
+        );
         try {
           await this.manager.connect(name, definition);
           logger.debug(`Reconnected to ${name}`);

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -1,8 +1,18 @@
 import type { ServerDefinition } from "./types.ts";
 import type { McpServerManager } from "./server-manager.ts";
+import { McpEventBus, NOOP_EVENT_BUS, type McpTransportKind } from "./mcp-events.ts";
 import { logger } from "./logger.ts";
 
 export type ReconnectCallback = (serverName: string) => void;
+
+/**
+ * Best-effort transport label from config alone — used before a connection
+ * exists (the `reconnecting` event). The precise sse-vs-http distinction is
+ * carried by the connection-lifecycle events emitted from the manager.
+ */
+function definitionTransportKind(definition: ServerDefinition): McpTransportKind {
+  return definition.command ? "stdio" : "http";
+}
 
 export class McpLifecycleManager {
   private manager: McpServerManager;
@@ -13,9 +23,15 @@ export class McpLifecycleManager {
   private healthCheckInterval?: NodeJS.Timeout;
   private onReconnect?: ReconnectCallback;
   private onIdleShutdown?: (serverName: string) => void;
-  
+  private events: McpEventBus = NOOP_EVENT_BUS;
+
   constructor(manager: McpServerManager) {
     this.manager = manager;
+  }
+
+  /** Wire the lifecycle event bus. No-op bus until `init.ts` provides PI's. */
+  setEventBus(bus: McpEventBus): void {
+    this.events = bus;
   }
   
   /**
@@ -57,9 +73,15 @@ export class McpLifecycleManager {
       const connection = this.manager.getConnection(name);
       
       if (!connection || connection.status !== "connected") {
+        this.events.emitServer(name, definitionTransportKind(definition), "reconnecting");
         try {
           await this.manager.connect(name, definition);
           logger.debug(`Reconnected to ${name}`);
+          this.events.emitServer(
+            name,
+            this.manager.getTransportKind(name) ?? definitionTransportKind(definition),
+            "reconnected",
+          );
           // Notify extension to update metadata
           this.onReconnect?.(name);
         } catch (error) {
@@ -72,7 +94,8 @@ export class McpLifecycleManager {
       if (this.keepAliveServers.has(name)) continue;
       const timeout = this.getIdleTimeout(name);
       if (timeout > 0 && this.manager.isIdle(name, timeout)) {
-        await this.manager.close(name);
+        // close() with reason "idle" emits the idle_shutdown phase itself.
+        await this.manager.close(name, { reason: "idle" });
         this.onIdleShutdown?.(name);
       }
     }

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -29,10 +29,20 @@ import {
   clearOAuthState,
   type StoredTokens,
 } from "./mcp-auth.ts"
+import { McpEventBus, NOOP_EVENT_BUS, toEventError } from "./mcp-events.ts"
 import type { ServerEntry } from "./types.ts"
 
 /** Auth status for a server */
 export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
+
+// OAuth is a process-global flow (one callback server, module-level pending
+// state), so its event bus is module-global too. init.ts sets it per session.
+let authEventBus: McpEventBus = NOOP_EVENT_BUS
+
+/** Wire the OAuth event bus. No-op bus until `init.ts` provides PI's. */
+export function setAuthEventBus(bus: McpEventBus): void {
+  authEventBus = bus
+}
 
 // Track pending transports for auth completion
 const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
@@ -179,6 +189,8 @@ export async function authenticate(
       return "authenticated"
     }
 
+    authEventBus.emitAuth(serverName, "http", "auth_required", { authorizationUrl })
+
     // Get the state that was already generated and stored in startAuth()
     const oauthState = await getOAuthState(serverName)
     if (!oauthState) {
@@ -229,7 +241,14 @@ export async function authenticate(
   pendingAuthentications.set(serverName, operation)
 
   try {
-    return await operation
+    const status = await operation
+    if (status === "authenticated") {
+      authEventBus.emitAuth(serverName, "http", "auth_succeeded")
+    }
+    return status
+  } catch (error) {
+    authEventBus.emitAuth(serverName, "http", "auth_failed", { error: toEventError(error) })
+    throw error
   } finally {
     if (pendingAuthentications.get(serverName) === operation) {
       pendingAuthentications.delete(serverName)

--- a/mcp-events.ts
+++ b/mcp-events.ts
@@ -133,6 +133,7 @@ export function toEventError(err: unknown): { message: string; code?: string } {
 export class McpEventBus {
   private sink?: McpEventSink;
   private snapshotProvider?: McpStateSnapshotProvider;
+  private lastSnapshotKey?: string;
   private readonly now: () => number;
 
   constructor(sink?: McpEventSink, now: () => number = Date.now) {
@@ -229,10 +230,18 @@ export class McpEventBus {
     const provider = this.snapshotProvider;
     if (!sink?.appendEntry || !provider) return;
     try {
+      const servers = provider();
+      // Coalesce: a mid-session consumer only needs the latest reconstructable
+      // state, so skip the append when nothing observable changed. Otherwise a
+      // churny multi-server config amplifies session-JSONL writes (one per
+      // transition, including no-op reconnect attempts).
+      const key = JSON.stringify(servers);
+      if (key === this.lastSnapshotKey) return;
+      this.lastSnapshotKey = key;
       const snapshot: McpStateSnapshot = {
         v: MCP_EVENT_VERSION,
         at: this.now(),
-        servers: provider(),
+        servers,
       };
       sink.appendEntry(MCP_STATE_ENTRY_TYPE, snapshot);
     } catch (err) {

--- a/mcp-events.ts
+++ b/mcp-events.ts
@@ -1,0 +1,245 @@
+/**
+ * mcp-events.ts — MCP lifecycle events on `pi.events`.
+ *
+ * This module is the integration contract. It emits a typed, versioned event
+ * on the shared PI event bus at each MCP server state transition, under the
+ * reserved `mcp:` channel namespace, and (when a snapshot provider is set)
+ * mirrors current state durably via `pi.appendEntry("mcp:state", …)`.
+ *
+ * Emission is fire-and-forget and additive: nothing here changes existing
+ * tool/command/UI behaviour, and a missing or faulty sink can never wedge a
+ * connection. Keep this file dependency-free so it stays trivially testable.
+ *
+ * Schema notes:
+ * - `v` is mandatory; subscribers branch on it. Additive fields within a
+ *   version are allowed; semantic changes bump `v`.
+ * - No secrets, ever. `authorizationUrl` is the only auth-adjacent field and
+ *   only for the interactive `auth_required` phase.
+ */
+
+/** Reserved channel namespace: every channel is prefixed "mcp:". */
+export const MCP_EVENT_CHANNELS = {
+  /** Connection / health lifecycle. */
+  server: "mcp:server",
+  /** Capability set changed. */
+  tools: "mcp:tools",
+  /** Remote-server OAuth. */
+  auth: "mcp:auth",
+} as const;
+
+/** Durable session-entry customType written via `pi.appendEntry`. */
+export const MCP_STATE_ENTRY_TYPE = "mcp:state";
+
+/** Current schema version. Bump only on semantic (non-additive) changes. */
+export const MCP_EVENT_VERSION = 1 as const;
+
+/** Bound `mcp:tools.toolNames` so a huge server doesn't bloat every event. */
+export const MCP_TOOL_NAMES_LIMIT = 100;
+
+export type McpTransportKind = "stdio" | "http" | "sse";
+
+export interface McpEventEnvelope {
+  v: typeof MCP_EVENT_VERSION;
+  /** Configured server key. */
+  serverId: string;
+  transport: McpTransportKind;
+  /** Epoch ms. */
+  at: number;
+}
+
+export type McpServerPhase =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "reconnecting"
+  | "reconnected"
+  | "idle_shutdown"
+  | "errored";
+
+/** channel: "mcp:server" — connection lifecycle. */
+export type McpServerEvent = McpEventEnvelope & {
+  phase: McpServerPhase;
+  error?: { message: string; code?: string };
+};
+
+/** channel: "mcp:tools" — capability set changed. */
+export type McpToolsEvent = McpEventEnvelope & {
+  toolCount: number;
+  /** Omitted for large servers to bound payload size. */
+  toolNames?: string[];
+  source: "connect" | "refresh" | "cache";
+};
+
+export type McpAuthPhase = "auth_required" | "auth_succeeded" | "auth_failed";
+
+/** channel: "mcp:auth" — remote-server OAuth. */
+export type McpAuthEvent = McpEventEnvelope & {
+  phase: McpAuthPhase;
+  /** Present only for the interactive "auth_required" phase. */
+  authorizationUrl?: string;
+  error?: { message: string };
+};
+
+export type McpStateStatus =
+  | "connected"
+  | "disconnected"
+  | "needs-auth"
+  | "failed"
+  | "cached";
+
+export interface McpStateSnapshotServer {
+  serverId: string;
+  transport: McpTransportKind;
+  status: McpStateStatus;
+  toolCount: number;
+}
+
+/** Durable snapshot written via `pi.appendEntry("mcp:state", …)`. */
+export interface McpStateSnapshot {
+  v: typeof MCP_EVENT_VERSION;
+  at: number;
+  servers: McpStateSnapshotServer[];
+}
+
+/**
+ * Minimal subset of the PI `ExtensionAPI` this bus depends on. Keeping it a
+ * structural type means tests can hand in a plain spy with no PI runtime.
+ */
+export interface McpEventSink {
+  emit(channel: string, data: unknown): void;
+  appendEntry?(customType: string, data: unknown): void;
+}
+
+export type McpStateSnapshotProvider = () => McpStateSnapshotServer[];
+
+/** Normalize an arbitrary thrown value into the event `error` shape. */
+export function toEventError(err: unknown): { message: string; code?: string } {
+  if (err instanceof Error) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" || typeof code === "number"
+      ? { message: err.message, code: String(code) }
+      : { message: err.message };
+  }
+  return { message: String(err) };
+}
+
+/**
+ * Emits MCP lifecycle events on a sink (PI's `pi.events` + `pi.appendEntry`).
+ *
+ * Construct with no sink for a no-op bus — that is the default the manager and
+ * lifecycle hold until `init.ts` wires the real PI sink, and what tests use
+ * when they don't care about events.
+ */
+export class McpEventBus {
+  private sink?: McpEventSink;
+  private snapshotProvider?: McpStateSnapshotProvider;
+  private readonly now: () => number;
+
+  constructor(sink?: McpEventSink, now: () => number = Date.now) {
+    this.sink = sink;
+    this.now = now;
+  }
+
+  setSink(sink: McpEventSink | undefined): void {
+    this.sink = sink;
+  }
+
+  /**
+   * Register a provider of the current per-server snapshot. When set (and the
+   * sink supports `appendEntry`), every emitted transition also writes a
+   * durable `mcp:state` entry so a consumer attaching mid-session can
+   * reconstruct state by replaying entries instead of racing a `status` pull.
+   */
+  setSnapshotProvider(provider: McpStateSnapshotProvider | undefined): void {
+    this.snapshotProvider = provider;
+  }
+
+  emitServer(
+    serverId: string,
+    transport: McpTransportKind,
+    phase: McpServerPhase,
+    error?: { message: string; code?: string },
+  ): void {
+    const payload: McpServerEvent = {
+      ...this.envelope(serverId, transport),
+      phase,
+      ...(error ? { error } : {}),
+    };
+    this.dispatch(MCP_EVENT_CHANNELS.server, payload);
+  }
+
+  emitTools(
+    serverId: string,
+    transport: McpTransportKind,
+    toolCount: number,
+    source: McpToolsEvent["source"],
+    toolNames?: string[],
+  ): void {
+    const payload: McpToolsEvent = {
+      ...this.envelope(serverId, transport),
+      toolCount,
+      source,
+    };
+    if (toolNames && toolNames.length > 0 && toolNames.length <= MCP_TOOL_NAMES_LIMIT) {
+      payload.toolNames = toolNames;
+    }
+    this.dispatch(MCP_EVENT_CHANNELS.tools, payload);
+  }
+
+  emitAuth(
+    serverId: string,
+    transport: McpTransportKind,
+    phase: McpAuthPhase,
+    opts?: { authorizationUrl?: string; error?: { message: string } },
+  ): void {
+    const payload: McpAuthEvent = {
+      ...this.envelope(serverId, transport),
+      phase,
+    };
+    // authorizationUrl is interactive-only and never carried on success/failure.
+    if (phase === "auth_required" && opts?.authorizationUrl) {
+      payload.authorizationUrl = opts.authorizationUrl;
+    }
+    if (opts?.error) {
+      payload.error = opts.error;
+    }
+    this.dispatch(MCP_EVENT_CHANNELS.auth, payload);
+  }
+
+  private envelope(serverId: string, transport: McpTransportKind): McpEventEnvelope {
+    return { v: MCP_EVENT_VERSION, serverId, transport, at: this.now() };
+  }
+
+  private dispatch(channel: string, data: unknown): void {
+    const sink = this.sink;
+    if (!sink) return;
+    // Fire-and-forget: a faulty subscriber or sink must never wedge a
+    // connection. PI's EventBus already wraps handlers; this guards the
+    // synchronous emit() call and our own snapshot mirror.
+    try {
+      sink.emit(channel, data);
+    } catch (err) {
+      console.error(`MCP: failed to emit ${channel}`, err);
+    }
+    this.mirrorSnapshot();
+  }
+
+  private mirrorSnapshot(): void {
+    const sink = this.sink;
+    const provider = this.snapshotProvider;
+    if (!sink?.appendEntry || !provider) return;
+    try {
+      const snapshot: McpStateSnapshot = {
+        v: MCP_EVENT_VERSION,
+        at: this.now(),
+        servers: provider(),
+      };
+      sink.appendEntry(MCP_STATE_ENTRY_TYPE, snapshot);
+    } catch (err) {
+      console.error("MCP: failed to append mcp:state snapshot", err);
+    }
+  }
+}
+
+/** Shared no-op bus used until a real PI sink is wired in. */
+export const NOOP_EVENT_BUS = new McpEventBus();

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "tool-result-renderer.ts",
     "resource-tools.ts",
     "lifecycle.ts",
+    "mcp-events.ts",
     "metadata-cache.ts",
     "host-html-template.ts",
     "ui-resource-handler.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -39,6 +39,10 @@ export class McpServerManager {
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
   private events: McpEventBus = NOOP_EVENT_BUS;
+  // Last transport kind actually observed per server, retained across
+  // disconnect so the lifecycle manager can label a `reconnecting` event
+  // (no live connection yet) precisely instead of guessing http for SSE.
+  private lastTransportKind = new Map<string, McpTransportKind>();
 
   setSamplingConfig(config: ServerSamplingConfig | undefined): void {
     this.samplingConfig = config;
@@ -122,6 +126,7 @@ export class McpServerManager {
       ]);
 
       const kind = transportKind(definition, transport);
+      this.lastTransportKind.set(name, kind);
       this.events.emitServer(name, kind, "connected");
       this.events.emitTools(
         name,
@@ -148,7 +153,9 @@ export class McpServerManager {
         await client.close().catch(() => {});
         await transport.close().catch(() => {});
 
-        this.events.emitAuth(name, transportKind(definition, transport), "auth_required");
+        const authKind = transportKind(definition, transport);
+        this.lastTransportKind.set(name, authKind);
+        this.events.emitAuth(name, authKind, "auth_required");
 
         return {
           client,
@@ -357,13 +364,17 @@ export class McpServerManager {
   }
 
   /**
-   * Precise transport kind for a live connection, used by the lifecycle
-   * manager when labelling health/idle events.
+   * Precise transport kind for a server, used by the lifecycle manager when
+   * labelling health/idle events. Falls back to the last kind actually
+   * observed (retained across disconnect) so a `reconnecting` event for a
+   * previously-connected SSE server is not mislabelled as http.
    */
   getTransportKind(name: string): McpTransportKind | undefined {
     const connection = this.connections.get(name);
-    if (!connection) return undefined;
-    return transportKind(connection.definition, connection.transport);
+    if (connection) {
+      return transportKind(connection.definition, connection.transport);
+    }
+    return this.lastTransportKind.get(name);
   }
 
   touch(name: string): void {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -18,6 +18,7 @@ import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { supportsOAuth } from "./mcp-auth-flow.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
+import { McpEventBus, NOOP_EVENT_BUS, toEventError, type McpTransportKind } from "./mcp-events.ts";
 
 interface ServerConnection {
   client: Client;
@@ -37,9 +38,15 @@ export class McpServerManager {
   private connectPromises = new Map<string, Promise<ServerConnection>>();
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
+  private events: McpEventBus = NOOP_EVENT_BUS;
 
   setSamplingConfig(config: ServerSamplingConfig | undefined): void {
     this.samplingConfig = config;
+  }
+
+  /** Wire the lifecycle event bus. No-op bus until `init.ts` provides PI's. */
+  setEventBus(bus: McpEventBus): void {
+    this.events = bus;
   }
   
   async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
@@ -71,8 +78,10 @@ export class McpServerManager {
     name: string,
     definition: ServerDefinition
   ): Promise<ServerConnection> {
+    this.events.emitServer(name, transportKind(definition), "connecting");
+
     const client = this.createClient(name);
-    
+
     let transport: Transport;
     
     if (definition.command) {
@@ -111,7 +120,17 @@ export class McpServerManager {
         this.fetchAllTools(client),
         this.fetchAllResources(client),
       ]);
-      
+
+      const kind = transportKind(definition, transport);
+      this.events.emitServer(name, kind, "connected");
+      this.events.emitTools(
+        name,
+        kind,
+        tools.length,
+        "connect",
+        tools.map((t) => t.name),
+      );
+
       return {
         client,
         transport,
@@ -129,6 +148,8 @@ export class McpServerManager {
         await client.close().catch(() => {});
         await transport.close().catch(() => {});
 
+        this.events.emitAuth(name, transportKind(definition, transport), "auth_required");
+
         return {
           client,
           transport,
@@ -140,10 +161,16 @@ export class McpServerManager {
           status: "needs-auth",
         };
       }
-      
+
       // Clean up both client and transport on any error
       await client.close().catch(() => {});
       await transport.close().catch(() => {});
+      this.events.emitServer(
+        name,
+        transportKind(definition, transport),
+        "errored",
+        toEventError(error),
+      );
       throw error;
     }
   }
@@ -294,10 +321,17 @@ export class McpServerManager {
     }
   }
   
-  async close(name: string): Promise<void> {
+  /**
+   * Close a server connection. `reason: "idle"` emits the `idle_shutdown`
+   * phase instead of `disconnected` so the idle path keeps a single, properly
+   * labelled transition (the lifecycle manager passes it on idle shutdown).
+   */
+  async close(name: string, opts?: { reason?: "idle" }): Promise<void> {
     const connection = this.connections.get(name);
     if (!connection) return;
-    
+
+    const kind = transportKind(connection.definition, connection.transport);
+
     // Delete from map BEFORE async cleanup to prevent a race where a
     // concurrent connect() creates a new connection that our deferred
     // delete() would then remove, orphaning the new server process.
@@ -305,6 +339,8 @@ export class McpServerManager {
     this.connections.delete(name);
     await connection.client.close().catch(() => {});
     await connection.transport.close().catch(() => {});
+
+    this.events.emitServer(name, kind, opts?.reason === "idle" ? "idle_shutdown" : "disconnected");
   }
   
   async closeAll(): Promise<void> {
@@ -318,6 +354,16 @@ export class McpServerManager {
   
   getAllConnections(): Map<string, ServerConnection> {
     return new Map(this.connections);
+  }
+
+  /**
+   * Precise transport kind for a live connection, used by the lifecycle
+   * manager when labelling health/idle events.
+   */
+  getTransportKind(name: string): McpTransportKind | undefined {
+    const connection = this.connections.get(name);
+    if (!connection) return undefined;
+    return transportKind(connection.definition, connection.transport);
   }
 
   touch(name: string): void {
@@ -347,6 +393,18 @@ export class McpServerManager {
     if (connection.inFlight > 0) return false;
     return (Date.now() - connection.lastUsedAt) > timeoutMs;
   }
+}
+
+/**
+ * Classify a connection's transport for the event envelope. `command`
+ * servers are stdio; URL servers are http unless we resolved to the SSE
+ * fallback transport. Pre-transport callers omit `transport` and get the
+ * http/stdio best guess.
+ */
+function transportKind(definition: ServerDefinition, transport?: Transport): McpTransportKind {
+  if (definition.command) return "stdio";
+  if (transport instanceof SSEClientTransport) return "sse";
+  return "http";
 }
 
 /**


### PR DESCRIPTION
Add a typed, versioned event contract on the shared PI event bus under the reserved mcp: namespace (mcp:server / mcp:tools / mcp:auth), plus a durable mcp:state mirror via pi.appendEntry so consumers attaching mid-session can reconstruct state by replaying entries.

Emission is additive and fire-and-forget: no existing tool/command/UI behaviour changes, and a faulty sink/subscriber cannot wedge a connection. Wired at the existing transition seams in server-manager, lifecycle, and the OAuth flow. Includes schema docs (README) and tests.