### PR TITLE
fix: honor MCP requestTimeoutMs during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Pi-specific files are the write targets for imported or shared global servers wh
       "command": "npx",
       "args": ["-y", "some-mcp-server"],
       "lifecycle": "lazy",
-      "idleTimeout": 10
+      "idleTimeout": 10,
+      "requestTimeoutMs": 30000
     }
   }
 }
@@ -135,6 +136,7 @@ Pi-specific files are the write targets for imported or shared global servers wh
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation |
 | `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
+| `requestTimeoutMs` | Request timeout in milliseconds for live MCP calls (overrides global, `<= 0` uses SDK default) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
@@ -174,7 +176,8 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 {
   "settings": {
     "toolPrefix": "server",
-    "idleTimeout": 10
+    "idleTimeout": 10,
+    "requestTimeoutMs": 30000
   },
   "mcpServers": { }
 }
@@ -184,6 +187,7 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 |---------|-------------|
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
+| `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (`<= 0` uses the MCP SDK default timeout) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
@@ -191,7 +195,7 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 | `samplingAutoApprove` | Skip sampling confirmation prompts. Required for sampling in non-UI sessions (default: false). |
 | `elicitation` | Allow MCP servers to request user input through Pi dialogs (default: true when Pi UI is available). |
 
-Per-server `idleTimeout` overrides the global setting.
+Per-server `idleTimeout` and `requestTimeoutMs` override the global settings.
 
 ### MCP Elicitation
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -29,7 +29,7 @@ describe("config discovery", () => {
     const realProject = realpathSync(project);
 
     writeJson(join(home, ".config", "mcp", "mcp.json"), {
-      settings: { idleTimeout: 5 },
+      settings: { idleTimeout: 5, requestTimeoutMs: 1500 },
       mcpServers: {
         shared: { command: "generic" },
         genericOnly: { command: "generic-only" },
@@ -70,6 +70,7 @@ describe("config discovery", () => {
     expect(config.mcpServers.projectPiOnly).toMatchObject({ command: "project-pi-only" });
     expect(config.settings).toEqual({
       idleTimeout: 5,
+      requestTimeoutMs: 1500,
       toolPrefix: "none",
       directTools: true,
       autoAuth: true,

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -59,6 +59,7 @@ describe("direct tools auto auth", () => {
           connection = undefined;
         }),
         getConnection: vi.fn(() => connection),
+        getRequestOptions: vi.fn(() => ({ timeout: 4321 })),
         touch: vi.fn(),
         incrementInFlight: vi.fn(),
         decrementInFlight: vi.fn(),
@@ -79,7 +80,8 @@ describe("direct tools auto auth", () => {
       },
     );
 
-    const result = await executor("id", { q: "hello" }, undefined as any, () => {}, undefined as any);
+    const controller = new AbortController();
+    const result = await executor("id", { q: "hello" }, controller.signal, () => {}, undefined as any);
 
     expect(mocks.authenticate).toHaveBeenCalledWith(
       "demo",
@@ -87,7 +89,67 @@ describe("direct tools auto auth", () => {
       state.config.mcpServers.demo,
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
+    expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
+    expect(connected.client.callTool).toHaveBeenCalledWith(
+      {
+        name: "search",
+        arguments: { q: "hello" },
+        _meta: undefined,
+      },
+      undefined,
+      { timeout: 4321 },
+    );
     expect(result.content[0].text).toContain("ok");
+  });
+
+  it("surfaces aborted direct tool calls via the forwarded AbortSignal", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const controller = new AbortController();
+    controller.abort();
+
+    const requestOptions = { signal: controller.signal, timeout: 4321 };
+    const connection = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async (_params: unknown, _schema: unknown, options: { signal?: AbortSignal }) => {
+          if (options.signal?.aborted) {
+            throw new Error("request aborted");
+          }
+          return { isError: false, content: [{ type: "text", text: "ok" }] };
+        }),
+      },
+    };
+    const state = {
+      config: { settings: {}, mcpServers: { demo: { command: "demo" } } },
+      manager: {
+        getConnection: vi.fn(() => connection),
+        getRequestOptions: vi.fn(() => requestOptions),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+    mocks.lazyConnect.mockResolvedValue(true);
+
+    const executor = createDirectToolExecutor(() => state, () => null, {
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Search",
+    });
+
+    const result = await executor("id", {}, controller.signal, undefined, undefined as any);
+
+    expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
+    expect(connection.client.callTool).toHaveBeenCalledWith(
+      { name: "search", arguments: {}, _meta: undefined },
+      undefined,
+      requestOptions,
+    );
+    expect(result.details).toMatchObject({ error: "call_failed", server: "demo" });
+    expect(result.content[0].text).toContain("request aborted");
   });
 
   it("fails fast in non-ui context for browser-based OAuth", async () => {

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -249,6 +249,40 @@ describe("mcpAdapter session lifecycle", () => {
     );
   });
 
+  it("forwards the proxy tool AbortSignal into executeCall", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeCall.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    expect(proxyTool).toBeDefined();
+
+    const controller = new AbortController();
+    await proxyTool.execute(
+      "call-1",
+      { tool: "demo_search", args: '{"q":"hello"}' },
+      controller.signal,
+    );
+
+    expect(mocks.executeCall).toHaveBeenCalledWith(
+      state,
+      "demo_search",
+      { q: "hello" },
+      undefined,
+      expect.any(Function),
+      controller.signal,
+    );
+  });
+
   it("starts a replacement init immediately and shuts down stale init results", async () => {
     const first = createDeferred<any>();
     const second = createDeferred<any>();

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -8,6 +8,12 @@ const mocks = vi.hoisted(() => ({
   updateMetadataCache: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
   updateStatusBar: vi.fn(),
+  clients: [] as any[],
+  transports: [] as any[],
+  connectImpl: vi.fn(),
+  listToolsImpl: vi.fn(),
+  listResourcesImpl: vi.fn(),
+  callToolImpl: vi.fn(),
 }));
 
 vi.mock("../mcp-auth-flow.ts", () => ({
@@ -23,6 +29,49 @@ vi.mock("../init.ts", () => ({
   updateStatusBar: mocks.updateStatusBar,
 }));
 
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
+    this.info = info;
+    this.options = options;
+    this.setRequestHandler = vi.fn();
+    this.setNotificationHandler = vi.fn();
+    this.connect = vi.fn((transport: unknown, requestOptions: unknown) =>
+      mocks.connectImpl(transport, requestOptions)
+    );
+    this.listTools = vi.fn((params: unknown, requestOptions: unknown) =>
+      mocks.listToolsImpl(params, requestOptions)
+    );
+    this.listResources = vi.fn((params: unknown, requestOptions: unknown) =>
+      mocks.listResourcesImpl(params, requestOptions)
+    );
+    this.callTool = vi.fn((params: unknown, schema: unknown, requestOptions: unknown) =>
+      mocks.callToolImpl(params, schema, requestOptions)
+    );
+    this.close = vi.fn(async () => undefined);
+    mocks.clients.push(this);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
+    this.options = options;
+    this.close = vi.fn(async () => undefined);
+    mocks.transports.push(this);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
 describe("proxy auto auth", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -33,6 +82,15 @@ describe("proxy auto auth", () => {
     mocks.updateMetadataCache.mockReset();
     mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
     mocks.updateStatusBar.mockReset();
+    mocks.clients.length = 0;
+    mocks.transports.length = 0;
+    mocks.connectImpl.mockReset().mockResolvedValue(undefined);
+    mocks.listToolsImpl.mockReset().mockResolvedValue({ tools: [] });
+    mocks.listResourcesImpl.mockReset().mockResolvedValue({ resources: [] });
+    mocks.callToolImpl.mockReset().mockResolvedValue({
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+    });
   });
 
   it("auto-authenticates and retries executeConnect once", async () => {
@@ -209,6 +267,7 @@ describe("proxy auto auth", () => {
         current = undefined;
       }),
       getConnection: vi.fn(() => current),
+      getRequestOptions: vi.fn(() => ({ timeout: 1234 })),
       touch: vi.fn(),
       incrementInFlight: vi.fn(),
       decrementInFlight: vi.fn(),
@@ -240,7 +299,8 @@ describe("proxy auto auth", () => {
       completedUiSessions: [],
     } as any;
 
-    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+    const controller = new AbortController();
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo", undefined, controller.signal);
 
     expect(mocks.authenticate).toHaveBeenCalledWith(
       "demo",
@@ -248,6 +308,145 @@ describe("proxy auto auth", () => {
       state.config.mcpServers.demo,
     );
     expect(manager.connect).toHaveBeenCalledTimes(1);
+    expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
+    expect(connected.client.callTool).toHaveBeenCalledWith(
+      {
+        name: "search",
+        arguments: { q: "hello" },
+        _meta: undefined,
+      },
+      undefined,
+      { timeout: 1234 },
+    );
     expect(result.content[0].text).toContain("ok");
+  });
+
+  it("surfaces aborted proxy tool calls via the forwarded AbortSignal", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const controller = new AbortController();
+    controller.abort();
+
+    const requestOptions = { signal: controller.signal, timeout: 1234 };
+    const connection = {
+      status: "connected",
+      client: {
+        callTool: vi.fn(async (_params: unknown, _schema: unknown, options: { signal?: AbortSignal }) => {
+          if (options.signal?.aborted) {
+            throw new Error("request aborted");
+          }
+          return { isError: false, content: [{ type: "text", text: "ok" }] };
+        }),
+      },
+    };
+    const manager = {
+      getConnection: vi.fn(() => connection),
+      getRequestOptions: vi.fn(() => requestOptions),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: { command: "demo" } } },
+      manager,
+      toolMetadata: new Map([["demo", [{
+        name: "demo_search",
+        originalName: "search",
+        description: "Search",
+        inputSchema: { type: "object", properties: {} },
+      }]]]),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", {}, "demo", undefined, controller.signal);
+
+    expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
+    expect(connection.client.callTool).toHaveBeenCalledWith(
+      { name: "search", arguments: {}, _meta: undefined },
+      undefined,
+      requestOptions,
+    );
+    expect(result.details).toMatchObject({ error: "call_failed", message: "request aborted" });
+    expect(result.content[0].text).toContain("request aborted");
+  });
+
+  it("shares one cold connect across concurrent proxy calls and applies timeout during bootstrap", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const { McpServerManager } = await import("../server-manager.ts");
+
+    const pause = () => new Promise((resolve) => setTimeout(resolve, 10));
+    mocks.connectImpl.mockImplementation(async () => {
+      await pause();
+    });
+    mocks.listToolsImpl.mockImplementation(async () => {
+      await pause();
+      return {
+        tools: [{
+          name: "search",
+          description: "Search",
+          inputSchema: { type: "object", properties: {} },
+        }],
+      };
+    });
+    mocks.listResourcesImpl.mockImplementation(async () => {
+      await pause();
+      return { resources: [] };
+    });
+    mocks.lazyConnect.mockImplementation(async (state: any, serverName: string) => {
+      const connection = await state.manager.connect(serverName, state.config.mcpServers[serverName]);
+      if (connection.status !== "connected") {
+        return false;
+      }
+      state.toolMetadata.set(serverName, [{
+        name: "demo_search",
+        originalName: "search",
+        description: "Search",
+        inputSchema: { type: "object", properties: {} },
+      }]);
+      return true;
+    });
+
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2500);
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: {
+          demo: { command: "node", args: ["server.js"], requestTimeoutMs: 5000 },
+        },
+      },
+      manager,
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const [first, second] = await Promise.all([
+      executeCall(state, "demo_search", { q: "one" }),
+      executeCall(state, "demo_search", { q: "two" }),
+    ]);
+
+    expect(mocks.clients).toHaveLength(1);
+    const client = mocks.clients[0];
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 5000 });
+    expect(client.listTools).toHaveBeenCalledTimes(1);
+    expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 5000 });
+    expect(client.listResources).toHaveBeenCalledTimes(1);
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 5000 });
+    expect(client.callTool).toHaveBeenNthCalledWith(
+      1,
+      { name: "search", arguments: { q: "one" }, _meta: undefined },
+      undefined,
+      { timeout: 5000 },
+    );
+    expect(client.callTool).toHaveBeenNthCalledWith(
+      2,
+      { name: "search", arguments: { q: "two" }, _meta: undefined },
+      undefined,
+      { timeout: 5000 },
+    );
+    expect(first.content[0].text).toContain("ok");
+    expect(second.content[0].text).toContain("ok");
   });
 });

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -23,20 +23,25 @@ type HttpTransportMock = {
 };
 
 const mocks = vi.hoisted(() => ({
+  clients: [] as any[],
   httpTransports: [] as HttpTransportMock[],
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
-  Client: vi.fn().mockImplementation((info: unknown, options: unknown) => ({
-    info,
-    options,
-    setRequestHandler: vi.fn(),
-    setNotificationHandler: vi.fn(),
-    connect: vi.fn(async () => undefined),
-    listTools: vi.fn(async () => ({ tools: [] })),
-    listResources: vi.fn(async () => ({ resources: [] })),
-    close: vi.fn(async () => undefined),
-  })),
+  Client: vi.fn().mockImplementation((info: unknown, options: unknown) => {
+    const client = {
+      info,
+      options,
+      setRequestHandler: vi.fn(),
+      setNotificationHandler: vi.fn(),
+      connect: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => ({ tools: [] })),
+      listResources: vi.fn(async () => ({ resources: [] })),
+      close: vi.fn(async () => undefined),
+    };
+    mocks.clients.push(client);
+    return client;
+  }),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
@@ -66,6 +71,7 @@ describe("McpServerManager HTTP bearer auth", () => {
   };
 
   beforeEach(() => {
+    mocks.clients.length = 0;
     mocks.httpTransports.length = 0;
   });
 
@@ -140,5 +146,19 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(authProvider?.clientMetadata?.redirect_uris).toEqual(["http://127.0.0.1:3118/callback"]);
     expect(authProvider?.clientMetadata?.client_name).toBe("Custom MCP");
     expect(authProvider?.clientMetadata?.client_uri).toBe("https://example.com/custom-mcp");
+  });
+
+  it("applies the configured timeout to the HTTP probe connect", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2500);
+    await manager.connect("remote", {
+      url: "https://example.test/mcp",
+      requestTimeoutMs: 5000,
+    });
+
+    expect(mocks.clients[1].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
+    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[1], { timeout: 5000 });
   });
 });

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -233,4 +233,48 @@ describe("McpServerManager sampling", () => {
     expect(mocks.transports[0].options).toMatchObject({ cwd: "/tmp/pi-mcp-cwd/nested" });
     expect(mocks.transports[1].options).toMatchObject({ cwd: join(homedir(), "nested") });
   });
+
+  it("applies the global timeout to connect and discovery requests", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2500);
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    const client = mocks.clients[0];
+    expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 2500 });
+    expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 2500 });
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 2500 });
+  });
+
+  it("prefers the per-server timeout for connect and discovery requests", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2500);
+
+    await manager.connect("demo", { command: "node", args: ["server.js"], requestTimeoutMs: 5000 });
+
+    const client = mocks.clients[0];
+    expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 5000 });
+    expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 5000 });
+    expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 5000 });
+  });
+
+  it("builds request options from global and per-server timeouts", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2500);
+
+    await manager.connect("demo", { command: "node", args: ["server.js"], requestTimeoutMs: 5000 });
+    await manager.connect("sdk-default", { command: "node", args: ["server.js"], requestTimeoutMs: 0 });
+
+    const signal = new AbortController().signal;
+    expect(manager.getRequestOptions("demo", signal)).toEqual({ signal, timeout: 5000 });
+    expect(manager.getRequestOptions("missing", signal)).toEqual({ signal, timeout: 2500 });
+    expect(manager.getRequestOptions("missing")).toEqual({ timeout: 2500 });
+    expect(manager.getRequestOptions("sdk-default")).toBeUndefined();
+
+    manager.setDefaultRequestTimeoutMs(0);
+    expect(manager.getRequestOptions("missing")).toBeUndefined();
+  });
 });

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -121,6 +121,7 @@ function createMockManager(overrides: Partial<McpServerManager> = {}): McpServer
     incrementInFlight: vi.fn(),
     decrementInFlight: vi.fn(),
     readResource: vi.fn(),
