### PR TITLE
use 127.0.0.1 loopback IP literal instead of localhost for OAuth redirect URI

### DIFF
--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -178,7 +178,7 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
           reject(err)
         })
 
-        candidateServer.listen(candidatePort, "localhost", () => {
+        candidateServer.listen(candidatePort, "127.0.0.1", () => {
           resolve()
         })
       })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -88,7 +88,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   get redirectUrl(): string | undefined {
     if (this.usesClientCredentials) return undefined
-    return `http://localhost:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+    return `http://127.0.0.1:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
   }
 
   /**


### PR DESCRIPTION
Per RFC 8252 §7.3, OAuth native-app clients should use the loopback IP literals (127.0.0.1, [::1]) for redirect URIs rather than the hostname 'localhost'.

This is a resubmission of #60, originally I encountered this problem with the datadog MCP but have just encountered the same issue with the official Slack MCP.