### PR TITLE
fix(mcp): fall back to structuredContent when content is empty

### DIFF
--- a/__tests__/structured-content-fallback-integration.test.ts
+++ b/__tests__/structured-content-fallback-integration.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// End-to-end coverage for the structuredContent fallback.
+
+const mocks = vi.hoisted(() => ({
+  lazyConnect: vi.fn(),
+  getFailureAgeSeconds: vi.fn(),
+}));
+
+vi.mock("../init.ts", () => ({
+  lazyConnect: mocks.lazyConnect,
+  getFailureAgeSeconds: mocks.getFailureAgeSeconds,
+  updateServerMetadata: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+function textOf(result: any): string {
+  return result.content.map((c: any) => c.text ?? "").join("\n");
+}
+
+function makeState(callToolResult: unknown, toolName = "tool") {
+  const connection = {
+    status: "connected",
+    client: { callTool: vi.fn(async () => callToolResult) },
+  };
+  return {
+    config: { settings: {}, mcpServers: { demo: { command: "demo" } } },
+    toolMetadata: new Map([
+      ["demo", [{ name: `demo_${toolName}`, originalName: toolName, description: toolName }]],
+    ]),
+    manager: {
+      getConnection: vi.fn(() => connection),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    },
+    failureTracker: new Map(),
+    ui: undefined,
+    completedUiSessions: [],
+  } as any;
+}
+
+describe("structuredContent fallback — direct tool executor", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.lazyConnect.mockReset().mockResolvedValue(true);
+    mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
+  });
+
+  it("surfaces structuredContent to the model when content is empty", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const structured = { status: "available", summary: "## Notes" };
+    const state = makeState({ isError: false, content: [], structuredContent: structured });
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      { serverName: "demo", originalName: "get-summary", prefixedName: "demo_get-summary", description: "Get summary" },
+    );
+
+    const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
+
+    expect(textOf(result)).toBe(JSON.stringify(structured, null, 2));
+    expect(textOf(result)).not.toContain("(empty result)");
+  });
+
+  it("still shows (empty result) when both content and structuredContent are empty", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const state = makeState({ isError: false, content: [] });
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      { serverName: "demo", originalName: "noop", prefixedName: "demo_noop", description: "Noop" },
+    );
+
+    const result = await executor("id", {}, undefined as any, () => {}, undefined as any);
+
+    expect(textOf(result)).toBe("(empty result)");
+  });
+});
+
+describe("structuredContent fallback — proxy executeCall", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.lazyConnect.mockReset().mockResolvedValue(true);
+    mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
+  });
+
+  it("surfaces structuredContent to the model when content is empty", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const structured = { status: "available", summary: "## Notes" };
+    const state = makeState({ isError: false, content: [], structuredContent: structured }, "get-summary");
+
+    const result = await executeCall(state, "demo_get-summary", {}, "demo");
+
+    expect(textOf(result)).toContain(JSON.stringify(structured, null, 2));
+    expect(textOf(result)).not.toContain("(empty result)");
+  });
+
+  it("still shows (empty result) when both content and structuredContent are empty", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const state = makeState({ isError: false, content: [] }, "noop");
+
+    const result = await executeCall(state, "demo_noop", {}, "demo");
+
+    expect(textOf(result)).toContain("(empty result)");
+  });
+});

--- a/__tests__/tool-registrar-structured-content.test.ts
+++ b/__tests__/tool-registrar-structured-content.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { resolveMcpResultContent } from "../tool-registrar.ts";
+
+describe("resolveMcpResultContent", () => {
+  it("returns transformed content blocks when content is present", () => {
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "text", text: "hello" }],
+      structuredContent: { ignored: true },
+    });
+
+    expect(blocks).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("falls back to structuredContent when content is empty", () => {
+    const structured = { status: "available", summary: "## Notes" };
+    const blocks = resolveMcpResultContent({
+      content: [],
+      structuredContent: structured,
+    });
+
+    expect(blocks).toEqual([
+      { type: "text", text: JSON.stringify(structured, null, 2) },
+    ]);
+  });
+
+  it("falls back to structuredContent when content is omitted entirely", () => {
+    const structured = { value: 42 };
+    const blocks = resolveMcpResultContent({ structuredContent: structured });
+
+    expect(blocks).toEqual([
+      { type: "text", text: JSON.stringify(structured, null, 2) },
+    ]);
+  });
+
+  it("returns empty array when both content and structuredContent are absent", () => {
+    expect(resolveMcpResultContent({ content: [] })).toEqual([]);
+    expect(resolveMcpResultContent({})).toEqual([]);
+  });
+
+  it("does not treat null structuredContent as a fallback payload", () => {
+    expect(
+      resolveMcpResultContent({ content: [], structuredContent: null }),
+    ).toEqual([]);
+  });
+
+  it("treats an empty structuredContent object as a present payload", () => {
+    // guards against a truthy check that would drop a legitimately empty object
+    expect(
+      resolveMcpResultContent({ content: [], structuredContent: {} }),
+    ).toEqual([{ type: "text", text: "{}" }]);
+  });
+
+  it("does not fall back when content has a non-text block", () => {
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+      structuredContent: { should: "not appear" },
+    });
+
+    expect(blocks).toEqual([{ type: "image", data: "abc", mimeType: "image/png" }]);
+  });
+
+  it("degrades gracefully when structuredContent is not serializable", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    const blocks = resolveMcpResultContent({ content: [], structuredContent: circular });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: "text" });
+  });
+
+  it("prefers real content over structuredContent even for a single block", () => {
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "text", text: "real" }],
+      structuredContent: { fallback: "should not appear" },
+    });
+
+    expect(blocks).toEqual([{ type: "text", text: "real" }]);
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -6,7 +6,7 @@ import type { MetadataCache } from "./metadata-cache.ts";
 import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
 import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
