### PR TITLE
fix: prevent OAuth callback server port exhaustion

### DIFF
--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
       }),
       close: vi.fn((cb?: () => void) => cb?.()),
       unref: vi.fn(),
+      address: vi.fn(() => ({ port: 4338, family: "IPv6", address: "::1" })),
     };
 
     runtime.servers.push(server);
@@ -88,7 +89,8 @@ describe("mcp-callback-server", () => {
 
     await ensureCallbackServer();
 
-    expect(mocks.runtime.servers[0]?.listen).toHaveBeenCalledWith(4337, "localhost", expect.any(Function));
+    // Non-strict mode uses listen(0) for OS-assigned port
+    expect(mocks.runtime.servers[0]?.listen).toHaveBeenCalledWith(0, "localhost", expect.any(Function));
     expect(mocks.runtime.servers[0]?.unref).toHaveBeenCalledTimes(1);
   });
 
@@ -106,43 +108,19 @@ describe("mcp-callback-server", () => {
   });
 
   it("rebinds to the configured port when strict mode is requested", async () => {
-    let firstConfiguredAttemptBlocked = true;
-    mocks.runtime.listenImpl = (_server, port, onListen, handlers) => {
-      if (port === mocks.state.configuredPort && firstConfiguredAttemptBlocked) {
-        firstConfiguredAttemptBlocked = false;
-        Promise.resolve().then(() => {
-          handlers.get("error")?.(Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" }));
-        });
-        return;
-      }
-
-      onListen();
-    };
-
     const { ensureCallbackServer } = await import("../mcp-callback-server.ts");
 
+    // First call: non-strict, gets OS-assigned port via listen(0)
     await ensureCallbackServer();
     expect(mocks.state.activePort).toBe(4338);
 
+    // Second call: strict mode, must bind on the configured port
     await ensureCallbackServer({ strictPort: true });
 
     expect(mocks.state.activePort).toBe(4337);
   });
 
   it("does not switch ports in strict mode while callbacks are pending", async () => {
-    let firstConfiguredAttemptBlocked = true;
-    mocks.runtime.listenImpl = (_server, port, onListen, handlers) => {
-      if (port === mocks.state.configuredPort && firstConfiguredAttemptBlocked) {
-        firstConfiguredAttemptBlocked = false;
-        Promise.resolve().then(() => {
-          handlers.get("error")?.(Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" }));
-        });
-        return;
-      }
-
-      onListen();
-    };
-
     const {
       ensureCallbackServer,
       waitForCallback,

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -347,10 +347,12 @@ export function supportsOAuth(definition: ServerEntry): boolean {
 
 /**
  * Initialize the OAuth system on startup.
- * Starts the callback server if there are any OAuth servers configured.
+ * No-op: the callback server starts on demand via ensureCallbackServer()
+ * inside startAuth(). This avoids binding a port at init time when no
+ * OAuth flow will occur, preventing EADDRINUSE with concurrent sessions.
  */
 export async function initializeOAuth(): Promise<void> {
-  await ensureCallbackServer()
+  // Lazy — callback server is started on demand by startAuth()
 }
 
 /**

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -69,7 +69,44 @@ const pendingAuths = new Map<string, PendingAuth>()
 /** Timeout for callback completion (5 minutes) */
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
 
-const MAX_PORT_SCAN_ATTEMPTS = 25
+/** Whether process exit handlers have been registered */
+let exitHandlersRegistered = false
+
+/**
+ * Register process signal/exit handlers to ensure the callback server is
+ * cleaned up even when the process is terminated abnormally (SIGTERM, SIGINT,
+ * SIGHUP, etc.). Without this, the HTTP server keeps the port occupied after
+ * the parent process is killed, eventually exhausting the entire port range.
+ */
+function registerExitHandlers(): void {
+  if (exitHandlersRegistered) return
+  exitHandlersRegistered = true
+
+  const cleanup = (): void => {
+    if (server) {
+      try { server.close() } catch { /* best effort */ }
+      server = undefined
+    }
+  }
+
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    const listeners = process.listeners(signal)
+    // Only register if no other listener has claimed the signal
+    if (listeners.length === 0) {
+      process.once(signal, () => {
+        cleanup()
+        process.exit(128 + (signal === "SIGINT" ? 2 : signal === "SIGTERM" ? 15 : 1))
+      })
+    } else {
+      // Prepend our cleanup so it runs before existing handlers
+      process.prependOnceListener(signal, cleanup)
+    }
+  }
+
+  // Also handle normal process exit (covers cases where node exits cleanly
+  // but the extension shutdown hook didn't fire)
+  process.on("exit", cleanup)
+}
 
 interface EnsureCallbackServerOptions {
   strictPort?: boolean
@@ -146,7 +183,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 /**
  * Ensure the callback server is running.
  * If strictPort is true, requires binding on the configured callback port.
- * If strictPort is false, scans forward for an available local port.
+ * If strictPort is false, uses port 0 to let the OS assign a free ephemeral port.
  */
 export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
   const configuredPort = getConfiguredOAuthCallbackPort()
@@ -164,54 +201,43 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
     await stopCallbackServer()
   }
 
-  const preferredPort = configuredPort
-  const maxAttempts = strictPort ? 1 : MAX_PORT_SCAN_ATTEMPTS
-  let lastError: Error | undefined
-
-  for (let offset = 0; offset < maxAttempts; offset++) {
-    const candidatePort = preferredPort + offset
-    const candidateServer = createServer(handleRequest)
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        candidateServer.once("error", (err) => {
-          reject(err)
-        })
-
-        candidateServer.listen(candidatePort, "localhost", () => {
-          resolve()
-        })
-      })
-
-      server = candidateServer
-      server.unref()
-      setOAuthCallbackPort(candidatePort)
-      return
-    } catch (error) {
-      const nodeError = error as NodeJS.ErrnoException
-      await new Promise<void>((resolve) => {
-        candidateServer.close(() => resolve())
-      })
-
-      if (nodeError.code !== "EADDRINUSE") {
-        throw error
-      }
-
-      lastError = error instanceof Error ? error : new Error(String(error))
-    }
-  }
+  const candidateServer = createServer(handleRequest)
 
   if (strictPort) {
-    throw new Error(
-      `OAuth callback port ${preferredPort} is already in use. Pre-registered OAuth clients require an exact redirect URI; set MCP_OAUTH_CALLBACK_PORT to your registered port or free port ${preferredPort}`,
-      { cause: lastError }
-    )
+    // Pre-registered OAuth clients require an exact redirect URI.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        candidateServer.once("error", reject)
+        candidateServer.listen(configuredPort, "localhost", () => resolve())
+      })
+    } catch (error) {
+      await new Promise<void>((resolve) => { candidateServer.close(() => resolve()) })
+      throw new Error(
+        `OAuth callback port ${configuredPort} is already in use. Pre-registered OAuth clients require an exact redirect URI; set MCP_OAUTH_CALLBACK_PORT to your registered port or free port ${configuredPort}`,
+        { cause: error instanceof Error ? error : new Error(String(error)) }
+      )
+    }
+    server = candidateServer
+    server.unref()
+    setOAuthCallbackPort(configuredPort)
+    registerExitHandlers()
+    return
   }
 
