### PR TITLE
Add OAuth client metadata and redirect URI overrides

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -73,6 +73,9 @@ You can optionally provide a pre-registered client:
 - `oauth.clientId` - Pre-registered client ID (optional, SDK tries dynamic registration if not provided)
 - `oauth.clientSecret` - Client secret for confidential clients (optional)
 - `oauth.scope` - Requested OAuth scopes (optional)
+- `oauth.redirectUri` - Full redirect URI for authorization-code flow. Overrides the default `http://localhost:<port>/callback` callback URI.
+- `oauth.clientName` - Dynamic registration `client_name` override (default: `Pi Coding Agent`).
+- `oauth.clientUri` - Dynamic registration `client_uri` override (default: this package repository).
 
 ### Non-Interactive `client_credentials`
 
@@ -174,18 +177,19 @@ If no `clientId` is provided, the SDK:
 
 1. Discovers the registration endpoint from OAuth metadata
 2. Registers a new client with:
-   - `client_name`: "Pi Coding Agent"
-   - `redirect_uris`: `["http://localhost:<active-callback-port>/callback"]`
+   - `client_name`: `oauth.clientName` or "Pi Coding Agent"
+   - `client_uri`: `oauth.clientUri` or this package repository
+   - `redirect_uris`: `[oauth.redirectUri]` when configured, otherwise `["http://localhost:<active-callback-port>/callback"]`
    - `grant_types`: `["authorization_code", "refresh_token"]`
 3. Stores the registered client credentials
 
 ### Callback Server
 
-A Node.js HTTP server runs on `localhost` at path `/callback`:
+A Node.js HTTP server runs on `localhost` at path `/callback` by default. When `oauth.redirectUri` is configured, the callback server uses that URI's path.
 
 - Preferred callback port is `19876` (or `MCP_OAUTH_CALLBACK_PORT` if set)
