### PR TITLE
fix: support manual OAuth for remote MCP auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added manual remote/headless OAuth proxy actions for copying authorization URLs and completing pasted redirect URLs or codes. Thanks @Gabrielgvl for PR #120.
+
 ### Fixed
 - Included configured OAuth scopes in authorization-code flows while preserving token endpoint authentication method selection. Thanks @carlosdagos for PR #140.
 - Fixed MCP elicitation on stock Pi, including form dialogs with validation and review, consent-based URL handling, URL-required errors, completion notifications, and TUI-only browser navigation. Thanks @dmmulroy for PR #139.

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -14,7 +14,8 @@ The Pi MCP Adapter uses the official MCP SDK's built-in OAuth implementation, wh
 ## Features
 
 - ✅ **PKCE (S256)** - Mandatory code challenge method for OAuth 2.1
-- ✅ **Automatic Callback Server** - No URL copying needed, browser redirects automatically
+- ✅ **Automatic Callback Server** - Local browser redirects automatically when available
+- ✅ **Manual Remote Flow** - Copy auth URLs and pasted redirect URLs/codes for headless SSH sessions
 - ✅ **Dynamic Client Registration** - Automatically registers with OAuth servers
 - ✅ **Auto-Discovery** - Discovers OAuth endpoints from server metadata
 - ✅ **Automatic Token Refresh** - SDK handles expired tokens automatically
@@ -123,6 +124,26 @@ This will:
 5. Wait for the automatic callback
 6. Complete the OAuth flow
 7. Store tokens securely
+
+### Remote/headless authentication
+
+When Pi runs over SSH or in a headless environment, use the proxy tool to retrieve the authorization URL instead of relying on OS browser launch:
+
+```
+mcp({ action: "auth-start", server: "my-oauth-server" })
+```
+
+Open the returned URL in your local browser. After approval, copy the full redirected localhost URL from the browser address bar (the page may fail to load locally) and complete the same pending auth flow:
+
+```
+mcp({
+  action: "auth-complete",
+  server: "my-oauth-server",
+  args: '{"redirectUrl":"http://localhost:19876/callback?code=...&state=..."}'
+})
+```
+
+You can also pass only the `code` query parameter with `args: '{"code":"..."}'`. Redirect URL completion validates the saved OAuth state; raw code completion is available for providers that display a code directly.
 
 ### Step 2: Use the Server
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 | Call | `mcp({ tool: "...", args: '{"key": "value"}' })` |
 | Connect | `mcp({ connect: "server-name" })` |
 | UI messages | `mcp({ action: "ui-messages" })` |
+| Auth start | `mcp({ action: "auth-start", server: "name" })` |
+| Auth complete | `mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' })` |
 
 MCP proxy and direct-tool results render compactly by default: long text shows the first three lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
 
@@ -388,7 +390,7 @@ Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_li
 
 If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls automatically run OAuth when needed and retry once.
 
-In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. In non-interactive sessions, browser-based OAuth still requires `/mcp-auth <server>`. `/mcp-auth` without a server only opens a picker in the interactive UI.
+In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. In remote/headless sessions, use the proxy tool's `auth-start` and `auth-complete` actions to copy the authorization URL locally and paste the redirect URL back into Pi. `/mcp-auth` without a server only opens a picker in the interactive UI.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ Pi-specific files are the write targets for imported or shared global servers wh
 
 For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
 
+### Remote/headless OAuth
+
+If Pi is running on a remote server and cannot open a local browser, start OAuth through the proxy tool:
+
+```js
+mcp({ action: "auth-start", server: "linear-server" })
+```
+
+Open the returned authorization URL in your local browser. After approval, your browser redirects to a localhost URL. On a remote server that local page may fail to load; copy the full URL from the browser address bar anyway and complete the flow in the same Pi session:
+
+```js
+mcp({
+  action: "auth-complete",
+  server: "linear-server",
+  args: '{"redirectUrl":"http://localhost:19876/callback?code=...&state=..."}'
+})
+```
+
+You can also pass only the `code` query parameter with `args: '{"code":"..."}'`. Treat authorization URLs and codes as sensitive; they can grant access to the MCP server until the flow expires or completes.
+
 ### Lifecycle Modes
 
 - **`lazy`** (default) — Don't connect at startup. Connect on first tool call. Disconnect after idle timeout. Cached metadata keeps search/list working without connections.

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -128,7 +128,7 @@ describe("direct tools auto auth", () => {
     const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
 
     expect(mocks.authenticate).not.toHaveBeenCalled();
-    expect(result.content[0].text).toContain("interactive session");
+    expect(result.content[0].text).toContain("auth-start");
     expect(result.content[0].text).toContain("/mcp-auth demo");
   });
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
   openMcpAuthPanel: vi.fn(),
   openMcpPanel: vi.fn(),
   openMcpSetup: vi.fn(),