-import { transformMcpContent } from "./tool-registrar.ts";
+import { transformMcpContent, resolveMcpResultContent } from "./tool-registrar.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
@@ -379,10 +379,9 @@ export function createDirectToolExecutor(
       const result = await resultPromise;
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
 
-      const mcpContent = (result.content ?? []) as McpContent[];
-      const content = transformMcpContent(mcpContent);
-
       if (result.isError) {
+        const mcpContent = (result.content ?? []) as McpContent[];
+        const content = transformMcpContent(mcpContent);
         let errorText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "Tool execution failed";
         if (spec.inputSchema) {
           errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`;
@@ -393,6 +392,7 @@ export function createDirectToolExecutor(
         };
       }
 
+      const content = resolveMcpResultContent(result);
       const resultText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "(empty result)";
       if (hasUi) {
         const uiMessage = uiSession?.reused

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -6,7 +6,7 @@ import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
-import { transformMcpContent } from "./tool-registrar.ts";
+import { transformMcpContent, resolveMcpResultContent } from "./tool-registrar.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
@@ -860,8 +860,7 @@ export async function executeCall(
     if (toolMeta.uiResourceUri) {
       const result = await resultPromise;
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
-      const mcpContent = (result.content ?? []) as McpContent[];
-      const content = transformMcpContent(mcpContent);
+      const content = resolveMcpResultContent(result);
 
       const mcpText = content
         .filter((c) => c.type === "text")
@@ -891,10 +890,9 @@ export async function executeCall(
 
     const result = await resultPromise;
 
-    const mcpContent = (result.content ?? []) as McpContent[];
-    const content = transformMcpContent(mcpContent);
-
     if (result.isError) {
+      const mcpContent = (result.content ?? []) as McpContent[];
+      const content = transformMcpContent(mcpContent);
       const errorText = content
         .filter((c) => c.type === "text")
         .map((c) => (c as { text: string }).text)
@@ -910,6 +908,8 @@ export async function executeCall(
         details: { mode: "call", error: "tool_error", mcpResult: result },
       };
     }
+
+    const content = resolveMcpResultContent(result);
 
     return {
       content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],

--- a/tool-registrar.ts
+++ b/tool-registrar.ts
@@ -44,3 +44,26 @@ export function transformMcpContent(content: McpContent[]): ContentBlock[] {
     return { type: "text" as const, text: JSON.stringify(c) };
   });
 }
+
+/**
+ * Resolve a tool result's content blocks, falling back to structuredContent
+ * when content is empty.
+ */
+export function resolveMcpResultContent(result: Record<string, unknown>): ContentBlock[] {
+  const blocks = transformMcpContent((Array.isArray(result.content) ? result.content : []) as McpContent[]);
+  if (blocks.length > 0) return blocks;
+
+  if (result.structuredContent !== undefined && result.structuredContent !== null) {
+    return [{ type: "text" as const, text: stringifyStructuredContent(result.structuredContent) }];
+  }
+
+  return [];
+}
+
+function stringifyStructuredContent(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value); // circular refs / throwing getters
+  }
+}


### PR DESCRIPTION
 ## Summary
Per the MCP spec, `content` is mandatory on a tool result while `structuredContent` is optional. Some servers, however, return their payload only in `structuredContent` and leave `content` empty (`content: []`). 

The adapter only ever read `content`, so those results reached the model as `(empty result)` and the actual data was silently dropped.

This change makes the adapter fall back to `structuredContent` when `content` resolves to no blocks, so the payload is no longer lost.

## Changes
- **structuredContent fallback**: new `resolveMcpResultContent` helper that transforms `content` and, when it yields no blocks, serializes `structuredContent` into a text block. Wired into both the proxy `executeCall` path and the direct-tool executor, in the success branch only (error handling is unchanged).

Closes #113.