### PR TITLE
Guard oversized MCP tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Oversized MCP tool/resource results are guarded by default so a single huge resp
 
 - Inline text output is capped at **50 KiB / 2,000 lines** (matching Pi's built-in `bash` guard). Larger output is truncated to a head preview and the full text is saved to a temp file whose path is included in the result, so the agent can `read`/`grep` it.
 - **Image content blocks pass through unchanged** — only text output is guarded. Images are delivered to the provider as native image content.
-- `details.mcpResult` is kept raw when its JSON is **≤ 16 KiB**; larger results are replaced with a compact summary (block counts, sizes, key previews) and the raw JSON is saved to a temp file.
+- In proxy mode, `details.mcpResult` is kept raw when its JSON is **≤ 16 KiB**; larger results are replaced with a compact summary (block counts, sizes, key previews) and the raw JSON is saved to a temp file. Direct tools keep their lean details and never carry `mcpResult`.
 
 Tune the limits with the object form:
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,29 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
 | `samplingAutoApprove` | Skip sampling confirmation prompts. Required for sampling in non-UI sessions (default: false). |
 | `elicitation` | Allow MCP servers to request user input through Pi dialogs (default: true when Pi UI is available). |
+| `outputGuard` | Guard oversized MCP output: `true` (default), `false`, or `{ maxBytes, maxLines, detailsMaxBytes }`. See [Output Guard](#output-guard). |
 
 Per-server `idleTimeout` overrides the global setting.
+
+### Output Guard
+
+Oversized MCP tool/resource results are guarded by default so a single huge response can't blow up the model context window or the session file:
+
+- Inline text output is capped at **50 KiB / 2,000 lines** (matching Pi's built-in `bash` guard). Larger output is truncated to a head preview and the full text is saved to a temp file whose path is included in the result, so the agent can `read`/`grep` it.
+- **Image content blocks pass through unchanged** — only text output is guarded. Images are delivered to the provider as native image content.
+- `details.mcpResult` is kept raw when its JSON is **≤ 16 KiB**; larger results are replaced with a compact summary (block counts, sizes, key previews) and the raw JSON is saved to a temp file.
+
+Tune the limits with the object form:
+
+```json
+{
+  "settings": {
+    "outputGuard": { "maxBytes": 51200, "maxLines": 2000, "detailsMaxBytes": 16384 }
+  }
+}
+```
+
+Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — to disable the guard and restore raw output behavior. Saved temp files are created with mode `0600` under the system temp directory and are not cleaned up automatically; note that spilled MCP output may contain sensitive data.
 
 ### MCP Elicitation
 

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { guardMcpOutput, resolveMcpOutputGuardOptions } from "../mcp-output-guard.ts";
+
+describe("guardMcpOutput", () => {
+  it("leaves small MCP output unchanged while summarizing raw details", async () => {
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text: "small result" }],
+      { rawMcpResult: { content: [{ type: "text", text: "small result" }], isError: false } },
+    );
+
+    expect(guarded.content).toEqual([{ type: "text", text: "small result" }]);
+    expect(guarded.outputGuard).toBeUndefined();
+    expect(guarded.mcpResult).toMatchObject({
+      omitted: true,
+      isError: false,
+      contentBlocks: 1,
+      contentSummary: [{ type: "text", bytes: 12, lines: 1, textOmitted: true }],
+    });
+    expect(JSON.stringify(guarded.mcpResult)).not.toContain("small result");
+  });
+
+  it("truncates large text output and saves the full output to a file", async () => {
+    const text = Array.from({ length: 20 }, (_, i) => `line-${i} ${"x".repeat(40)}`).join("\n");
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text }],
+      {
+        maxBytes: 220,
+        maxLines: 8,
+        detailsMaxBytes: 200,
+        rawMcpResult: { content: [{ type: "text", text }], isError: false, structuredContent: { rows: [text] } },
+      },
+    );
+
+    expect(guarded.outputGuard).toMatchObject({
+      truncated: true,
+      originalLines: 20,
+    });
+    expect(guarded.outputGuard?.fullOutputPath).toBeTruthy();
+    expect(guarded.content).toHaveLength(1);
+    expect(guarded.content[0]).toMatchObject({ type: "text" });
+    const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
+    expect(returnedText).toContain("MCP output truncated");
+    expect(returnedText).toContain("Full output saved to:");
+    expect(returnedText).not.toContain("line-19");
+
+    const saved = await readFile(guarded.outputGuard!.fullOutputPath!, "utf8");
+    expect(saved).toBe(text);
+    expect(guarded.mcpResult?.fullResultPath).toBeTruthy();
+    expect(JSON.stringify(guarded.mcpResult)).not.toContain("line-19");
+  });
+
+  it("keeps prefixes and suffixes inside the saved full output", async () => {
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text: "body" }],
+      { prefix: "Error: ", suffix: "\n\nExpected parameters:\n{}", maxBytes: 10, maxLines: 2 },
+    );
+
+    expect(guarded.outputGuard?.fullOutputPath).toBeTruthy();
+    const saved = await readFile(guarded.outputGuard!.fullOutputPath!, "utf8");
+    expect(saved).toBe("Error: body\n\nExpected parameters:\n{}");
+  });
+
+  it("can be disabled to return raw output and raw details", async () => {
+    const text = "x".repeat(1000);
+    const rawMcpResult = { content: [{ type: "text", text }], isError: false };
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text }],
+      { enabled: false, maxBytes: 10, maxLines: 1, rawMcpResult },
+    );
+
+    expect(guarded.content).toEqual([{ type: "text", text }]);
+    expect(guarded.outputGuard).toBeUndefined();
+    expect(guarded.mcpResult).toBe(rawMcpResult);
+  });
+
+  it("resolves config and environment overrides", () => {
+    const previous = process.env.MCP_OUTPUT_GUARD;
+    const previousBytes = process.env.MCP_OUTPUT_MAX_BYTES;
+    try {
+      process.env.MCP_OUTPUT_GUARD = "0";
+      process.env.MCP_OUTPUT_MAX_BYTES = "1234";
+
+      expect(resolveMcpOutputGuardOptions({ outputGuard: true, outputMaxBytes: 9999 })).toMatchObject({
+        enabled: false,
+        maxBytes: 1234,
+      });
+    } finally {
+      if (previous === undefined) delete process.env.MCP_OUTPUT_GUARD;
+      else process.env.MCP_OUTPUT_GUARD = previous;
+      if (previousBytes === undefined) delete process.env.MCP_OUTPUT_MAX_BYTES;
+      else process.env.MCP_OUTPUT_MAX_BYTES = previousBytes;
+    }
+  });
+});

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -121,12 +121,8 @@ describe("guardMcpOutput", () => {
     expect(guarded.mcpResult).toBe(rawMcpResult);
   });
 
