### PR TITLE
Superseded by #132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added MCP client-side elicitation support. MCP servers can now use standard `elicitation/create` form requests, routed through Pi's trusted interactive UI instead of model-visible approval tools.
+
 ## [2.8.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,8 +169,12 @@ For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact c
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
 | `samplingAutoApprove` | Skip sampling confirmation prompts. Required for sampling in non-UI sessions (default: false). |
+| `elicitation` | Allow MCP servers to ask for trusted user input through Pi's interactive UI (default: true when UI is available). |
+| `elicitationTimeoutMs` | Timeout for each trusted elicitation UI step in milliseconds (default: 300000). |
 
 Per-server `idleTimeout` overrides the global setting.
+
+MCP elicitation is routed through Pi's trusted UI path, not through model-visible tools. Form elicitation supports simple top-level primitive fields; do not use it to collect secrets.
 
 ### Direct Tools
 
@@ -379,3 +383,4 @@ In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or 
 - Cross-session server sharing not yet implemented (each Pi session runs its own server processes)
 - Compact MCP result rendering summarizes text, but inline images are still controlled by Pi's image display settings and may render below the compact text summary.
 - MCP sampling support is text-only; context inclusion, tools, stop sequences, audio, and image content are rejected with explicit errors.
+- MCP elicitation support is form-only for simple top-level primitive schemas; URL elicitation is cancelled for now.

--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ElicitRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { ElicitationHandlerOptions } from "../elicitation-handler.ts";
+
+function createOptions(overrides: Partial<ElicitationHandlerOptions> = {}): ElicitationHandlerOptions {
+  return {
+    serverName: "github",
+    ui: {
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => "value"),
+      select: vi.fn(async (_title: string, options: string[]) => options[0]),
+    } as any,
+    timeoutMs: 300000,
+    ...overrides,
+  };
+}
+
+function createElicitationRequest(params: ElicitRequest["params"]): ElicitRequest {
+  return { method: "elicitation/create", params };
+}
+
+describe("elicitation handler", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("collects and validates simple form fields before accepting", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn(async () => true),
+      input: vi
+        .fn()
+        .mockResolvedValueOnce("Release note")
+        .mockResolvedValueOnce("42")
+        .mockResolvedValueOnce("7"),
+      select: vi
+        .fn()
+        .mockResolvedValueOnce("true")
+        .mockResolvedValueOnce("High"),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve publishing this change?",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          comment: { type: "string", minLength: 3 },
+          score: { type: "number", minimum: 1, maximum: 100 },
+          retries: { type: "integer", default: 7 },
+          approved: { type: "boolean" },
+          priority: { type: "string", enum: ["low", "high"], enumNames: ["Low", "High"] },
+        },
+        required: ["comment", "score", "approved", "priority"],
+      },
+    }));
+
+    expect(result).toEqual({
+      action: "accept",
+      content: {
+        comment: "Release note",
+        score: 42,
+        retries: 7,
+        approved: true,
+        priority: "high",
+      },
+    });
+    expect(ui.confirm).toHaveBeenCalledTimes(2);
+    expect(ui.confirm.mock.calls[0][0]).toBe("MCP request from github");
+    expect(ui.confirm.mock.calls[0][2]).toEqual({ timeout: 300000 });
+    expect(ui.input.mock.calls[0]).toEqual(["comment (required)", "", { timeout: 300000 }]);
+    expect(ui.input.mock.calls[1]).toEqual(["score (required)", "", { timeout: 300000 }]);
+    expect(ui.input.mock.calls[2]).toEqual(["retries", "7", { timeout: 300000 }]);
+    expect(ui.select.mock.calls[0]).toEqual(["approved (required)", ["true", "false"], { timeout: 300000 }]);
+    expect(ui.select.mock.calls[1]).toEqual(["priority (required)", ["Low", "High"], { timeout: 300000 }]);
+    expect(ui.confirm.mock.calls[1][1]).toContain("\"priority\": \"high\"");
+    expect(ui.confirm.mock.calls[1][2]).toEqual({ timeout: 300000 });
+  });
+
+  it("returns decline for explicit initial denial", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = { confirm: vi.fn(async () => false), input: vi.fn(), select: vi.fn() };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: { type: "object", properties: {} },
+    }));
+
+    expect(result).toEqual({ action: "decline" });
+    expect(ui.input).not.toHaveBeenCalled();
+  });
+
+  it("returns decline for explicit final denial", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+      input: vi.fn(async () => "ok"),
+      select: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: { comment: { type: "string" } },
+        required: ["comment"],
+      },
+    }));
+
+    expect(result).toEqual({ action: "decline" });
+  });
+
+  it("returns cancel when UI is unavailable", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+
+    const result = await handleElicitationRequest(createOptions({ ui: undefined }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: { type: "object", properties: {} },
+    }));
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel for URL and non-form elicitation modes", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      mode: "url",
+      message: "Open this URL?",
+      requestedSchema: { type: "object", properties: {} },
+    } as any))).resolves.toEqual({ action: "cancel" });
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      mode: "custom",
+      message: "Custom?",
+      requestedSchema: { type: "object", properties: {} },
+    } as any))).resolves.toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel for missing or invalid schemas", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      message: "Approve?",
+    } as any))).resolves.toEqual({ action: "cancel" });
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: { type: "array" },
+    } as any))).resolves.toEqual({ action: "cancel" });
+  });
+
+  it("skips unsupported optional fields and cancels unsupported required fields", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          optionalList: { type: "array" },
+        },
+      },
+    } as any))).resolves.toEqual({ action: "accept", content: {} });
+
+    await expect(handleElicitationRequest(createOptions(), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          requiredList: { type: "array" },
+        },
+        required: ["requiredList"],
+      },
+    } as any))).resolves.toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel when field validation fails", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => "101"),
+      select: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: { score: { type: "number", maximum: 100 } },
+        required: ["score"],
+      },
+    }));
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel when field input is dismissed", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => undefined),
+      select: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: { comment: { type: "string" } },
+        required: ["comment"],
+      },
+    }));
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel when a trusted UI call fails", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => {
+        throw new Error("dismissed");
+      }),
+      select: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: {
+        type: "object",
+        properties: { comment: { type: "string" } },
+        required: ["comment"],
+      },
+    }));
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("returns cancel on trusted UI timeout", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      confirm: vi.fn(async (_title: string, _message: string, opts?: { timeout?: number }) => {
+        return opts?.timeout === 10 ? undefined : true;
+      }),
+      input: vi.fn(),
+      select: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(createOptions({ ui: ui as any, timeoutMs: 10 }), createElicitationRequest({
+      message: "Approve?",
+      requestedSchema: { type: "object", properties: {} },
+    }));
+
+    expect(result).toEqual({ action: "cancel" });
+    expect(ui.confirm.mock.calls[0][2]).toEqual({ timeout: 10 });
+  });
+});

