### PR TITLE
Harden MCP elicitation failures

### DIFF
--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -13,7 +13,8 @@ function formRequest(params: ElicitRequest["params"]): ElicitRequest {
 
 describe("elicitation handler", () => {
   beforeEach(() => {
-    mocks.open.mockClear();
+    mocks.open.mockReset();
+    mocks.open.mockResolvedValue(undefined);
   });
 
   it("converts form elicitation schemas to Pi forms and returns accepted content", async () => {
@@ -144,7 +145,7 @@ describe("elicitation handler", () => {
     expect(result).toEqual({ action: "accept" });
   });
 
-  it("rejects non-browser URL elicitation schemes before prompting or opening", async () => {
+  it("cancels non-browser URL elicitation schemes before prompting or opening", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
     const ui = {
       form: vi.fn(async () => ({ action: "submit", values: {} })),
@@ -161,11 +162,134 @@ describe("elicitation handler", () => {
           url: "file:///etc/passwd",
         }),
       ),
-    ).rejects.toThrow("MCP URL elicitation only supports http/https URLs: file:");
+    ).resolves.toEqual({ action: "cancel" });
 
     expect(ui.form).not.toHaveBeenCalled();
     expect(mocks.open).not.toHaveBeenCalled();
     expect(ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("cancels form elicitations when the UI form fails", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => {
+        throw new Error("form unavailable");
+      }),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "demo", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "form",
+        message: "Collect input",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            note: { type: "string", title: "Note" },
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("cancels form elicitations when submitted values fail validation", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => ({
+        action: "submit",
+        values: { count: "not a number" },
+      })),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "demo", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "form",
+        message: "Collect count",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            count: { type: "number", title: "Count" },
+          },
+          required: ["count"],
+        },
+      }),
+    );
+
+    expect(result).toEqual({ action: "cancel" });
+  });
+
+  it("cancels URL elicitations when the prompt fails before opening", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => {
+        throw new Error("form unavailable");
+      }),
+      notify: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "demo", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "url",
+        message: "Approve access",
+        elicitationId: "elicit_prompt_error",
+        url: "https://example.com/approve",
+      }),
+    );
+
+    expect(result).toEqual({ action: "cancel" });
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("cancels URL elicitations when opening the accepted URL fails", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    mocks.open.mockRejectedValueOnce(new Error("browser unavailable"));
+    const ui = {
+      form: vi.fn(async () => ({ action: "submit", values: {} })),
+      notify: vi.fn(),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "demo", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "url",
+        message: "Approve access",
+        elicitationId: "elicit_open_error",
+        url: "https://example.com/approve",
+      }),
+    );
+
+    expect(result).toEqual({ action: "cancel" });
+    expect(mocks.open).toHaveBeenCalledWith("https://example.com/approve");
+    expect(ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("ignores notification failures after opening an accepted URL", async () => {
+    const { handleElicitationRequest } = await import("../elicitation-handler.ts");
+    const ui = {
+      form: vi.fn(async () => ({ action: "submit", values: {} })),
+      notify: vi.fn(() => {
+        throw new Error("notification unavailable");
+      }),
+    };
+
+    const result = await handleElicitationRequest(
+      { serverName: "demo", ui: ui as any, autoOpenUrls: false },
+      formRequest({
+        mode: "url",
+        message: "Approve access",
+        elicitationId: "elicit_notify_error",
+        url: "https://example.com/approve",
+      }),
+    );
+
+    expect(result).toEqual({ action: "accept" });
+    expect(mocks.open).toHaveBeenCalledWith("https://example.com/approve");
+    expect(ui.notify).toHaveBeenCalledWith("Opened browser for MCP elicitation.", "info");
   });
 
   it("preserves empty strings for string fields unless schema constraints reject them", async () => {

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -113,46 +113,60 @@ export async function handleFormElicitation(
   options: ElicitationHandlerOptions,
   params: ElicitRequestFormParams,
 ): Promise<ElicitResult> {
-  const form = convertMcpSchemaToPiForm(options.serverName, params);
-  const result = await options.ui.form(form);
-  if (result.action !== "submit") {
-    return convertPiFormResultToMcpResult(result);
+  try {
+    const form = convertMcpSchemaToPiForm(options.serverName, params);
+    const result = await options.ui.form(form);
+    if (result.action !== "submit") {
+      return convertPiFormResultToMcpResult(result);
+    }
+    return {
+      action: "accept",
+      content: coerceAndValidateFormValues(params, result.values),
+    };
+  } catch {
+    return { action: "cancel" };
   }
-  return {
-    action: "accept",
-    content: coerceAndValidateFormValues(params, result.values),
-  };
 }
 
 export async function handleUrlElicitation(
   options: ElicitationHandlerOptions,
   params: ElicitRequestURLParams,
 ): Promise<ElicitResult> {
-  const browserUrl = getBrowserElicitationUrl(params.url);
-  if (!options.autoOpenUrls) {
-    const result = await options.ui.form({
-      title: "MCP Browser Request",
-      message: [
-        `Server: ${options.serverName}`,
-        "",
-        params.message,
-        "",
-        `Domain: ${browserUrl.host}`,
-        `URL: ${browserUrl.toString()}`,
-        "",
-        "Open this URL in your browser?",
-      ].join("\n"),
-      fields: [],
-      submitLabel: "Open",
-      secondaryLabel: "Decline",
-      cancelLabel: "Cancel",
-    });
-    if (result.action === "secondary") return { action: "decline" };
-    if (result.action === "cancel") return { action: "cancel" };
+  let browserUrl: URL;
+  try {
+    browserUrl = getBrowserElicitationUrl(params.url);
+    if (!options.autoOpenUrls) {
+      const result = await options.ui.form({
+        title: "MCP Browser Request",
+        message: [
+          `Server: ${options.serverName}`,
+          "",
+          params.message,
+          "",
+          `Domain: ${browserUrl.host}`,
+          `URL: ${browserUrl.toString()}`,
+          "",
+          "Open this URL in your browser?",
+        ].join("\n"),
+        fields: [],
+        submitLabel: "Open",
+        secondaryLabel: "Decline",
+        cancelLabel: "Cancel",
+      });
+      if (result.action === "secondary") return { action: "decline" };
+      if (result.action === "cancel") return { action: "cancel" };
+    }
+
+    await open(browserUrl.toString());
+  } catch {
+    return { action: "cancel" };
   }
 
-  await open(browserUrl.toString());
-  options.ui.notify("Opened browser for MCP elicitation.", "info");
+  try {
+    await Promise.resolve(options.ui.notify("Opened browser for MCP elicitation.", "info"));
+  } catch {
+    // Notification failure should not overturn a browser launch the user already accepted.
+  }
   return { action: "accept" };
 }
 


### PR DESCRIPTION
## Summary

This follows up the merged MCP elicitation support by making elicitation error handling fail closed instead of bubbling host/UI/runtime errors back through the MCP request handler.

- Return MCP `cancel` for form UI failures and submitted values that fail schema validation.
- Return MCP `cancel` for invalid URL elicitations, prompt failures, and browser launch failures.
- Keep explicit user decline/cancel behavior unchanged.
- Ignore notification failures after an accepted URL has already opened, so a post-open UI notification issue does not misreport the accepted action as failed.

## Why

The current upstream behavior can throw from the elicitation request handler for recoverable local failures such as a missing UI form, invalid submitted values, invalid URL schemes, or browser launch errors. For a server-initiated elicitation, the safer behavior is to fail closed and report `cancel` unless the user explicitly accepted and the browser action actually happened.

## Validation

- `npm test -- --maxWorkers=1 --minWorkers=1`
- `npx tsc --noEmit`