-  it("omits details when disabled with disabledMcpResult=omit", async () => {
-    const rawMcpResult = { content: [], isError: false };
-    const guarded = await guardMcpOutput(
-      [{ type: "text", text: "x" }],
-      { enabled: false, rawMcpResult, disabledMcpResult: "omit" },
-    );
+  it("returns no mcpResult when rawMcpResult is not provided", async () => {
+    const guarded = await guardMcpOutput([{ type: "text", text: "x" }], {});
     expect(guarded.mcpResult).toBeUndefined();
   });
 });

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -1,23 +1,18 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
-import { guardMcpOutput, resolveMcpOutputGuardOptions } from "../mcp-output-guard.ts";
+import { guardMcpOutput, resolveMcpOutputGuardOptions, type McpResultSummary } from "../mcp-output-guard.ts";
 
 describe("guardMcpOutput", () => {
-  it("leaves small MCP output unchanged while summarizing raw details", async () => {
+  it("leaves small MCP output unchanged and keeps the raw result in details", async () => {
+    const rawMcpResult = { content: [{ type: "text", text: "small result" }], isError: false, structuredContent: { ok: true } };
     const guarded = await guardMcpOutput(
       [{ type: "text", text: "small result" }],
-      { rawMcpResult: { content: [{ type: "text", text: "small result" }], isError: false } },
+      { rawMcpResult },
     );
 
     expect(guarded.content).toEqual([{ type: "text", text: "small result" }]);
     expect(guarded.outputGuard).toBeUndefined();
-    expect(guarded.mcpResult).toMatchObject({
-      omitted: true,
-      isError: false,
-      contentBlocks: 1,
-      contentSummary: [{ type: "text", bytes: 12, lines: 1, textOmitted: true }],
-    });
-    expect(JSON.stringify(guarded.mcpResult)).not.toContain("small result");
+    expect(guarded.mcpResult).toBe(rawMcpResult);
   });
 
   it("truncates large text output and saves the full output to a file", async () => {
@@ -25,7 +20,7 @@ describe("guardMcpOutput", () => {
     const guarded = await guardMcpOutput(
       [{ type: "text", text }],
       {
-        maxBytes: 220,
+        maxBytes: 300,
         maxLines: 8,
         detailsMaxBytes: 200,
         rawMcpResult: { content: [{ type: "text", text }], isError: false, structuredContent: { rows: [text] } },
@@ -40,14 +35,66 @@ describe("guardMcpOutput", () => {
     expect(guarded.content).toHaveLength(1);
     expect(guarded.content[0]).toMatchObject({ type: "text" });
     const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
-    expect(returnedText).toContain("MCP output truncated");
-    expect(returnedText).toContain("Full output saved to:");
+    expect(returnedText).toContain("MCP text output truncated");
+    expect(returnedText).toContain("Full text saved to:");
     expect(returnedText).not.toContain("line-19");
 
     const saved = await readFile(guarded.outputGuard!.fullOutputPath!, "utf8");
     expect(saved).toBe(text);
-    expect(guarded.mcpResult?.fullResultPath).toBeTruthy();
-    expect(JSON.stringify(guarded.mcpResult)).not.toContain("line-19");
+
+    const summary = guarded.mcpResult as McpResultSummary;
+    expect(summary).toMatchObject({ omitted: true, isError: false, contentBlocks: 1 });
+    expect(summary.fullResultPath).toBeTruthy();
+    expect(summary.structuredContent).toMatchObject({ omitted: true });
+    expect(JSON.stringify(summary)).not.toContain("line-19");
+  });
+
+  it("summarizes details.mcpResult only when it exceeds detailsMaxBytes", async () => {
+    const rawMcpResult = { content: [{ type: "text", text: "ok" }], isError: false, structuredContent: { rows: "y".repeat(500) } };
+    const kept = await guardMcpOutput([{ type: "text", text: "ok" }], { detailsMaxBytes: 5000, rawMcpResult });
+    expect(kept.mcpResult).toBe(rawMcpResult);
+
+    const summarized = await guardMcpOutput([{ type: "text", text: "ok" }], { detailsMaxBytes: 100, rawMcpResult });
+    expect((summarized.mcpResult as McpResultSummary).omitted).toBe(true);
+    expect((summarized.mcpResult as McpResultSummary).fullResultPath).toBeTruthy();
+  });
+
+  it("passes image blocks through untouched, even large ones", async () => {
+    const image = { type: "image" as const, data: "A".repeat(100_000), mimeType: "image/png" };
+    const guarded = await guardMcpOutput(
+      [image, { type: "text", text: "caption" }],
+      { maxBytes: 1000, maxLines: 10 },
+    );
+
+    expect(guarded.outputGuard).toBeUndefined();
+    expect(guarded.content).toEqual([image, { type: "text", text: "caption" }]);
+  });
+
+  it("keeps image blocks when text output is truncated", async () => {
+    const text = Array.from({ length: 50 }, (_, i) => `row-${i}`).join("\n");
+    const image = { type: "image" as const, data: "abc", mimeType: "image/png" };
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text }, image],
+      { maxBytes: 250, maxLines: 5 },
+    );
+
+    expect(guarded.outputGuard).toMatchObject({ truncated: true, imageBlocksPassedThrough: 1 });
+    expect(guarded.content).toHaveLength(2);
+    expect(guarded.content[0].type).toBe("text");
+    expect(guarded.content[1]).toEqual(image);
+
+    const saved = await readFile(guarded.outputGuard!.fullOutputPath!, "utf8");
+    expect(saved).toBe(text);
+  });
+
+  it("truncates on line count alone", async () => {
+    const text = Array.from({ length: 30 }, (_, i) => `entry-${i}`).join("\n");
+    const guarded = await guardMcpOutput([{ type: "text", text }], { maxBytes: 10_000, maxLines: 10 });
+
+    expect(guarded.outputGuard).toMatchObject({ truncated: true, originalLines: 30 });
+    const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
+    expect(returnedText).toContain("entry-0");
+    expect(returnedText).not.toContain("entry-29");
   });
 
   it("keeps prefixes and suffixes inside the saved full output", async () => {
@@ -74,22 +121,47 @@ describe("guardMcpOutput", () => {
     expect(guarded.mcpResult).toBe(rawMcpResult);
   });
 
-  it("resolves config and environment overrides", () => {
+  it("omits details when disabled with disabledMcpResult=omit", async () => {
+    const rawMcpResult = { content: [], isError: false };
+    const guarded = await guardMcpOutput(
+      [{ type: "text", text: "x" }],
+      { enabled: false, rawMcpResult, disabledMcpResult: "omit" },
+    );
+    expect(guarded.mcpResult).toBeUndefined();
+  });
+});
+
+describe("resolveMcpOutputGuardOptions", () => {
+  it("defaults to enabled with standard limits", () => {
+    expect(resolveMcpOutputGuardOptions(undefined)).toEqual({
+      enabled: true,
+      maxBytes: 50 * 1024,
+      maxLines: 2000,
+      detailsMaxBytes: 16 * 1024,
+    });
+  });
+
+  it("supports boolean and object settings", () => {
+    expect(resolveMcpOutputGuardOptions({ outputGuard: false }).enabled).toBe(false);
+    expect(resolveMcpOutputGuardOptions({ outputGuard: true }).enabled).toBe(true);
+    expect(resolveMcpOutputGuardOptions({ outputGuard: { maxBytes: 1234, maxLines: 50 } })).toMatchObject({
+      enabled: true,
+      maxBytes: 1234,
+      maxLines: 50,
+      detailsMaxBytes: 16 * 1024,
+    });
+  });
+
+  it("honors the MCP_OUTPUT_GUARD env kill switch", () => {
     const previous = process.env.MCP_OUTPUT_GUARD;
-    const previousBytes = process.env.MCP_OUTPUT_MAX_BYTES;
     try {
       process.env.MCP_OUTPUT_GUARD = "0";
-      process.env.MCP_OUTPUT_MAX_BYTES = "1234";
-
-      expect(resolveMcpOutputGuardOptions({ outputGuard: true, outputMaxBytes: 9999 })).toMatchObject({
-        enabled: false,
-        maxBytes: 1234,
-      });
+      expect(resolveMcpOutputGuardOptions({ outputGuard: true }).enabled).toBe(false);
+      process.env.MCP_OUTPUT_GUARD = "1";
+      expect(resolveMcpOutputGuardOptions({ outputGuard: false }).enabled).toBe(true);
     } finally {
       if (previous === undefined) delete process.env.MCP_OUTPUT_GUARD;
       else process.env.MCP_OUTPUT_GUARD = previous;
-      if (previousBytes === undefined) delete process.env.MCP_OUTPUT_MAX_BYTES;
-      else process.env.MCP_OUTPUT_MAX_BYTES = previousBytes;
     }
   });
 });

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -7,6 +7,7 @@ import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
 import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
+import { guardMcpOutput, resolveMcpOutputGuardOptions, type GuardedMcpOutput } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
@@ -19,6 +20,13 @@ type DirectAutoAuthResult =
   | { status: "skipped" }
   | { status: "success" }
   | { status: "failed"; message: string };
+
+function guardedDetails(guarded: GuardedMcpOutput): Record<string, unknown> {
+  return {
+    ...(guarded.mcpResult ? { mcpResult: guarded.mcpResult } : {}),
+    ...(guarded.outputGuard ? { outputGuard: guarded.outputGuard } : {}),
+  };
+}
 
 function getDirectAuthRequiredMessage(
   state: McpExtensionState,
@@ -343,6 +351,8 @@ export function createDirectToolExecutor(
 
     let uiSession: UiSessionRuntime | null = null;
 
+    const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
+
     try {
       state.manager.touch(spec.serverName);
       state.manager.incrementInFlight(spec.serverName);
@@ -353,9 +363,10 @@ export function createDirectToolExecutor(
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
         }));
+        const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
         return {
-          content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
-          details: { server: spec.serverName, resourceUri: spec.resourceUri },
+          content: guarded.content,
+          details: { server: spec.serverName, resourceUri: spec.resourceUri, ...guardedDetails(guarded) },
         };
       }
 
@@ -381,32 +392,32 @@ export function createDirectToolExecutor(
 
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
       if (result.isError) {
-        let errorText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "Tool execution failed";
-        if (spec.inputSchema) {
-          errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`;
-        }
+        const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result, disabledMcpResult: "omit" });
         return {
-          content: [{ type: "text" as const, text: `Error: ${errorText}` }],
-          details: { error: "tool_error", server: spec.serverName },
+          content: guarded.content,
+          details: { error: "tool_error", server: spec.serverName, ...guardedDetails(guarded) },
         };
       }
 
-      const resultText = content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("\n") || "(empty result)";
       if (hasUi) {
         const uiMessage = uiSession?.reused
           ? "Updated the open UI."
           : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result, disabledMcpResult: "omit" });
         return {
-          content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
-          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true },
+          content: guarded.content,
+          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...guardedDetails(guarded) },
         };
       }
 
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result, disabledMcpResult: "omit" });
       return {
-        content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
-        details: { server: spec.serverName, tool: spec.originalName },
+        content: guarded.content,
+        details: { server: spec.serverName, tool: spec.originalName, ...guardedDetails(guarded) },
       };
     } catch (error) {
       if (error instanceof UrlElicitationRequiredError) {
@@ -422,13 +433,11 @@ export function createDirectToolExecutor(
       }
       const message = error instanceof Error ? error.message : String(error);
       uiSession?.sendToolCancelled(message);
-      let errorText = `Failed to call tool: ${message}`;
-      if (spec.inputSchema) {
-        errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`;
-      }
+      const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
+      const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
       return {
-        content: [{ type: "text" as const, text: errorText }],
-        details: { error: "call_failed", server: spec.serverName },
+        content: guarded.content,
+        details: { error: "call_failed", server: spec.serverName, ...guardedDetails(guarded) },
       };
     } finally {
       if (uiSession?.reused) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -389,7 +389,7 @@ export function createDirectToolExecutor(
 
       if (result.isError) {
         const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
-        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result, disabledMcpResult: "omit" });
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText });
         return {
           content: guarded.content,
           details: { error: "tool_error", server: spec.serverName, ...guardedMcpDetails(guarded) },
@@ -400,14 +400,14 @@ export function createDirectToolExecutor(
         const uiMessage = uiSession?.reused
           ? "Updated the open UI."
           : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
-        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result, disabledMcpResult: "omit" });
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}` });
         return {
           content: guarded.content,
           details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...guardedMcpDetails(guarded) },
         };
       }
 
-      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result, disabledMcpResult: "omit" });
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions });
       return {
         content: guarded.content,
         details: { server: spec.serverName, tool: spec.originalName, ...guardedMcpDetails(guarded) },

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -7,7 +7,7 @@ import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
 import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
-import { guardMcpOutput, resolveMcpOutputGuardOptions, type GuardedMcpOutput } from "./mcp-output-guard.ts";
+import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
@@ -20,13 +20,6 @@ type DirectAutoAuthResult =
   | { status: "skipped" }
   | { status: "success" }
   | { status: "failed"; message: string };
-
-function guardedDetails(guarded: GuardedMcpOutput): Record<string, unknown> {
-  return {
-    ...(guarded.mcpResult ? { mcpResult: guarded.mcpResult } : {}),
-    ...(guarded.outputGuard ? { outputGuard: guarded.outputGuard } : {}),
-  };
-}
 
 function getDirectAuthRequiredMessage(
   state: McpExtensionState,
@@ -366,7 +359,7 @@ export function createDirectToolExecutor(
         const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
         return {
           content: guarded.content,
-          details: { server: spec.serverName, resourceUri: spec.resourceUri, ...guardedDetails(guarded) },
+          details: { server: spec.serverName, resourceUri: spec.resourceUri, ...guardedMcpDetails(guarded) },
         };
       }
 
@@ -399,7 +392,7 @@ export function createDirectToolExecutor(
         const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result, disabledMcpResult: "omit" });
         return {
           content: guarded.content,
-          details: { error: "tool_error", server: spec.serverName, ...guardedDetails(guarded) },
+          details: { error: "tool_error", server: spec.serverName, ...guardedMcpDetails(guarded) },
         };
       }
 
@@ -410,14 +403,14 @@ export function createDirectToolExecutor(
         const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result, disabledMcpResult: "omit" });
         return {
           content: guarded.content,
-          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...guardedDetails(guarded) },
+          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...guardedMcpDetails(guarded) },
         };
       }
 
       const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result, disabledMcpResult: "omit" });
       return {
         content: guarded.content,
-        details: { server: spec.serverName, tool: spec.originalName, ...guardedDetails(guarded) },
+        details: { server: spec.serverName, tool: spec.originalName, ...guardedMcpDetails(guarded) },
       };
     } catch (error) {
       if (error instanceof UrlElicitationRequiredError) {
@@ -437,7 +430,7 @@ export function createDirectToolExecutor(
       const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
       return {
         content: guarded.content,
-        details: { error: "call_failed", server: spec.serverName, ...guardedDetails(guarded) },
+        details: { error: "call_failed", server: spec.serverName, ...guardedMcpDetails(guarded) },
       };
     } finally {
       if (uiSession?.reused) {

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -1,0 +1,366 @@
+import { randomBytes } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ContentBlock, McpSettings } from "./types.ts";
+
+export const DEFAULT_MCP_OUTPUT_MAX_BYTES = 50 * 1024;
+export const DEFAULT_MCP_OUTPUT_MAX_LINES = 2000;
+export const DEFAULT_MCP_DETAILS_MAX_BYTES = 16 * 1024;
+
+const CONTENT_SUMMARY_LIMIT = 20;
+const KEY_PREVIEW_LIMIT = 20;
+const KEY_MAX_CHARS = 120;
+
+type Recordish = Record<string, unknown>;
+
+export interface McpOutputGuardDetails {
+  truncated: true;
+  originalBytes: number;
+  returnedBytes: number;
+  originalLines: number;
+  returnedLines: number;
+  fullOutputPath?: string;
+  writeError?: string;
+}
+
+export interface McpResultSummary {
+  omitted: true;
+  reason: string;
+  isError: boolean;
+  contentBlocks: number;
+  contentSummary: Array<Record<string, unknown>>;
+  structuredContent?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+  extraFields?: Array<Record<string, unknown>>;
+  rawResultBytes?: number;
+  fullResultPath?: string;
+  resultWriteError?: string;
+  outputGuard?: McpOutputGuardDetails;
+}
+
+export interface McpOutputGuardOptions {
+  enabled?: boolean;
+  prefix?: string;
+  suffix?: string;
+  maxBytes?: number;
+  maxLines?: number;
+  detailsMaxBytes?: number;
+  rawMcpResult?: unknown;
+  disabledMcpResult?: "raw" | "omit";
+}
+
+export interface GuardedMcpOutput {
+  content: ContentBlock[];
+  outputGuard?: McpOutputGuardDetails;
+  mcpResult?: unknown;
+}
+
+export function resolveMcpOutputGuardOptions(settings?: McpSettings): Pick<McpOutputGuardOptions, "enabled" | "maxBytes" | "maxLines" | "detailsMaxBytes"> {
+  return {
+    enabled: envBoolean("MCP_OUTPUT_GUARD", "PI_MCP_OUTPUT_GUARD") ?? settings?.outputGuard ?? true,
+    maxBytes: envPositiveInt("MCP_OUTPUT_MAX_BYTES", "PI_MCP_OUTPUT_MAX_BYTES") ?? positiveInt(settings?.outputMaxBytes) ?? DEFAULT_MCP_OUTPUT_MAX_BYTES,
+    maxLines: envPositiveInt("MCP_OUTPUT_MAX_LINES", "PI_MCP_OUTPUT_MAX_LINES") ?? positiveInt(settings?.outputMaxLines) ?? DEFAULT_MCP_OUTPUT_MAX_LINES,
+    detailsMaxBytes: envPositiveInt("MCP_DETAILS_MAX_BYTES", "PI_MCP_DETAILS_MAX_BYTES") ?? positiveInt(settings?.detailsMaxBytes) ?? DEFAULT_MCP_DETAILS_MAX_BYTES,
+  };
+}
+
+export async function guardMcpOutput(
+  content: ContentBlock[],
+  options: McpOutputGuardOptions = {},
+): Promise<GuardedMcpOutput> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MCP_OUTPUT_MAX_BYTES;
+  const maxLines = options.maxLines ?? DEFAULT_MCP_OUTPUT_MAX_LINES;
+  const detailsMaxBytes = options.detailsMaxBytes ?? DEFAULT_MCP_DETAILS_MAX_BYTES;
+  const prefix = options.prefix ?? "";
+  const suffix = options.suffix ?? "";
+
+  const normalizedContent = content.length > 0
+    ? sanitizeContent(content)
+    : [{ type: "text" as const, text: "(empty result)" }];
+
+  if (options.enabled === false) {
+    return {
+      content: addAffixes(normalizedContent, prefix, suffix),
+      mcpResult: options.disabledMcpResult === "omit" ? undefined : options.rawMcpResult,
+    };
+  }
+
+  const textOutput = serializeContent(normalizedContent);
+  const composedOutput = `${prefix}${textOutput}${suffix}`;
+  const stats = textStats(composedOutput);
+  const oversizedPayload = hasOversizedNonTextPayload(normalizedContent, maxBytes);
+
+  let guardedContent: ContentBlock[] = addAffixes(normalizedContent, prefix, suffix);
+  let outputGuard: McpOutputGuardDetails | undefined;
+
+  if (stats.bytes > maxBytes || stats.lines > maxLines || oversizedPayload) {
+    const { path: fullOutputPath, error: writeError } = await saveArtifact("output", composedOutput);
+    const notice = formatTruncationNotice(stats, fullOutputPath, writeError);
+    const previewBudget = reserveBudget(maxBytes, maxLines, notice);
+    const preview = truncateHead(composedOutput, previewBudget.maxBytes, previewBudget.maxLines);
+    const finalText = `${preview.content}\n\n${notice}`;
+    const finalStats = textStats(finalText);
+
+    guardedContent = [{ type: "text" as const, text: finalText }];
+    outputGuard = {
+      truncated: true,
+      originalBytes: stats.bytes,
+      returnedBytes: finalStats.bytes,
+      originalLines: stats.lines,
+      returnedLines: finalStats.lines,
+      fullOutputPath,
+      writeError,
+    };
+  }
+
+  const mcpResult = options.rawMcpResult === undefined
+    ? undefined
+    : await summarizeMcpResult(options.rawMcpResult, outputGuard, detailsMaxBytes);
+
+  return { content: guardedContent, outputGuard, mcpResult };
+}
+
+function sanitizeContent(content: ContentBlock[]): ContentBlock[] {
+  return content.map((block) => {
+    if (block.type !== "image") return block;
+    const mimeType = typeof block.mimeType === "string" && block.mimeType.trim()
+      ? block.mimeType.trim().slice(0, 100)
+      : "image/png";
+    return { ...block, mimeType };
+  });
+}
+
+function addAffixes(content: ContentBlock[], prefix: string, suffix: string): ContentBlock[] {
+  if (!prefix && !suffix) return content;
+  const next: ContentBlock[] = [];
+  if (prefix) next.push({ type: "text", text: prefix });
+  next.push(...content);
+  if (suffix) next.push({ type: "text", text: suffix });
+  return next;
+}
+
+function serializeContent(content: ContentBlock[]): string {
+  return content.map((block) => {
+    if (block.type === "text") return block.text;
+    const dataBytes = block.data ? byteLength(block.data) : 0;
+    return `[Image content omitted from text preview: ${block.mimeType ?? "image/*"}, ${formatSize(dataBytes)} base64 payload]`;
+  }).join("\n");
+}
+
+function hasOversizedNonTextPayload(content: ContentBlock[], maxBytes: number): boolean {
+  return content.some((block) => block.type === "image" && byteLength(block.data ?? "") > maxBytes);
+}
+
+function reserveBudget(maxBytes: number, maxLines: number, notice: string): { maxBytes: number; maxLines: number } {
+  const noticeStats = textStats(`\n\n${notice}`);
+  return {
+    maxBytes: Math.max(0, maxBytes - noticeStats.bytes),
+    maxLines: Math.max(0, maxLines - noticeStats.lines),
+  };
+}
+
+function truncateHead(text: string, maxBytes: number, maxLines: number): { content: string; bytes: number; lines: number } {
+  const lines = text.split("\n");
+  const output: string[] = [];
+  let bytes = 0;
+
+  for (const line of lines) {
+    if (output.length >= maxLines) break;
+    const separatorBytes = output.length > 0 ? 1 : 0;
+    const lineBytes = byteLength(line);
+    if (bytes + separatorBytes + lineBytes > maxBytes) {
+      const remaining = maxBytes - bytes - separatorBytes;
+      if (remaining > 0 && output.length < maxLines) {
+        output.push(truncateStringToBytes(line, remaining));
+      }
+      break;
+    }
+    output.push(line);
+    bytes += separatorBytes + lineBytes;
+  }
+
+  const content = output.join("\n");
+  const stats = textStats(content);
+  return { content, bytes: stats.bytes, lines: stats.lines };
+}
+
+function truncateStringToBytes(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) return value;
+  const buffer = Buffer.from(value, "utf8");
+  let end = Math.max(0, maxBytes);
+  while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
+  return buffer.subarray(0, end).toString("utf8");
+}
+
+function formatTruncationNotice(
+  stats: { bytes: number; lines: number },
+  fullOutputPath: string | undefined,
+  writeError: string | undefined,
+): string {
+  const base = `[MCP output truncated: original ${stats.lines.toLocaleString()} lines / ${formatSize(stats.bytes)}.`;
+  if (fullOutputPath) {
+    return `${base} Full output saved to: ${fullOutputPath}]`;
+  }
+  return `${base} Full output could not be saved: ${writeError ?? "unknown error"}]`;
+}
+
+async function summarizeMcpResult(
+  result: unknown,
+  outputGuard: McpOutputGuardDetails | undefined,
+  detailsMaxBytes: number,
+): Promise<McpResultSummary> {
+  const raw = safeStringify(result);
+  const rawBytes = byteLength(raw);
+  let fullResultPath: string | undefined;
+  let resultWriteError: string | undefined;
+
+  if (rawBytes > detailsMaxBytes) {
+    const saved = await saveArtifact("mcp-result", raw);
+    fullResultPath = saved.path;
+    resultWriteError = saved.error;
+  }
+
+  const record = asRecord(result);
+  const content = Array.isArray(record?.content) ? record.content : [];
+  const summary: McpResultSummary = {
+    omitted: true,
+    reason: "Raw MCP result omitted from Pi session details to keep model/session context bounded.",
+    isError: record?.isError === true,
+    contentBlocks: content.length,
+    contentSummary: summarizeContent(content),
+    rawResultBytes: rawBytes,
+    fullResultPath,
+    resultWriteError,
+    outputGuard,
+  };
+
+  if (record && "structuredContent" in record) {
+    summary.structuredContent = summarizeValue(record.structuredContent);
+  }
+  if (record && "_meta" in record) {
+    summary.meta = summarizeValue(record._meta);
+  }
+  if (record) {
+    const standard = new Set(["content", "isError", "structuredContent", "_meta"]);
+    const extraFields = Object.keys(record)
+      .filter((key) => !standard.has(key))
+      .slice(0, KEY_PREVIEW_LIMIT)
+      .map((key) => ({ key: truncateKey(key), type: typeof record[key], estimatedBytes: estimateValueBytes(record[key]), omitted: true }));
+    if (extraFields.length > 0) summary.extraFields = extraFields;
+  }
+
+  return summary;
+}
+
+function summarizeContent(content: unknown[]): Array<Record<string, unknown>> {
+  const summaries: Array<Record<string, unknown>> = content.slice(0, CONTENT_SUMMARY_LIMIT).map((block) => {
+    const record = asRecord(block);
+    if (!record) return { type: typeof block, omitted: true };
+    if (record.type === "text") {
+      const text = typeof record.text === "string" ? record.text : "";
+      return { type: "text", bytes: byteLength(text), lines: textStats(text).lines, textOmitted: true };
+    }
+    if (record.type === "image") {
+      const data = typeof record.data === "string" ? record.data : "";
+      return { type: "image", mimeType: typeof record.mimeType === "string" ? record.mimeType : undefined, dataBytes: byteLength(data), dataOmitted: true };
+    }
+    return { type: typeof record.type === "string" ? record.type : "unknown", estimatedBytes: estimateValueBytes(record), omitted: true };
+  });
+  if (content.length > CONTENT_SUMMARY_LIMIT) {
+    summaries.push({ type: "omitted", count: content.length - CONTENT_SUMMARY_LIMIT });
+  }
+  return summaries;
+}
+
+function summarizeValue(value: unknown): Record<string, unknown> {
+  const record = asRecord(value);
+  if (!record) {
+    return { type: value === null ? "null" : typeof value, estimatedBytes: estimateValueBytes(value), omitted: true };
+  }
+  const keys = Object.keys(record);
+  return {
+    type: Array.isArray(value) ? "array" : "object",
+    estimatedBytes: estimateValueBytes(value),
+    keyCount: keys.length,
+    keysPreview: keys.slice(0, KEY_PREVIEW_LIMIT).map(truncateKey),
+    omitted: true,
+  };
+}
+
+function estimateValueBytes(value: unknown, depth = 0): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return byteLength(value);
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return byteLength(String(value));
+  const record = asRecord(value);
+  if (!record || depth >= 2) return 0;
+  const values = Array.isArray(value) ? value.slice(0, KEY_PREVIEW_LIMIT) : Object.values(record).slice(0, KEY_PREVIEW_LIMIT);
+  return values.reduce((total, item) => total + estimateValueBytes(item, depth + 1), 0);
+}
+
+function truncateKey(key: string): string {
+  return key.length <= KEY_MAX_CHARS ? key : `${key.slice(0, KEY_MAX_CHARS - 1)}…`;
+}
+
+async function saveArtifact(kind: string, text: string): Promise<{ path?: string; error?: string }> {
+  try {
+    const dir = await mkdtemp(join(tmpdir(), "pi-mcp-output-"));
+    const path = join(dir, `${kind}-${randomBytes(4).toString("hex")}.txt`);
+    await writeFile(path, text, { encoding: "utf8", mode: 0o600 });
+    return { path };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function asRecord(value: unknown): Recordish | undefined {
+  return typeof value === "object" && value !== null ? value as Recordish : undefined;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function textStats(text: string): { bytes: number; lines: number } {
+  return { bytes: byteLength(text), lines: text.length === 0 ? 0 : text.split("\n").length };
+}
+
+function byteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function positiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const integer = Math.floor(value);
+  return integer > 0 ? integer : undefined;
+}
+
+function envPositiveInt(...names: string[]): number | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (!value) continue;
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}
+
+function envBoolean(...names: string[]): boolean | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim().toLowerCase();
+    if (!value) continue;
+    if (["0", "false", "no", "off"].includes(value)) return false;
+    if (["1", "true", "yes", "on"].includes(value)) return true;
+  }
+  return undefined;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -47,9 +47,13 @@ export interface McpOutputGuardOptions {
   maxBytes?: number;
   maxLines?: number;
   detailsMaxBytes?: number;
+  /**
+   * Raw MCP result to expose as details.mcpResult. Kept raw when its JSON
+   * fits detailsMaxBytes (or when the guard is disabled); otherwise replaced
+   * with a compact summary and spilled to a temp file. Omit for call sites
+   * whose details never carried the raw result (e.g. direct tools).
+   */
   rawMcpResult?: unknown;
-  /** How to expose rawMcpResult in details when the guard is disabled. */
-  disabledMcpResult?: "raw" | "omit";
 }
 
 export interface GuardedMcpOutput {
@@ -99,7 +103,7 @@ export async function guardMcpOutput(
   if (options.enabled === false) {
     return {
       content: addAffixes(normalizedContent, prefix, suffix),
-      mcpResult: options.disabledMcpResult === "omit" ? undefined : options.rawMcpResult,
+      mcpResult: options.rawMcpResult,
     };
   }
 

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -20,6 +20,8 @@ export interface McpOutputGuardDetails {
   returnedBytes: number;
   originalLines: number;
   returnedLines: number;
+  /** Number of image content blocks returned untouched alongside the truncated text. */
+  imageBlocksPassedThrough?: number;
   fullOutputPath?: string;
   writeError?: string;
 }
@@ -33,10 +35,9 @@ export interface McpResultSummary {
   structuredContent?: Record<string, unknown>;
   meta?: Record<string, unknown>;
   extraFields?: Array<Record<string, unknown>>;
-  rawResultBytes?: number;
+  rawResultBytes: number;
   fullResultPath?: string;
   resultWriteError?: string;
-  outputGuard?: McpOutputGuardDetails;
 }
 
 export interface McpOutputGuardOptions {
@@ -47,6 +48,7 @@ export interface McpOutputGuardOptions {
   maxLines?: number;
   detailsMaxBytes?: number;
   rawMcpResult?: unknown;
+  /** How to expose rawMcpResult in details when the guard is disabled. */
   disabledMcpResult?: "raw" | "omit";
 }
 
@@ -57,14 +59,29 @@ export interface GuardedMcpOutput {
 }
 
 export function resolveMcpOutputGuardOptions(settings?: McpSettings): Pick<McpOutputGuardOptions, "enabled" | "maxBytes" | "maxLines" | "detailsMaxBytes"> {
+  const configured = settings?.outputGuard;
+  const tuning = typeof configured === "object" && configured !== null ? configured : undefined;
   return {
-    enabled: envBoolean("MCP_OUTPUT_GUARD", "PI_MCP_OUTPUT_GUARD") ?? settings?.outputGuard ?? true,
-    maxBytes: envPositiveInt("MCP_OUTPUT_MAX_BYTES", "PI_MCP_OUTPUT_MAX_BYTES") ?? positiveInt(settings?.outputMaxBytes) ?? DEFAULT_MCP_OUTPUT_MAX_BYTES,
-    maxLines: envPositiveInt("MCP_OUTPUT_MAX_LINES", "PI_MCP_OUTPUT_MAX_LINES") ?? positiveInt(settings?.outputMaxLines) ?? DEFAULT_MCP_OUTPUT_MAX_LINES,
-    detailsMaxBytes: envPositiveInt("MCP_DETAILS_MAX_BYTES", "PI_MCP_DETAILS_MAX_BYTES") ?? positiveInt(settings?.detailsMaxBytes) ?? DEFAULT_MCP_DETAILS_MAX_BYTES,
+    enabled: envKillSwitch("MCP_OUTPUT_GUARD") ?? configured !== false,
+    maxBytes: positiveInt(tuning?.maxBytes) ?? DEFAULT_MCP_OUTPUT_MAX_BYTES,
+    maxLines: positiveInt(tuning?.maxLines) ?? DEFAULT_MCP_OUTPUT_MAX_LINES,
+    detailsMaxBytes: positiveInt(tuning?.detailsMaxBytes) ?? DEFAULT_MCP_DETAILS_MAX_BYTES,
   };
 }
 
+/** Spread helper for tool-result details: includes mcpResult/outputGuard only when present. */
+export function guardedMcpDetails(guarded: GuardedMcpOutput): Record<string, unknown> {
+  return {
+    ...(guarded.mcpResult !== undefined ? { mcpResult: guarded.mcpResult } : {}),
+    ...(guarded.outputGuard ? { outputGuard: guarded.outputGuard } : {}),
+  };
+}
+
+/**
+ * Bound model-facing MCP output. Text output is capped at maxBytes/maxLines and
+ * spilled to a temp file when oversized. Image blocks pass through untouched —
+ * they are delivered to the provider as native image content, not text context.
+ */
 export async function guardMcpOutput(
   content: ContentBlock[],
   options: McpOutputGuardOptions = {},
@@ -86,15 +103,18 @@ export async function guardMcpOutput(
     };
   }
 
-  const textOutput = serializeContent(normalizedContent);
+  const imageBlocks = normalizedContent.filter((block) => block.type === "image");
+  const textOutput = normalizedContent
+    .filter((block) => block.type === "text")
+    .map((block) => (block as { text: string }).text)
+    .join("\n");
   const composedOutput = `${prefix}${textOutput}${suffix}`;
   const stats = textStats(composedOutput);
-  const oversizedPayload = hasOversizedNonTextPayload(normalizedContent, maxBytes);
 
   let guardedContent: ContentBlock[] = addAffixes(normalizedContent, prefix, suffix);
   let outputGuard: McpOutputGuardDetails | undefined;
 
-  if (stats.bytes > maxBytes || stats.lines > maxLines || oversizedPayload) {
+  if (stats.bytes > maxBytes || stats.lines > maxLines) {
     const { path: fullOutputPath, error: writeError } = await saveArtifact("output", composedOutput);
     const notice = formatTruncationNotice(stats, fullOutputPath, writeError);
     const previewBudget = reserveBudget(maxBytes, maxLines, notice);
@@ -102,13 +122,14 @@ export async function guardMcpOutput(
     const finalText = `${preview.content}\n\n${notice}`;
     const finalStats = textStats(finalText);
 
-    guardedContent = [{ type: "text" as const, text: finalText }];
+    guardedContent = [{ type: "text" as const, text: finalText }, ...imageBlocks];
     outputGuard = {
       truncated: true,
       originalBytes: stats.bytes,
       returnedBytes: finalStats.bytes,
       originalLines: stats.lines,
       returnedLines: finalStats.lines,
+      ...(imageBlocks.length > 0 ? { imageBlocksPassedThrough: imageBlocks.length } : {}),
       fullOutputPath,
       writeError,
     };
@@ -116,7 +137,7 @@ export async function guardMcpOutput(
 
   const mcpResult = options.rawMcpResult === undefined
     ? undefined
-    : await summarizeMcpResult(options.rawMcpResult, outputGuard, detailsMaxBytes);
+    : await boundMcpResult(options.rawMcpResult, detailsMaxBytes);
 
   return { content: guardedContent, outputGuard, mcpResult };
 }
@@ -140,18 +161,6 @@ function addAffixes(content: ContentBlock[], prefix: string, suffix: string): Co
   return next;
 }
 
-function serializeContent(content: ContentBlock[]): string {
-  return content.map((block) => {
-    if (block.type === "text") return block.text;
-    const dataBytes = block.data ? byteLength(block.data) : 0;
-    return `[Image content omitted from text preview: ${block.mimeType ?? "image/*"}, ${formatSize(dataBytes)} base64 payload]`;
-  }).join("\n");
-}
-
-function hasOversizedNonTextPayload(content: ContentBlock[], maxBytes: number): boolean {
-  return content.some((block) => block.type === "image" && byteLength(block.data ?? "") > maxBytes);
-}
-
 function reserveBudget(maxBytes: number, maxLines: number, notice: string): { maxBytes: number; maxLines: number } {
   const noticeStats = textStats(`\n\n${notice}`);
   return {
@@ -171,7 +180,7 @@ function truncateHead(text: string, maxBytes: number, maxLines: number): { conte
     const lineBytes = byteLength(line);
     if (bytes + separatorBytes + lineBytes > maxBytes) {
       const remaining = maxBytes - bytes - separatorBytes;
-      if (remaining > 0 && output.length < maxLines) {
+      if (remaining > 0) {
         output.push(truncateStringToBytes(line, remaining));
       }
       break;
@@ -198,41 +207,39 @@ function formatTruncationNotice(
   fullOutputPath: string | undefined,
   writeError: string | undefined,
 ): string {
-  const base = `[MCP output truncated: original ${stats.lines.toLocaleString()} lines / ${formatSize(stats.bytes)}.`;
+  const base = `[MCP text output truncated: original ${stats.lines.toLocaleString()} lines / ${formatSize(stats.bytes)}.`;
   if (fullOutputPath) {
-    return `${base} Full output saved to: ${fullOutputPath}]`;
+    return `${base} Full text saved to: ${fullOutputPath} — use read with offset/limit or grep to inspect.]`;
   }
   return `${base} Full output could not be saved: ${writeError ?? "unknown error"}]`;
 }
 
-async function summarizeMcpResult(
-  result: unknown,
-  outputGuard: McpOutputGuardDetails | undefined,
-  detailsMaxBytes: number,
-): Promise<McpResultSummary> {
+/**
+ * Bound details.mcpResult: keep the raw result when its JSON fits within
+ * detailsMaxBytes; otherwise replace it with a compact summary and spill the
+ * raw JSON to a temp file.
+ */
+async function boundMcpResult(result: unknown, detailsMaxBytes: number): Promise<unknown> {
   const raw = safeStringify(result);
   const rawBytes = byteLength(raw);
-  let fullResultPath: string | undefined;
-  let resultWriteError: string | undefined;
+  if (rawBytes <= detailsMaxBytes) return result;
+  return summarizeMcpResult(result, raw, rawBytes);
+}
 
-  if (rawBytes > detailsMaxBytes) {
-    const saved = await saveArtifact("mcp-result", raw);
-    fullResultPath = saved.path;
-    resultWriteError = saved.error;
-  }
+async function summarizeMcpResult(result: unknown, raw: string, rawBytes: number): Promise<McpResultSummary> {
+  const { path: fullResultPath, error: resultWriteError } = await saveArtifact("mcp-result", raw);
 
   const record = asRecord(result);
   const content = Array.isArray(record?.content) ? record.content : [];
   const summary: McpResultSummary = {
     omitted: true,
-    reason: "Raw MCP result omitted from Pi session details to keep model/session context bounded.",
+    reason: "Raw MCP result exceeded the details size limit and was replaced with this summary to keep session context bounded.",
     isError: record?.isError === true,
     contentBlocks: content.length,
     contentSummary: summarizeContent(content),
     rawResultBytes: rawBytes,
     fullResultPath,
     resultWriteError,
-    outputGuard,
   };
 
   if (record && "structuredContent" in record) {
@@ -339,23 +346,11 @@ function positiveInt(value: unknown): number | undefined {
   return integer > 0 ? integer : undefined;
 }
 
-function envPositiveInt(...names: string[]): number | undefined {
-  for (const name of names) {
-    const value = process.env[name]?.trim();
-    if (!value) continue;
-    const parsed = Number.parseInt(value, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
-  return undefined;
-}
-
-function envBoolean(...names: string[]): boolean | undefined {
-  for (const name of names) {
-    const value = process.env[name]?.trim().toLowerCase();
-    if (!value) continue;
-    if (["0", "false", "no", "off"].includes(value)) return false;
-    if (["1", "true", "yes", "on"].includes(value)) return true;
-  }
+function envKillSwitch(name: string): boolean | undefined {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return undefined;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  if (["1", "true", "yes", "on"].includes(value)) return true;
   return undefined;
 }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "elicitation-handler.ts",
     "tool-registrar.ts",
     "tool-result-renderer.ts",
+    "mcp-output-guard.ts",
     "resource-tools.ts",
     "lifecycle.ts",
     "metadata-cache.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -7,6 +7,7 @@ import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
+import { guardMcpOutput, resolveMcpOutputGuardOptions, type GuardedMcpOutput } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
@@ -19,6 +20,13 @@ const REGEX_SAFETY_CHECK_PARAMS = {
   incubationTimeout: 50,
   timeout: 250,
 } as const;
+
+function guardedDetails(guarded: GuardedMcpOutput): Record<string, unknown> {
+  return {
+    ...(guarded.mcpResult ? { mcpResult: guarded.mcpResult } : {}),
+    ...(guarded.outputGuard ? { outputGuard: guarded.outputGuard } : {}),
+  };
+}
 
 type AutoAuthResult =
   | { status: "skipped" }
@@ -825,6 +833,8 @@ export async function executeCall(
 
   let uiSession: UiSessionRuntime | null = null;
 
+  const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
+
   try {
     state.manager.touch(serverName);
     state.manager.incrementInFlight(serverName);
@@ -835,9 +845,10 @@ export async function executeCall(
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
       }));
+      const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
       return {
-        content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
-        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName },
+        content: guarded.content,
+        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName, ...guardedDetails(guarded) },
       };
     }
 
@@ -862,30 +873,24 @@ export async function executeCall(
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
-
-      const mcpText = content
-        .filter((c) => c.type === "text")
-        .map((c) => (c as { text: string }).text)
-        .join("\n");
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
       if (result.isError) {
-        let errorWithSchema = `Error: ${mcpText || "Tool execution failed"}`;
-        if (toolMeta.inputSchema) {
-          errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-        }
+        const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result });
         return {
-          content: [{ type: "text" as const, text: errorWithSchema }],
-          details: { mode: "call", error: "tool_error", mcpResult: result },
+          content: guarded.content,
+          details: { mode: "call", error: "tool_error", ...guardedDetails(guarded) },
         };
       }
 
-      const resultText = mcpText || "(empty result)";
       const uiMessage = uiSession?.reused
         ? "Updated the open UI."
         : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result });
       return {
-        content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
-        details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName, uiOpen: true },
+        content: guarded.content,
+        details: { mode: "call", ...guardedDetails(guarded), server: serverName, tool: toolMeta.originalName, uiOpen: true },
       };
     }
 
@@ -893,27 +898,21 @@ export async function executeCall(
 
     const mcpContent = (result.content ?? []) as McpContent[];
     const content = transformMcpContent(mcpContent);
+    const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
 
     if (result.isError) {
-      const errorText = content
-        .filter((c) => c.type === "text")
-        .map((c) => (c as { text: string }).text)
-        .join("\n") || "Tool execution failed";
-
-      let errorWithSchema = `Error: ${errorText}`;
-      if (toolMeta.inputSchema) {
-        errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-      }
-
+      const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result });
       return {
-        content: [{ type: "text" as const, text: errorWithSchema }],
-        details: { mode: "call", error: "tool_error", mcpResult: result },
+        content: guarded.content,
+        details: { mode: "call", error: "tool_error", ...guardedDetails(guarded) },
       };
     }
 
+    const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
     return {
-      content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
-      details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName },
+      content: guarded.content,
+      details: { mode: "call", ...guardedDetails(guarded), server: serverName, tool: toolMeta.originalName },
     };
   } catch (error) {
     if (error instanceof UrlElicitationRequiredError) {
@@ -930,14 +929,12 @@ export async function executeCall(
     const message = error instanceof Error ? error.message : String(error);
     uiSession?.sendToolCancelled(message);
 
-    let errorWithSchema = `Failed to call tool: ${message}`;
-    if (toolMeta.inputSchema) {
-      errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`;
-    }
+    const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+    const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
 
     return {
-      content: [{ type: "text" as const, text: errorWithSchema }],
-      details: { mode: "call", error: "call_failed", message },
+      content: guarded.content,
+      details: { mode: "call", error: "call_failed", message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedDetails(guarded) },
     };
   } finally {
     if (uiSession?.reused) {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -7,7 +7,7 @@ import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { transformMcpContent } from "./tool-registrar.ts";
-import { guardMcpOutput, resolveMcpOutputGuardOptions, type GuardedMcpOutput } from "./mcp-output-guard.ts";
+import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
@@ -20,13 +20,6 @@ const REGEX_SAFETY_CHECK_PARAMS = {
   incubationTimeout: 50,
   timeout: 250,
 } as const;
-
-function guardedDetails(guarded: GuardedMcpOutput): Record<string, unknown> {
-  return {
-    ...(guarded.mcpResult ? { mcpResult: guarded.mcpResult } : {}),
-    ...(guarded.outputGuard ? { outputGuard: guarded.outputGuard } : {}),
-  };
-}
 
 type AutoAuthResult =
   | { status: "skipped" }
@@ -848,7 +841,7 @@ export async function executeCall(
       const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
       return {
         content: guarded.content,
-        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName, ...guardedDetails(guarded) },
+        details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName, ...guardedMcpDetails(guarded) },
       };
     }
 
@@ -880,7 +873,7 @@ export async function executeCall(
         const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result });
         return {
           content: guarded.content,
-          details: { mode: "call", error: "tool_error", ...guardedDetails(guarded) },
+          details: { mode: "call", error: "tool_error", ...guardedMcpDetails(guarded) },
         };
       }
 
@@ -890,7 +883,7 @@ export async function executeCall(
       const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result });
       return {
         content: guarded.content,
-        details: { mode: "call", ...guardedDetails(guarded), server: serverName, tool: toolMeta.originalName, uiOpen: true },
+        details: { mode: "call", ...guardedMcpDetails(guarded), server: serverName, tool: toolMeta.originalName, uiOpen: true },
       };
     }
 
