### PR TITLE
Preserve npx argument separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Preserved `--` separators when resolving `npx` wrapper commands so subcommand flags are not consumed by tools like `dotenv-cli`.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-describe("npx-resolver cache path", () => {
+describe("npx-resolver", () => {
   const originalHome = process.env.HOME;
   const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
   const originalNpmCache = process.env.NPM_CONFIG_CACHE;
@@ -35,14 +35,7 @@ describe("npx-resolver cache path", () => {
     process.env.PI_CODING_AGENT_DIR = agentDir;
     process.env.NPM_CONFIG_CACHE = npmCache;
 
-    const packageDir = join(npmCache, "_npx", "fixture", "node_modules", "demo-pkg");
-    mkdirSync(join(packageDir, "bin"), { recursive: true });
-    writeFileSync(
-      join(packageDir, "package.json"),
-      JSON.stringify({ name: "demo-pkg", version: "1.0.0", bin: "bin/cli.js" }),
-      "utf-8",
-    );
-    writeFileSync(join(packageDir, "bin", "cli.js"), "#!/usr/bin/env node\nconsole.log('ok')\n", "utf-8");
+    writeCachedPackage(npmCache, "demo-pkg");
 
     const { resolveNpxBinary } = await import("../npx-resolver.ts");
     const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
@@ -51,4 +44,61 @@ describe("npx-resolver cache path", () => {
     expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(true);
     expect(existsSync(join(home, ".pi", "agent", "mcp-npx-cache.json"))).toBe(false);
   });
+
+  it("preserves npx separators for wrapper package arguments", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    writeCachedPackage(npmCache, "dotenv-cli");
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", [
+      "--yes",
+      "dotenv-cli",
+      "--",
+      "npx",
+      "--yes",
+      "@upstash/context7-mcp",
+    ]);
+
+    expect(result?.extraArgs).toEqual(["--", "npx", "--yes", "@upstash/context7-mcp"]);
+  });
+
+  it("does not add separators to npx invocations that did not include one", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    writeCachedPackage(npmCache, "dotenv-cli");
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", [
+      "--yes",
+      "dotenv-cli",
+      "github-mcp-server",
+      "stdio",
+    ]);
+
+    expect(result?.extraArgs).toEqual(["github-mcp-server", "stdio"]);
+  });
 });
+
+function writeCachedPackage(npmCache: string, packageName: string): void {
+  const packageDir = join(npmCache, "_npx", "fixture", "node_modules", packageName);
+  mkdirSync(join(packageDir, "bin"), { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name: packageName, version: "1.0.0", bin: "bin/cli.js" }),
+    "utf-8",
+  );
+  writeFileSync(join(packageDir, "bin", "cli.js"), "#!/usr/bin/env node\nconsole.log('ok')\n", "utf-8");
+}

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -107,16 +107,18 @@ function parseNpxArgs(args: string[]): ParsedInvocation | null {
     foundFirstPositional = true;
   }
 
+  const separatedAfter = separatorIndex >= 0 && after.length > 0 ? ["--", ...after] : after;
+
   if (sawPackageFlag) {
     const binName = positionals[0];
     if (!packageSpec || !binName) return null;
-    const extraArgs = positionals.slice(1).concat(after);
+    const extraArgs = positionals.slice(1).concat(separatedAfter);
     return { packageSpec, binName, extraArgs };
   }
 
   const packagePositional = positionals[0];
   if (!packagePositional) return null;
-  const extraArgs = positionals.slice(1).concat(after);
+  const extraArgs = positionals.slice(1).concat(separatedAfter);
   return { packageSpec: packagePositional, extraArgs };
 }
 


### PR DESCRIPTION
This keeps the original `--` separator when the npx resolver swaps a wrapper package like `dotenv-cli` for its cached binary, so subcommand flags still reach the tool they belong to. Added focused resolver coverage and kept the existing no-separator behavior unchanged. Fixes #15.