### PR TITLE
Fix CLI init through symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Fixed the `pi-mcp-adapter` bin entrypoint when invoked through installed symlinks, so `init` runs instead of silently exiting.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 
 function writeJson(path: string, value: unknown): void {
@@ -82,6 +83,28 @@ describe("cli init helper", () => {
     const config = JSON.parse(readFileSync(piConfigPath, "utf-8"));
     expect(config.imports).toContain("claude-code");
     expect(logs.join("\n")).toContain(piConfigPath);
+  });
+
+  it("runs when invoked through a symlinked bin path", () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-cli-home-"));
+    const binDir = mkdtempSync(join(tmpdir(), "pi-mcp-cli-bin-"));
+    const symlinkPath = join(binDir, "pi-mcp-adapter");
+    symlinkSync(resolve("cli.js"), symlinkPath);
+
+    const result = spawnSync(process.execPath, [symlinkPath, "init", "--dry-run"], {
+      cwd: mkdtempSync(join(tmpdir(), "pi-mcp-cli-project-")),
+      env: {
+        ...process.env,
+        HOME: home,
+        PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
+      },
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Config discovery:");
+    expect(result.stdout).toContain("No Pi config changes needed.");
   });
 
   it("explains that install now goes through `pi install`", async () => {

--- a/cli.js
+++ b/cli.js
@@ -172,7 +172,8 @@ export async function main(argv = process.argv.slice(2), log = console.log, erro
   return 1;
 }
 
-const isEntrypoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const resolvedEntrypoint = process.argv[1] ? fs.realpathSync(process.argv[1]) : undefined;
+const isEntrypoint = resolvedEntrypoint && import.meta.url === pathToFileURL(resolvedEntrypoint).href;
 
 if (isEntrypoint) {
   main().then((code) => {


### PR DESCRIPTION
This fixes the CLI entrypoint check so installed or Homebrew-style symlinked bin paths still run the helper instead of no-oping. I added a regression test that invokes the bin through a symlink and confirms `init --dry-run` actually prints the discovery output. Fixes #95.