### PR TITLE
fix: propagate Pi abort signals to MCP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
+### Fixed
+- Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
+
 ## [2.10.0] - 2026-06-13
 
 ### Added

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { abortable } from "../abort.ts";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { executeCall, executeConnect } from "../proxy-modes.ts";
+import { lazyConnect } from "../init.ts";
+import { McpServerManager } from "../server-manager.ts";
+
+function connectedState(client: Record<string, unknown>) {
+  return {
+    config: {
+      settings: { toolPrefix: "server" },
+      mcpServers: { demo: { command: "node", args: ["server.js"] } },
+    },
+    manager: {
+      getConnection: vi.fn(() => ({ status: "connected", client, tools: [], resources: [] })),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      close: vi.fn(async () => undefined),
+    },
+    toolMetadata: new Map([
+      [
+        "demo",
+        [
+          {
+            name: "demo_slow",
+            originalName: "slow",
+            description: "Slow tool",
+          },
+        ],
+      ],
+    ]),
+    failureTracker: new Map(),
+    ui: undefined,
+  } as any;
+}
+
+describe("AbortSignal propagation", () => {
+  it("abortable rejects promptly when the host signal aborts", async () => {
+    const controller = new AbortController();
+    const inFlight = abortable(new Promise<never>(() => {}), controller.signal);
+
+    controller.abort(new Error("user cancelled"));
+
+    await expect(inFlight).rejects.toThrow("user cancelled");
+  });
+
+  it("direct tools pass AbortSignal to MCP callTool and settle if the MCP SDK promise hangs", async () => {
+    const controller = new AbortController();
+    const callTool = vi.fn(() => new Promise<never>(() => {}));
+    const state = connectedState({ callTool });
+    const execute = createDirectToolExecutor(
+      () => state,
+      () => null,
+      {
+        serverName: "demo",
+        originalName: "slow",
+        prefixedName: "demo_slow",
+        description: "Slow tool",
+      },
+    );
+
+    const inFlight = execute("call-1", {}, controller.signal, undefined, {} as any);
+    await Promise.resolve();
+    controller.abort(new Error("user cancelled"));
+
+    const result = await inFlight;
+    expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
+    expect(result.details.error).toBe("call_failed");
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "slow", arguments: {}, _meta: undefined },
+      undefined,
+      { signal: controller.signal },
+    );
+    expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
+  });
+
+  it("proxy tool calls pass AbortSignal to MCP callTool and settle if the MCP SDK promise hangs", async () => {
+    const controller = new AbortController();
+    const callTool = vi.fn(() => new Promise<never>(() => {}));
+    const state = connectedState({ callTool });
+
+    const inFlight = executeCall(state, "demo_slow", {}, undefined, undefined, controller.signal);
+    await Promise.resolve();
+    controller.abort(new Error("user cancelled"));
+
+    const result = await inFlight;
+    expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
+    expect(result.details.error).toBe("call_failed");
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "slow", arguments: {}, _meta: undefined },
+      undefined,
+      { signal: controller.signal },
+    );
+    expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
+  });
+
+  it("proxy connect passes AbortSignal to manager.connect and does not record aborts as server failures", async () => {
+    const controller = new AbortController();
+    const state = {
+      config: { mcpServers: { demo: { command: "node", args: ["server.js"] } } },
+      manager: {
+        connect: vi.fn(async (_name, _definition, signal?: AbortSignal) => {
+          controller.abort(new Error("user cancelled"));
+          signal?.throwIfAborted();
+          return { status: "connected", tools: [], resources: [] };
+        }),
+        getAllConnections: vi.fn(() => new Map()),
+      },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+      ui: undefined,
+    } as any;
+
+    const result = await executeConnect(state, "demo", controller.signal);
+
+    expect(result.details.error).toBe("aborted");
+    expect(state.manager.connect).toHaveBeenCalledWith("demo", state.config.mcpServers.demo, controller.signal);
+    expect(state.failureTracker.size).toBe(0);
+  });
+
+  it("lazyConnect rethrows host aborts without updating the failure backoff", async () => {
+    const controller = new AbortController();
+    const state = {
+      config: { mcpServers: { demo: { command: "node", args: ["server.js"] } } },
+      manager: {
+        getConnection: vi.fn(() => undefined),
+        connect: vi.fn(async (_name, _definition, signal?: AbortSignal) => {
+          signal?.throwIfAborted();
+          return { status: "connected", tools: [], resources: [] };
+        }),
+      },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+    } as any;
+
+    controller.abort(new Error("user cancelled"));
+
+    await expect(lazyConnect(state, "demo", controller.signal)).rejects.toThrow("user cancelled");
+    expect(state.failureTracker.size).toBe(0);
+  });
+
+  it("server-manager resource discovery does not swallow host aborts", async () => {
+    const controller = new AbortController();
+    const client = {
+      listResources: vi.fn(async (_params, options?: { signal?: AbortSignal }) => {
+        options?.signal?.throwIfAborted();
+        return { resources: [] };
+      }),
+    };
+    const manager = new McpServerManager({} as any);
+
+    controller.abort(new Error("user cancelled"));
+
+    await expect((manager as any).fetchAllResources(client, controller.signal)).rejects.toThrow("user cancelled");
+  });
+
+  it("server-manager readResource passes AbortSignal through the MCP SDK request options", async () => {
+    const controller = new AbortController();
+    const readResource = vi.fn(async () => ({ contents: [] }));
+    const manager = new McpServerManager({} as any);
+    (manager as any).connections.set("demo", {
+      status: "connected",
+      client: { readResource },
+    });
+
+    await manager.readResource("demo", "resource://demo", controller.signal);
+
+    expect(readResource).toHaveBeenCalledWith(
+      { uri: "resource://demo" },
+      { signal: controller.signal },
+    );
+  });
+});

