### PR TITLE
fix: honor user keybindings for navigation in MCP panels

### DIFF
--- a/__tests__/mcp-panel-keybindings.test.ts
+++ b/__tests__/mcp-panel-keybindings.test.ts
@@ -1,0 +1,186 @@
+import { KeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpPanel } from "../mcp-panel.ts";
+import { createMcpSetupPanel, type SetupPanelCallbacks } from "../mcp-setup-panel.ts";
+import { createPanelKeys } from "../panel-keys.ts";
+import type { McpDiscoverySummary } from "../config.ts";
+import type { McpConfig, McpPanelCallbacks } from "../types.ts";
+
+const CTRL_P = "\x10";
+const CTRL_N = "\x0e";
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+
+function createEmacsKeybindings(): KeybindingsManager {
+  return new KeybindingsManager(TUI_KEYBINDINGS, {
+    "tui.select.up": ["up", "ctrl+p"],
+    "tui.select.down": ["down", "ctrl+n"],
+  });
+}
+
+function createTwoServerConfig(): McpConfig {
+  return {
+    mcpServers: {
+      alpha: { url: "https://alpha.example.com/mcp", auth: "oauth" },
+      beta: { url: "https://beta.example.com/mcp", auth: "oauth" },
+    },
+  };
+}
+
+function createAuthCallbacks(): McpPanelCallbacks {
+  return {
+    reconnect: async () => true,
+    canAuthenticate: () => true,
+    authenticate: vi.fn(async () => ({ ok: true })),
+    getConnectionStatus: () => "needs-auth",
+    refreshCacheAfterReconnect: () => null,
+  };
+}
+
+function createEmptyDiscovery(): McpDiscoverySummary {
+  return {
+    sources: [],
+    imports: [],
+    hasAnyConfig: false,
+    hasAnyDetectedPaths: false,
+    hasSharedServers: false,
+    hasPiOwnedServers: false,
+    totalServerCount: 0,
+    fingerprint: "test",
+    repoPrompt: { configured: false },
+  };
+}
+
+function createSetupCallbacks(): SetupPanelCallbacks {
+  const preview = { path: "/tmp/x", existed: false, changed: true, beforeText: "", afterText: "", diffText: "" };
+  return {
+    previewImports: () => preview,
+    previewStarterProject: () => preview,
+    previewRepoPrompt: () => null,
+    adoptImports: async () => ({ added: [], path: "/tmp/x" }),
+    scaffoldProjectConfig: vi.fn(async () => ({ path: "/tmp/x" })),
+    addRepoPrompt: async () => ({ path: "/tmp/x", serverName: "repoprompt" }),
+    openPath: async () => {},
+    markSetupCompleted: () => {},
+  };
+}
+
+describe("panel-keys", () => {
+  it("honors user keybindings when a manager is provided", () => {
+    const keys = createPanelKeys(createEmacsKeybindings());
+    expect(keys.selectUp(CTRL_P)).toBe(true);
+    expect(keys.selectUp(UP)).toBe(true);
+    expect(keys.selectDown(CTRL_N)).toBe(true);
+    expect(keys.selectDown(DOWN)).toBe(true);
+    expect(keys.selectConfirm(ENTER)).toBe(true);
+  });
+
+  it("falls back to hardcoded defaults without a manager", () => {
+    const keys = createPanelKeys();
+    expect(keys.selectUp(UP)).toBe(true);
+    expect(keys.selectUp(CTRL_P)).toBe(false);
+    expect(keys.selectDown(DOWN)).toBe(true);
+    expect(keys.selectDown(CTRL_N)).toBe(false);
+    expect(keys.selectConfirm(ENTER)).toBe(true);
+  });
+
+  it("respects rebinding that removes a default key", () => {
+    const manager = new KeybindingsManager(TUI_KEYBINDINGS, {
+      "tui.select.up": "ctrl+p",
+    });
+    const keys = createPanelKeys(manager);
+    expect(keys.selectUp(CTRL_P)).toBe(true);
+    expect(keys.selectUp(UP)).toBe(false);
+  });
+});
+
+describe("mcp-panel custom keybindings", () => {
+  it("navigates with ctrl+n/ctrl+p when bound to tui.select.down/up", async () => {
+    const callbacks = createAuthCallbacks();
+    const panel = createMcpPanel(
+      createTwoServerConfig(),
+      null,
+      new Map(),
+      callbacks,
+      { requestRender: () => {} },
+      () => {},
+      { authOnly: true, keybindings: createEmacsKeybindings() },
+    );
+
+    panel.handleInput(CTRL_N);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    expect(callbacks.authenticate).toHaveBeenLastCalledWith("beta");
+
+    panel.handleInput(CTRL_P);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    expect(callbacks.authenticate).toHaveBeenLastCalledWith("alpha");
+    panel.dispose();
+  });
+
+  it("keeps arrow keys working alongside custom bindings", async () => {
+    const callbacks = createAuthCallbacks();
+    const panel = createMcpPanel(
+      createTwoServerConfig(),
+      null,
+      new Map(),
+      callbacks,
+      { requestRender: () => {} },
+      () => {},
+      { authOnly: true, keybindings: createEmacsKeybindings() },
+    );
+
+    panel.handleInput(DOWN);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    expect(callbacks.authenticate).toHaveBeenLastCalledWith("beta");
+    panel.dispose();
+  });
+
+  it("treats ctrl+p/ctrl+n as unbound without a keybindings manager", async () => {
+    const callbacks = createAuthCallbacks();
+    const panel = createMcpPanel(
+      createTwoServerConfig(),
+      null,
+      new Map(),
+      callbacks,
+      { requestRender: () => {} },
+      () => {},
+      { authOnly: true },
+    );
+
+    panel.handleInput(CTRL_N);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    // Cursor did not move: still authenticates the first server.
+    expect(callbacks.authenticate).toHaveBeenLastCalledWith("alpha");
+    panel.dispose();
+  });
+});
+
+describe("mcp-setup-panel custom keybindings", () => {
+  it("navigates actions with ctrl+n and confirms with enter", async () => {
+    const callbacks = createSetupCallbacks();
+    const panel = createMcpSetupPanel(
+      createEmptyDiscovery(),
+      callbacks,
+      {
+        mode: "setup",
+        onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+        keybindings: createEmacsKeybindings(),
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    // Actions for this discovery: view-example, scaffold-project, show-precedence, close.
+    panel.handleInput(CTRL_N);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(callbacks.scaffoldProjectConfig).toHaveBeenCalledTimes(1);
+    panel.dispose();
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -286,8 +286,8 @@ export async function openMcpSetup(
 
   return new Promise<PanelFlowResult>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, _keybindings, done) => {
-        return createMcpSetupPanel(discovery, callbacks, { mode, onboardingState }, tui, () => {
+      (tui, _theme, keybindings, done) => {
+        return createMcpSetupPanel(discovery, callbacks, { mode, onboardingState, keybindings }, tui, () => {
           done(undefined);
           resolve({ configChanged });
         });
@@ -358,7 +358,7 @@ export async function openMcpPanel(
 
   await new Promise<void>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, _keybindings, done) => {
+      (tui, _theme, keybindings, done) => {
         return createMcpPanel(config, cache, provenanceMap, callbacks, tui, (result: McpPanelResult) => {
           if (!result.cancelled && result.changes.size > 0) {
             writeDirectToolsConfig(result.changes, provenanceMap, config);
@@ -367,7 +367,7 @@ export async function openMcpPanel(
           }
           done(undefined);
           resolve();
-        }, { noticeLines });
+        }, { noticeLines, keybindings });
       },
       { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
     );
@@ -403,12 +403,13 @@ export async function openMcpAuthPanel(
 
   await new Promise<void>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, _keybindings, done) => {
+      (tui, _theme, keybindings, done) => {
         return createMcpPanel(config, cache, provenanceMap, callbacks, tui, () => {
           done(undefined);
           resolve();
         }, {
           authOnly: true,
+          keybindings,
           noticeLines: ["Select an OAuth MCP server and press Enter or ctrl+a to authenticate."],
         });
       },

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,4 +1,5 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import { isToolExcluded } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
@@ -126,6 +127,7 @@ class McpPanel {
   private tui: { requestRender(): void };
   private t = DEFAULT_THEME;
   private authOnly: boolean;
+  private keys: PanelKeys;
 
   private static readonly MAX_VISIBLE = 12;
   private static readonly INACTIVITY_MS = 60_000;
@@ -137,11 +139,12 @@ class McpPanel {
     private callbacks: McpPanelCallbacks,
     tui: { requestRender(): void },
     private done: (result: McpPanelResult) => void,
-    options: { noticeLines?: string[]; authOnly?: boolean } = {},
+    options: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings } = {},
   ) {
     this.tui = tui;
     this.noticeLines = options.noticeLines ?? [];
     this.authOnly = options.authOnly === true;
+    this.keys = createPanelKeys(options.keybindings);
     this.prefix = config.settings?.toolPrefix ?? "server";
 
     for (const [serverName, definition] of Object.entries(config.mcpServers)) {
@@ -318,7 +321,7 @@ class McpPanel {
 
     // Modal description search mode
     if (this.descSearchActive) {
-      if (matchesKey(data, "escape") || matchesKey(data, "return")) {
+      if (matchesKey(data, "escape") || this.keys.selectConfirm(data)) {
         this.descSearchActive = false;
         this.descQuery = "";
         this.rebuildVisibleItems();
@@ -333,8 +336,8 @@ class McpPanel {
         }
         return;
       }
-      if (matchesKey(data, "up")) { this.moveCursor(-1); return; }
-      if (matchesKey(data, "down")) { this.moveCursor(1); return; }
+      if (this.keys.selectUp(data)) { this.moveCursor(-1); return; }
+      if (this.keys.selectDown(data)) { this.moveCursor(1); return; }
       if (matchesKey(data, "space")) {
         // Toggle even while in desc search
         const item = this.visibleItems[this.cursorIndex];
@@ -367,8 +370,8 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "up")) { this.moveCursor(-1); return; }
-    if (matchesKey(data, "down")) { this.moveCursor(1); return; }
+    if (this.keys.selectUp(data)) { this.moveCursor(-1); return; }
+    if (this.keys.selectDown(data)) { this.moveCursor(1); return; }
 
     if (matchesKey(data, "space")) {
       const item = this.visibleItems[this.cursorIndex];
@@ -376,7 +379,7 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "return")) {
+    if (this.keys.selectConfirm(data)) {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
       const server = this.servers[item.serverIndex];
@@ -518,7 +521,7 @@ class McpPanel {
       this.confirmingDiscard = false;
       return;
     }
-    if (matchesKey(data, "return")) {
+    if (this.keys.selectConfirm(data)) {
       if (this.discardSelected === 0) {
         this.cleanup();
         this.done({ cancelled: true, changes: new Map() });
@@ -820,7 +823,7 @@ export function createMcpPanel(
   callbacks: McpPanelCallbacks,
   tui: { requestRender(): void },
   done: (result: McpPanelResult) => void,
-  options?: { noticeLines?: string[]; authOnly?: boolean },
+  options?: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings },
 ): McpPanel & { dispose(): void } {
   return new McpPanel(config, cache, provenance, callbacks, tui, done, options ?? {});
 }

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -1,4 +1,5 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import type { ImportKind } from "./types.ts";
 import type { ConfigWritePreview, McpDiscoverySummary } from "./config.ts";
 import type { McpOnboardingState } from "./onboarding-state.ts";
@@ -59,6 +60,7 @@ export interface SetupPanelCallbacks {
 export interface SetupPanelOptions {
   mode: "empty" | "setup";
   onboardingState: McpOnboardingState;
+  keybindings?: PanelKeybindings;
 }
 
 type Screen = "empty" | "setup" | "imports" | "paths";
@@ -89,6 +91,7 @@ export class McpSetupPanel {
   private notice: { text: string; tone: "success" | "warning" | "muted" } | null = null;
   private tui: { requestRender(): void };
   private t = DEFAULT_THEME;
+  private keys: PanelKeys;
   private inactivityTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly INACTIVITY_MS = 60_000;
 
@@ -100,6 +103,7 @@ export class McpSetupPanel {
     private done: () => void,
   ) {
     this.tui = tui;
+    this.keys = createPanelKeys(options.keybindings);
     this.screen = options.mode;
     for (const entry of discovery.imports) {
       this.selectedImports.add(entry.kind);
@@ -191,17 +195,17 @@ export class McpSetupPanel {
     }
 
     const actions = this.getActions();
-    if (matchesKey(data, "up")) {
+    if (this.keys.selectUp(data)) {
       this.actionCursor = Math.max(0, this.actionCursor - 1);
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "down")) {
+    if (this.keys.selectDown(data)) {
       this.actionCursor = Math.min(actions.length - 1, this.actionCursor + 1);
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "return")) {
+    if (this.keys.selectConfirm(data)) {
       const selected = this.getSelectedAction();
       if (selected) void this.runAction(selected.id);
     }
@@ -209,12 +213,12 @@ export class McpSetupPanel {
 
   private handleImportsInput(data: string): void {
     const imports = this.discovery.imports;
-    if (matchesKey(data, "up")) {
+    if (this.keys.selectUp(data)) {
       this.importCursor = Math.max(0, this.importCursor - 1);
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "down")) {
+    if (this.keys.selectDown(data)) {
       this.importCursor = Math.min(imports.length - 1, this.importCursor + 1);
       this.tui.requestRender();
       return;
@@ -230,24 +234,24 @@ export class McpSetupPanel {
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "return")) {
+    if (this.keys.selectConfirm(data)) {
       void this.applySelectedImports();
     }
   }
 
   private handlePathsInput(data: string): void {
     const paths = this.getDetectedPaths();
-    if (matchesKey(data, "up")) {
+    if (this.keys.selectUp(data)) {
       this.pathCursor = Math.max(0, this.pathCursor - 1);
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "down")) {
+    if (this.keys.selectDown(data)) {
       this.pathCursor = Math.min(paths.length - 1, this.pathCursor + 1);
       this.tui.requestRender();
       return;
     }
-    if (matchesKey(data, "return")) {
+    if (this.keys.selectConfirm(data)) {
       const selected = paths[this.pathCursor];
       if (!selected) return;
       void this.runBusy(async () => {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mcp-callback-server.ts",
     "mcp-auth-flow.ts",
     "mcp-panel.ts",
+    "panel-keys.ts",
     "logger.ts",
     "errors.ts",
     "app-bridge.bundle.js",

--- a/panel-keys.ts
+++ b/panel-keys.ts
@@ -1,0 +1,37 @@
+import { matchesKey } from "@earendil-works/pi-tui";
+
+/** The `tui.select.*` keybinding ids the adapter panels resolve. */
+export type PanelSelectKeybinding =
+  | "tui.select.up"
+  | "tui.select.down"
+  | "tui.select.confirm";
+
+/** Structural subset of pi-tui's `KeybindingsManager` (which satisfies it). */
+export interface PanelKeybindings {
+  matches(data: string, keybinding: PanelSelectKeybinding): boolean;
+}
+
+/**
+ * Key matchers for list navigation: user's `tui.select.*` bindings when a
+ * manager is provided, otherwise the previous hardcoded defaults.
+ */
+export interface PanelKeys {
+  selectUp(data: string): boolean;
+  selectDown(data: string): boolean;
+  selectConfirm(data: string): boolean;
+}
+
+export function createPanelKeys(keybindings?: PanelKeybindings): PanelKeys {
+  if (keybindings) {
+    return {
+      selectUp: (data) => keybindings.matches(data, "tui.select.up"),
+      selectDown: (data) => keybindings.matches(data, "tui.select.down"),
+      selectConfirm: (data) => keybindings.matches(data, "tui.select.confirm"),
+    };
+  }
+  return {
+    selectUp: (data) => matchesKey(data, "up"),
+    selectDown: (data) => matchesKey(data, "down"),
+    selectConfirm: (data) => matchesKey(data, "return"),
+  };
+}


### PR DESCRIPTION
Fixes #137.

The `/mcp` panel and setup flow hardcoded `matchesKey(data, "up"/"down"/"return")`
and discarded the `KeybindingsManager` that pi injects into `ctx.ui.custom()`
factories, so custom `tui.select.*` bindings (e.g. emacs-style ctrl+p/ctrl+n)
worked in pi core selectors but not here.

- `panel-keys.ts`: `createPanelKeys(keybindings?)` resolves up/down/confirm
  through the user's `tui.select.*` bindings, falling back to the previous
  hardcoded keys when no manager is supplied (panels stay constructible
  standalone, as existing tests do). The manager is typed as a minimal
  structural interface so the panels don't depend on the concrete class.
- `commands.ts`: all three `ctx.ui.custom()` call sites now pass the
  previously discarded `keybindings` argument into the panel options.
- `escape`/`ctrl+c` stay hardcoded: the panels give them distinct semantics
  (back/clear-search vs hard-quit) that don't decompose onto the single
  `tui.select.cancel` binding.

No behavior change for default keybindings: `tui.select.confirm` defaults to
`enter` (alias of `return`), up/down default to the arrow keys.

Testing: `npx tsc --noEmit` clean; new `__tests__/mcp-panel-keybindings.test.ts`
(7 tests, real `KeybindingsManager`) covers custom bindings, defaults,
rebinding that removes a default, and the no-manager fallback. Full suite:
327 passed, 2 failed — both `interactive-visualizer-server.test.ts`, failing
identically on `main` (needs a built example; unrelated). Manually verified
ctrl+p/ctrl+n in `/mcp`, `/mcp-auth`, and the setup flow.
