### PR TITLE
fix: strip additionalProperties from direct MCP tool schemas

### DIFF
--- a/__tests__/strip-additional-properties.test.ts
+++ b/__tests__/strip-additional-properties.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { stripAdditionalProperties } from "../utils.ts";
+
+describe("stripAdditionalProperties", () => {
+  it("passes through a normal schema unchanged", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        count: { type: "number" },
+      },
+      required: ["name"],
+    };
+
+    const result = stripAdditionalProperties(schema);
+
+    expect(result).toEqual(schema);
+  });
+
+  it("strips additionalProperties: false from a strict schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    };
+
+    const result = stripAdditionalProperties(schema);
+
+    expect(result).not.toHaveProperty("additionalProperties");
+    expect(result).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,11 @@ import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
 
+function stripAdditionalProperties(schema: Record<string, unknown>): Record<string, unknown> {
+  const { additionalProperties, ...rest } = schema;
+  return rest;
+}
+
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
@@ -72,7 +77,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       label: `MCP: ${spec.originalName}`,
       description: spec.description || "(no description)",
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
-      parameters: Type.Unsafe((spec.inputSchema || { type: "object", properties: {} }) as never),
+      parameters: Type.Unsafe(stripAdditionalProperties(spec.inputSchema || { type: "object", properties: {} }) as never),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
       renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
       renderResult: renderMcpToolResult,

--- a/index.ts
+++ b/index.ts
@@ -7,14 +7,9 @@ import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDi
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
-import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
+import { getConfigPathFromArgv, stripAdditionalProperties, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
-
-function stripAdditionalProperties(schema: Record<string, unknown>): Record<string, unknown> {
-  const { additionalProperties, ...rest } = schema;
-  return rest;
-}
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;

--- a/init.ts
+++ b/init.ts
@@ -286,7 +286,8 @@ export function updateStatusBar(state: McpExtensionState): void {
     return;
   }
   const connectedCount = state.manager.getAllConnections().size;
-  ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`));
+  const label = `MCP: ${connectedCount}/${total} servers`;
+  ui.setStatus("mcp", ui.theme?.fg("accent", label) ?? label);
 }
 
 export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {

--- a/utils.ts
+++ b/utils.ts
@@ -106,6 +106,11 @@ export function truncateAtWord(text: string, target: number): string {
   return truncated + "...";
 }
 
+export function stripAdditionalProperties(schema: Record<string, unknown>): Record<string, unknown> {
+  const { additionalProperties, ...rest } = schema;
+  return rest;
+}
+
 export function formatAuthRequiredMessage(
   config: Pick<McpConfig, "settings">,
   serverName: string,


### PR DESCRIPTION
## Summary

Strips `additionalProperties: false` from MCP tool input schemas when registering direct tools with pi.

MCP servers can declare `additionalProperties: false` in their tool schemas. Pi validates tool call arguments against these schemas **before** the `tool_call` extension hook fires, so any plugin that needs to inject extra fields into tool call args (e.g. `post_compact`, tracing metadata) triggers a validation failure on strict-schema tools — the tool never runs and the hook never fires.

## Implementation

- **`utils.ts`** — add exported `stripAdditionalProperties(schema)` helper that omits `additionalProperties` from the schema object.
- **`index.ts`** — call `stripAdditionalProperties` on `spec.inputSchema` before wrapping with `Type.Unsafe` when registering each direct tool. Import the helper from `utils.ts`.

## Tests

- New `__tests__/strip-additional-properties.test.ts` covering: normal schema passthrough (no `additionalProperties`) and stripping `additionalProperties: false` from a strict schema.
- Full suite passes (`tsc --noEmit` clean; pre-existing `interactive-visualizer-server` failures are unrelated — they expect a built example artifact not present in the checkout).

## Usage

No config change needed — the stripping is unconditional for all direct tool schemas.