### PR TITLE
fix: preserve OAuth token auth while adding scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Implemented MCP form elicitation with stock Pi dialogs, including validation and review/edit before submission.
-- Added consent-based URL elicitation, URL-required tool error handling, and completion notifications.
-- Kept RPC sessions form-only so browser navigation occurs only in TUI mode.
+- Included configured OAuth scopes in authorization-code flows while preserving token endpoint authentication method selection. Thanks @carlosdagos for PR #140.
+- Fixed MCP elicitation on stock Pi, including form dialogs with validation and review, consent-based URL handling, URL-required errors, completion notifications, and TUI-only browser navigation. Thanks @dmmulroy for PR #139.
 - Expanded MCP schema formatting for nested `anyOf`/`oneOf` variants, `const` discriminators, nested object properties, and array items.
 
 ## [2.9.0] - 2026-06-04

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -6,6 +6,143 @@ import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
 import { saveAuthEntry, updateOAuthState } from "../mcp-auth.ts";
 
+describe("McpOAuthProvider clientMetadata scope", () => {
+  it("includes configured scope in authorization_code client metadata", () => {
+    const provider = new McpOAuthProvider(
+      "scope-test",
+      "https://api.example.com/mcp",
+      { scope: "api://resource/.default openid" },
+      { onRedirect: async () => {} },
+    );
+
+    expect(provider.clientMetadata.scope).toBe("api://resource/.default openid");
+  });
+
+  it("omits scope from client metadata when not configured", () => {
+    const provider = new McpOAuthProvider(
+      "no-scope-test",
+      "https://api.example.com/mcp",
+      {},
+      { onRedirect: async () => {} },
+    );
+
+    expect(provider.clientMetadata).not.toHaveProperty("scope");
+  });
+});
+
+describe("McpOAuthProvider addClientAuthentication", () => {
+  const originalOAuthDir = process.env.MCP_OAUTH_DIR;
+  const serverUrl = "https://api.example.com/mcp";
+  let authDir: string;
+
+  beforeEach(() => {
+    authDir = mkdtempSync(join(tmpdir(), "pi-mcp-oauth-auth-"));
+    process.env.MCP_OAUTH_DIR = authDir;
+  });
+
+  afterEach(() => {
+    rmSync(authDir, { recursive: true, force: true });
+    if (originalOAuthDir === undefined) {
+      delete process.env.MCP_OAUTH_DIR;
+    } else {
+      process.env.MCP_OAUTH_DIR = originalOAuthDir;
+    }
+  });
+
+  it("adds configured scope to authorization_code token params", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-scope",
+      serverUrl,
+      { clientId: "my-client", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    );
+    const params = new URLSearchParams({ grant_type: "authorization_code", code: "abc" });
+
+    await provider.addClientAuthentication(new Headers(), params, new URL("https://auth.example.com/token"));
+
+    expect(params.get("scope")).toBe("api://res/.default");
+    expect(params.get("client_id")).toBe("my-client");
+  });
+
+  it("uses client_secret_basic when the token endpoint only supports basic auth", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-basic",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    );
+    const headers = new Headers();
+    const params = new URLSearchParams({ grant_type: "authorization_code", code: "abc" });
+
+    await provider.addClientAuthentication(headers, params, new URL("https://auth.example.com/token"), {
+      issuer: "https://auth.example.com",
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: "https://auth.example.com/token",
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code"],
+      token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    });
+
+    expect(headers.get("Authorization")).toBe(`Basic ${Buffer.from("my-client:my-secret").toString("base64")}`);
+    expect(params.get("scope")).toBe("api://res/.default");
+    expect(params.has("client_id")).toBe(false);
+    expect(params.has("client_secret")).toBe(false);
+  });
+
+  it("uses client_secret_post when metadata is absent", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-post",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret" },
+      { onRedirect: async () => {} },
+    );
+    const headers = new Headers();
+    const params = new URLSearchParams({ grant_type: "authorization_code", code: "abc" });
+
+    await provider.addClientAuthentication(headers, params, new URL("https://auth.example.com/token"));
+
+    expect(headers.has("Authorization")).toBe(false);
+    expect(params.get("client_id")).toBe("my-client");
+    expect(params.get("client_secret")).toBe("my-secret");
+  });
+
+  it("does not overwrite token params that are already present", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-no-overwrite",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    );
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      scope: "already-set",
+      client_id: "already-set-id",
+      client_secret: "already-set-secret",
+    });
+
+    await provider.addClientAuthentication(new Headers(), params, new URL("https://auth.example.com/token"));
+
+    expect(params.get("scope")).toBe("already-set");
+    expect(params.get("client_id")).toBe("already-set-id");
+    expect(params.get("client_secret")).toBe("already-set-secret");
+  });
+
+  it("does not add scope to refresh token requests", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-refresh",
+      serverUrl,
+      { clientId: "my-client", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    );
+    const params = new URLSearchParams({ grant_type: "refresh_token", refresh_token: "refresh" });
+
+    await provider.addClientAuthentication(new Headers(), params, new URL("https://auth.example.com/token"));
+
+    expect(params.has("scope")).toBe(false);
+    expect(params.get("client_id")).toBe("my-client");
+  });
+});
+
 describe("McpOAuthProvider authorization fallback", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
   const serverUrl = "https://api.example.com/mcp";

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -5,7 +5,7 @@
  * Handles OAuth client registration, token storage, and authorization redirection.
  */
 
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import type { AddClientAuthentication, OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
   OAuthClientMetadata,
@@ -135,6 +135,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
+      ...(this.config.scope !== undefined ? { scope: this.config.scope } : {}),
     }
   }
 