--- a/__tests__/init-elicitation.test.ts
+++ b/__tests__/init-elicitation.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { McpConfig } from "../types.ts";
+
+function writeConfig(config: McpConfig): string {
+  const dir = mkdtempSync(join(tmpdir(), "pi-mcp-elicitation-"));
+  const path = join(dir, "mcp.json");
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+  return path;
+}
+
+function createPi(configPath: string) {
+  return {
+    getFlag: () => configPath,
+    sendMessage: () => undefined,
+  } as any;
+}
+
+function createContext(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: process.cwd(),
+    hasUI: true,
+    ui: { confirm: async () => true },
+    modelRegistry: {},
+    model: undefined,
+    signal: undefined,
+    ...overrides,
+  } as any;
+}
+
+describe("initializeMcp elicitation config", () => {
+  const originalHome = process.env.HOME;
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+  });
+
+  it("enables elicitation by default when a trusted UI exists", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const configPath = writeConfig({ mcpServers: {} });
+    const ui = { confirm: async () => true };
+
+    const state = await initializeMcp(createPi(configPath), createContext({ ui }));
+
+    expect((state.manager as any).elicitationConfig).toEqual({
+      ui,
+      timeoutMs: undefined,
+    });
+  });
+
+  it("passes through custom elicitation timeout settings", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const configPath = writeConfig({
+      settings: { elicitationTimeoutMs: 120000 },
+      mcpServers: {},
+    });
+
+    const state = await initializeMcp(createPi(configPath), createContext());
+
+    expect((state.manager as any).elicitationConfig.timeoutMs).toBe(120000);
+  });
+
+  it("does not enable elicitation when disabled by settings", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const configPath = writeConfig({
+      settings: { elicitation: false },
+      mcpServers: {},
+    });
+
+    const state = await initializeMcp(createPi(configPath), createContext());
+
+    expect((state.manager as any).elicitationConfig).toBeUndefined();
+  });
+
+  it("does not enable elicitation without a trusted UI", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const configPath = writeConfig({ mcpServers: {} });
+
+    const state = await initializeMcp(createPi(configPath), createContext({ hasUI: false, ui: undefined }));
+
+    expect((state.manager as any).elicitationConfig).toBeUndefined();
+  });
+});

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -77,6 +77,56 @@ describe("McpServerManager sampling", () => {
     );
   });
 
