### PR TITLE
Forward agent abort signal so Esc/Ctrl+C cancels MCP tool calls (fixes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Forwarded the agent's abort signal to MCP `callTool`/`readResource` requests so pressing `Esc`/`Ctrl+C` cancels in-flight tool calls (the SDK now emits `notifications/cancelled`) instead of running them to completion. Fixes #40.
+
 ## [2.10.0] - 2026-06-13
 
 ### Added

--- a/__tests__/abort-signal-forwarding.test.ts
+++ b/__tests__/abort-signal-forwarding.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// These tests lock in that the agent's AbortSignal (raised when the user hits
+// Esc / Ctrl+C) is forwarded to the MCP SDK's callTool/readResource as
+// RequestOptions.signal. Without it, the SDK never emits notifications/cancelled
+// and long-running tool calls keep running after the user cancels (issue #40).
+
+const mocks = vi.hoisted(() => ({
+  lazyConnect: vi.fn(),
+  getFailureAgeSeconds: vi.fn(),
+}));
+
+vi.mock("../init.ts", () => ({
+  lazyConnect: mocks.lazyConnect,
+  getFailureAgeSeconds: mocks.getFailureAgeSeconds,
+}));
+
+describe("abort signal forwarding", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.lazyConnect.mockReset().mockResolvedValue(true);
+    mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
+  });
+
+  it("executeCall forwards the abort signal to callTool", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const callTool = vi.fn(async () => ({
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+    }));
+    const connection = { status: "connected", client: { callTool } };
+
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: { demo: { command: "npx", args: ["demo"] } },
+      },
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_search",
+              originalName: "search",
+              description: "Search",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        ],
+      ]),
+      manager: {
+        getConnection: vi.fn(() => connection),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+    } as any;
+
+    const signal = new AbortController().signal;
+    const result = await executeCall(state, "demo_search", { q: "hi" }, "demo", undefined, signal);
+
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "search", arguments: { q: "hi" }, _meta: undefined },
+      undefined,
+      { signal },
+    );
+    expect(result.content[0].text).toContain("ok");
+  });
+
+  it("executeCall forwards the abort signal to readResource for resource tools", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+
+    const readResource = vi.fn(async () => ({
+      contents: [{ uri: "res://x", text: "hello" }],
+    }));
+    const connection = { status: "connected", client: { readResource } };
+
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: { demo: { command: "npx", args: ["demo"] } },
+      },
+      toolMetadata: new Map([
+        [
+          "demo",
+          [
+            {
+              name: "demo_doc",
+              originalName: "doc",
+              description: "Doc",
+              resourceUri: "res://x",
+            },
+          ],
+        ],
+      ]),
+      manager: {
+        getConnection: vi.fn(() => connection),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+    } as any;
+
+    const signal = new AbortController().signal;
+    await executeCall(state, "demo_doc", undefined, "demo", undefined, signal);
+
+    expect(readResource).toHaveBeenCalledWith({ uri: "res://x" }, { signal });
+  });
+
+  it("createDirectToolExecutor forwards the abort signal to callTool", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+
+    const callTool = vi.fn(async () => ({
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+    }));
+    const connection = { status: "connected", client: { callTool } };
+
+    const state = {
+      config: {
+        settings: {},
+        mcpServers: { demo: { command: "npx", args: ["demo"] } },
+      },
+      manager: {
+        getConnection: vi.fn(() => connection),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search",
+      },
+    );
+
+    const signal = new AbortController().signal;
+    const result = await executor("id", { q: "hello" }, signal, () => {}, undefined as any);
+
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "search", arguments: { q: "hello" }, _meta: undefined },
+      undefined,
+      { signal },
+    );
+    expect(result.content[0].text).toContain("ok");
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -276,7 +276,7 @@ export function createDirectToolExecutor(
   getInitPromise: () => Promise<McpExtensionState> | null,
   spec: DirectToolSpec
 ): DirectToolExecute {
-  return async function execute(_toolCallId, params) {
+  return async function execute(_toolCallId, params, signal) {
     let state = getState();
     const initPromise = getInitPromise();
 
@@ -348,7 +348,7 @@ export function createDirectToolExecutor(
       state.manager.incrementInFlight(spec.serverName);
 
       if (spec.resourceUri) {
-        const result = await connection.client.readResource({ uri: spec.resourceUri });
+        const result = await connection.client.readResource({ uri: spec.resourceUri }, { signal });
         const content = (result.contents ?? []).map(c => ({
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -374,7 +374,7 @@ export function createDirectToolExecutor(
         name: spec.originalName,
         arguments: params ?? {},
         _meta: uiSession?.requestMeta,
-      });
+      }, undefined, { signal });
 
       const result = await resultPromise;
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);

--- a/index.ts
+++ b/index.ts
@@ -276,7 +276,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         includeSchemas?: boolean;
         server?: string;
         action?: string;
-      }, _signal, _onUpdate, _ctx) {
+      }, signal, _onUpdate, _ctx) {
         let parsedArgs: Record<string, unknown> | undefined;
         if (params.args) {
           try {
@@ -340,7 +340,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           return executeAuthComplete(state, params.server, input);
         }
         if (params.tool) {
-          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools);
+          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, signal);
         }
         if (params.connect) {
           return executeConnect(state, params.connect);

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -581,6 +581,7 @@ export async function executeCall(
   args?: Record<string, unknown>,
   serverOverride?: string,
   getPiTools?: () => ToolInfo[],
+  signal?: AbortSignal,
 ): Promise<ProxyToolResult> {
   let serverName: string | undefined = serverOverride;
   let toolMeta: ToolMetadata | undefined;
@@ -830,7 +831,7 @@ export async function executeCall(
     state.manager.incrementInFlight(serverName);
 
     if (toolMeta.resourceUri) {
-      const result = await connection.client.readResource({ uri: toolMeta.resourceUri });
+      const result = await connection.client.readResource({ uri: toolMeta.resourceUri }, { signal });
       const content = (result.contents ?? []).map(c => ({
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -855,7 +856,7 @@ export async function executeCall(
       name: toolMeta.originalName,
       arguments: args ?? {},
       _meta: uiSession?.requestMeta,
-    });
+    }, undefined, { signal });
 
     if (toolMeta.uiResourceUri) {
       const result = await resultPromise;


### PR DESCRIPTION
## Summary

Pressing <kbd>Esc</kbd>/<kbd>Ctrl+C</kbd> in Pi doesn't cancel an in-flight MCP tool call — the call runs to completion and Pi discards the (late) result. This is especially painful for long-running tools, which block the agent until they finish or time out.

Fixes #40 (also addresses the "propagate abort signal" item in #18).

## Root cause

Pi passes a per-turn `AbortSignal` into every tool's `execute(toolCallId, params, signal, ...)` and aborts it on <kbd>Esc</kbd>/<kbd>Ctrl+C</kbd>. The MCP SDK already knows how to act on this: when `callTool`/`readResource` are given `RequestOptions.signal`, an abort triggers a `notifications/cancelled` JSON-RPC notification to the server.

But the adapter dropped the signal on the floor in all three execution paths:

- **`index.ts`** — the gateway `mcp` tool's `execute` ignored its signal (`}, _signal, _onUpdate, _ctx) {`) and didn't pass it to `executeCall`.
- **`proxy-modes.ts`** — `executeCall` had no signal parameter, and its `callTool`/`readResource` calls passed no `RequestOptions`.
- **`direct-tools.ts`** — the executor wrapper `return async function execute(_toolCallId, params)` didn't even declare the signal arg, and its `callTool`/`readResource` calls passed no `RequestOptions`.

Because no `signal` reached the SDK, `notifications/cancelled` was never sent, so the server kept working and Pi ignored the eventual result.

## Changes

- Capture the abort `signal` in the gateway `mcp` tool (`index.ts`) and the direct-tool executor (`direct-tools.ts`).
- Add a `signal?: AbortSignal` parameter to `executeCall` (`proxy-modes.ts`) and thread it through from `index.ts`.
- Forward the signal as `RequestOptions` to `callTool` (`{...}, undefined, { signal }`) and `readResource` (`{ uri }, { signal }`) in both the proxy and direct-tool paths.

The browser-driven `ui-server.ts` `callTool` is intentionally left alone — it has no Pi `AbortSignal` in scope and already has its own browser "Cancel" flow.

## Testing

- Added `__tests__/abort-signal-forwarding.test.ts` covering all three: `executeCall` → `callTool`, `executeCall` → `readResource` (resource tools), and `createDirectToolExecutor` → `callTool`. Each asserts the exact `RequestOptions.signal` is forwarded.
- `npx tsc --noEmit` passes.
- Full suite: 373 pre-existing tests pass + 3 new. The only failures (`interactive-visualizer-server.test.ts`, 2 tests) are pre-existing and unrelated — they read a build artifact (`examples/interactive-visualizer/dist/`) that isn't generated without a build step, and fail identically on a clean `main`.
