### PR TITLE
fix: expand MCP schema formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented MCP form elicitation with stock Pi dialogs, including validation and review/edit before submission.
 - Added consent-based URL elicitation, URL-required tool error handling, and completion notifications.
 - Kept RPC sessions form-only so browser navigation occurs only in TUI mode.
+- Expanded MCP schema formatting for nested `anyOf`/`oneOf` variants, `const` discriminators, nested object properties, and array items.
 
 ## [2.9.0] - 2026-06-04
 

--- a/__tests__/tool-metadata.test.ts
+++ b/__tests__/tool-metadata.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { formatSchema } from "../tool-metadata.ts";
+
+describe("formatSchema", () => {
+  it("keeps simple object schemas compact", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search term", default: "all" },
+        limit: { type: ["number", "null"] },
+        mode: { enum: ["fast", "safe"] },
+      },
+      required: ["query"],
+    };
+
+    expect(formatSchema(schema)).toBe([
+      "  query (string) *required* - Search term [default: \"all\"]",
+      "  limit (number | null)",
+      "  mode (enum: \"fast\", \"safe\")",
+    ].join("\n"));
+  });
+
+  it("expands union branches with const discriminator fields", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        document: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                type: { const: "text" },
+                content: { type: "string", minLength: 1 },
+              },
+              required: ["type", "content"],
+            },
+            {
+              type: "object",
+              properties: {
+                type: { const: "file" },
+                path: { type: "string", minLength: 1 },
+              },
+              required: ["type", "path"],
+            },
+          ],
+        },
+      },
+      required: ["document"],
+    };
+
+    expect(formatSchema(schema)).toBe([
+      "  document *required*",
+      "    anyOf:",
+      "      - object",
+      "        type (const \"text\") *required*",
+      "        content (string) *required* [minLength: 1]",
+      "      - object",
+      "        type (const \"file\") *required*",
+      "        path (string) *required* [minLength: 1]",
+    ].join("\n"));
+  });
+
+  it("formats oneOf branches", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        target: {
+          oneOf: [
+            { const: "draft" },
+            { const: "published" },
+          ],
+        },
+      },
+    };
+
+    expect(formatSchema(schema)).toBe([
+      "  target",
+      "    oneOf:",
+      "      - const \"draft\"",
+      "      - const \"published\"",
+    ].join("\n"));
+  });
+
+  it("formats nested object properties and array items", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        config: {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            tags: {
+              type: "array",
+              items: { enum: ["alpha", "beta"] },
+              minItems: 1,
+            },
+          },
+          required: ["enabled"],
+        },
+      },
+      required: ["config"],
+    };
+
+    expect(formatSchema(schema)).toBe([
+      "  config (object) *required*",
+      "    enabled (boolean) *required*",
+      "    tags (array) [minItems: 1]",
+      "      items (enum: \"alpha\", \"beta\")",
+    ].join("\n"));
+  });
+});

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -80,15 +80,15 @@ export function findToolByName(metadata: ToolMetadata[] | undefined, toolName: s
 }
 
 export function formatSchema(schema: unknown, indent = "  "): string {
-  if (!schema || typeof schema !== "object") {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return `${indent}(no schema)`;
   }
 
   const s = schema as Record<string, unknown>;
 
-  if (s.type === "object" && s.properties && typeof s.properties === "object") {
+  if (s.type === "object" && s.properties && typeof s.properties === "object" && !Array.isArray(s.properties)) {
     const props = s.properties as Record<string, unknown>;
-    const required = Array.isArray(s.required) ? s.required as string[] : [];
+    const required = Array.isArray(s.required) ? s.required.filter((name): name is string => typeof name === "string") : [];
 
     if (Object.keys(props).length === 0) {
       return `${indent}(no parameters)`;
@@ -96,57 +96,121 @@ export function formatSchema(schema: unknown, indent = "  "): string {
 
     const lines: string[] = [];
     for (const [name, propSchema] of Object.entries(props)) {
-      const isRequired = required.includes(name);
-      const propLine = formatProperty(name, propSchema, isRequired, indent);
-      lines.push(propLine);
+      lines.push(...formatProperty(name, propSchema, required.includes(name), indent));
     }
     return lines.join("\n");
   }
 
-  if (s.type) {
-    return `${indent}(${s.type})`;
+  const lines = formatNestedSchema(s, indent);
+  if (lines.length > 0) {
+    return lines.join("\n");
+  }
+
+  const typeStr = formatType(s);
+  if (typeStr) {
+    return `${indent}(${typeStr})`;
   }
 
   return `${indent}(complex schema)`;
 }
 
-function formatProperty(name: string, schema: unknown, required: boolean, indent: string): string {
-  if (!schema || typeof schema !== "object") {
-    return `${indent}${name}${required ? " *required*" : ""}`;
+function formatProperty(name: string, schema: unknown, required: boolean, indent: string): string[] {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return [`${indent}${name}${required ? " *required*" : ""}`];
   }
 
   const s = schema as Record<string, unknown>;
-  const parts: string[] = [];
-
-  let typeStr = "";
-  if (s.type) {
-    if (Array.isArray(s.type)) {
-      typeStr = s.type.join(" | ");
-    } else {
-      typeStr = String(s.type);
-    }
-  } else if (s.enum) {
-    typeStr = "enum";
-  } else if (s.anyOf || s.oneOf) {
-    typeStr = "union";
-  }
-
-  if (Array.isArray(s.enum)) {
-    const enumVals = s.enum.map(v => JSON.stringify(v)).join(", ");
-    typeStr = `enum: ${enumVals}`;
-  }
-
-  parts.push(`${indent}${name}`);
+  const parts = [`${indent}${name}`];
+  const typeStr = formatType(s);
   if (typeStr) parts.push(`(${typeStr})`);
   if (required) parts.push("*required*");
+  appendSchemaAnnotations(parts, s);
 
-  if (s.description && typeof s.description === "string") {
-    parts.push(`- ${s.description}`);
+  return [parts.join(" "), ...formatNestedSchema(s, `${indent}  `)];
+}
+
+function formatNestedSchema(schema: Record<string, unknown>, indent: string): string[] {
+  const lines: string[] = [];
+
+  if (Array.isArray(schema.anyOf)) {
+    lines.push(...formatVariants("anyOf", schema.anyOf, indent));
+  }
+  if (Array.isArray(schema.oneOf)) {
+    lines.push(...formatVariants("oneOf", schema.oneOf, indent));
+  }
+  if (schema.items !== undefined) {
+    lines.push(...formatProperty("items", schema.items, false, indent));
+  }
+  if (schema.properties && typeof schema.properties === "object" && !Array.isArray(schema.properties)) {
+    const required = Array.isArray(schema.required) ? schema.required.filter((name): name is string => typeof name === "string") : [];
+    for (const [name, propSchema] of Object.entries(schema.properties as Record<string, unknown>)) {
+      lines.push(...formatProperty(name, propSchema, required.includes(name), indent));
+    }
   }
 
-  if (s.default !== undefined) {
-    parts.push(`[default: ${JSON.stringify(s.default)}]`);
+  return lines;
+}
+
+function formatVariants(keyword: "anyOf" | "oneOf", variants: unknown[], indent: string): string[] {
+  const lines = [`${indent}${keyword}:`];
+
+  for (const variant of variants) {
+    if (!variant || typeof variant !== "object" || Array.isArray(variant)) {
+      lines.push(`${indent}  - ${JSON.stringify(variant)}`);
+      continue;
+    }
+
+    const s = variant as Record<string, unknown>;
+    const typeStr = formatType(s) || "schema";
+    const parts = [`${indent}  - ${typeStr}`];
+    appendSchemaAnnotations(parts, s);
+    lines.push(parts.join(" "));
+    lines.push(...formatNestedSchema(s, `${indent}    `));
   }
 
-  return parts.join(" ");
+  return lines;
+}
+
+function formatType(schema: Record<string, unknown>): string {
+  if (Object.hasOwn(schema, "const")) {
+    return `const ${JSON.stringify(schema.const)}`;
+  }
+
+  if (Array.isArray(schema.enum)) {
+    return `enum: ${schema.enum.map(v => JSON.stringify(v)).join(", ")}`;
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type.map(type => String(type)).join(" | ");
+  }
+
+  if (schema.type) {
+    return String(schema.type);
+  }
+
+  if (schema.properties && typeof schema.properties === "object" && !Array.isArray(schema.properties)) {
+    return "object";
+  }
+
+  if (schema.items !== undefined) {
+    return "array";
+  }
+
+  return "";
+}
+
+function appendSchemaAnnotations(parts: string[], schema: Record<string, unknown>): void {
+  if (schema.description && typeof schema.description === "string") {
+    parts.push(`- ${schema.description}`);
+  }
+
+  for (const key of ["minLength", "maxLength", "minimum", "maximum", "minItems", "maxItems", "format", "pattern"] as const) {
+    if (schema[key] !== undefined) {
+      parts.push(`[${key}: ${JSON.stringify(schema[key])}]`);
+    }
+  }
+
+  if (schema.default !== undefined) {
+    parts.push(`[default: ${JSON.stringify(schema.default)}]`);
+  }
 }


### PR DESCRIPTION
Fixes `mcp describe` and schema-inclusive search output for nested JSON Schema variants.

This expands the schema formatter so agents can see `anyOf`/`oneOf` branches, `const` discriminator values, nested object properties, array item schemas, and common constraints like `minLength` and `minItems`.

Validation:
- `npm test`

Closes #127