+    getRequestOptions: vi.fn().mockReturnValue(undefined),
     ...overrides,
   } as unknown as McpServerManager;
 }
@@ -433,8 +434,10 @@ describe("UiServer", () => {
       const mockClient = {
         callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "tool result" }] }),
       };
+      const requestOptions = { timeout: 4321 };
       const manager = createMockManager({
         getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
+        getRequestOptions: vi.fn().mockReturnValue(requestOptions),
       });
       handle = await startUiServer(createServerOptions({ manager }));
 
@@ -451,10 +454,15 @@ describe("UiServer", () => {
         ok: true,
         result: { content: [{ type: "text", text: "tool result" }] },
       });
-      expect(mockClient.callTool).toHaveBeenCalledWith({
-        name: "some_tool",
-        arguments: { arg1: "value1" },
-      });
+      expect(manager.getRequestOptions).toHaveBeenCalledWith("test-server");
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        {
+          name: "some_tool",
+          arguments: { arg1: "value1" },
+        },
+        undefined,
+        requestOptions,
+      );
     });
 
     it("checks consent before calling tool", async () => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -276,7 +276,7 @@ export function createDirectToolExecutor(
   getInitPromise: () => Promise<McpExtensionState> | null,
   spec: DirectToolSpec
 ): DirectToolExecute {
-  return async function execute(_toolCallId, params) {
+  return async function execute(_toolCallId, params, signal) {
     let state = getState();
     const initPromise = getInitPromise();
 
@@ -342,13 +342,14 @@ export function createDirectToolExecutor(
     }
 
     let uiSession: UiSessionRuntime | null = null;
+    const requestOptions = state.manager.getRequestOptions?.(spec.serverName, signal);
 
     try {
       state.manager.touch(spec.serverName);
       state.manager.incrementInFlight(spec.serverName);
 
       if (spec.resourceUri) {
-        const result = await connection.client.readResource({ uri: spec.resourceUri });
+        const result = await connection.client.readResource({ uri: spec.resourceUri }, requestOptions);
         const content = (result.contents ?? []).map(c => ({
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -374,7 +375,7 @@ export function createDirectToolExecutor(
         name: spec.originalName,
         arguments: params ?? {},
         _meta: uiSession?.requestMeta,
-      });
+      }, undefined, requestOptions);
 
       const result = await resultPromise;
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);

--- a/index.ts
+++ b/index.ts
@@ -340,7 +340,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           return executeAuthComplete(state, params.server, input);
         }
         if (params.tool) {
-          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools);
+          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, _signal);
         }
         if (params.connect) {
           return executeConnect(state, params.connect);

--- a/init.ts
+++ b/init.ts
@@ -37,6 +37,7 @@ export async function initializeMcp(
   const config = loadMcpConfig(configPath, ctx.cwd);
 
   const manager = new McpServerManager();
+  manager.setDefaultRequestTimeoutMs(config.settings?.requestTimeoutMs);
   const samplingAutoApprove = config.settings?.samplingAutoApprove === true;
   if (config.settings?.sampling !== false && (ctx.hasUI || samplingAutoApprove)) {
     manager.setSamplingConfig({

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -83,7 +83,7 @@ export function saveMetadataCache(cache: MetadataCache): void {
 
 export function computeServerHash(definition: ServerEntry): string {
   // Hash only fields that affect server identity and tool/resource output.
-  // Exclude lifecycle, idleTimeout, debug — those are runtime behavior settings
+  // Exclude lifecycle, idleTimeout, requestTimeoutMs, debug — those are runtime behavior settings
   // that don't change which tools a server exposes.
   const identity: Record<string, unknown> = {
     command: definition.command,

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -581,6 +581,7 @@ export async function executeCall(
   args?: Record<string, unknown>,
   serverOverride?: string,
   getPiTools?: () => ToolInfo[],
+  signal?: AbortSignal,
 ): Promise<ProxyToolResult> {
   let serverName: string | undefined = serverOverride;
   let toolMeta: ToolMetadata | undefined;
@@ -824,13 +825,14 @@ export async function executeCall(
   }
 
   let uiSession: UiSessionRuntime | null = null;
+  const requestOptions = state.manager.getRequestOptions?.(serverName, signal);
 
   try {
     state.manager.touch(serverName);
     state.manager.incrementInFlight(serverName);
 
     if (toolMeta.resourceUri) {
-      const result = await connection.client.readResource({ uri: toolMeta.resourceUri });
+      const result = await connection.client.readResource({ uri: toolMeta.resourceUri }, requestOptions);
       const content = (result.contents ?? []).map(c => ({
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -855,7 +857,7 @@ export async function executeCall(
       name: toolMeta.originalName,
       arguments: args ?? {},
       _meta: uiSession?.requestMeta,
-    });
+    }, undefined, requestOptions);
 
     if (toolMeta.uiResourceUri) {
       const result = await resultPromise;

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -3,6 +3,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
   ElicitationCompleteNotificationSchema,
   type ReadResourceResult,
@@ -48,6 +49,7 @@ export class McpServerManager {
   private samplingConfig: ServerSamplingConfig | undefined;
   private elicitationConfig: ServerElicitationConfig | undefined;
   private acceptedUrlElicitations = new Map<string, Set<string>>();
+  private defaultRequestTimeoutMs: number | undefined;
 
   setSamplingConfig(config: ServerSamplingConfig | undefined): void {
     this.samplingConfig = config;
@@ -55,6 +57,38 @@ export class McpServerManager {
 
   setElicitationConfig(config: ServerElicitationConfig | undefined): void {
     this.elicitationConfig = config;
+  }
+
+  setDefaultRequestTimeoutMs(timeoutMs: number | undefined): void {
+    this.defaultRequestTimeoutMs = normalizeRequestTimeoutMs(timeoutMs);
+  }
+
+  getRequestOptions(name: string, signal?: AbortSignal): RequestOptions | undefined {
+    const connection = this.connections.get(name);
+    return this.buildRequestOptions(connection?.definition, signal);
+  }
+
+  private getResolvedRequestTimeoutMs(definition?: ServerDefinition): number | undefined {
+    if (definition?.requestTimeoutMs !== undefined) {
+      return normalizeRequestTimeoutMs(definition.requestTimeoutMs);
+    }
+    return this.defaultRequestTimeoutMs;
+  }
+
+  private buildRequestOptions(
+    definition?: ServerDefinition,
+    signal?: AbortSignal,
+  ): RequestOptions | undefined {
+    const timeout = this.getResolvedRequestTimeoutMs(definition);
+
+    if (!signal && timeout === undefined) {
+      return undefined;
+    }
+
+    return {
+      ...(signal ? { signal } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
   }
 
   async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
@@ -117,14 +151,16 @@ export class McpServerManager {
       throw new Error(`Server ${name} has no command or url`);
     }
 
+    const requestOptions = this.buildRequestOptions(definition);
+
     try {
-      await client.connect(transport);
+      await client.connect(transport, requestOptions);
       this.attachAdapterNotificationHandlers(name, client);
 
       // Discover tools and resources
       const [tools, resources] = await Promise.all([
-        this.fetchAllTools(client),
-        this.fetchAllResources(client),
+        this.fetchAllTools(client, requestOptions),
+        this.fetchAllResources(client, requestOptions),
       ]);
 
       return {
@@ -276,7 +312,7 @@ export class McpServerManager {
     try {
       // Create a test client to verify the transport works
       const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
-      await testClient.connect(streamableTransport);
+      await testClient.connect(streamableTransport, this.buildRequestOptions(definition));
       await testClient.close().catch(() => {});
       // Close probe transport before creating fresh one
       await streamableTransport.close().catch(() => {});
@@ -297,12 +333,12 @@ export class McpServerManager {
     }
   }
 
-  private async fetchAllTools(client: Client): Promise<McpTool[]> {
+  private async fetchAllTools(client: Client, requestOptions?: RequestOptions): Promise<McpTool[]> {
     const allTools: McpTool[] = [];
     let cursor: string | undefined;
 
     do {
-      const result = await client.listTools(cursor ? { cursor } : undefined);
+      const result = await client.listTools(cursor ? { cursor } : undefined, requestOptions);
       allTools.push(...(result.tools ?? []));
       cursor = result.nextCursor;
     } while (cursor);
@@ -310,13 +346,13 @@ export class McpServerManager {
     return allTools;
   }
 
-  private async fetchAllResources(client: Client): Promise<McpResource[]> {
+  private async fetchAllResources(client: Client, requestOptions?: RequestOptions): Promise<McpResource[]> {
     try {
       const allResources: McpResource[] = [];
       let cursor: string | undefined;
 
       do {
-        const result = await client.listResources(cursor ? { cursor } : undefined);
+        const result = await client.listResources(cursor ? { cursor } : undefined, requestOptions);
         allResources.push(...(result.resources ?? []));
         cursor = result.nextCursor;
       } while (cursor);
@@ -344,7 +380,7 @@ export class McpServerManager {
     this.uiStreamListeners.delete(streamToken);
   }
 
-  async readResource(name: string, uri: string): Promise<ReadResourceResult> {
+  async readResource(name: string, uri: string, signal?: AbortSignal): Promise<ReadResourceResult> {
     const connection = this.connections.get(name);
     if (!connection || connection.status !== "connected") {
       throw new Error(`Server "${name}" is not connected`);
@@ -353,7 +389,7 @@ export class McpServerManager {
     try {
       this.touch(name);
       this.incrementInFlight(name);
-      return await connection.client.readResource({ uri });
+      return await connection.client.readResource({ uri }, this.getRequestOptions(name, signal));
     } finally {
       this.decrementInFlight(name);
       this.touch(name);
@@ -439,4 +475,10 @@ function resolveEnv(env?: Record<string, string>): Record<string, string> {
  */
 function resolveHeaders(headers?: Record<string, string>): Record<string, string> | undefined {
   return interpolateEnvRecord(headers);
+}
+
+function normalizeRequestTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : undefined;
 }

--- a/types.ts
+++ b/types.ts
@@ -307,6 +307,7 @@ export interface ServerEntry {
   oauth?: OAuthConfig | false;
   lifecycle?: "keep-alive" | "lazy" | "eager";
   idleTimeout?: number; // minutes, overrides global setting
+  requestTimeoutMs?: number; // milliseconds, overrides global request timeout when > 0
   // Resource handling
   exposeResources?: boolean;
   // Direct tool registration
@@ -321,6 +322,7 @@ export interface ServerEntry {
 export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
   idleTimeout?: number; // minutes, default 10, 0 to disable
+  requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
   disableProxyTool?: boolean;
   autoAuth?: boolean;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -346,7 +346,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
                 ? callParams.arguments
                 : {},
-          });
+          }, undefined, options.manager.getRequestOptions?.(options.serverName));
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);


### PR DESCRIPTION
## Summary
- Thread resolved `requestTimeoutMs` through MCP bootstrap so `client.connect()`, `listTools()`, `listResources()`, and the StreamableHTTP probe all honor the configured timeout.
- Preserve the existing precedence rules: per-server `requestTimeoutMs` overrides the global fallback.
- Add regression coverage for concurrent cold starts, HTTP auth, direct/proxy forwarding, and UI proxy call paths.

## Verification
- `npx tsc --noEmit`
- `npx vitest run __tests__/init-elicitation.test.ts __tests__/server-manager-sampling.test.ts __tests__/server-manager-http-auth.test.ts __tests__/proxy-modes-auto-auth.test.ts __tests__/direct-tools-auto-auth.test.ts __tests__/index-lifecycle.test.ts __tests__/ui-server.test.ts`
- `git diff --check`

## Notes
- `npm run typecheck` is not listed because this package does not define a `typecheck` script.
- `npm test` currently fails only in `__tests__/interactive-visualizer-server.test.ts` because `examples/interactive-visualizer/dist/app.html` and `dist/server.js` are not present in this checkout; the timeout-related tests pass.
