### PR TITLE
Fix direct tool schema registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Normalized direct MCP tool schemas so draft metadata and strict top-level additional properties do not break Pi registration. Thanks @marchellodev for issue #2/PR #3 and @comtihon for PR #144.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/direct-tool-schema.test.ts
+++ b/__tests__/direct-tool-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDirectToolInputSchema } from "../utils.ts";
+
+describe("normalizeDirectToolInputSchema", () => {
+  it("removes top-level draft metadata and strict additional properties", () => {
+    const schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        options: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    };
+
+    expect(normalizeDirectToolInputSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        options: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+      required: ["query"],
+    });
+  });
+
+  it("uses an empty object schema when the MCP tool omits inputSchema", () => {
+    expect(normalizeDirectToolInputSchema(undefined)).toEqual({ type: "object", properties: {} });
+  });
+});

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -30,6 +30,9 @@ const mocks = vi.hoisted(() => ({
   executeStatus: vi.fn(),
   executeUiMessages: vi.fn(),
   getConfigPathFromArgv: vi.fn(() => undefined),
+  normalizeDirectToolInputSchema: vi.fn((schema: unknown) => schema && typeof schema === "object" && !Array.isArray(schema)
+    ? Object.fromEntries(Object.entries(schema).filter(([key]) => key !== "$schema" && key !== "additionalProperties"))
+    : { type: "object", properties: {} }),
   truncateAtWord: vi.fn((text: string) => text),
 }));
 
@@ -84,6 +87,7 @@ vi.mock("../proxy-modes.ts", () => ({
 
 vi.mock("../utils.ts", () => ({
   getConfigPathFromArgv: mocks.getConfigPathFromArgv,
+  normalizeDirectToolInputSchema: mocks.normalizeDirectToolInputSchema,
   truncateAtWord: mocks.truncateAtWord,
 }));
 
@@ -147,6 +151,9 @@ describe("mcpAdapter session lifecycle", () => {
     mocks.getMissingConfiguredDirectToolServers.mockReturnValue([]);
     mocks.resolveDirectTools.mockReturnValue([]);
     mocks.getConfigPathFromArgv.mockReturnValue(undefined);
+    mocks.normalizeDirectToolInputSchema.mockImplementation((schema: unknown) => schema && typeof schema === "object" && !Array.isArray(schema)
+      ? Object.fromEntries(Object.entries(schema).filter(([key]) => key !== "$schema" && key !== "additionalProperties"))
+      : { type: "object", properties: {} });
     mocks.truncateAtWord.mockImplementation((text: string) => text);
   });
 
@@ -187,6 +194,51 @@ describe("mcpAdapter session lifecycle", () => {
       name: "mcp",
       renderResult: expect.any(Function),
     }));
+  });
+
+  it("normalizes direct MCP tool schemas before registration", async () => {
+    const schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        nested: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    };
+    mocks.resolveDirectTools.mockReturnValue([
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search demo",
+        inputSchema: schema,
+      },
+    ]);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    expect(mocks.normalizeDirectToolInputSchema).toHaveBeenCalledWith(schema);
+    const directTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "demo_search")?.[0];
+    expect(directTool.parameters).toMatchObject({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        nested: {
+          type: "object",
+          additionalProperties: false,
+        },
+      },
+      required: ["query"],
+    });
+    expect(directTool.parameters).not.toHaveProperty("$schema");
+    expect(directTool.parameters).not.toHaveProperty("additionalProperties");
   });
 
   it("skips the proxy tool once direct tools are fully available", async () => {

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDi
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
-import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
+import { getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
 import { toolErrorOverride } from "./error-signal.ts";
@@ -73,7 +73,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       label: `MCP: ${spec.originalName}`,
       description: spec.description || "(no description)",
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
-      parameters: Type.Unsafe((spec.inputSchema || { type: "object", properties: {} }) as never),
+      parameters: Type.Unsafe(normalizeDirectToolInputSchema(spec.inputSchema) as never),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
       renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
       renderResult: renderMcpToolResult,

--- a/utils.ts
+++ b/utils.ts
@@ -106,6 +106,14 @@ export function truncateAtWord(text: string, target: number): string {
   return truncated + "...";
 }
 
+export function normalizeDirectToolInputSchema(schema: unknown): Record<string, unknown> {
+  const inputSchema = schema && typeof schema === "object" && !Array.isArray(schema)
+    ? schema as Record<string, unknown>
+    : { type: "object", properties: {} };
+  const { $schema, additionalProperties, ...normalized } = inputSchema;
+  return normalized;
+}
+
 export function formatAuthRequiredMessage(
   config: Pick<McpConfig, "settings">,
   serverName: string,


### PR DESCRIPTION
Normalizes direct MCP tool schemas before handing them to Pi so draft-2020-12 metadata and strict top-level additional properties don’t break registration. This builds on the direction from @comtihon’s PR #144, with focused coverage for the fallback and registration path. Fixes #2.