-- For dynamic registration, if the preferred port is busy, the adapter scans forward for a free local port
-- For pre-registered clients (`oauth.clientId`), the adapter requires the exact configured callback port
+- For dynamic registration without an explicit `oauth.redirectUri`, if the preferred port is busy, the adapter scans forward for a free local port
+- For pre-registered clients (`oauth.clientId`) or explicit redirect URIs (`oauth.redirectUri`), the adapter requires the exact configured callback port
 
 - Handles `code`, `state`, and `error` parameters
 - Displays success/error HTML pages

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
+| `oauth.clientId` | Pre-registered client ID (optional, SDK tries dynamic registration if not provided) |
+| `oauth.clientSecret` | Client secret for confidential clients (optional) |
+| `oauth.scope` | Requested OAuth scopes (optional) |
+| `oauth.redirectUri` | Full OAuth redirect URI for authorization-code flow. Overrides the default `http://localhost:<port>/callback` callback URI. |
+| `oauth.clientName` | Dynamic registration `client_name` override (default: `Pi Coding Agent`). |
+| `oauth.clientUri` | Dynamic registration `client_uri` override (default: this package repository). |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -62,7 +62,7 @@ vi.mock("http", () => ({
 }));
 
 vi.mock("../mcp-oauth-provider.ts", () => ({
-  OAUTH_CALLBACK_PATH: "/callback",
+  getOAuthCallbackPath: vi.fn(() => "/callback"),
   getConfiguredOAuthCallbackPort: mocks.getConfiguredOAuthCallbackPort,
   getOAuthCallbackPort: mocks.getOAuthCallbackPort,
   setOAuthCallbackPort: mocks.setOAuthCallbackPort,

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -10,7 +10,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/auth.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import open from "open"
-import { McpOAuthProvider, type McpOAuthConfig } from "./mcp-oauth-provider.ts"
+import { McpOAuthProvider, setOAuthCallbackPath, type McpOAuthConfig } from "./mcp-oauth-provider.ts"
 import {
   ensureCallbackServer,
   waitForCallback,
@@ -62,6 +62,9 @@ function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     clientId: definition.oauth?.clientId,
     clientSecret: definition.oauth?.clientSecret,
     scope: definition.oauth?.scope,
+    redirectUri: definition.oauth?.redirectUri,
+    clientName: definition.oauth?.clientName,
+    clientUri: definition.oauth?.clientUri,
   }
 }
 
@@ -97,8 +100,12 @@ export async function startAuth(
   }
 
   // Start the callback server.
-  // Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
-  await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
+  // Pre-registered OAuth clients and explicit redirect URIs require an exact redirect URI, so enforce strict port binding.
+  if (config.redirectUri) {
+    const redirect = new URL(config.redirectUri)
+    setOAuthCallbackPath(redirect.pathname)
+  }
+  await ensureCallbackServer({ strictPort: Boolean(config.clientId || config.redirectUri) })
 
   const oauthState = generateState()
   await updateOAuthState(serverName, oauthState, serverUrl)

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -7,7 +7,7 @@
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http"
 import {
-  OAUTH_CALLBACK_PATH,
+  getOAuthCallbackPath,
   getConfiguredOAuthCallbackPort,
   getOAuthCallbackPort,
   setOAuthCallbackPort,
@@ -82,7 +82,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
   const url = new URL(req.url || "/", `http://${req.headers.host}`)
 
   // Only handle the callback path
-  if (url.pathname !== OAUTH_CALLBACK_PATH) {
+  if (url.pathname !== getOAuthCallbackPath()) {
     res.writeHead(404, { "Content-Type": "text/plain" })
     res.end("Not found")
     return

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -47,7 +47,7 @@ describe("McpOAuthProvider", () => {
     redirectCaptured = undefined
   })
 
-  function createProvider(config: { clientId?: string; clientSecret?: string; scope?: string } = {}) {
+  function createProvider(config: { clientId?: string; clientSecret?: string; scope?: string; redirectUri?: string; clientName?: string; clientUri?: string } = {}) {
     return new McpOAuthProvider(serverName, serverUrl, config, {
       onRedirect: async (url) => {
         redirectCaptured = url
@@ -61,6 +61,14 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(
         provider.redirectUrl,
         "http://localhost:19876/callback"
+      )
+    })
+
+    it("should use configured redirect URI when provided", () => {
+      const provider = createProvider({ redirectUri: "http://127.0.0.1:19876/oauth/callback" })
+      assert.strictEqual(
+        provider.redirectUrl,
+        "http://127.0.0.1:19876/oauth/callback"
       )
     })
   })
@@ -83,6 +91,19 @@ describe("McpOAuthProvider", () => {
       const metadata = provider.clientMetadata
 
       assert.strictEqual(metadata.token_endpoint_auth_method, "client_secret_post")
+    })
+
+    it("should return configured OAuth client metadata", () => {
+      const provider = createProvider({
+        redirectUri: "http://127.0.0.1:19876/oauth/callback",
+        clientName: "Custom MCP Client",
+        clientUri: "https://example.com/custom-mcp-client",
+      })
+      const metadata = provider.clientMetadata
+
+      assert.deepStrictEqual(metadata.redirect_uris, ["http://127.0.0.1:19876/oauth/callback"])
+      assert.strictEqual(metadata.client_name, "Custom MCP Client")
+      assert.strictEqual(metadata.client_uri, "https://example.com/custom-mcp-client")
     })
   })
 

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -28,7 +28,7 @@ import {
 
 // Callback server configuration
 const DEFAULT_OAUTH_CALLBACK_PORT = 19876
-const OAUTH_CALLBACK_PATH = "/callback"
+let configuredOAuthCallbackPath = process.env.MCP_OAUTH_CALLBACK_PATH || "/callback"
 
 let configuredOAuthCallbackPort = DEFAULT_OAUTH_CALLBACK_PORT
 
@@ -53,12 +53,23 @@ export function setOAuthCallbackPort(port: number): void {
   oauthCallbackPort = port
 }
 
+export function getOAuthCallbackPath(): string {
+  return configuredOAuthCallbackPath
+}
+
+export function setOAuthCallbackPath(path: string): void {
+  configuredOAuthCallbackPath = path.startsWith("/") ? path : `/${path}`
+}
+
 /** Configuration options for OAuth */
 export interface McpOAuthConfig {
   grantType?: "authorization_code" | "client_credentials"
   clientId?: string
   clientSecret?: string
   scope?: string
+  redirectUri?: string
+  clientName?: string
+  clientUri?: string
 }
 
 /** Callbacks for OAuth flow interactions */
@@ -88,7 +99,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
    */
   get redirectUrl(): string | undefined {
     if (this.usesClientCredentials) return undefined
-    return `http://localhost:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+    if (this.config.redirectUri) return this.config.redirectUri
+    return `http://localhost:${getOAuthCallbackPort()}${getOAuthCallbackPath()}`
   }
 
   /**
@@ -98,7 +110,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   get clientMetadata(): OAuthClientMetadata {
     if (this.usesClientCredentials) {
       return {
-        client_name: "Pi Coding Agent",
+        client_name: this.config.clientName ?? "Pi Coding Agent",
         redirect_uris: [],
         grant_types: ["client_credentials"],
         token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -112,8 +124,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     return {
       redirect_uris: [redirectUrl],
-      client_name: "Pi Coding Agent",
-      client_uri: "https://github.com/nicobailon/pi-mcp-adapter",
+      client_name: this.config.clientName ?? "Pi Coding Agent",
+      client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -299,4 +311,4 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 }
 
-export { DEFAULT_OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }
+export { DEFAULT_OAUTH_CALLBACK_PORT }

--- a/types.ts
+++ b/types.ts
@@ -272,6 +272,12 @@ export interface OAuthConfig {
   clientSecret?: string;
   /** Requested OAuth scopes */
   scope?: string;
+  /** Full redirect URI for authorization_code flow. Overrides the default localhost callback URI. */
+  redirectUri?: string;
+  /** OAuth dynamic registration client_name. */
+  clientName?: string;
+  /** OAuth dynamic registration client_uri. */
+  clientUri?: string;
 }
 
 // Server configuration


### PR DESCRIPTION
## Summary

Adds optional per-server OAuth overrides for authorization-code flows:

- `oauth.redirectUri`
- `oauth.clientName`
- `oauth.clientUri`

When `oauth.redirectUri` is set, the OAuth provider uses that exact redirect URI for dynamic client registration and the callback server accepts that URI's path. Explicit redirect URIs use strict callback port binding, matching the existing behavior for pre-registered clients.

## Why

Some OAuth-protected MCP servers apply allowlisting or display/approval policy based on the registered OAuth client metadata or redirect URI. The current hardcoded values work for many servers, but some require a stable or client-compatible identity.

This keeps the current defaults unchanged while allowing users to configure compatible metadata when needed.

## Testing

- `npm run test:oauth-provider`
- `npx vitest run __tests__/mcp-callback-server-unref.test.ts __tests__/mcp-auth-flow-client-credentials.test.ts __tests__/config.test.ts`
- `npm test` mostly passed, but the existing `interactive-visualizer` dist artifact tests failed locally because `examples/interactive-visualizer/dist/*` is not present in this checkout.
