### PR TITLE
Add MCP elicitation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,14 @@ For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact c
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
 | `samplingAutoApprove` | Skip sampling confirmation prompts. Required for sampling in non-UI sessions (default: false). |
+| `elicitation` | Allow MCP servers to request user input through Pi UI forms/URL prompts (default: true when Pi UI form support is available). |
+| `elicitationAutoOpenUrls` | Automatically open URL elicitations without prompting first (default: false). |
 
 Per-server `idleTimeout` overrides the global setting.
+
+### MCP Elicitation
+
+When Pi exposes UI, the adapter advertises MCP elicitation support. Form elicitations are rendered with `ctx.ui.form()` and map Pi actions to MCP actions: submit → `accept`, secondary → `decline`, cancel → `cancel`. URL elicitations prompt before opening a browser unless `elicitationAutoOpenUrls` is enabled.
 
 ### Direct Tools
 

--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ElicitRequest } from "@modelcontextprotocol/sdk/types.js";
+
+const mocks = vi.hoisted(() => ({
+  open: vi.fn(async () => undefined),
+}));
+
+vi.mock("open", () => ({ default: mocks.open }));
+
+function formRequest(params: ElicitRequest["params"]): ElicitRequest {
+  return { method: "elicitation/create", params } as ElicitRequest;
+}
+
+describe("elicitation handler", () => {
+  it("converts form elicitation schemas to Pi forms and returns accepted content", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => ({
+        action: "submit",
+        values: {
+          title: "Bug in auth flow",
+          priority: "medium",
+          assignToMe: true,
+        },
+      })),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "github", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "form",
+        message: "Create a new issue",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              title: "Title",
+              description: "Issue title",
+              minLength: 1,
+            },
+            priority: {
+              type: "string",
+              title: "Priority",
+              enum: ["low", "medium", "high"],
+              default: "medium",
+            },
+            assignToMe: {
+              type: "boolean",
+              title: "Assign to me",
+              default: false,
+            },
+          },
+          required: ["title"],
+        },
+      }),
+    );
+
+    expect(ui.form).toHaveBeenCalledWith({
+      title: "MCP Input Request",
+      message: "Server: github\n\nCreate a new issue",
+      submitLabel: "Submit",
+      secondaryLabel: "Decline",
+      cancelLabel: "Cancel",
+      fields: [
+        {
+          type: "text",
+          name: "title",
+          label: "Title",
+          description: "Issue title",
+          required: true,
+          minLength: 1,
+        },
+        {
+          type: "select",
+          name: "priority",
+          label: "Priority",
+          required: false,
+          options: [
+            { value: "low" },
+            { value: "medium" },
+            { value: "high" },
+          ],
+          defaultValue: "medium",
+        },
+        {
+          type: "boolean",
+          name: "assignToMe",
+          label: "Assign to me",
+          defaultValue: false,
+        },
+      ],
+    });
+    expect(result).toEqual({
+      action: "accept",
+      content: {
+        title: "Bug in auth flow",
+        priority: "medium",
+        assignToMe: true,
+      },
+    });
+  });
+
+  it("shows URL elicitations as a Pi form and opens accepted URLs", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => ({ action: "submit", values: {} })),
+      notify: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "stripe", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "url",
+        message: "Confirm payment authorization",
+        elicitationId: "elicit_123",
+        url: "https://checkout.stripe.com/c/pay/cs_test_123",
+      }),
+    );
+
+    expect(ui.form).toHaveBeenCalledWith({
+      title: "MCP Browser Request",
+      message: [
+        "Server: stripe",
+        "",
+        "Confirm payment authorization",
+        "",
+        "Domain: checkout.stripe.com",
+        "URL: https://checkout.stripe.com/c/pay/cs_test_123",
+        "",
+        "Open this URL in your browser?",
+      ].join("\n"),
+      fields: [],
+      submitLabel: "Open",
+      secondaryLabel: "Decline",
+      cancelLabel: "Cancel",
+    });
+    expect(mocks.open).toHaveBeenCalledWith("https://checkout.stripe.com/c/pay/cs_test_123");
+    expect(ui.notify).toHaveBeenCalledWith("Opened browser for MCP elicitation.", "info");
+    expect(result).toEqual({ action: "accept" });
+  });
+
+  it("maps Pi secondary and cancel form actions to MCP decline and cancel", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const makeRequest = () =>
+      formRequest({
+        mode: "form",
+        message: "Continue?",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            reason: { type: "string", title: "Reason" },
+          },
+        },
+      });
+
+    const declineUi = { form: vi.fn(async () => ({ action: "secondary" })) };
+    const cancelUi = { form: vi.fn(async () => ({ action: "cancel" })) };
+
+    await expect(
+      handleElicitationRequest({ serverName: "demo", ui: declineUi as any, autoOpenUrls: false }, makeRequest()),
+    ).resolves.toEqual({ action: "decline" });
+    await expect(
+      handleElicitationRequest({ serverName: "demo", ui: cancelUi as any, autoOpenUrls: false }, makeRequest()),
+    ).resolves.toEqual({ action: "cancel" });
+  });
+});