+  executeAuthComplete: vi.fn(),
+  executeAuthStart: vi.fn(),
   executeCall: vi.fn(),
   executeConnect: vi.fn(),
   executeDescribe: vi.fn(),
@@ -69,6 +71,8 @@ vi.mock("../commands.ts", () => ({
 }));
 
 vi.mock("../proxy-modes.ts", () => ({
+  executeAuthComplete: mocks.executeAuthComplete,
+  executeAuthStart: mocks.executeAuthStart,
   executeCall: mocks.executeCall,
   executeConnect: mocks.executeConnect,
   executeDescribe: mocks.executeDescribe,
@@ -210,6 +214,39 @@ describe("mcpAdapter session lifecycle", () => {
       renderResult: expect.any(Function),
     }));
     expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
+  });
+
+  it("routes manual auth actions through the proxy tool", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeAuthStart.mockResolvedValue({ content: [{ type: "text", text: "auth url" }] });
+    mocks.executeAuthComplete.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    expect(proxyTool).toBeDefined();
+
+    await proxyTool.execute("call-1", { action: "auth-start", server: "demo" });
+    await proxyTool.execute("call-2", {
+      action: "auth-complete",
+      server: "demo",
+      args: '{"redirectUrl":"http://localhost:19876/callback?code=abc&state=state"}',
+    });
+
+    expect(mocks.executeAuthStart).toHaveBeenCalledWith(state, "demo");
+    expect(mocks.executeAuthComplete).toHaveBeenCalledWith(
+      state,
+      "demo",
+      "http://localhost:19876/callback?code=abc&state=state",
+    );
   });
 
   it("starts a replacement init immediately and shuts down stale init results", async () => {

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -76,6 +76,38 @@ describe("mcp-auth-flow explicit auth", () => {
     }
   });
 
+  it("parses manual OAuth redirect URL and code input", async () => {
+    const { parseAuthorizationCodeInput } = await import("../mcp-auth-flow.ts");
+
+    expect(parseAuthorizationCodeInput(
+      "http://localhost:19876/callback?code=abc123&state=state123",
+      "state123",
+    )).toBe("abc123");
+    expect(parseAuthorizationCodeInput("code=abc123&state=state123", "state123")).toBe("abc123");
+    expect(parseAuthorizationCodeInput(
+      "http://localhost:19876/callback#code=abc123&state=state123",
+      "state123",
+    )).toBe("abc123");
+    expect(parseAuthorizationCodeInput("abc123")).toBe("abc123");
+  });
+
+  it("rejects invalid manual OAuth redirect input", async () => {
+    const { parseAuthorizationCodeInput } = await import("../mcp-auth-flow.ts");
+
+    expect(() => parseAuthorizationCodeInput(
+      "http://localhost:19876/callback?error=access_denied&error_description=Denied&state=state123",
+      "state123",
+    )).toThrow("access_denied: Denied");
+    expect(() => parseAuthorizationCodeInput(
+      "http://localhost:19876/callback?code=abc123",
+      "state123",
+    )).toThrow("state missing");
+    expect(() => parseAuthorizationCodeInput(
+      "http://localhost:19876/callback?code=abc123&state=wrong",
+      "state123",
+    )).toThrow("state mismatch");
+  });
+
   it("does not start the callback server during OAuth initialization", async () => {
     const { initializeOAuth } = await import("../mcp-auth-flow.ts");
 
@@ -456,21 +488,23 @@ describe("mcp-auth-flow explicit auth", () => {
     }));
   });
 
