### PR TITLE
feat: add lazy-keep-alive server lifecycle mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `oauth.clientName` | Client display name advertised during dynamic registration |
 | `oauth.clientUri` | Client homepage URI advertised during dynamic registration |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation |
-| `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
+| `lifecycle` | `"lazy"` (default), `"eager"`, `"keep-alive"`, or `"lazy-keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
 | `requestTimeoutMs` | Request timeout in milliseconds for live MCP calls (overrides global; if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
@@ -171,6 +171,7 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 - **`lazy`** (default) — Don't connect at startup. Connect on first tool call. Disconnect after idle timeout. Cached metadata keeps search/list working without connections.
 - **`eager`** — Connect at startup but don't auto-reconnect if the connection drops. No idle timeout by default (set `idleTimeout` explicitly to enable).
 - **`keep-alive`** — Connect at startup. Auto-reconnect via health checks. No idle timeout. Use for servers you always need available.
+- **`lazy-keep-alive`** — Don't connect at startup. Connect on first tool call (like `lazy`). Once spawned, never idle-shut down and auto-reconnect via health checks if the process dies (like `keep-alive`). Use for servers that are expensive to start but should stay resident after their first use.
 
 ### Settings
 

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -14,6 +14,7 @@ vi.mock("../mcp-auth-flow.ts", () => ({
 vi.mock("../init.ts", () => ({
   getFailureAgeSeconds: vi.fn(() => null),
   lazyConnect: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
   updateMetadataCache: vi.fn(),
   updateStatusBar: vi.fn(),
 }));

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cachePath: "",
+  cache: null as { version: 1; servers: Record<string, unknown> } | null,
+  config: { settings: {}, mcpServers: {} } as any,
+  manager: undefined as any,
+  getMissingConfiguredDirectToolServers: vi.fn(() => [] as string[]),
+  buildToolMetadata: vi.fn(() => ({ metadata: [], failedTools: [] })),
+}));
+
+vi.mock("../config.ts", () => ({
+  loadMcpConfig: vi.fn(() => mocks.config),
+}));
+
+vi.mock("../metadata-cache.ts", () => ({
+  computeServerHash: vi.fn(() => "hash"),
+  getMetadataCachePath: vi.fn(() => mocks.cachePath),
+  isServerCacheValid: vi.fn(() => false),
+  loadMetadataCache: vi.fn(() => mocks.cache),
+  reconstructToolMetadata: vi.fn(() => []),
+  saveMetadataCache: vi.fn((cache) => {
+    mocks.cache = cache;
+  }),
+  serializeResources: vi.fn(() => []),
+  serializeTools: vi.fn(() => []),
+}));
+
+vi.mock("../server-manager.ts", () => ({
+  McpServerManager: vi.fn(() => mocks.manager),
+}));
+
+vi.mock("../tool-metadata.ts", () => ({
+  buildToolMetadata: mocks.buildToolMetadata,
+  totalToolCount: vi.fn(() => 0),
+}));
+
+vi.mock("../direct-tools.ts", () => ({
+  getMissingConfiguredDirectToolServers: mocks.getMissingConfiguredDirectToolServers,
+}));
+
+function createManager() {
+  const connection = {
+    status: "connected" as const,
+    tools: [],
+    resources: [],
+  };
+  let current: typeof connection | undefined;
+  const manager = {
+    setDefaultRequestTimeoutMs: vi.fn(),
+    setSamplingConfig: vi.fn(),
+    setElicitationConfig: vi.fn(),
+    getConnection: vi.fn(() => current),
+    getAllConnections: vi.fn(() => current ? new Map([["srv", current]]) : new Map()),
+    connect: vi.fn(async () => {
+      current = connection;
+      return connection;
+    }),
+    isIdle: vi.fn(() => false),
+    closeAll: vi.fn(),
+    close: vi.fn(async () => {
+      current = undefined;
+    }),
+    clear: () => {
+      current = undefined;
+    },
+  };
+  return manager;
+}
+
+describe("lazy-keep-alive initializeMcp integration", () => {
+  const originalDirectTools = process.env.MCP_DIRECT_TOOLS;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.MCP_DIRECT_TOOLS;
+    tempDir = mkdtempSync(join(tmpdir(), "pi-mcp-lifecycle-init-"));
+    mocks.cachePath = join(tempDir, "mcp-cache.json");
+    mocks.cache = { version: 1, servers: {} };
+    mocks.config = {
+      settings: {},
+      mcpServers: { srv: { command: "demo", lifecycle: "lazy-keep-alive", directTools: true } },
+    };
+    mocks.manager = createManager();
+    mocks.getMissingConfiguredDirectToolServers.mockReset().mockReturnValue([]);
+    mocks.buildToolMetadata.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDirectTools === undefined) {
+      delete process.env.MCP_DIRECT_TOOLS;
+    } else {
+      process.env.MCP_DIRECT_TOOLS = originalDirectTools;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("marks no-cache bootstrap spawns for health-check reconnects", async () => {
+    mocks.cache = null;
+    const { initializeMcp } = await import("../init.ts");
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+      signal: undefined,
+    } as any);
+
+    mocks.manager.clear();
+    await (state.lifecycle as any).checkConnections();
+
+    expect(mocks.manager.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks direct-tool metadata bootstrap spawns for health-check reconnects", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.getMissingConfiguredDirectToolServers.mockReturnValue(["srv"]);
+    const { initializeMcp } = await import("../init.ts");
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+      signal: undefined,
+    } as any);
+
+    mocks.manager.clear();
+    await (state.lifecycle as any).checkConnections();
+
+    expect(mocks.manager.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpLifecycleManager } from "../lifecycle.ts";
+import type { ServerDefinition } from "../types.ts";
+
+interface FakeConnection {
+  status: "connected" | "closed" | "needs-auth";
+}
+
+class FakeManager {
+  connections = new Map<string, FakeConnection>();
+  connectCalls: string[] = [];
+  closeCalls: string[] = [];
+  idleResponses = new Map<string, boolean>();
+
+  setConnection(name: string, status: FakeConnection["status"] | null): void {
+    if (status === null) {
+      this.connections.delete(name);
+    } else {
+      this.connections.set(name, { status });
+    }
+  }
+
+  getConnection(name: string): FakeConnection | undefined {
+    return this.connections.get(name);
+  }
+
+  async connect(name: string): Promise<FakeConnection> {
+    this.connectCalls.push(name);
+    const connection: FakeConnection = { status: "connected" };
+    this.connections.set(name, connection);
+    return connection;
+  }
+
+  async close(name: string): Promise<void> {
+    this.closeCalls.push(name);
+    this.connections.delete(name);
+  }
+
+  isIdle(name: string): boolean {
+    return this.idleResponses.get(name) ?? false;
+  }
+}
+
+function makeDefinition(lifecycle: ServerDefinition["lifecycle"]): ServerDefinition {
+  return { command: "echo", args: [], lifecycle };
+}
+
+describe("lazy-keep-alive lifecycle", () => {
+  let fake: FakeManager;
+  let lifecycle: McpLifecycleManager;
+
+  beforeEach(() => {
+    fake = new FakeManager();
+    lifecycle = new McpLifecycleManager(fake as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reconnects after first spawn when the process dies", async () => {
+    const def = makeDefinition("lazy-keep-alive");
+    lifecycle.registerServer("srv", def, { idleTimeout: 0 });
+
+    lifecycle.startHealthChecks(1000);
+    await Promise.resolve();
+    expect(fake.connectCalls).not.toContain("srv");
+
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected");
+
+    fake.setConnection("srv", null);
+    await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
+
+    expect(fake.connectCalls).toContain("srv");
+  });
+
+  it("never idle-shuts a server registered with idleTimeout 0", async () => {
+    const def = makeDefinition("lazy-keep-alive");
+    lifecycle.registerServer("srv", def, { idleTimeout: 0 });
+    fake.setConnection("srv", "connected");
+    fake.idleResponses.set("srv", true);
+
+    await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
+
+    expect(fake.closeCalls).not.toContain("srv");
+  });
+
+  it("idle-shuts a plain lazy server past its timeout", async () => {
+    const def = makeDefinition("lazy");
+    lifecycle.registerServer("srv", def, { idleTimeout: 1 });
+    fake.setConnection("srv", "connected");
+    fake.idleResponses.set("srv", true);
+
+    await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
+
+    expect(fake.closeCalls).toContain("srv");
+  });
+});

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -1,5 +1,11 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lazyConnect } from "../init.ts";
 import { McpLifecycleManager } from "../lifecycle.ts";
+import { executeCall } from "../proxy-modes.ts";
+import { reconnectServers } from "../commands.ts";
 import type { ServerDefinition } from "../types.ts";
 
 interface FakeConnection {
@@ -46,16 +52,26 @@ function makeDefinition(lifecycle: ServerDefinition["lifecycle"]): ServerDefinit
 }
 
 describe("lazy-keep-alive lifecycle", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  let tempAgentDir: string;
   let fake: FakeManager;
   let lifecycle: McpLifecycleManager;
 
   beforeEach(() => {
+    tempAgentDir = mkdtempSync(join(tmpdir(), "pi-mcp-lifecycle-"));
+    process.env.PI_CODING_AGENT_DIR = tempAgentDir;
     fake = new FakeManager();
     lifecycle = new McpLifecycleManager(fake as never);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    rmSync(tempAgentDir, { recursive: true, force: true });
   });
 
   it("reconnects after first spawn when the process dies", async () => {
@@ -95,5 +111,109 @@ describe("lazy-keep-alive lifecycle", () => {
     await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
 
     expect(fake.closeCalls).toContain("srv");
+  });
+
+  it("marks lazyConnect first spawns for health-check reconnects", async () => {
+    const connection = {
+      status: "connected" as const,
+      tools: [],
+      resources: [],
+    };
+    let current: typeof connection | undefined;
+    const manager = {
+      getConnection: vi.fn(() => current),
+      connect: vi.fn(async () => {
+        current = connection;
+        return connection;
+      }),
+      isIdle: vi.fn(() => false),
+    };
+    const state = {
+      config: { settings: {}, mcpServers: { srv: makeDefinition("lazy-keep-alive") } },
+      manager,
+      lifecycle: new McpLifecycleManager(manager as never),
+      toolMetadata: new Map(),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+    } as never;
+
+    await lazyConnect(state, "srv");
+    current = undefined;
+    await (state as any).lifecycle.checkConnections();
+
+    expect(manager.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks cached proxy first-use connects for health-check reconnects", async () => {
+    const connection = {
+      status: "connected" as const,
+      tools: [{ name: "search", description: "Search", inputSchema: { type: "object" } }],
+      resources: [],
+      client: { callTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })) },
+    };
+    let current: typeof connection | undefined;
+    const manager = {
+      getConnection: vi.fn(() => current),
+      connect: vi.fn(async () => {
+        current = connection;
+        return connection;
+      }),
+      isIdle: vi.fn(() => false),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getRequestOptions: vi.fn(() => undefined),
+    };
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { srv: makeDefinition("lazy-keep-alive") } },
+      manager,
+      lifecycle: new McpLifecycleManager(manager as never),
+      toolMetadata: new Map([["srv", [{ name: "srv_search", originalName: "search", description: "Search" }]]]),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as never;
+
+    const result = await executeCall(state, "srv_search", {}, "srv");
+    expect(result.content[0]?.text).toBe("ok");
+
+    current = undefined;
+    await (state as any).lifecycle.checkConnections();
+
+    expect(manager.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks manual reconnects for lazy-keep-alive servers", async () => {
+    const connection = {
+      status: "connected" as const,
+      tools: [],
+      resources: [],
+    };
+    let current: typeof connection | undefined;
+    const manager = {
+      close: vi.fn(async () => {
+        current = undefined;
+      }),
+      getConnection: vi.fn(() => current),
+      connect: vi.fn(async () => {
+        current = connection;
+        return connection;
+      }),
+      isIdle: vi.fn(() => false),
+    };
+    const state = {
+      config: { settings: {}, mcpServers: { srv: makeDefinition("lazy-keep-alive") } },
+      manager,
+      lifecycle: new McpLifecycleManager(manager as never),
+      toolMetadata: new Map(),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+    } as never;
+
+    await reconnectServers(state, { hasUI: false } as never, "srv");
+    current = undefined;
+    await (state as any).lifecycle.checkConnections();
+
+    expect(manager.connect).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   lazyConnect: vi.fn(),
   updateServerMetadata: vi.fn(),
   updateMetadataCache: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
   updateStatusBar: vi.fn(),
   clients: [] as any[],
@@ -25,6 +26,7 @@ vi.mock("../init.ts", () => ({
   lazyConnect: mocks.lazyConnect,
   updateServerMetadata: mocks.updateServerMetadata,
   updateMetadataCache: mocks.updateMetadataCache,
+  markKeepAliveAfterConnect: mocks.markKeepAliveAfterConnect,
   getFailureAgeSeconds: mocks.getFailureAgeSeconds,
   updateStatusBar: mocks.updateStatusBar,
 }));
@@ -87,6 +89,7 @@ describe("proxy auto auth", () => {
     mocks.lazyConnect.mockReset().mockResolvedValue(false);
     mocks.updateServerMetadata.mockReset();
     mocks.updateMetadataCache.mockReset();
+    mocks.markKeepAliveAfterConnect.mockReset();
     mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
     mocks.updateStatusBar.mockReset();
     mocks.clients.length = 0;

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   lazyConnect: vi.fn(),
   updateServerMetadata: vi.fn(),
   updateMetadataCache: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
   updateStatusBar: vi.fn(),
 }));
@@ -22,6 +23,7 @@ vi.mock("../init.ts", () => ({
   lazyConnect: mocks.lazyConnect,
   updateServerMetadata: mocks.updateServerMetadata,
   updateMetadataCache: mocks.updateMetadataCache,
+  markKeepAliveAfterConnect: mocks.markKeepAliveAfterConnect,
   getFailureAgeSeconds: mocks.getFailureAgeSeconds,
   updateStatusBar: mocks.updateStatusBar,
 }));

--- a/commands.ts
+++ b/commands.ts
@@ -12,7 +12,7 @@ import {
   writeSharedServerEntry,
   writeStarterProjectConfig,
 } from "./config.ts";
-import { lazyConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds } from "./init.ts";
+import { lazyConnect, markKeepAliveAfterConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
@@ -118,6 +118,7 @@ export async function reconnectServers(
         state.serverInstructions.delete(name);
       }
       updateMetadataCache(state, name);
+      markKeepAliveAfterConnect(state, name);
       state.failureTracker.delete(name);
 
       if (ctx.hasUI) {

--- a/init.ts
+++ b/init.ts
@@ -166,6 +166,7 @@ export async function initializeMcp(
       serverInstructions.delete(name);
     }
     updateMetadataCache(state, name);
+    markKeepAliveAfterConnect(state, name);
 
     if (failedTools.length > 0 && ctx.hasUI) {
       ctx.ui.notify(
@@ -203,6 +204,7 @@ export async function initializeMcp(
             }
             updateServerMetadata(state, name);
             updateMetadataCache(state, name);
+            markKeepAliveAfterConnect(state, name);
             return { name, ok: true };
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -234,6 +236,13 @@ export async function initializeMcp(
   lifecycle.startHealthChecks();
 
   return state;
+}
+
+export function markKeepAliveAfterConnect(state: McpExtensionState, serverName: string): void {
+  const definition = state.config.mcpServers[serverName];
+  if ((definition?.lifecycle ?? "lazy") === "lazy-keep-alive") {
+    state.lifecycle.markKeepAlive(serverName, definition);
+  }
 }
 
 export function updateServerMetadata(state: McpExtensionState, serverName: string): void {
@@ -323,6 +332,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
   }
   if (connection?.status === "connected") {
     updateServerMetadata(state, serverName);
+    markKeepAliveAfterConnect(state, serverName);
     return true;
   }
 
@@ -343,10 +353,8 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     state.failureTracker.delete(serverName);
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
+    markKeepAliveAfterConnect(state, serverName);
     updateStatusBar(state);
-    if ((definition.lifecycle ?? "lazy") === "lazy-keep-alive") {
-      state.lifecycle.markKeepAlive(serverName, definition);
-    }
     return true;
   } catch (error) {
     if (signal?.aborted) {

--- a/init.ts
+++ b/init.ts
@@ -104,7 +104,8 @@ export async function initializeMcp(
 
   for (const [name, definition] of serverEntries) {
     const lifecycleMode = definition.lifecycle ?? "lazy";
-    const idleOverride = definition.idleTimeout ?? (lifecycleMode === "eager" ? 0 : undefined);
+    const persistsAfterFirstSpawn = lifecycleMode === "eager" || lifecycleMode === "lazy-keep-alive";
+    const idleOverride = definition.idleTimeout ?? (persistsAfterFirstSpawn ? 0 : undefined);
     lifecycle.registerServer(
       name,
       definition,
@@ -343,6 +344,9 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
     updateStatusBar(state);
+    if ((definition.lifecycle ?? "lazy") === "lazy-keep-alive") {
+      state.lifecycle.markKeepAlive(serverName, definition);
+    }
     return true;
   } catch (error) {
     if (signal?.aborted) {
@@ -363,6 +367,6 @@ function getEffectiveIdleTimeoutMinutes(state: McpExtensionState, serverName: st
   }
   if (typeof definition.idleTimeout === "number") return definition.idleTimeout;
   const mode = definition.lifecycle ?? "lazy";
-  if (mode === "eager") return 0;
+  if (mode === "eager" || mode === "lazy-keep-alive") return 0;
   return typeof state.config.settings?.idleTimeout === "number" ? state.config.settings.idleTimeout : 10;
 }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -614,6 +614,9 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     updateMetadataCache(state, serverName);
     state.failureTracker.delete(serverName);
     updateStatusBar(state);
+    if ((definition.lifecycle ?? "lazy") === "lazy-keep-alive") {
+      state.lifecycle.markKeepAlive(serverName, definition);
+    }
     return executeList(state, serverName);
   } catch (error) {
     if (!signal?.aborted) {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -4,7 +4,7 @@ import { checkSync } from "recheck";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
-import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
+import { lazyConnect, markKeepAliveAfterConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
@@ -612,11 +612,9 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       state.serverInstructions.delete(serverName);
     }
     updateMetadataCache(state, serverName);
+    markKeepAliveAfterConnect(state, serverName);
     state.failureTracker.delete(serverName);
     updateStatusBar(state);
-    if ((definition.lifecycle ?? "lazy") === "lazy-keep-alive") {
-      state.lifecycle.markKeepAlive(serverName, definition);
-    }
     return executeList(state, serverName);
   } catch (error) {
     if (!signal?.aborted) {
@@ -858,6 +856,7 @@ export async function executeCall(
       state.failureTracker.delete(serverName);
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
+      markKeepAliveAfterConnect(state, serverName);
       updateStatusBar(state);
       toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
       if (!toolMeta) {

--- a/types.ts
+++ b/types.ts
@@ -305,7 +305,7 @@ export interface ServerEntry {
    * Set to false to explicitly disable OAuth for this server.
    */
   oauth?: OAuthConfig | false;
-  lifecycle?: "keep-alive" | "lazy" | "eager";
+  lifecycle?: "keep-alive" | "lazy" | "lazy-keep-alive" | "eager";
   idleTimeout?: number; // minutes, overrides global setting
   requestTimeoutMs?: number; // milliseconds, overrides global request timeout when > 0
   // Resource handling


### PR DESCRIPTION
## Summary

Adds a new `lazy-keep-alive` server lifecycle mode: the MCP server spawns lazily on first tool use (not at pi startup), then stays resident — it never idle-shuts down and auto-reconnects via health checks if the process dies.

This fills the gap between the existing modes:

- `lazy` — spawns on first use, idle-shuts down after timeout
- `eager` — spawns at startup, no idle timeout, no auto-reconnect
- `keep-alive` — spawns at startup, no idle timeout, auto-reconnects
- **`lazy-keep-alive` (new)** — spawns on first use, no idle timeout, auto-reconnects

Useful for servers that are expensive to start but should stay resident once they've been used at least once.

## Implementation

- **`types.ts`** — add `"lazy-keep-alive"` to the `lifecycle` union.
- **`init.ts`** — register the server with `idleTimeout: 0` (never idle-shutdown), keep it out of the startup spawn filter, and call `markKeepAlive` only after the first successful lazy connect so health-check resurrection kicks in only after first use. `getEffectiveIdleTimeoutMinutes` treats it like `eager`.
- **`proxy-modes.ts`** — `executeConnect` (the explicit `mcp({connect})` path) also marks keep-alive on success so every first-spawn path persists it.
- **README** — documented the new mode.

## Tests

- New `__tests__/lifecycle-lazy-keep-alive.test.ts` covering: reconnect-after-death, never idle-shut when `idleTimeout: 0`, and confirming plain `lazy` still idle-shuts.
- `tsc --noEmit` clean; full suite passes (the 2 pre-existing `interactive-visualizer-server` failures are unrelated — they expect a built example artifact not present in the checkout).

## Usage

```json
{ "mcpServers": { "myserver": { "command": "...", "lifecycle": "lazy-keep-alive" } } }
```