--- a/__tests__/init-elicitation.test.ts
+++ b/__tests__/init-elicitation.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadMcpConfig: vi.fn(),
+  managers: [] as any[],
+}));
+
+vi.mock("../config.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config.ts")>()),
+  loadMcpConfig: mocks.loadMcpConfig,
+}));
+
+vi.mock("../server-manager.ts", () => ({
+  McpServerManager: vi.fn().mockImplementation(function (this: any) {
+    this.setSamplingConfig = vi.fn();
+    this.setElicitationConfig = vi.fn();
+    this.getConnection = vi.fn();
+    this.connect = vi.fn();
+    mocks.managers.push(this);
+  }),
+}));
+
+describe("initializeMcp elicitation config", () => {
+  beforeEach(() => {
+    mocks.managers.length = 0;
+    mocks.loadMcpConfig.mockReturnValue({ mcpServers: {}, settings: {} });
+  });
+
+  it("enables elicitation when UI is available", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { form: vi.fn(), confirm: vi.fn(), notify: vi.fn() };
+
+    await initializeMcp({ getFlag: vi.fn() } as any, {
+      cwd: "/tmp/project",
+      hasUI: true,
+      ui,
+      modelRegistry: {},
+    } as any);
+
+    expect(mocks.managers[0].setElicitationConfig).toHaveBeenCalledWith({
+      ui,
+      autoOpenUrls: false,
+    });
+  });
+
+  it("does not enable elicitation without UI or when disabled in settings", async () => {
+    const { initializeMcp } = await import("../init.ts");
+
+    await initializeMcp({ getFlag: vi.fn() } as any, {
+      cwd: "/tmp/project",
+      hasUI: false,
+      modelRegistry: {},
+    } as any);
+    expect(mocks.managers[0].setElicitationConfig).not.toHaveBeenCalled();
+
+    mocks.loadMcpConfig.mockReturnValue({ mcpServers: {}, settings: { elicitation: false } });
+    await initializeMcp({ getFlag: vi.fn() } as any, {
+      cwd: "/tmp/project",
+      hasUI: true,
+      ui: { form: vi.fn() },
+      modelRegistry: {},
+    } as any);
+    expect(mocks.managers[1].setElicitationConfig).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -77,6 +77,59 @@ describe("McpServerManager sampling", () => {
     );
   });
 
+  it("advertises elicitation capabilities and registers the handler before connecting", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setElicitationConfig({
+      autoOpenUrls: false,
+      ui: {} as any,
+    });
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    const client = mocks.clients[0];
+    expect(client.options).toEqual({
+      capabilities: {
+        elicitation: {
+          form: { applyDefaults: true },
+          url: {},
+        },
+      },
+    });
+    expect(client.setRequestHandler).toHaveBeenCalledTimes(1);
+    expect(client.setRequestHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      client.connect.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("advertises sampling and elicitation together", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setSamplingConfig({
+      autoApprove: true,
+      modelRegistry: {} as any,
+      getCurrentModel: () => undefined,
+      getSignal: () => undefined,
+    });
+    manager.setElicitationConfig({
+      autoOpenUrls: false,
+      ui: {} as any,
+    });
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    expect(mocks.clients[0].options).toEqual({
+      capabilities: {
+        sampling: {},
+        elicitation: {
+          form: { applyDefaults: true },
+          url: {},
+        },
+      },
+    });
+    expect(mocks.clients[0].setRequestHandler).toHaveBeenCalledTimes(2);
+  });
+
   it("does not advertise sampling when no sampling config is set", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -1,0 +1,352 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  ElicitRequestSchema,
+  type ElicitRequest,
+  type ElicitRequestFormParams,
+  type ElicitRequestURLParams,
+  type ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import open from "open";
+
+export type ExtensionUIFormValue = string | number | boolean | string[] | undefined;
+
+export interface ExtensionUIFormSelectOption {
+  value: string;
+  label?: string;
+  description?: string;
+}
+
+export type ExtensionUIFormField =
+  | {
+      type: "text";
+      name: string;
+      label: string;
+      description?: string;
+      placeholder?: string;
+      required?: boolean;
+      defaultValue?: string;
+      minLength?: number;
+      maxLength?: number;
+      pattern?: string;
+    }
+  | {
+      type: "number" | "integer";
+      name: string;
+      label: string;
+      description?: string;
+      required?: boolean;
+      defaultValue?: number;
+      minimum?: number;
+      maximum?: number;
+    }
+  | {
+      type: "boolean";
+      name: string;
+      label: string;
+      description?: string;
+      defaultValue?: boolean;
+    }
+  | {
+      type: "select";
+      name: string;
+      label: string;
+      description?: string;
+      required?: boolean;
+      options: ExtensionUIFormSelectOption[];
+      defaultValue?: string;
+    }
+  | {
+      type: "multiSelect";
+      name: string;
+      label: string;
+      description?: string;
+      required?: boolean;
+      options: ExtensionUIFormSelectOption[];
+      defaultValue?: string[];
+    };
+
+export interface ExtensionUIFormRequest {
+  title: string;
+  message?: string;
+  fields: ExtensionUIFormField[];
+  submitLabel?: string;
+  secondaryLabel?: string;
+  cancelLabel?: string;
+}
+
+export type ExtensionUIFormResult =
+  | { action: "submit"; values: Record<string, ExtensionUIFormValue> }
+  | { action: "secondary" }
+  | { action: "cancel" };
+
+export interface ElicitationUIContext extends ExtensionUIContext {
+  form(request: ExtensionUIFormRequest): Promise<ExtensionUIFormResult>;
+}
+
+export interface ElicitationHandlerOptions {
+  serverName: string;
+  ui: ElicitationUIContext;
+  autoOpenUrls: boolean;
+}
+
+export type ServerElicitationConfig = Omit<ElicitationHandlerOptions, "serverName">;
+
+export function registerElicitationHandler(client: Client, options: ElicitationHandlerOptions): void {
+  client.setRequestHandler(ElicitRequestSchema, (request) => {
+    return handleElicitationRequest(options, request as ElicitRequest);
+  });
+}
+
+export async function handleElicitationRequest(
+  options: ElicitationHandlerOptions,
+  request: ElicitRequest,
+): Promise<ElicitResult> {
+  const params = request.params;
+  if (params.mode === "url") {
+    return handleUrlElicitation(options, params);
+  }
+  return handleFormElicitation(options, params);
+}
+
+export async function handleFormElicitation(
+  options: ElicitationHandlerOptions,
+  params: ElicitRequestFormParams,
+): Promise<ElicitResult> {
+  const form = convertMcpSchemaToPiForm(options.serverName, params);
+  const result = await options.ui.form(form);
+  if (result.action !== "submit") {
+    return convertPiFormResultToMcpResult(result);
+  }
+  return {
+    action: "accept",
+    content: coerceAndValidateFormValues(params, result.values),
+  };
+}
+
+export async function handleUrlElicitation(
+  options: ElicitationHandlerOptions,
+  params: ElicitRequestURLParams,
+): Promise<ElicitResult> {
+  if (!options.autoOpenUrls) {
+    const result = await options.ui.form({
+      title: "MCP Browser Request",
+      message: [
+        `Server: ${options.serverName}`,
+        "",
+        params.message,
+        "",
+        `Domain: ${safeUrlHost(params.url)}`,
+        `URL: ${params.url}`,
+        "",
+        "Open this URL in your browser?",
+      ].join("\n"),
+      fields: [],
+      submitLabel: "Open",
+      secondaryLabel: "Decline",
+      cancelLabel: "Cancel",
+    });
+    if (result.action === "secondary") return { action: "decline" };
+    if (result.action === "cancel") return { action: "cancel" };
+  }
+
+  await open(params.url);
+  options.ui.notify("Opened browser for MCP elicitation.", "info");
+  return { action: "accept" };
+}
+
+export function convertMcpSchemaToPiForm(
+  serverName: string,
+  params: ElicitRequestFormParams,
+): ExtensionUIFormRequest {
+  const required = new Set(params.requestedSchema.required ?? []);
+  return {
+    title: "MCP Input Request",
+    message: `Server: ${serverName}\n\n${params.message}`,
+    submitLabel: "Submit",
+    secondaryLabel: "Decline",
+    cancelLabel: "Cancel",
+    fields: Object.entries(params.requestedSchema.properties).map(([name, schema]): ExtensionUIFormField => {
+      const label = schema.title ?? humanizeName(name);
+      const base = {
+        name,
+        label,
+        description: schema.description,
+        required: required.has(name),
+      };
+
+      if (schema.type === "string" && "oneOf" in schema && Array.isArray(schema.oneOf)) {
+        return omitUndefined({
+          ...base,
+          type: "select" as const,
+          options: schema.oneOf.map((option) => ({ value: option.const, label: option.title })),
+          defaultValue: schema.default,
+        });
+      }
+
+      if (schema.type === "string" && "enum" in schema && Array.isArray(schema.enum)) {
+        const enumNames = "enumNames" in schema && Array.isArray(schema.enumNames) ? schema.enumNames : undefined;
+        return omitUndefined({
+          ...base,
+          type: "select" as const,
+          options: schema.enum.map((value, index) => omitUndefined({ value, label: enumNames?.[index] })),
+          defaultValue: schema.default,
+        });
+      }
+
+      if (schema.type === "array") {
+        return omitUndefined({
+          ...base,
+          type: "multiSelect" as const,
+          options: extractMultiSelectOptions(schema),
+          defaultValue: schema.default,
+        });
+      }
+
+      if (schema.type === "number" || schema.type === "integer") {
+        return omitUndefined({
+          ...base,
+          type: schema.type,
+          defaultValue: schema.default,
+          minimum: schema.minimum,
+          maximum: schema.maximum,
+        });
+      }
+
+      if (schema.type === "boolean") {
+        return omitUndefined({
+          type: "boolean" as const,
+          name,
+          label,
+          description: schema.description,
+          defaultValue: schema.default,
+        });
+      }
+
+      const stringSchema = schema as { default?: string; minLength?: number; maxLength?: number };
+      return omitUndefined({
+        ...base,
+        type: "text" as const,
+        defaultValue: stringSchema.default,
+        minLength: stringSchema.minLength,
+        maxLength: stringSchema.maxLength,
+      });
+    }),
+  };
+}
+
+export function convertPiFormResultToMcpResult(result: ExtensionUIFormResult): ElicitResult {
+  if (result.action === "secondary") return { action: "decline" };
+  if (result.action === "cancel") return { action: "cancel" };
+  return { action: "accept", content: stripUndefined(result.values) as ElicitResult["content"] };
+}
+
+export function coerceAndValidateFormValues(
+  params: ElicitRequestFormParams,
+  values: Record<string, ExtensionUIFormValue>,
+): Record<string, string | number | boolean | string[]> {
+  const output: Record<string, string | number | boolean | string[]> = {};
+  const required = new Set(params.requestedSchema.required ?? []);
+
+  for (const [name, schema] of Object.entries(params.requestedSchema.properties)) {
+    const raw = values[name] ?? schema.default;
+    if (raw === undefined || raw === "") {
+      if (required.has(name)) throw new Error(`Missing required elicitation field: ${name}`);
+      continue;
+    }
+
+    if (schema.type === "string") {
+      const stringSchema = schema as { minLength?: number; maxLength?: number };
+      const value = String(raw);
+      if (stringSchema.minLength !== undefined && value.length < stringSchema.minLength) {
+        throw new Error(`Elicitation field ${name} is shorter than minimum length ${stringSchema.minLength}`);
+      }
+      if (stringSchema.maxLength !== undefined && value.length > stringSchema.maxLength) {
+        throw new Error(`Elicitation field ${name} is longer than maximum length ${stringSchema.maxLength}`);
+      }
+      if ("enum" in schema && Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+        throw new Error(`Elicitation field ${name} is not an allowed value`);
+      }
+      if ("oneOf" in schema && Array.isArray(schema.oneOf) && !schema.oneOf.some((option) => option.const === value)) {
+        throw new Error(`Elicitation field ${name} is not an allowed value`);
+      }
+      output[name] = value;
+      continue;
+    }
+
+    if (schema.type === "number" || schema.type === "integer") {
+      const value = typeof raw === "number" ? raw : Number(raw);
+      if (!Number.isFinite(value)) throw new Error(`Elicitation field ${name} must be a number`);
+      if (schema.type === "integer" && !Number.isInteger(value)) throw new Error(`Elicitation field ${name} must be an integer`);
+      if (schema.minimum !== undefined && value < schema.minimum) {
+        throw new Error(`Elicitation field ${name} is below minimum ${schema.minimum}`);
+      }
+      if (schema.maximum !== undefined && value > schema.maximum) {
+        throw new Error(`Elicitation field ${name} is above maximum ${schema.maximum}`);
+      }
+      output[name] = value;
+      continue;
+    }
+
+    if (schema.type === "boolean") {
+      output[name] = typeof raw === "boolean" ? raw : raw === "true";
+      continue;
+    }
+
+    if (schema.type === "array") {
+      if (!Array.isArray(raw)) throw new Error(`Elicitation field ${name} must be a list`);
+      const allowed = new Set(extractMultiSelectOptions(schema).map((option) => option.value));
+      const value = raw.map(String);
+      if (schema.minItems !== undefined && value.length < schema.minItems) {
+        throw new Error(`Elicitation field ${name} has fewer than ${schema.minItems} selections`);
+      }
+      if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+        throw new Error(`Elicitation field ${name} has more than ${schema.maxItems} selections`);
+      }
+      for (const item of value) {
+        if (!allowed.has(item)) throw new Error(`Elicitation field ${name} contains an invalid selection`);
+      }
+      output[name] = value;
+    }
+  }
+
+  return output;
+}
+
+function extractMultiSelectOptions(schema: Extract<ElicitRequestFormParams["requestedSchema"]["properties"][string], { type: "array" }>): ExtensionUIFormSelectOption[] {
+  const items = schema.items as { enum?: string[]; anyOf?: Array<{ const: string; title: string }> };
+  if (Array.isArray(items.anyOf)) {
+    return items.anyOf.map((option) => ({ value: option.const, label: option.title }));
+  }
+  return (items.enum ?? []).map((value) => ({ value }));
+}
+
+function humanizeName(name: string): string {
+  return name
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function safeUrlHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "unknown";
+  }
+}
+
+function stripUndefined(values: Record<string, ExtensionUIFormValue>): Record<string, string | number | boolean | string[]> {
+  const output: Record<string, string | number | boolean | string[]> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) output[key] = value;
+  }
+  return output;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) delete value[key];
+  }
+  return value;
+}

