### PR TITLE
Merge imported server overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Merged partial per-server Pi overrides into imported MCP server definitions instead of replacing the full server entry.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -99,6 +99,61 @@ describe("config discovery", () => {
     );
   });
 
+  it("merges partial Pi overrides into shared and imported server definitions", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-merge-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-merge-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".config", "mcp", "mcp.json"), {
+      mcpServers: {
+        sharedServer: { command: "shared", args: ["--stdio"], env: { TOKEN: "shared-token" } },
+      },
+    });
+
+    writeJson(join(home, ".cursor", "mcp.json"), {
+      mcpServers: {
+        importedStdio: { command: "cursor-stdio", args: ["--from-cursor"], env: { TOKEN: "cursor-token" } },
+        importedHttp: {
+          url: "https://api.example.com/mcp",
+          headers: { Authorization: "Bearer imported" },
+          auth: "bearer",
+        },
+      },
+    });
+
+    writeJson(join(home, ".pi", "agent", "mcp.json"), {
+      imports: ["cursor"],
+      mcpServers: {
+        sharedServer: { directTools: true },
+        importedStdio: { directTools: ["search"] },
+        importedHttp: { directTools: true, auth: false },
+      },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.sharedServer).toEqual({
+      command: "shared",
+      args: ["--stdio"],
+      env: { TOKEN: "shared-token" },
+      directTools: true,
+    });
+    expect(config.mcpServers.importedStdio).toEqual({
+      command: "cursor-stdio",
+      args: ["--from-cursor"],
+      env: { TOKEN: "cursor-token" },
+      directTools: ["search"],
+    });
+    expect(config.mcpServers.importedHttp).toEqual({
+      url: "https://api.example.com/mcp",
+      headers: { Authorization: "Bearer imported" },
+      auth: false,
+      directTools: true,
+    });
+  });
+
   it("tracks provenance so project servers write locally and shared/imported servers write to Pi config", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-project-"));

--- a/config.ts
+++ b/config.ts
@@ -250,10 +250,21 @@ function getConfigSources(overridePath?: string, cwd = process.cwd()): ConfigSou
 
 function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
   return {
-    mcpServers: { ...base.mcpServers, ...next.mcpServers },
+    mcpServers: mergeServerMaps(base.mcpServers, next.mcpServers),
     imports: mergeImports(base.imports, next.imports),
     settings: next.settings ? { ...base.settings, ...next.settings } : base.settings,
   };
+}
+
+function mergeServerMaps(
+  base: Record<string, ServerEntry>,
+  next: Record<string, ServerEntry>,
+): Record<string, ServerEntry> {
+  const merged = { ...base };
+  for (const [name, definition] of Object.entries(next)) {
+    merged[name] = { ...(merged[name] ?? {}), ...definition };
+  }
+  return merged;
 }
 
 function mergeImports(left: ImportKind[] | undefined, right: ImportKind[] | undefined): ImportKind[] | undefined {
@@ -286,7 +297,7 @@ function expandImports(config: McpConfig, cwd = process.cwd()): McpConfig {
   return {
     imports: config.imports,
     settings: config.settings,
-    mcpServers: { ...importedServers, ...config.mcpServers },
+    mcpServers: mergeServerMaps(importedServers, config.mcpServers),
   };
 }
 


### PR DESCRIPTION
This fixes the config layering bug where Pi-only per-server settings like `directTools` replaced imported server definitions instead of merging with them. Partial overrides now preserve the imported command/url details for stdio and HTTP servers, with focused config coverage and a changelog note. Fixes #94.