--- a/abort.ts
+++ b/abort.ts
@@ -1,0 +1,34 @@
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "MCP request aborted"));
+}
+
+export async function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  throwIfAborted(signal);
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "MCP request aborted")));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      value => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      error => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -4,6 +4,7 @@ import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
 import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
+import { abortable, throwIfAborted } from "./abort.ts";
 import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
@@ -276,7 +277,8 @@ export function createDirectToolExecutor(
   getInitPromise: () => Promise<McpExtensionState> | null,
   spec: DirectToolSpec
 ): DirectToolExecute {
-  return async function execute(_toolCallId, params) {
+  return async function execute(_toolCallId, params, signal) {
+    throwIfAborted(signal);
     let state = getState();
     const initPromise = getInitPromise();
 
@@ -298,7 +300,7 @@ export function createDirectToolExecutor(
       };
     }
 
-    let connected = await lazyConnect(state, spec.serverName);
+    let connected = await lazyConnect(state, spec.serverName, signal);
     let autoAuthAttempted = false;
 
     if (!connected && state.manager.getConnection(spec.serverName)?.status === "needs-auth") {
@@ -313,7 +315,7 @@ export function createDirectToolExecutor(
       if (autoAuth.status === "success") {
         await state.manager.close(spec.serverName);
         state.failureTracker.delete(spec.serverName);
-        connected = await lazyConnect(state, spec.serverName);
+        connected = await lazyConnect(state, spec.serverName, signal);
       }
     }
 
@@ -348,7 +350,7 @@ export function createDirectToolExecutor(
       state.manager.incrementInFlight(spec.serverName);
 
       if (spec.resourceUri) {
-        const result = await connection.client.readResource({ uri: spec.resourceUri });
+        const result = await connection.client.readResource({ uri: spec.resourceUri }, { signal });
         const content = (result.contents ?? []).map(c => ({
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -374,9 +376,9 @@ export function createDirectToolExecutor(
         name: spec.originalName,
         arguments: params ?? {},
         _meta: uiSession?.requestMeta,
-      });
+      }, undefined, { signal });
 
-      const result = await resultPromise;
+      const result = await abortable(resultPromise, signal);
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
 
       const mcpContent = (result.content ?? []) as McpContent[];

--- a/index.ts
+++ b/index.ts
@@ -276,7 +276,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         includeSchemas?: boolean;
         server?: string;
         action?: string;
-      }, _signal, _onUpdate, _ctx) {
+      }, signal, _onUpdate, _ctx) {
         let parsedArgs: Record<string, unknown> | undefined;
         if (params.args) {
           try {
@@ -340,10 +340,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           return executeAuthComplete(state, params.server, input);
         }
         if (params.tool) {
-          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools);
+          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, signal);
         }
         if (params.connect) {
-          return executeConnect(state, params.connect);
+          return executeConnect(state, params.connect, signal);
         }
         if (params.describe) {
           return executeDescribe(state, params.describe);

--- a/init.ts
+++ b/init.ts
@@ -22,6 +22,7 @@ import { UiResourceHandler } from "./ui-resource-handler.ts";
 import { openUrl, parallelLimit } from "./utils.ts";
 import { logger } from "./logger.ts";
 import { getMissingConfiguredDirectToolServers } from "./direct-tools.ts";
+import { throwIfAborted } from "./abort.ts";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
 
@@ -129,7 +130,7 @@ export async function initializeMcp(
 
   const results = await parallelLimit(startupServers, 10, async ([name, definition]) => {
     try {
-      const connection = await manager.connect(name, definition);
+      const connection = await manager.connect(name, definition, ctx.signal);
       if (connection.status === "needs-auth") {
         return { name, definition, connection: null, error: `OAuth authentication required. Run /mcp-auth ${name}.` };
       }
@@ -183,7 +184,7 @@ export async function initializeMcp(
         async (name) => {
           const definition = config.mcpServers[name];
           try {
-            const connection = await manager.connect(name, definition);
+            const connection = await manager.connect(name, definition, ctx.signal);
             if (connection.status === "needs-auth") {
               return { name, ok: false };
             }
@@ -297,7 +298,7 @@ export function getFailureAgeSeconds(state: McpExtensionState, serverName: strin
   return Math.round(ageMs / 1000);
 }
 
-export async function lazyConnect(state: McpExtensionState, serverName: string): Promise<boolean> {
+export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {
   const connection = state.manager.getConnection(serverName);
   if (connection?.status === "needs-auth") {
     return false;
@@ -317,7 +318,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string):
     if (state.ui) {
       state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
     }
-    const newConnection = await state.manager.connect(serverName, definition);
+    const newConnection = await state.manager.connect(serverName, definition, signal);
     if (newConnection.status === "needs-auth") {
       return false;
     }
@@ -327,6 +328,9 @@ export async function lazyConnect(state: McpExtensionState, serverName: string):
     updateStatusBar(state);
     return true;
   } catch (error) {
+    if (signal?.aborted) {
+      throwIfAborted(signal);
+    }
     state.failureTracker.set(serverName, Date.now());
     const message = error instanceof Error ? error.message : String(error);
     logger.debug(`MCP: lazy connect failed for ${serverName}: ${message}`);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "index.ts",
     "state.ts",
     "utils.ts",
+    "abort.ts",
     "tool-metadata.ts",
     "init.ts",
     "ui-session.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -5,6 +5,7 @@ import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
+import { abortable, throwIfAborted } from "./abort.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
@@ -523,7 +524,8 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
   };
 }
 
-export async function executeConnect(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+export async function executeConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+  throwIfAborted(signal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
@@ -536,7 +538,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     if (state.ui) {
       state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
     }
-    let connection = await state.manager.connect(serverName, definition);
+    let connection = await state.manager.connect(serverName, definition, signal);
     if (connection.status === "needs-auth") {
       const autoAuth = await attemptAutoAuth(state, serverName);
       if (autoAuth.status === "failed") {
@@ -547,7 +549,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       }
       if (autoAuth.status === "success") {
         await state.manager.close(serverName);
-        connection = await state.manager.connect(serverName, definition);
+        connection = await state.manager.connect(serverName, definition, signal);
       }
       if (connection.status === "needs-auth") {
         const message = getAuthRequiredMessage(state, serverName);
@@ -565,12 +567,14 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     updateStatusBar(state);
     return executeList(state, serverName);
   } catch (error) {
-    state.failureTracker.set(serverName, Date.now());
+    if (!signal?.aborted) {
+      state.failureTracker.set(serverName, Date.now());
+    }
     updateStatusBar(state);
     const message = error instanceof Error ? error.message : String(error);
     return {
       content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-      details: { mode: "connect", error: "connect_failed", server: serverName, message },
+      details: { mode: "connect", error: signal?.aborted ? "aborted" : "connect_failed", server: serverName, message },
     };
   }
 }
@@ -581,7 +585,9 @@ export async function executeCall(
   args?: Record<string, unknown>,
   serverOverride?: string,
   getPiTools?: () => ToolInfo[],
+  signal?: AbortSignal,
 ): Promise<ProxyToolResult> {
+  throwIfAborted(signal);
   let serverName: string | undefined = serverOverride;
   let toolMeta: ToolMetadata | undefined;
   let autoAuthAttempted = false;
@@ -608,7 +614,7 @@ export async function executeCall(
   }
 
   if (serverName && !toolMeta) {
-    const connected = await lazyConnect(state, serverName);
+    const connected = await lazyConnect(state, serverName, signal);
     if (connected) {
       toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
     } else {
@@ -626,7 +632,7 @@ export async function executeCall(
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
             state.failureTracker.delete(serverName);
-            const connectedAfterAuth = await lazyConnect(state, serverName);
+            const connectedAfterAuth = await lazyConnect(state, serverName, signal);
             if (connectedAfterAuth) {
               toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
               if (!toolMeta) {
@@ -673,7 +679,7 @@ export async function executeCall(
       const failedAgo = getFailureAgeSeconds(state, configuredServer);
       if (failedAgo !== null && existingConnection?.status !== "needs-auth") continue;
 
-      let connected = await lazyConnect(state, configuredServer);
+      let connected = await lazyConnect(state, configuredServer, signal);
       if (!connected && state.manager.getConnection(configuredServer)?.status === "needs-auth" && !autoAuthAttempted) {
         autoAuthAttempted = true;
         const autoAuth = await attemptAutoAuth(state, configuredServer);
@@ -686,7 +692,7 @@ export async function executeCall(
         if (autoAuth.status === "success") {
           await state.manager.close(configuredServer);
           state.failureTracker.delete(configuredServer);
-          connected = await lazyConnect(state, configuredServer);
+          connected = await lazyConnect(state, configuredServer, signal);
         }
       }
 
@@ -772,7 +778,7 @@ export async function executeCall(
       if (state.ui) {
         state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
       }
-      connection = await state.manager.connect(serverName, definition);
+      connection = await state.manager.connect(serverName, definition, signal);
       if (connection.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
@@ -785,7 +791,7 @@ export async function executeCall(
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
-            connection = await state.manager.connect(serverName, definition);
+            connection = await state.manager.connect(serverName, definition, signal);
           }
         }
 
@@ -813,12 +819,14 @@ export async function executeCall(
         };
       }
     } catch (error) {
-      state.failureTracker.set(serverName, Date.now());
+      if (!signal?.aborted) {
+        state.failureTracker.set(serverName, Date.now());
+      }
       updateStatusBar(state);
       const message = error instanceof Error ? error.message : String(error);
       return {
         content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-        details: { mode: "call", error: "connect_failed", message },
+        details: { mode: "call", error: signal?.aborted ? "aborted" : "connect_failed", message },
       };
     }
   }
@@ -830,7 +838,7 @@ export async function executeCall(
     state.manager.incrementInFlight(serverName);
 
     if (toolMeta.resourceUri) {
-      const result = await connection.client.readResource({ uri: toolMeta.resourceUri });
+      const result = await connection.client.readResource({ uri: toolMeta.resourceUri }, { signal });
       const content = (result.contents ?? []).map(c => ({
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -855,10 +863,10 @@ export async function executeCall(
       name: toolMeta.originalName,
       arguments: args ?? {},
       _meta: uiSession?.requestMeta,
-    });
+    }, undefined, { signal });
 
     if (toolMeta.uiResourceUri) {
-      const result = await resultPromise;
+      const result = await abortable(resultPromise, signal);
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
@@ -889,7 +897,7 @@ export async function executeCall(
       };
     }
 
-    const result = await resultPromise;
+    const result = await abortable(resultPromise, signal);
 
     const mcpContent = (result.content ?? []) as McpContent[];
     const content = transformMcpContent(mcpContent);

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -27,6 +27,7 @@ import {
   type ServerElicitationConfig,
 } from "./elicitation-handler.ts";
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
+import { abortable, throwIfAborted } from "./abort.ts";
 
 interface ServerConnection {
   client: Client;
@@ -57,10 +58,11 @@ export class McpServerManager {
     this.elicitationConfig = config;
   }
 
-  async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
+  async connect(name: string, definition: ServerDefinition, signal?: AbortSignal): Promise<ServerConnection> {
+    throwIfAborted(signal);
     // Dedupe concurrent connection attempts
     if (this.connectPromises.has(name)) {
-      return this.connectPromises.get(name)!;
+      return abortable(this.connectPromises.get(name)!, signal);
     }
 
     // Reuse existing connection if healthy
@@ -70,7 +72,7 @@ export class McpServerManager {
       return existing;
     }
 
-    const promise = this.createConnection(name, definition);
+    const promise = this.createConnection(name, definition, signal);
     this.connectPromises.set(name, promise);
 
     try {
@@ -84,8 +86,10 @@ export class McpServerManager {
 
   private async createConnection(
     name: string,
-    definition: ServerDefinition
+    definition: ServerDefinition,
+    signal?: AbortSignal,
   ): Promise<ServerConnection> {
+    throwIfAborted(signal);
     const client = this.createClient(name);
 
     let transport: Transport;
@@ -112,19 +116,19 @@ export class McpServerManager {
       });
     } else if (definition.url) {
       // HTTP transport with fallback
-      transport = await this.createHttpTransport(definition, name);
+      transport = await this.createHttpTransport(definition, name, signal);
     } else {
       throw new Error(`Server ${name} has no command or url`);
     }
 
     try {
-      await client.connect(transport);
+      await client.connect(transport, { signal });
       this.attachAdapterNotificationHandlers(name, client);
 
       // Discover tools and resources
       const [tools, resources] = await Promise.all([
-        this.fetchAllTools(client),
-        this.fetchAllResources(client),
+        this.fetchAllTools(client, signal),
+        this.fetchAllResources(client, signal),
       ]);
 
       return {
@@ -233,8 +237,10 @@ export class McpServerManager {
 
   private async createHttpTransport(
     definition: ServerDefinition,
-    serverName: string
+    serverName: string,
+    signal?: AbortSignal,
   ): Promise<Transport> {
+    throwIfAborted(signal);
     const url = new URL(definition.url!);
 
     // Build headers first (including any bearer token)
@@ -276,7 +282,7 @@ export class McpServerManager {
     try {
       // Create a test client to verify the transport works
       const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
-      await testClient.connect(streamableTransport);
+      await testClient.connect(streamableTransport, { signal });
       await testClient.close().catch(() => {});
       // Close probe transport before creating fresh one
       await streamableTransport.close().catch(() => {});
@@ -286,6 +292,12 @@ export class McpServerManager {
     } catch (error) {
       // StreamableHTTP failed, close and try SSE fallback
       await streamableTransport.close().catch(() => {});
+
+      // Host cancellation is not transport capability evidence; do not fall
+      // through to SSE when the caller is trying to cancel the connect.
+      if (signal?.aborted) {
+        throwIfAborted(signal);
+      }
 
       // If this was an UnauthorizedError, don't try SSE - the server needs auth
       if (error instanceof UnauthorizedError) {
@@ -297,12 +309,12 @@ export class McpServerManager {
     }
   }
 
-  private async fetchAllTools(client: Client): Promise<McpTool[]> {
+  private async fetchAllTools(client: Client, signal?: AbortSignal): Promise<McpTool[]> {
     const allTools: McpTool[] = [];
     let cursor: string | undefined;
 
     do {
-      const result = await client.listTools(cursor ? { cursor } : undefined);
+      const result = await client.listTools(cursor ? { cursor } : undefined, { signal });
       allTools.push(...(result.tools ?? []));
       cursor = result.nextCursor;
     } while (cursor);
@@ -310,19 +322,22 @@ export class McpServerManager {
     return allTools;
   }
 
-  private async fetchAllResources(client: Client): Promise<McpResource[]> {
+  private async fetchAllResources(client: Client, signal?: AbortSignal): Promise<McpResource[]> {
     try {
       const allResources: McpResource[] = [];
       let cursor: string | undefined;
 
       do {
-        const result = await client.listResources(cursor ? { cursor } : undefined);
+        const result = await client.listResources(cursor ? { cursor } : undefined, { signal });
         allResources.push(...(result.resources ?? []));
         cursor = result.nextCursor;
       } while (cursor);
 
       return allResources;
     } catch {
+      if (signal?.aborted) {
+        throwIfAborted(signal);
+      }
       // Server may not support resources
       return [];
     }
@@ -344,7 +359,7 @@ export class McpServerManager {
     this.uiStreamListeners.delete(streamToken);
   }
 
-  async readResource(name: string, uri: string): Promise<ReadResourceResult> {
+  async readResource(name: string, uri: string, signal?: AbortSignal): Promise<ReadResourceResult> {
     const connection = this.connections.get(name);
     if (!connection || connection.status !== "connected") {
       throw new Error(`Server "${name}" is not connected`);
@@ -353,7 +368,7 @@ export class McpServerManager {
     try {
       this.touch(name);
       this.incrementInFlight(name);
-      return await connection.client.readResource({ uri });
+      return await connection.client.readResource({ uri }, { signal });
     } finally {
       this.decrementInFlight(name);
       this.touch(name);


### PR DESCRIPTION
## Summary

This propagates Pi's `AbortSignal` through pi-mcp-adapter so pressing `Escape` in Pi cancels the underlying MCP SDK work instead of leaving MCP requests running until they complete or time out.

Fixes https://github.com/nicobailon/pi-mcp-adapter/issues/150
Fixes https://github.com/nicobailon/pi-mcp-adapter/issues/40
Addresses the abort-signal part of https://github.com/nicobailon/pi-mcp-adapter/issues/18
Related Pi issue: https://github.com/earendil-works/pi/issues/6234

## Background

Pi issue 6234 documents the outer UI failure mode: when an extension hook/tool never settles, the real Pi TUI can remain in `Working...` after `Escape`, so double-Escape is still swallowed by the streaming-abort path and Session Tree never opens.

A Pi core fix can make the outer agent run recover from stuck extension promises, but pi-mcp-adapter still needs cooperative cancellation for correctness: otherwise Pi may return to idle while the MCP request/socket/resource read continues in the background, and user-triggered aborts may be misinterpreted as MCP server failures.

## Changes

- Add shared abort helpers for MCP adapter operations.
- Forward the Pi tool `signal` through direct/promoted MCP tools.
- Forward the signal through the proxy `mcp` tool path.
- Pass `{ signal }` into MCP SDK calls including:
  - `client.callTool(...)`
  - `client.readResource(...)`
  - tool/resource discovery paths that can run during lazy connect
- Make `lazyConnect` / server-manager connection paths abort-aware.
- Avoid recording user aborts as MCP server failure/backoff evidence.
- Ensure aborted HTTP transport attempts do not fall through to the SSE fallback path.
- Add regression tests for direct/proxy call cancellation and resource-discovery abort behavior.

## Validation

Validated locally:

```bash
npx vitest run __tests__/abort-signal.test.ts __tests__/server-manager-http-auth.test.ts --reporter dot
npx tsc --noEmit
git diff --check
```

The targeted abort-signal and HTTP-auth tests pass, TypeScript passes, and whitespace checks pass.

Known repo-local caveat: a full `npm test -- --reporter dot` run passes 40/41 test files and 376/378 tests in this clean checkout; the remaining failures are unrelated missing built artifact fixtures for `examples/interactive-visualizer/dist/app.html` and `dist/server.js`.