--- a/init.ts
+++ b/init.ts
@@ -43,6 +43,16 @@ export async function initializeMcp(
       getSignal: () => ctx.signal,
     });
   }
+  const elicitationEnabled =
+    config.settings?.elicitation !== false &&
+    ctx.hasUI &&
+    typeof (ctx.ui as { form?: unknown }).form === "function";
+  if (elicitationEnabled) {
+    manager.setElicitationConfig({
+      ui: ctx.ui as any,
+      autoOpenUrls: config.settings?.elicitationAutoOpenUrls === true,
+    });
+  }
   const lifecycle = new McpLifecycleManager(manager);
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const failureTracker = new Map<string, number>();

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "config.ts",
     "server-manager.ts",
     "sampling-handler.ts",
+    "elicitation-handler.ts",
     "tool-registrar.ts",
     "tool-result-renderer.ts",
     "resource-tools.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -17,6 +17,7 @@ import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth } from "./mcp-auth-flow.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
+import { registerElicitationHandler, type ServerElicitationConfig } from "./elicitation-handler.ts";
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
 
 interface ServerConnection {
@@ -37,9 +38,14 @@ export class McpServerManager {
   private connectPromises = new Map<string, Promise<ServerConnection>>();
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
+  private elicitationConfig: ServerElicitationConfig | undefined;
 
   setSamplingConfig(config: ServerSamplingConfig | undefined): void {
     this.samplingConfig = config;
+  }
+
+  setElicitationConfig(config: ServerElicitationConfig | undefined): void {
+    this.elicitationConfig = config;
   }
   
   async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
@@ -148,13 +154,31 @@ export class McpServerManager {
     }
   }
   
+  private buildClientCapabilities() {
+    return {
+      ...(this.samplingConfig ? { sampling: {} } : {}),
+      ...(this.elicitationConfig
+        ? {
+            elicitation: {
+              form: { applyDefaults: true },
+              url: {},
+            },
+          }
+        : {}),
+    };
+  }
+
   private createClient(serverName: string): Client {
+    const capabilities = this.buildClientCapabilities();
     const client = new Client(
       { name: `pi-mcp-${serverName}`, version: "1.0.0" },
-      this.samplingConfig ? { capabilities: { sampling: {} } } : undefined,
+      Object.keys(capabilities).length > 0 ? { capabilities } : undefined,
     );
     if (this.samplingConfig) {
       registerSamplingHandler(client, { ...this.samplingConfig, serverName });
+    }
+    if (this.elicitationConfig) {
+      registerElicitationHandler(client, { ...this.elicitationConfig, serverName });
     }
     return client;
   }

--- a/types.ts
+++ b/types.ts
@@ -326,6 +326,8 @@ export interface McpSettings {
   autoAuth?: boolean;
   sampling?: boolean;
   samplingAutoApprove?: boolean;
+  elicitation?: boolean;
+  elicitationAutoOpenUrls?: boolean;
   /**
    * Message returned in tool results when a server needs (re-)authentication.
    * "${server}" is substituted with the server name. Defaults to a TUI


### PR DESCRIPTION
## Summary

- Adds MCP elicitation support for `elicitation/create` form and URL requests.
- Advertises elicitation client capabilities only when Pi UI form support is available.
- Converts MCP form schemas to Pi form requests and maps Pi submit/secondary/cancel results back to MCP accept/decline/cancel.
- Handles URL elicitation with an explicit Open/Decline/Cancel prompt.
- Adds focused tests for handler behavior, init gating, and server capability registration.

## Proof video

The proof video is attached via a fork release asset, not committed to this PR:

<video src="https://github.com/dmmulroy/pi-mcp-adapter/releases/download/elicitation-proof-pr-129/elicitation-real-pi-e2e.mp4" controls="controls" muted="muted"></video>

Direct link: https://github.com/dmmulroy/pi-mcp-adapter/releases/download/elicitation-proof-pr-129/elicitation-real-pi-e2e.mp4

The video shows a real Pi session opening, invoking `/proof-all`, hitting a local stdio MCP fixture server that sends real `server.server.elicitInput(...)` requests, and interacting through all code paths:

- form submit → MCP `accept` with content
- form secondary/decline → MCP `decline`
- form escape/cancel → MCP `cancel`
- URL open → MCP `accept`

Final proof text:

```text
FORM_RESULT action=accept content={"title":"Proof Issue","priority":"medium","assignToMe":true}
FORM_RESULT action=decline content=null
FORM_RESULT action=cancel content=null
URL_RESULT action=accept content=null
PROOF_DONE all MCP elicitation code paths completed
```

## Verification

```bash
pnpm exec tsc --noEmit
pnpm vitest run __tests__/elicitation-handler.test.ts __tests__/init-elicitation.test.ts __tests__/server-manager-sampling.test.ts
```

Focused verification passes: 3 test files, 10 tests.

Note: full suite still has unrelated failures for missing `examples/interactive-visualizer/dist/*` assets in this checkout.