+  it("advertises elicitation and registers the handler before connecting", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setElicitationConfig({
+      ui: {} as any,
+      timeoutMs: 300000,
+    });
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    const client = mocks.clients[0];
+    expect(client.options).toEqual({ capabilities: { elicitation: { form: {} } } });
+    expect(client.setRequestHandler).toHaveBeenCalledTimes(1);
+    expect(client.setRequestHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      client.connect.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("advertises sampling and elicitation together when both configs are set", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setSamplingConfig({
+      autoApprove: true,
+      modelRegistry: {} as any,
+      getCurrentModel: () => undefined,
+      getSignal: () => undefined,
+    });
+    manager.setElicitationConfig({
+      ui: {} as any,
+      timeoutMs: 300000,
+    });
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    const client = mocks.clients[0];
+    expect(client.options).toEqual({
+      capabilities: {
+        sampling: {},
+        elicitation: { form: {} },
+      },
+    });
+    expect(client.setRequestHandler).toHaveBeenCalledTimes(2);
+    expect(client.setRequestHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      client.connect.mock.invocationCallOrder[0],
+    );
+    expect(client.setRequestHandler.mock.invocationCallOrder[1]).toBeLessThan(
+      client.connect.mock.invocationCallOrder[0],
+    );
+  });
+
   it("does not advertise sampling when no sampling config is set", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -1,0 +1,347 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  ElicitRequestSchema,
+  type ElicitRequest,
+  type ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import { formatSchema } from "./tool-metadata.ts";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const TIMEOUT = Symbol("timeout");
+const UI_FAILURE = Symbol("ui-failure");
+
+export interface ElicitationHandlerOptions {
+  serverName: string;
+  ui?: ExtensionUIContext;
+  timeoutMs?: number;
+}
+
+export type ServerElicitationConfig = Omit<ElicitationHandlerOptions, "serverName">;
+
+interface ElicitationSchema {
+  type?: unknown;
+  properties?: unknown;
+  required?: unknown;
+}
+
+interface PropertySchema {
+  type?: unknown;
+  description?: unknown;
+  default?: unknown;
+  enum?: unknown;
+  enumNames?: unknown;
+  minimum?: unknown;
+  maximum?: unknown;
+  minLength?: unknown;
+  maxLength?: unknown;
+}
+
+interface FieldSpec {
+  name: string;
+  schema: PropertySchema;
+  required: boolean;
+  type: "string" | "number" | "integer" | "boolean";
+  enumValues?: string[];
+  enumNames?: string[];
+}
+
+type ElicitationValue = string | number | boolean | string[];
+type ElicitationContent = Record<string, ElicitationValue>;
+
+export function registerElicitationHandler(client: Client, options: ElicitationHandlerOptions): void {
+  client.setRequestHandler(ElicitRequestSchema, (request) => {
+    return handleElicitationRequest(options, request as ElicitRequest);
+  });
+}
+
+export async function handleElicitationRequest(
+  options: ElicitationHandlerOptions,
+  request: ElicitRequest,
+): Promise<ElicitResult> {
+  const params = request.params as ElicitRequest["params"] & {
+    mode?: string;
+    requestedSchema?: unknown;
+  };
+
+  if (params.mode && params.mode !== "form") {
+    return { action: "cancel" };
+  }
+  if (!options.ui) {
+    return { action: "cancel" };
+  }
+
+  const schema = parseObjectSchema(params.requestedSchema);
+  if (!schema) {
+    return { action: "cancel" };
+  }
+
+  const fields = getFieldSpecs(schema);
+  if (!fields) {
+    return { action: "cancel" };
+  }
+
+  const approved = await callTrustedUi(
+    options,
+    () => options.ui!.confirm(
+      `MCP request from ${options.serverName}`,
+      formatInitialApproval(options.serverName, params.message, schema),
+      dialogOptions(options),
+    ),
+  );
+  if (approved === TIMEOUT || approved === UI_FAILURE) return { action: "cancel" };
+  if (approved === undefined) return { action: "cancel" };
+  if (!approved) return { action: "decline" };
+
+  const content: ElicitationContent = {};
+  for (const field of fields) {
+    const value = await collectFieldValue(options, field);
+    if (value === TIMEOUT || value === UI_FAILURE) return { action: "cancel" };
+    if (value === undefined) {
+      if (field.required) return { action: "cancel" };
+      continue;
+    }
+    content[field.name] = value;
+  }
+
+  if (!validateContent(fields, content)) {
+    return { action: "cancel" };
+  }
+
+  const finalApproval = await callTrustedUi(
+    options,
+    () => options.ui!.confirm(
+      `Return MCP response to ${options.serverName}`,
+      `The MCP server will receive:\n\n${JSON.stringify(content, null, 2)}`,
+      dialogOptions(options),
+    ),
+  );
+  if (finalApproval === TIMEOUT || finalApproval === UI_FAILURE) return { action: "cancel" };
+  if (finalApproval === undefined) return { action: "cancel" };
+  if (!finalApproval) return { action: "decline" };
+
+  return { action: "accept", content };
+}
+
+function parseObjectSchema(schema: unknown): ElicitationSchema | null {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return null;
+  const objectSchema = schema as ElicitationSchema;
+  if (objectSchema.type !== "object") return null;
+  if (
+    objectSchema.properties !== undefined
+    && (typeof objectSchema.properties !== "object" || objectSchema.properties === null || Array.isArray(objectSchema.properties))
+  ) {
+    return null;
+  }
+  if (objectSchema.required !== undefined && !Array.isArray(objectSchema.required)) {
+    return null;
+  }
+  return objectSchema;
+}
+
+function getFieldSpecs(schema: ElicitationSchema): FieldSpec[] | null {
+  const properties = (schema.properties ?? {}) as Record<string, unknown>;
+  const required = Array.isArray(schema.required) ? schema.required.filter((value): value is string => typeof value === "string") : [];
+  const fields: FieldSpec[] = [];
+
+  for (const [name, rawProperty] of Object.entries(properties)) {
+    const property = parsePropertySchema(rawProperty);
+    const isRequired = required.includes(name);
+    if (!property) {
+      if (isRequired) return null;
+      continue;
+    }
+    fields.push({ name, required: isRequired, ...property });
+  }
+
+  for (const requiredName of required) {
+    if (!Object.prototype.hasOwnProperty.call(properties, requiredName)) {
+      return null;
+    }
+  }
+
+  return fields;
+}
+
+function parsePropertySchema(schema: unknown): Omit<FieldSpec, "name" | "required"> | null {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return null;
+  const property = schema as PropertySchema;
+  const enumValues = Array.isArray(property.enum)
+    ? property.enum.filter((value): value is string => typeof value === "string")
+    : undefined;
+  const enumNames = Array.isArray(property.enumNames)
+    ? property.enumNames.filter((value): value is string => typeof value === "string")
+    : undefined;
+
+  if (enumValues && enumValues.length > 0) {
+    if (property.type !== undefined && property.type !== "string") return null;
+    return {
+      schema: property,
+      type: "string",
+      enumValues,
+      enumNames: enumNames && enumNames.length === enumValues.length ? enumNames : undefined,
+    };
+  }
+
+  if (property.type === "string" || property.type === "number" || property.type === "integer" || property.type === "boolean") {
+    return { schema: property, type: property.type };
+  }
+
+  return null;
+}
+
+async function collectFieldValue(options: ElicitationHandlerOptions, field: FieldSpec): Promise<ElicitationValue | undefined | typeof TIMEOUT | typeof UI_FAILURE> {
+  if (field.enumValues) {
+    return collectEnumValue(options, field);
+  }
+  if (field.type === "boolean") {
+    return collectBooleanValue(options, field);
+  }
+  return collectInputValue(options, field);
+}
+
+async function collectEnumValue(options: ElicitationHandlerOptions, field: FieldSpec): Promise<string | undefined | typeof TIMEOUT | typeof UI_FAILURE> {
+  const choices = field.enumNames ?? field.enumValues!;
+  const selected = await callTrustedUi(
+    options,
+    () => (options.ui! as any).select(
+      fieldTitle(field),
+      choices,
+      dialogOptions(options),
+    ),
+  );
+  if (selected === TIMEOUT) return TIMEOUT;
+  if (selected === UI_FAILURE) return UI_FAILURE;
+  if (typeof selected !== "string") return undefined;
+  const index = choices.indexOf(selected);
+  return index >= 0 ? field.enumValues![index] : undefined;
+}
+
+async function collectBooleanValue(options: ElicitationHandlerOptions, field: FieldSpec): Promise<boolean | undefined | typeof TIMEOUT | typeof UI_FAILURE> {
+  const selected = await callTrustedUi(
+    options,
+    () => (options.ui! as any).select(
+      fieldTitle(field),
+      ["true", "false"],
+      dialogOptions(options),
+    ),
+  );
+  if (selected === TIMEOUT) return TIMEOUT;
+  if (selected === UI_FAILURE) return UI_FAILURE;
+  if (selected === "true") return true;
+  if (selected === "false") return false;
+  return undefined;
+}
+
+async function collectInputValue(options: ElicitationHandlerOptions, field: FieldSpec): Promise<ElicitationValue | undefined | typeof TIMEOUT | typeof UI_FAILURE> {
+  const answer = await callTrustedUi(
+    options,
+    () => (options.ui! as any).input(
+      fieldTitle(field),
+      inputPlaceholder(field),
+      dialogOptions(options),
+    ),
+  );
+  if (answer === TIMEOUT) return TIMEOUT;
+  if (answer === UI_FAILURE) return UI_FAILURE;
+  if (typeof answer !== "string") return undefined;
+  if (answer === "" && field.schema.default !== undefined) return defaultValue(field);
+  if (field.type === "string") return answer;
+
+  const parsed = Number(answer);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (field.type === "integer" && !Number.isInteger(parsed)) return undefined;
+  return parsed;
+}
+
+async function callTrustedUi<T>(
+  options: ElicitationHandlerOptions,
+  fn: () => Promise<T>,
+): Promise<T | typeof TIMEOUT | typeof UI_FAILURE> {
+  const timeoutMs = timeoutMsForOptions(options);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<typeof TIMEOUT>((resolve) => {
+        timeout = setTimeout(() => resolve(TIMEOUT), timeoutMs);
+      }),
+    ]);
+  } catch {
+    return UI_FAILURE;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function validateContent(fields: FieldSpec[], content: ElicitationContent): boolean {
+  for (const field of fields) {
+    if (!Object.prototype.hasOwnProperty.call(content, field.name)) {
+      if (field.required) return false;
+      continue;
+    }
+    if (!validateFieldValue(field, content[field.name])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validateFieldValue(field: FieldSpec, value: unknown): boolean {
+  if (field.enumValues) {
+    return typeof value === "string" && field.enumValues.includes(value);
+  }
+  if (field.type === "boolean") {
+    return typeof value === "boolean";
+  }
+  if (field.type === "string") {
+    if (typeof value !== "string") return false;
+    if (typeof field.schema.minLength === "number" && value.length < field.schema.minLength) return false;
+    if (typeof field.schema.maxLength === "number" && value.length > field.schema.maxLength) return false;
+    return true;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) return false;
+  if (field.type === "integer" && !Number.isInteger(value)) return false;
+  if (typeof field.schema.minimum === "number" && value < field.schema.minimum) return false;
+  if (typeof field.schema.maximum === "number" && value > field.schema.maximum) return false;
+  return true;
+}
+
+function defaultValue(field: FieldSpec): ElicitationValue | undefined {
+  const value = field.schema.default;
+  if (field.type === "string") return typeof value === "string" ? value : undefined;
+  if (field.type === "number") return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  if (field.type === "integer") return typeof value === "number" && Number.isInteger(value) ? value : undefined;
+  if (field.type === "boolean") return typeof value === "boolean" ? value : undefined;
+  return undefined;
+}
+
+function dialogOptions(options: ElicitationHandlerOptions): { timeout: number } {
+  return { timeout: timeoutMsForOptions(options) };
+}
+
+function formatInitialApproval(serverName: string, message: string, schema: ElicitationSchema): string {
+  return `${serverName} is requesting user input:\n\n${message}\n\nRequested fields:\n${formatSchema(schema)}`;
+}
+
+function fieldTitle(field: FieldSpec): string {
+  return `${field.name}${field.required ? " (required)" : ""}`;
+}
+
+function inputPlaceholder(field: FieldSpec): string {
+  if (typeof field.schema.description === "string") {
+    return field.schema.description;
+  }
+  return defaultText(field.schema.default) || "";
+}
+
+function defaultText(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return undefined;
+}
+
+function timeoutMsForOptions(options: ElicitationHandlerOptions): number {
+  return typeof options.timeoutMs === "number" && options.timeoutMs > 0 ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+}

--- a/init.ts
+++ b/init.ts
@@ -43,6 +43,14 @@ export async function initializeMcp(
       getSignal: () => ctx.signal,
     });
   }
+  if (config.settings?.elicitation !== false && ctx.hasUI) {
+    manager.setElicitationConfig({
+      ui: ctx.ui,
+      timeoutMs: typeof config.settings?.elicitationTimeoutMs === "number"
+        ? config.settings.elicitationTimeoutMs
+        : undefined,
+    });
+  }
   const lifecycle = new McpLifecycleManager(manager);
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const failureTracker = new Map<string, number>();

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "config.ts",
     "server-manager.ts",
     "sampling-handler.ts",
+    "elicitation-handler.ts",
     "tool-registrar.ts",
     "tool-result-renderer.ts",
     "resource-tools.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -17,6 +17,7 @@ import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth } from "./mcp-auth-flow.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
+import { registerElicitationHandler, type ServerElicitationConfig } from "./elicitation-handler.ts";
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
 
 interface ServerConnection {
@@ -37,9 +38,14 @@ export class McpServerManager {
   private connectPromises = new Map<string, Promise<ServerConnection>>();
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
+  private elicitationConfig: ServerElicitationConfig | undefined;
 
   setSamplingConfig(config: ServerSamplingConfig | undefined): void {
     this.samplingConfig = config;
+  }
+
+  setElicitationConfig(config: ServerElicitationConfig | undefined): void {
+    this.elicitationConfig = config;
   }
   
   async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
@@ -149,14 +155,29 @@ export class McpServerManager {
   }
   
   private createClient(serverName: string): Client {
+    const capabilities = this.createClientCapabilities();
     const client = new Client(
       { name: `pi-mcp-${serverName}`, version: "1.0.0" },
-      this.samplingConfig ? { capabilities: { sampling: {} } } : undefined,
+      capabilities ? { capabilities } : undefined,
     );
     if (this.samplingConfig) {
       registerSamplingHandler(client, { ...this.samplingConfig, serverName });
     }
+    if (this.elicitationConfig) {
+      registerElicitationHandler(client, { ...this.elicitationConfig, serverName });
+    }
     return client;
+  }
+
+  private createClientCapabilities(): Record<string, unknown> | undefined {
+    const capabilities: Record<string, unknown> = {};
+    if (this.samplingConfig) {
+      capabilities.sampling = {};
+    }
+    if (this.elicitationConfig) {
+      capabilities.elicitation = { form: {} };
+    }
+    return Object.keys(capabilities).length > 0 ? capabilities : undefined;
   }
 
   private async createHttpTransport(

--- a/types.ts
+++ b/types.ts
@@ -326,6 +326,8 @@ export interface McpSettings {
   autoAuth?: boolean;
   sampling?: boolean;
   samplingAutoApprove?: boolean;
+  elicitation?: boolean;
+  elicitationTimeoutMs?: number;
   /**
    * Message returned in tool results when a server needs (re-)authentication.
    * "${server}" is substituted with the server name. Defaults to a TUI


### PR DESCRIPTION
Superseded by #132.

This earlier branch is stale against current `main` after upstream merged and released MCP elicitation support. The remaining useful hardening work is now carried in #132.