@@ -905,14 +898,14 @@ export async function executeCall(
       const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, rawMcpResult: result });
       return {
         content: guarded.content,
-        details: { mode: "call", error: "tool_error", ...guardedDetails(guarded) },
+        details: { mode: "call", error: "tool_error", ...guardedMcpDetails(guarded) },
       };
     }
 
     const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
     return {
       content: guarded.content,
-      details: { mode: "call", ...guardedDetails(guarded), server: serverName, tool: toolMeta.originalName },
+      details: { mode: "call", ...guardedMcpDetails(guarded), server: serverName, tool: toolMeta.originalName },
     };
   } catch (error) {
     if (error instanceof UrlElicitationRequiredError) {
@@ -934,7 +927,7 @@ export async function executeCall(
 
     return {
       content: guarded.content,
-      details: { mode: "call", error: "call_failed", message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedDetails(guarded) },
+      details: { mode: "call", error: "call_failed", message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedMcpDetails(guarded) },
     };
   } finally {
     if (uiSession?.reused) {

--- a/types.ts
+++ b/types.ts
@@ -328,6 +328,17 @@ export interface McpSettings {
   samplingAutoApprove?: boolean;
   elicitation?: boolean;
   /**
+   * Guard oversized MCP tool/resource output before it is returned to the model.
+   * Defaults to true. Set to false to restore raw MCP output behavior.
+   */
+  outputGuard?: boolean;
+  /** Maximum inline MCP output bytes before truncation/spill-to-disk. Defaults to 50 KiB. */
+  outputMaxBytes?: number;
+  /** Maximum inline MCP output lines before truncation/spill-to-disk. Defaults to 2000. */
+  outputMaxLines?: number;
+  /** Maximum details.mcpResult JSON bytes before replacing raw details with a summary. Defaults to 16 KiB. */
+  detailsMaxBytes?: number;
+  /**
    * Message returned in tool results when a server needs (re-)authentication.
    * "${server}" is substituted with the server name. Defaults to a TUI
    * instruction when unset.

--- a/types.ts
+++ b/types.ts
@@ -317,6 +317,16 @@ export interface ServerEntry {
   debug?: boolean;  // Show server stderr (default: false)
 }
 
+// Output guard tuning (settings.outputGuard object form)
+export interface McpOutputGuardSettings {
+  /** Maximum inline MCP text output bytes before truncation/spill-to-disk. Defaults to 51200 (50 KiB). */
+  maxBytes?: number;
+  /** Maximum inline MCP text output lines before truncation/spill-to-disk. Defaults to 2000. */
+  maxLines?: number;
+  /** Maximum details.mcpResult JSON bytes kept raw; larger results are summarized and spilled to disk. Defaults to 16384 (16 KiB). */
+  detailsMaxBytes?: number;
+}
+
 // Settings
 export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
@@ -329,15 +339,11 @@ export interface McpSettings {
   elicitation?: boolean;
   /**
    * Guard oversized MCP tool/resource output before it is returned to the model.
-   * Defaults to true. Set to false to restore raw MCP output behavior.
+   * Defaults to true (50 KiB / 2,000 lines inline text, 16 KiB details.mcpResult).
+   * Set to false to restore raw MCP output behavior, or pass an object to tune
+   * the limits. Env kill switch: MCP_OUTPUT_GUARD=0.
    */
-  outputGuard?: boolean;
-  /** Maximum inline MCP output bytes before truncation/spill-to-disk. Defaults to 50 KiB. */
-  outputMaxBytes?: number;
-  /** Maximum inline MCP output lines before truncation/spill-to-disk. Defaults to 2000. */
-  outputMaxLines?: number;
-  /** Maximum details.mcpResult JSON bytes before replacing raw details with a summary. Defaults to 16 KiB. */
-  detailsMaxBytes?: number;
+  outputGuard?: boolean | McpOutputGuardSettings;
   /**
    * Message returned in tool results when a server needs (re-)authentication.
    * "${server}" is substituted with the server name. Defaults to a TUI


### PR DESCRIPTION
Hey @nicobailon!

I noticed some MCPs were dumping quite a lot into context which can sometimes overload the context window. Looking at how other harnesses handle this (codex/cc/amp), they all bound large results, though mostly through errors or lossy truncation. 

This is a PR that truncates MCP outputs above 50kb and saves the full output to a file the agent can read/grep, just like how Pi handles this for bash results (same 50kb threshold)

I've made this default, but giving users option to turn it off.

Let me know what you think // happy to amend if you have a different implementation in mind!

Cheers :)
Thomas

## Problem

A single oversized MCP result can blow up the model context and fail the turn. Real-world example that triggered this work: one `monaco_list_sequences` call through the `mcp` proxy tool injected **~318k chars** into context. Inspecting the session JSONL showed the damage was double:

- tool results carried **26–51 KB of inline text** into model context, and
- each result was **duplicated raw in `details.mcpResult`** (56–83 KB per call) in the session file.

High-volume MCP tools (logs, search, CRM listings) are exactly the ones this breaks. Fixes #55.

## What other harnesses do

Before implementing, I checked how other agent CLIs handle oversized (MCP) tool output:

| Harness | Behavior |
|---|---|
| **Pi built-in `bash`** | Truncates at 2,000 lines / 50 KiB, saves full output to a temp file, returns the path |
| **Claude Code** | Hard limit via `MAX_MCP_OUTPUT_TOKENS` (default 25k tokens, warning at 10k) — oversized results **error out** rather than truncate; servers can opt up via `_meta["anthropic/maxResultSizeChars"]` |
| **Codex CLI** | Truncates tool output at ~10 KiB / 256 lines (head+tail), **lossy** — no temp-file spill, not configurable (open issues [#5913](https://github.com/openai/codex/issues/5913), [#4550](https://github.com/openai/codex/issues/4550)) |
| **Amp** | No documented client-side guard found; guidance is server-side pagination/query narrowing |

Truncate-and-spill (Pi's own `bash` pattern) is the best of these: the turn survives, a useful preview stays inline, and the full data remains reachable via `read`/`grep`. This PR applies that pattern to MCP output, with the same 50 KiB / 2,000-line defaults so behavior is consistent inside Pi.

## What this PR does

Adds a centralized guard (`mcp-output-guard.ts`) applied to all MCP result paths — proxy calls, direct tools, resources, UI tools, tool errors, and call failures:

- **Text output** is capped at 50 KiB / 2,000 lines; larger output is truncated to a head preview and the full text is saved to a temp file (mode `0600`), with the path and `read`/`grep` guidance in the notice
- **Image blocks pass through untouched** — they're delivered as native provider image content, never collapsed into text placeholders
- **`details.mcpResult` (proxy mode)** is kept raw when its JSON is ≤ 16 KiB; larger results become a compact summary (block counts, sizes, key previews) with the raw JSON spilled to a temp file. Direct tools keep their lean legacy details and never carry `mcpResult`
- Truncation metadata is recorded in `details.outputGuard`

## Configuration

One settings key, following the `directTools` boolean-or-shape convention:

```json
{
  "settings": {
    "outputGuard": true
  }
}
```

`true` (default) · `false` (disable, restore raw behavior) · or tune: `{ "maxBytes": 51200, "maxLines": 2000, "detailsMaxBytes": 16384 }`

One env kill switch, following the repo's `MCP_*` convention: `MCP_OUTPUT_GUARD=0`.

## Validation

```bash
npx tsc --noEmit   # clean
npx vitest run     # 382/384
```

The two failures are pre-existing on `main` and unrelated (missing built artifacts under `examples/interactive-visualizer/dist/`). New unit coverage: small output untouched with raw details kept, byte- and line-based truncation with spill-to-file, the `detailsMaxBytes` raw-vs-summary boundary, image passthrough (alone and alongside truncated text), prefix/suffix preservation in saved artifacts, disabled mode, and settings/env resolution.