@@ -302,6 +303,52 @@ export class McpOAuthProvider implements OAuthClientProvider {
       case "tokens":
         clearTokens(this.serverName)
         break
+    }
+  }
+
+  /**
+   * Adds configured authorization-code scope without replacing the SDK's
+   * default token endpoint authentication behavior.
+   */
+  addClientAuthentication: AddClientAuthentication = async (headers, params, _url, metadata) => {
+    if (params.get("grant_type") === "authorization_code" && !params.has("scope") && this.config.scope) {
+      params.set("scope", this.config.scope)
+    }
+
+    const clientInfo = await this.clientInformation()
+    if (!clientInfo) {
+      return
+    }
+
+    const supportedMethods = metadata?.token_endpoint_auth_methods_supported ?? []
+    const hasClientSecret = clientInfo.client_secret !== undefined
+    let authMethod: "client_secret_basic" | "client_secret_post" | "none"
+
+    if (supportedMethods.length === 0) {
+      authMethod = hasClientSecret ? "client_secret_post" : "none"
+    } else if (hasClientSecret && supportedMethods.includes("client_secret_basic")) {
+      authMethod = "client_secret_basic"
+    } else if (hasClientSecret && supportedMethods.includes("client_secret_post")) {
+      authMethod = "client_secret_post"
+    } else if (supportedMethods.includes("none")) {
+      authMethod = "none"
+    } else {
+      authMethod = hasClientSecret ? "client_secret_post" : "none"
+    }
+
+    if (authMethod === "client_secret_basic") {
+      if (!clientInfo.client_secret) {
+        throw new Error("client_secret_basic authentication requires a client_secret")
+      }
+      headers.set("Authorization", `Basic ${Buffer.from(`${clientInfo.client_id}:${clientInfo.client_secret}`).toString("base64")}`)
+      return
+    }
+
+    if (!params.has("client_id")) {
+      params.set("client_id", clientInfo.client_id)
+    }
+    if (authMethod === "client_secret_post" && clientInfo.client_secret && !params.has("client_secret")) {
+      params.set("client_secret", clientInfo.client_secret)
     }
   }
 


### PR DESCRIPTION
Fixes the OAuth scope gap from #133 while preserving token endpoint auth-method selection for #140.

This keeps configured scopes in authorization-code client metadata and token exchange, but reimplements the SDK default token auth selection when the custom hook is present so `client_secret_basic` servers still receive a Basic auth header. The changelog credits @carlosdagos for PR #140 and @dmmulroy for PR #139.

Validation:
- npm test -- __tests__/mcp-oauth-provider.test.ts
- npx tsc --noEmit
- npm test
- npm run test:oauth-provider
- git diff --check
- npm pack --dry-run