### PR TITLE
fix: oauth scopes and inject auth params

### DIFF
--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -6,6 +6,92 @@ import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
 import { saveAuthEntry, updateOAuthState } from "../mcp-auth.ts";
 
+describe("McpOAuthProvider clientMetadata scope", () => {
+  it("includes scope in authorization_code clientMetadata when configured", () => {
+    const provider = new McpOAuthProvider(
+      "scope-test",
+      "https://api.example.com/mcp",
+      { scope: "api://resource/.default openid" },
+      { onRedirect: async () => {} },
+    )
+    expect(provider.clientMetadata.scope).toBe("api://resource/.default openid")
+  })
+
+  it("omits scope from clientMetadata when not configured", () => {
+    const provider = new McpOAuthProvider(
+      "no-scope-test",
+      "https://api.example.com/mcp",
+      {},
+      { onRedirect: async () => {} },
+    )
+    expect(provider.clientMetadata).not.toHaveProperty("scope")
+  })
+})
+
+describe("McpOAuthProvider addClientAuthentication", () => {
+  const originalOAuthDir = process.env.MCP_OAUTH_DIR
+  const serverUrl = "https://api.example.com/mcp"
+  let authDir: string
+
+  beforeEach(() => {
+    authDir = mkdtempSync(join(tmpdir(), "pi-mcp-oauth-auth-"))
+    process.env.MCP_OAUTH_DIR = authDir
+  })
+
+  afterEach(() => {
+    rmSync(authDir, { recursive: true, force: true })
+    if (originalOAuthDir === undefined) {
+      delete process.env.MCP_OAUTH_DIR
+    } else {
+      process.env.MCP_OAUTH_DIR = originalOAuthDir
+    }
+  })
+
+  it("injects scope, client_id, and client_secret into token params", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-inject",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    )
+    const params = new URLSearchParams({ grant_type: "authorization_code", code: "abc" })
+    await provider.addClientAuthentication(new Headers(), params)
+    expect(params.get("scope")).toBe("api://res/.default")
+    expect(params.get("client_id")).toBe("my-client")
+    expect(params.get("client_secret")).toBe("my-secret")
+  })
+
+  it("does not overwrite fields already present in params", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-no-overwrite",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    )
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      scope: "already-set",
+      client_id: "already-set-id",
+    })
+    await provider.addClientAuthentication(new Headers(), params)
+    expect(params.get("scope")).toBe("already-set")
+    expect(params.get("client_id")).toBe("already-set-id")
+  })
+
+  it("skips client_secret injection when not configured", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-no-secret",
+      serverUrl,
+      { clientId: "pub-client", scope: "openid" },
+      { onRedirect: async () => {} },
+    )
+    const params = new URLSearchParams({ grant_type: "authorization_code" })
+    await provider.addClientAuthentication(new Headers(), params)
+    expect(params.get("client_id")).toBe("pub-client")
+    expect(params.has("client_secret")).toBe(false)
+  })
+})
+
 describe("McpOAuthProvider authorization fallback", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
   const serverUrl = "https://api.example.com/mcp";

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -135,6 +135,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
+      ...(this.config.scope !== undefined ? { scope: this.config.scope } : {}),
     }
   }
 
@@ -302,6 +303,24 @@ export class McpOAuthProvider implements OAuthClientProvider {
       case "tokens":
         clearTokens(this.serverName)
         break
+    }
+  }
+
+  /**
+   * Inject scope, client_id, and client_secret into token request body.  Some
+   * IdP require these in the POST body for authorization_code flow.  The MCP
+   * SDK's prepareAuthorizationCodeRequest omits them, so this hook is required.
+   */
+  addClientAuthentication = async (_headers: Headers, params: URLSearchParams): Promise<void> => {
+    if (!params.has("scope") && this.config.scope) {
+      params.set("scope", this.config.scope)
+    }
+    const clientInfo = await this.clientInformation()
+    if (clientInfo?.client_id && !params.has("client_id")) {
+      params.set("client_id", clientInfo.client_id)
+    }
+    if (clientInfo?.client_secret && !params.has("client_secret")) {
+      params.set("client_secret", clientInfo.client_secret)
     }
   }
 


### PR DESCRIPTION
should fix #133 (issue I also had)

by using the hook `addClientAuthentication` we can supply the scopes as set out in user configs, otherwise they can get an error by the idp saying scopes are empty

also if the client_id is available, inject it too, as it seems to be required by idps such as entra