-  it("cleans up pending auth when the browser cannot open", async () => {
+  it("continues waiting for the OAuth callback when the browser cannot open", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
       return "REDIRECT";
     });
     mocks.open.mockRejectedValueOnce(new Error("no browser"));
+    mocks.waitForCallback.mockResolvedValueOnce("manual-code");
     const { authenticate } = await import("../mcp-auth-flow.ts");
     const { getOAuthState } = await import("../mcp-auth.ts");
 
     await expect(authenticate("browser-fail", "https://api.example.com/mcp", {
       url: "https://api.example.com/mcp",
       auth: "oauth",
-    })).rejects.toThrow("Could not open browser");
+    })).resolves.toBe("authenticated");
 
-    expect(mocks.cancelPendingCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.finishAuth).toHaveBeenCalledWith("manual-code");
+    expect(mocks.cancelPendingCallback).not.toHaveBeenCalled();
     expect(mocks.transportClose).toHaveBeenCalledTimes(1);
     expect(getOAuthState("browser-fail")).toBeUndefined();
   });

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -112,7 +112,7 @@ describe("proxy auto auth", () => {
     const result = await executeConnect(state, "demo");
 
     expect(mocks.authenticate).not.toHaveBeenCalled();
-    expect(result.content[0].text).toContain("interactive session");
+    expect(result.content[0].text).toContain("auth-start");
     expect(result.content[0].text).toContain("/mcp-auth demo");
   });
 

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  completeAuthFromInput: vi.fn(),
+  startAuth: vi.fn(),
+  supportsOAuth: vi.fn(),
+  lazyConnect: vi.fn(),
+  updateServerMetadata: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  getFailureAgeSeconds: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+vi.mock("../mcp-auth-flow.ts", () => ({
+  authenticate: vi.fn(),
+  completeAuthFromInput: mocks.completeAuthFromInput,
+  startAuth: mocks.startAuth,
+  supportsOAuth: mocks.supportsOAuth,
+}));
+
+vi.mock("../init.ts", () => ({
+  lazyConnect: mocks.lazyConnect,
+  updateServerMetadata: mocks.updateServerMetadata,
+  updateMetadataCache: mocks.updateMetadataCache,
+  getFailureAgeSeconds: mocks.getFailureAgeSeconds,
+  updateStatusBar: mocks.updateStatusBar,
+}));
+
+function createState(overrides: Record<string, unknown> = {}) {
+  return {
+    config: {
+      settings: {},
+      mcpServers: {
+        demo: { url: "https://api.example.com/mcp", auth: "oauth" },
+        bearer: { url: "https://api.example.com/mcp", auth: "bearer" },
+      },
+    },
+    manager: { close: vi.fn(async () => {}) },
+    toolMetadata: new Map(),
+    failureTracker: new Map([["demo", Date.now()]]),
+    ...overrides,
+  } as any;
+}
+
+describe("manual OAuth proxy actions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.completeAuthFromInput.mockReset().mockResolvedValue("authenticated");
+    mocks.startAuth.mockReset().mockResolvedValue({
+      authorizationUrl: "https://auth.example.com/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A19876%2Fcallback",
+    });
+    mocks.supportsOAuth.mockReset().mockImplementation((definition) => definition.auth === "oauth");
+    mocks.updateStatusBar.mockReset();
+  });
+
+  it("returns copyable instructions and authorization URL", async () => {
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+    const state = createState();
+
+    const result = await executeAuthStart(state, "demo");
+
+    expect(mocks.startAuth).toHaveBeenCalledWith("demo", "https://api.example.com/mcp", state.config.mcpServers.demo);
+    expect(result.content[0].text).toContain("Open this URL in your local browser");
+    expect(result.content[0].text).toContain("https://auth.example.com/authorize");
+    expect(result.content[0].text).toContain("auth-complete");
+    expect(result.details).toMatchObject({ mode: "auth-start", server: "demo" });
+  });
+
+  it("rejects auth-start for non-OAuth servers", async () => {
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+
+    const result = await executeAuthStart(createState(), "bearer");
+
+    expect(mocks.startAuth).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("not configured for OAuth");
+    expect(result.details).toMatchObject({ error: "oauth_not_supported" });
+  });
+
+  it("completes auth from a copied redirect URL and resets connection state", async () => {
+    const { executeAuthComplete } = await import("../proxy-modes.ts");
+    const state = createState();
+
+    const result = await executeAuthComplete(state, "demo", "http://localhost:19876/callback?code=abc&state=state");
+
+    expect(mocks.completeAuthFromInput).toHaveBeenCalledWith("demo", "http://localhost:19876/callback?code=abc&state=state");
+    expect(state.manager.close).toHaveBeenCalledWith("demo");
+    expect(state.failureTracker.has("demo")).toBe(false);
+    expect(mocks.updateStatusBar).toHaveBeenCalledWith(state);
+    expect(result.content[0].text).toContain("OAuth authentication successful");
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -22,7 +22,7 @@ type DirectAutoAuthResult =
 function getDirectAuthRequiredMessage(
   state: McpExtensionState,
   serverName: string,
-  defaultMessage = `MCP server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} first.`,
+  defaultMessage = `MCP server "${serverName}" requires OAuth authentication. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`,
 ): string {
   return formatAuthRequiredMessage(state.config, serverName, defaultMessage);
 }
@@ -32,7 +32,7 @@ function getDirectAuthFailedMessage(state: McpExtensionState, serverName: string
   if (customGuidance) {
     return `OAuth authentication failed for "${serverName}": ${message}. ${getDirectAuthRequiredMessage(state, serverName)}`;
   }
-  return `OAuth authentication failed for "${serverName}": ${message}. Run /mcp-auth ${serverName} first.`;
+  return `OAuth authentication failed for "${serverName}": ${message}. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`;
 }
 
 async function attemptDirectAutoAuth(
@@ -55,7 +55,7 @@ async function attemptDirectAutoAuth(
       message: getDirectAuthRequiredMessage(
         state,
         serverName,
-        `MCP server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} in an interactive session.`,
+        `MCP server "${serverName}" requires OAuth authentication. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`,
       ),
     };
   }
@@ -255,7 +255,9 @@ export function buildProxyDescription(
   desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`;
   desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`;
   desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`;
-  desc += `\nMode: tool (call) > connect > describe > search > server (list) > action > nothing (status)`;
+  desc += `  mcp({ action: "auth-start", server: "name" })      → Start manual OAuth and get a browser URL\n`;
+  desc += `  mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' }) → Complete manual OAuth\n`;
+  desc += `\nMode: action > tool (call) > connect > describe > search > server (list) > nothing (status)`;
 
   return desc;
 }

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { loadMcpConfig } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
-import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
+import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
@@ -263,7 +263,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
-        action: Type.Optional(Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" })),
+        action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
       }),
       renderResult: renderMcpToolResult,
       async execute(_toolCallId, params: {
@@ -313,6 +313,31 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
         if (params.action === "ui-messages") {
           return executeUiMessages(state);
+        }
+        if (params.action === "auth-start") {
+          if (!params.server) {
+            return {
+              content: [{ type: "text" as const, text: "auth-start requires `server`. Example: mcp({ action: \"auth-start\", server: \"linear-server\" })" }],
+              details: { mode: "auth-start", error: "missing_server" },
+            };
+          }
+          return executeAuthStart(state, params.server);
+        }
+        if (params.action === "auth-complete") {
+          if (!params.server) {
+            return {
+              content: [{ type: "text" as const, text: "auth-complete requires `server`." }],
+              details: { mode: "auth-complete", error: "missing_server" },
+            };
+          }
+          const input = parsedArgs?.redirectUrl ?? parsedArgs?.code ?? parsedArgs?.input;
+          if (typeof input !== "string" || input.trim().length === 0) {
+            return {
+              content: [{ type: "text" as const, text: "auth-complete requires args with `redirectUrl`, `code`, or `input`." }],
+              details: { mode: "auth-complete", error: "missing_input" },
+            };
+          }
+          return executeAuthComplete(state, params.server, input);
         }
         if (params.tool) {
           return executeCall(state, params.tool, parsedArgs, params.server, getPiTools);

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -38,9 +38,14 @@ export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 
 // Track pending transports for auth completion
 const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
+const pendingAuthStates = new Map<string, string>()
+const pendingAuthCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 // Deduplicate concurrent authenticate() calls per server.
 const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
+
+/** Timeout for manual auth completion (5 minutes) */
+const MANUAL_AUTH_TIMEOUT_MS = 5 * 60 * 1000
 
 /**
  * Generate a cryptographically secure random state parameter.
@@ -214,16 +219,122 @@ export async function startAuth(
     if (!capturedUrl) {
       throw new UnauthorizedError("OAuth authorization URL was not provided")
     }
-    pendingTransports.set(
-      serverName,
-      new StreamableHTTPClientTransport(new URL(serverUrl), { authProvider }),
-    )
+    const pendingTransport = new StreamableHTTPClientTransport(new URL(serverUrl), { authProvider })
+    await setPendingTransport(serverName, pendingTransport, oauthState)
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
-    releaseCallbackServer(oauthState)
-    await clearOAuthState(serverName)
+    await clearPendingAuth(serverName, oauthState)
     throw error
   }
+}
+
+async function setPendingTransport(
+  serverName: string,
+  transport: StreamableHTTPClientTransport,
+  oauthState: string,
+): Promise<void> {
+  await clearPendingAuth(serverName)
+  pendingTransports.set(serverName, transport)
+  pendingAuthStates.set(serverName, oauthState)
+  const cleanupTimer = setTimeout(() => {
+    void clearPendingAuth(serverName, oauthState)
+  }, MANUAL_AUTH_TIMEOUT_MS)
+  cleanupTimer.unref?.()
+  pendingAuthCleanupTimers.set(serverName, cleanupTimer)
+}
+
+async function clearPendingAuth(serverName: string, oauthState?: string): Promise<void> {
+  const pendingState = pendingAuthStates.get(serverName)
+  if (oauthState && pendingState && pendingState !== oauthState) return
+
+  const timer = pendingAuthCleanupTimers.get(serverName)
+  if (timer) {
+    clearTimeout(timer)
+    pendingAuthCleanupTimers.delete(serverName)
+  }
+
+  const transport = pendingTransports.get(serverName)
+  pendingTransports.delete(serverName)
+  pendingAuthStates.delete(serverName)
+  const stateToRelease = pendingState ?? oauthState
+  if (stateToRelease) {
+    releaseCallbackServer(stateToRelease)
+    const storedState = await getOAuthState(serverName)
+    if (storedState === stateToRelease) {
+      await clearOAuthState(serverName)
+    }
+  }
+  if (transport) {
+    await transport.close().catch(() => {})
+  }
+}
+
+function getSearchParamsFromInput(input: string): URLSearchParams | undefined {
+  try {
+    const url = new URL(input)
+    const params = new URLSearchParams(url.search)
+    if (url.hash) {
+      const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash
+      const hashParams = new URLSearchParams(hash)
+      for (const [key, value] of hashParams) {
+        if (!params.has(key)) params.set(key, value)
+      }
+    }
+    return params
+  } catch {
+    const query = input.includes("?") ? input.slice(input.indexOf("?") + 1) : input
+    const params = new URLSearchParams(query.startsWith("#") ? query.slice(1) : query)
+    return params.has("code") || params.has("state") || params.has("error") ? params : undefined
+  }
+}
+
+/**
+ * Extract an OAuth authorization code from either a raw code, a query string,
+ * or the full localhost redirect URL copied from the browser address bar.
+ */
+export function parseAuthorizationCodeInput(input: string, expectedState?: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    throw new Error("Authorization code or redirect URL is required")
+  }
+
+  const params = getSearchParamsFromInput(trimmed)
+  if (params) {
+    const error = params.get("error")
+    if (error) {
+      const description = params.get("error_description")
+      throw new Error(description ? `${error}: ${description}` : error)
+    }
+
+    const state = params.get("state")
+    if (expectedState && !state) {
+      throw new Error("OAuth state missing from redirect URL")
+    }
+    if (expectedState && state !== expectedState) {
+      throw new Error("OAuth state mismatch - potential CSRF attack")
+    }
+
+    const code = params.get("code")
+    if (code) return code
+  }
+
+  if (/^[A-Za-z0-9._~+/=-]+$/.test(trimmed)) {
+    return trimmed
+  }
+
+  throw new Error("Could not find an OAuth authorization code in the provided input")
+}
+
+/**
+ * Complete OAuth authentication from manual user input.
+ */
+export async function completeAuthFromInput(
+  serverName: string,
+  input: string,
+): Promise<AuthStatus> {
+  const oauthState = await getOAuthState(serverName)
+  const code = parseAuthorizationCodeInput(input, oauthState)
+  return completeAuth(serverName, code)
 }
 
 /**
@@ -245,12 +356,7 @@ export async function completeAuth(
     await transport.finishAuth(authorizationCode)
     return "authenticated"
   } finally {
-    if (oauthState) {
-      releaseCallbackServer(oauthState)
-    }
-    await clearOAuthState(serverName)
-    pendingTransports.delete(serverName)
-    await transport.close().catch(() => {})
+    await clearPendingAuth(serverName, oauthState)
   }
 }
 
@@ -291,16 +397,13 @@ export async function authenticate(
     const callbackPromise = waitForCallback(oauthState)
 
     try {
-      // Open browser
-      console.log(`MCP Auth: Opening browser for ${serverName}`)
+      // Open browser. Always print the URL first so remote/headless users can copy it
+      // even when the OS browser handoff is unavailable or invisible.
+      console.log(`MCP Auth: Open this URL to authenticate ${serverName}:\n${authorizationUrl}`)
       try {
         await open(authorizationUrl)
       } catch (error) {
-        console.warn(`MCP Auth: Failed to open browser for ${serverName}`, { error })
-        throw new Error(
-          `Could not open browser. Please open this URL manually: ${authorizationUrl}`,
-          { cause: error },
-        )
+        console.warn(`MCP Auth: Failed to open browser for ${serverName}; waiting for manual callback`, { error })
       }
 
       // Wait for callback
@@ -318,12 +421,7 @@ export async function authenticate(
       return await completeAuth(serverName, code)
     } catch (error) {
       cancelPendingCallback(oauthState)
-      await clearOAuthState(serverName)
-      const pendingTransport = pendingTransports.get(serverName)
-      if (pendingTransport) {
-        pendingTransports.delete(serverName)
-        await pendingTransport.close().catch(() => {})
-      }
+      await clearPendingAuth(serverName, oauthState)
       throw error
     }
   })()
@@ -418,11 +516,7 @@ export async function removeAuth(serverName: string): Promise<void> {
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  const pendingTransport = pendingTransports.get(serverName)
-  if (pendingTransport) {
-    pendingTransports.delete(serverName)
-    await pendingTransport.close().catch(() => {})
-  }
+  await clearPendingAuth(serverName, oauthState)
   clearAllCredentials(serverName)
   await clearOAuthState(serverName)
   console.log(`MCP Auth: Removed credentials for ${serverName}`)
@@ -458,5 +552,8 @@ export async function initializeOAuth(): Promise<void> {}
  * Stops the callback server and cancels pending auths.
  */
 export async function shutdownOAuth(): Promise<void> {
+  for (const serverName of Array.from(pendingTransports.keys())) {
+    await clearPendingAuth(serverName)
+  }
   await stopCallbackServer()
 }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -8,7 +8,7 @@ import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from ".
 import { transformMcpContent } from "./tool-registrar.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
-import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
+import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -27,7 +27,7 @@ type AutoAuthResult =
 function getAuthRequiredMessage(
   state: McpExtensionState,
   serverName: string,
-  defaultMessage = `Server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} first.`,
+  defaultMessage = `Server "${serverName}" requires OAuth authentication. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`,
 ): string {
   return formatAuthRequiredMessage(state.config, serverName, defaultMessage);
 }
@@ -37,7 +37,39 @@ function getAuthFailedMessage(state: McpExtensionState, serverName: string, mess
   if (customGuidance) {
     return `OAuth authentication failed for "${serverName}": ${message}. ${getAuthRequiredMessage(state, serverName)}`;
   }
-  return `OAuth authentication failed for "${serverName}": ${message}. Run /mcp-auth ${serverName} first.`;
+  return `OAuth authentication failed for "${serverName}": ${message}. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`;
+}
+
+function getRedirectPort(authorizationUrl: string): number | undefined {
+  try {
+    const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
+    if (!redirectUri) return undefined;
+    const port = Number.parseInt(new URL(redirectUri).port, 10);
+    return Number.isInteger(port) ? port : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatManualAuthInstructions(serverName: string, authorizationUrl: string): string {
+  const port = getRedirectPort(authorizationUrl);
+  const portNote = port
+    ? `\nThe redirect URL will use local port ${port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
+    : "";
+
+  return [
+    `MCP OAuth required for "${serverName}".`,
+    "",
+    "Open this URL in your local browser:",
+    "",
+    authorizationUrl,
+    "",
+    "After approving, copy the full redirected localhost URL from your browser address bar and send it back with:",
+    `mcp({ action: "auth-complete", server: "${serverName}", args: '{"redirectUrl":"PASTE_REDIRECT_URL_HERE"}' })`,
+    "",
+    "You can also pass just the `code` query parameter as `args: '{\"code\":\"PASTE_CODE_HERE\"}'`.",
+    portNote.trimEnd(),
+  ].filter(Boolean).join("\n");
 }
 
 async function attemptAutoAuth(
@@ -60,7 +92,7 @@ async function attemptAutoAuth(
       message: getAuthRequiredMessage(
         state,
         serverName,
-        `Server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} in an interactive session.`,
+        `Server "${serverName}" requires OAuth authentication. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`,
       ),
     };
   }
@@ -209,6 +241,77 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
     content: [{ type: "text" as const, text: text.trim() }],
     details: { mode: "status", servers, totalTools, connectedCount },
   };
+}
+
+export async function executeAuthStart(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+  const definition = state.config.mcpServers[serverName];
+  if (!definition) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "auth-start", error: "not_found", server: serverName },
+    };
+  }
+
+  if (!definition.url || !supportsOAuth(definition)) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
+      details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
+    };
+  }
+
+  try {
+    const { authorizationUrl } = await startAuth(serverName, definition.url, definition);
+    if (!authorizationUrl) {
+      return {
+        content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
+        details: { mode: "auth-start", server: serverName, authenticated: true },
+      };
+    }
+
+    return {
+      content: [{ type: "text" as const, text: formatManualAuthInstructions(serverName, authorizationUrl) }],
+      details: { mode: "auth-start", server: serverName, authorizationUrl },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text" as const, text: `Failed to start OAuth for "${serverName}": ${message}` }],
+      details: { mode: "auth-start", error: "auth_start_failed", server: serverName, message },
+    };
+  }
+}
+
+export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string): Promise<ProxyToolResult> {
+  if (!state.config.mcpServers[serverName]) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "auth-complete", error: "not_found", server: serverName },
+    };
+  }
+
+  try {
+    const status = await completeAuthFromInput(serverName, input);
+    if (status !== "authenticated") {
+      return {
+        content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],
+        details: { mode: "auth-complete", error: "not_authenticated", server: serverName, status },
+      };
+    }
+
+    await state.manager.close(serverName);
+    state.failureTracker.delete(serverName);
+    updateStatusBar(state);
+    return {
+      content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.` }],
+      details: { mode: "auth-complete", server: serverName, authenticated: true },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text" as const, text: `Failed to complete OAuth for "${serverName}": ${message}` }],
+      details: { mode: "auth-complete", error: "auth_complete_failed", server: serverName, message },
+    };
+  }
 }
 
 export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {


### PR DESCRIPTION
## Summary
- Add proxy-tool manual OAuth actions (`auth-start` / `auth-complete`) so remote/headless Pi sessions can copy the authorization URL and paste the redirected localhost URL or code.
- Keep `/mcp-auth` resilient by printing the authorization URL before attempting to open a browser and continuing to wait if browser launch fails.
- Track and clean pending manual auth transports/timers, validate OAuth state for pasted redirect URLs, and update auth-required guidance.
- Document the remote/headless flow in README and OAUTH docs.

## Tests
- `npm test`
- `npx tsc --noEmit`