-  throw new Error(
-    `OAuth callback port ${preferredPort} is already in use and no free port was found in range ${preferredPort}-${preferredPort + MAX_PORT_SCAN_ATTEMPTS - 1}`,
-    { cause: lastError }
-  )
+  // Non-strict: let the OS assign a guaranteed-free ephemeral port.
+  // This eliminates port scanning and scales to any number of concurrent sessions.
+  const assignedPort = await new Promise<number>((resolve, reject) => {
+    candidateServer.once("error", reject)
+    candidateServer.listen(0, "localhost", () => {
+      const addr = candidateServer.address()
+      resolve(typeof addr === "object" && addr ? addr.port : configuredPort)
+    })
+  })
+
+  server = candidateServer
+  server.unref()
+  setOAuthCallbackPort(assignedPort)
+  registerExitHandlers()
 }
 
 /**


### PR DESCRIPTION
## Problem

Closes #104

Each Pi session eagerly binds an OAuth callback port (19876-19900) at startup via `initializeOAuth()` → `ensureCallbackServer()`. When processes are killed or exit abnormally, ports leak. After ~25 leaked ports, new Pi instances fail with:

```
Error: OAuth callback port 19876 is already in use and no free port was found in range 19876-19900
```

## Three Complementary Fixes

### Fix 1: Lazy initialization (`mcp-auth-flow.ts`)

`initializeOAuth()` is now a no-op. The callback server starts on demand inside `startAuth()` via `ensureCallbackServer()`. Sessions that never use OAuth consume zero ports.

### Fix 2: OS-assigned ephemeral port (`mcp-callback-server.ts`)

Non-strict mode now uses `listen(0)` to let the OS assign a guaranteed-free ephemeral port, replacing the sequential scan of ports 19876-19900. This:

- Eliminates the 25-session concurrency ceiling
- Removes the need for `MAX_PORT_SCAN_ATTEMPTS`
- Zero collision risk regardless of concurrent session count

`strictPort` mode (pre-registered OAuth clients that need an exact redirect URI) preserves the existing behavior: bind the configured port or throw.

### Fix 3: Process exit handlers (`mcp-callback-server.ts`)

Registers `SIGTERM`/`SIGINT`/`SIGHUP` signal handlers and a `process.on("exit")` fallback to synchronously close the HTTP server when the process is killed or exits abnormally. This prevents port leaks from stale listeners even with fix 1 + fix 2.

## Testing

All 284 tests pass (including the 4 updated callback-server tests):

```
32 test files, 284 tests passed
```

## Changes

| File | Change |
|------|--------|
| `mcp-auth-flow.ts` | `initializeOAuth()` → no-op (lazy) |
| `mcp-callback-server.ts` | Non-strict: `listen(0)` instead of sequential scan; register exit handlers |
| `__tests__/mcp-callback-server-unref.test.ts` | Updated mocks and assertions for new behavior |