### PR TITLE
Keep OAuth auth URLs copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Routed interactive `/mcp-auth` OAuth URLs through Pi UI notifications so long authorization links remain intact instead of being truncated by raw terminal output. Thanks @feoh for PR #148.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  removeAuth: vi.fn(),
+}));
+
+vi.mock("../mcp-auth-flow.ts", () => ({
+  authenticate: mocks.authenticate,
+  removeAuth: mocks.removeAuth,
+  supportsOAuth: (definition: { url?: string; auth?: string }) => Boolean(definition.url) && definition.auth !== "bearer",
+}));
+
+vi.mock("../init.ts", () => ({
+  getFailureAgeSeconds: vi.fn(() => null),
+  lazyConnect: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+describe("authenticateServer", () => {
+  it("surfaces the exact OAuth URL through UI notification", async () => {
+    const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
+    mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
+      await options.onAuthorizationUrl(authorizationUrl);
+      return "authenticated";
+    });
+    const ui = { notify: vi.fn(), setStatus: vi.fn() };
+    const { authenticateServer } = await import("../commands.ts");
+
+    const result = await authenticateServer("sentry", {
+      mcpServers: {
+        sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
+      },
+    }, { hasUI: true, ui } as any);
+
+    expect(result.ok).toBe(true);
+    expect(mocks.authenticate).toHaveBeenCalledWith(
+      "sentry",
+      "https://mcp.sentry.dev/mcp",
+      { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
+      { onAuthorizationUrl: expect.any(Function) },
+    );
+    expect(ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining(authorizationUrl),
+      "info",
+    );
+  });
+});

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -509,6 +509,31 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("browser-fail")).toBeUndefined();
   });
 
+  it("uses a custom authorization URL handler instead of raw console output", async () => {
+    const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL(authorizationUrl));
+      return "REDIRECT";
+    });
+    mocks.waitForCallback.mockResolvedValueOnce("manual-code");
+    const onAuthorizationUrl = vi.fn();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { authenticate } = await import("../mcp-auth-flow.ts");
+
+    try {
+      await expect(authenticate("ui-auth", "https://api.example.com/mcp", {
+        url: "https://api.example.com/mcp",
+        auth: "oauth",
+      }, { onAuthorizationUrl })).resolves.toBe("authenticated");
+    } finally {
+      consoleLog.mockRestore();
+    }
+
+    expect(onAuthorizationUrl).toHaveBeenCalledWith(authorizationUrl);
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(mocks.open).toHaveBeenCalledWith(authorizationUrl);
+  });
+
   it("releases reserved callback state after direct completeAuth", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));

--- a/commands.ts
+++ b/commands.ts
@@ -168,7 +168,15 @@ export async function authenticateServer(
 
   try {
     ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
-    const status = await authenticate(serverName, definition.url, definition);
+    const status = await authenticate(serverName, definition.url, definition, {
+      onAuthorizationUrl: (authorizationUrl) => {
+        ctx.ui.notify(
+          `Open this URL to authenticate ${serverName}:\n\n${authorizationUrl}\n\n` +
+          "After approving, return to Pi; the local callback will complete automatically.",
+          "info"
+        );
+      },
+    });
 
     if (status === "authenticated") {
       const message = `OAuth authentication successful for "${serverName}"! Run /mcp reconnect ${serverName} to connect with the new token.`;

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -36,6 +36,10 @@ import type { ServerEntry } from "./types.ts"
 /** Auth status for a server */
 export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 
+export interface AuthenticateOptions {
+  onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
+}
+
 // Track pending transports for auth completion
 const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
 const pendingAuthStates = new Map<string, string>()
@@ -372,6 +376,7 @@ export async function authenticate(
   serverName: string,
   serverUrl: string,
   definition?: ServerEntry,
+  options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
   const inFlight = pendingAuthentications.get(serverName)
   if (inFlight) {
@@ -397,9 +402,13 @@ export async function authenticate(
     const callbackPromise = waitForCallback(oauthState)
 
     try {
-      // Open browser. Always print the URL first so remote/headless users can copy it
+      // Open browser. Always surface the URL first so remote/headless users can copy it
       // even when the OS browser handoff is unavailable or invisible.
-      console.log(`MCP Auth: Open this URL to authenticate ${serverName}:\n${authorizationUrl}`)
+      if (options.onAuthorizationUrl) {
+        await options.onAuthorizationUrl(authorizationUrl)
+      } else {
+        console.log(`MCP Auth: Open this URL to authenticate ${serverName}:\n${authorizationUrl}`)
+      }
       try {
         await open(authorizationUrl)
       } catch (error) {


### PR DESCRIPTION
This routes interactive /mcp-auth OAuth URLs through the Pi UI notification path instead of raw terminal output, so long auth links stay intact and copyable while headless/default auth still prints the URL. Built on the approach from @feoh's PR #148 and kept that credit in the changelog and commit metadata. Fixes #147.