### PR TITLE
Fix MCP panel text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Kept multiline/control MCP panel metadata from corrupting rows and made Keep & Close save dirty changes. Thanks @gpmarques for PR #14 and @markokocic for PR #135.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/mcp-panel-auth.test.ts
+++ b/__tests__/mcp-panel-auth.test.ts
@@ -98,6 +98,33 @@ describe("mcp-panel auth actions", () => {
     panel.dispose();
   });
 
+  it("sanitizes OSC sequences in auth notice server names and messages", async () => {
+    const serverName = "git\x1b]8;;https://example.invalid/server\x07hub\x1b]8;;\x07";
+    const config: McpConfig = {
+      mcpServers: {
+        [serverName]: { url: "https://api.githubcopilot.com/mcp", auth: "oauth" },
+      },
+    };
+    const callbacks = createCallbacks("needs-auth");
+    callbacks.canAuthenticate = () => true;
+    callbacks.authenticate = vi.fn(async () => ({
+      ok: false,
+      message: "browser \x1b]8;;https://example.invalid/error\x07launch\x1b]8;;\x07 failed",
+    }));
+    callbacks.getConnectionStatus = () => "needs-auth";
+    const panel = createMcpPanel(config, null, new Map(), callbacks, { requestRender: () => {} }, () => {});
+
+    panel.handleInput("\r");
+    await Promise.resolve();
+
+    const output = stripAnsi(panel.render(100).join("\n"));
+    expect(output).toContain("OAuth failed for github: browser launch failed");
+    expect(output).not.toContain("\x1b]");
+    expect(output).not.toContain("https://example.invalid/server");
+    expect(output).not.toContain("https://example.invalid/error");
+    panel.dispose();
+  });
+
   it("does not start duplicate auth while auth is already in flight", async () => {
     const config: McpConfig = {
       mcpServers: {

--- a/__tests__/mcp-panel-auth.test.ts
+++ b/__tests__/mcp-panel-auth.test.ts
@@ -99,7 +99,7 @@ describe("mcp-panel auth actions", () => {
   });
 
   it("sanitizes OSC sequences in auth notice server names and messages", async () => {
-    const serverName = "git\x1b]8;;https://example.invalid/server\x07hub\x1b]8;;\x07";
+    const serverName = "git\x9d8;;https://example.invalid/server\x1b\\hub\x9d8;;\x1b\\";
     const config: McpConfig = {
       mcpServers: {
         [serverName]: { url: "https://api.githubcopilot.com/mcp", auth: "oauth" },
@@ -109,7 +109,7 @@ describe("mcp-panel auth actions", () => {
     callbacks.canAuthenticate = () => true;
     callbacks.authenticate = vi.fn(async () => ({
       ok: false,
-      message: "browser \x1b]8;;https://example.invalid/error\x07launch\x1b]8;;\x07 failed",
+      message: "browser \x9d8;;https://example.invalid/error\x1b\\launch\x9d8;;\x1b\\ failed",
     }));
     callbacks.getConnectionStatus = () => "needs-auth";
     const panel = createMcpPanel(config, null, new Map(), callbacks, { requestRender: () => {} }, () => {});
@@ -120,6 +120,7 @@ describe("mcp-panel auth actions", () => {
     const output = stripAnsi(panel.render(100).join("\n"));
     expect(output).toContain("OAuth failed for github: browser launch failed");
     expect(output).not.toContain("\x1b]");
+    expect(output).not.toContain("\x9d");
     expect(output).not.toContain("https://example.invalid/server");
     expect(output).not.toContain("https://example.invalid/error");
     panel.dispose();

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -35,7 +35,7 @@ function createCache(config: McpConfig): MetadataCache {
         tools: [
           {
             name: "search\u0007issues",
-            description: "Search\r\n\x1b[31missues\x1b[0m\tby query\u0000now",
+            description: "Search\r\n\x1b[31m\x1b]8;;https://example.invalid/issues\x1b\\issues\x1b]8;;\x1b\\\x1b[0m\tby query\u0000now",
           },
           { name: "list_projects", description: "List projects" },
         ],
@@ -66,6 +66,28 @@ describe("mcp-panel rendering", () => {
     expect(output).toContain("Search issues by query now");
     expect(lines.some((line) => /[\r\n\u0000-\u001f\u007f-\u009f]/.test(stripAnsi(line)))).toBe(false);
     expect(output).not.toContain("[31m");
+    expect(output).not.toContain("\x1b]");
+    expect(output).not.toContain("https://example.invalid/issues");
+    panel.dispose();
+  });
+
+  it("sanitizes OSC sequences in notice lines before styling", () => {
+    const config = createConfig();
+    const panel = createMcpPanel(
+      config,
+      createCache(config),
+      new Map(),
+      createCallbacks(),
+      { requestRender: () => {} },
+      () => {},
+      { noticeLines: ["Open \x1b]8;;https://example.invalid/notice\x07docs\x1b]8;;\x07 now"] },
+    );
+
+    const output = stripAnsi(panel.render(120).join("\n"));
+
+    expect(output).toContain("Open docs now");
+    expect(output).not.toContain("\x1b]");
+    expect(output).not.toContain("https://example.invalid/notice");
     panel.dispose();
   });
 

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMcpPanel } from "../mcp-panel.ts";
+import { computeServerHash, type MetadataCache } from "../metadata-cache.ts";
+import type { McpConfig, McpPanelCallbacks, McpPanelResult } from "../types.ts";
+
+function stripAnsi(input: string): string {
+  return input.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function createCallbacks(): McpPanelCallbacks {
+  return {
+    reconnect: async () => true,
+    canAuthenticate: () => false,
+    authenticate: async () => ({ ok: false }),
+    getConnectionStatus: () => "idle",
+    refreshCacheAfterReconnect: () => null,
+  };
+}
+
+function createConfig(): McpConfig {
+  return {
+    mcpServers: {
+      atlassian: { command: "npx", args: ["-y", "atlassian-mcp"] },
+    },
+  };
+}
+
+function createCache(config: McpConfig): MetadataCache {
+  return {
+    version: 1,
+    servers: {
+      atlassian: {
+        configHash: computeServerHash(config.mcpServers.atlassian),
+        cachedAt: Date.now(),
+        tools: [
+          {
+            name: "search\u0007issues",
+            description: "Search\r\n\x1b[31missues\x1b[0m\tby query\u0000now",
+          },
+          { name: "list_projects", description: "List projects" },
+        ],
+        resources: [],
+      },
+    },
+  };
+}
+
+describe("mcp-panel rendering", () => {
+  it("renders MCP metadata as single-line display text", () => {
+    const config = createConfig();
+    const panel = createMcpPanel(
+      config,
+      createCache(config),
+      new Map(),
+      createCallbacks(),
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    panel.handleInput("\r");
+
+    const lines = panel.render(120);
+    const output = stripAnsi(lines.join("\n"));
+
+    expect(output).toContain("search issues");
+    expect(output).toContain("Search issues by query now");
+    expect(lines.some((line) => /[\r\n\u0000-\u001f\u007f-\u009f]/.test(stripAnsi(line)))).toBe(false);
+    expect(output).not.toContain("[31m");
+    panel.dispose();
+  });
+
+  it("keeps dirty changes and closes when Keep & Close is confirmed", () => {
+    const config = createConfig();
+    const done = vi.fn<(result: McpPanelResult) => void>();
+    const panel = createMcpPanel(
+      config,
+      createCache(config),
+      new Map(),
+      createCallbacks(),
+      { requestRender: () => {} },
+      done,
+    );
+
+    panel.handleInput("\r");
+    panel.handleInput("\x1b[B");
+    panel.handleInput("\r");
+    panel.handleInput("\x1b");
+
+    expect(stripAnsi(panel.render(120).join("\n"))).toContain("Keep & Close");
+
+    panel.handleInput("\r");
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const result = done.mock.calls[0][0];
+    expect(result.cancelled).toBe(false);
+    expect(result.changes.get("atlassian")).toEqual(["search\u0007issues"]);
+    panel.dispose();
+  });
+});

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -35,7 +35,7 @@ function createCache(config: McpConfig): MetadataCache {
         tools: [
           {
             name: "search\u0007issues",
-            description: "Search\r\n\x1b[31m\x1b]8;;https://example.invalid/issues\x1b\\issues\x1b]8;;\x1b\\\x1b[0m\tby query\u0000now",
+            description: "Search\r\n\x1b[31m\x9d8;;https://example.invalid/issues\x1b\\issues\x9d8;;\x1b\\\x1b[0m\tby query\u0000now",
           },
           { name: "list_projects", description: "List projects" },
         ],
@@ -67,6 +67,7 @@ describe("mcp-panel rendering", () => {
     expect(lines.some((line) => /[\r\n\u0000-\u001f\u007f-\u009f]/.test(stripAnsi(line)))).toBe(false);
     expect(output).not.toContain("[31m");
     expect(output).not.toContain("\x1b]");
+    expect(output).not.toContain("\x9d");
     expect(output).not.toContain("https://example.invalid/issues");
     panel.dispose();
   });

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -74,6 +74,41 @@ function fuzzyScore(query: string, text: string): number {
   return qi === lq.length ? score : 0;
 }
 
+function sanitizeDisplayText(text: string | null | undefined): string {
+  return (text ?? "")
+    .replace(/(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/g, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sanitizeRowContent(content: string): string {
+  let result = "";
+  let pendingSpace = false;
+  for (let i = 0; i < content.length; i++) {
+    const rest = content.slice(i);
+    const ansi = rest.match(/^(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/);
+    if (ansi) {
+      result += ansi[0];
+      i += ansi[0].length - 1;
+      continue;
+    }
+
+    const code = content.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace && result && !result.endsWith(" ")) {
+      result += " ";
+    }
+    pendingSpace = false;
+    result += content[i];
+  }
+  return result;
+}
+
 function estimateTokens(tool: CachedTool): number {
   const schemaLen = JSON.stringify(tool.inputSchema ?? {}).length;
   const descLen = tool.description?.length ?? 0;
@@ -522,11 +557,11 @@ class McpPanel {
       return;
     }
     if (this.keys.selectConfirm(data)) {
+      this.cleanup();
       if (this.discardSelected === 0) {
-        this.cleanup();
         this.done({ cancelled: true, changes: new Map() });
       } else {
-        this.confirmingDiscard = false;
+        this.done(this.buildResult());
       }
       return;
     }
@@ -600,7 +635,7 @@ class McpPanel {
     const inverse = (s: string) => `\x1b[7m${s}\x1b[27m`;
 
     const row = (content: string) =>
-      fg(t.border, "│") + truncateToWidth(" " + content, innerW, "…", true) + fg(t.border, "│");
+      fg(t.border, "│") + truncateToWidth(" " + sanitizeRowContent(content), innerW, "…", true) + fg(t.border, "│");
     const emptyRow = () => fg(t.border, "│") + " ".repeat(innerW) + fg(t.border, "│");
     const divider = () => fg(t.border, "├" + "─".repeat(innerW) + "┤");
 
@@ -681,8 +716,8 @@ class McpPanel {
         ? inverse(bold(fg(t.cancel, "  Discard  ")))
         : fg(t.hint, "  Discard  ");
       const keepBtn = this.discardSelected === 1
-        ? inverse(bold(fg(t.confirm, "  Keep  ")))
-        : fg(t.hint, "  Keep  ");
+        ? inverse(bold(fg(t.confirm, "  Keep & Close  ")))
+        : fg(t.hint, "  Keep & Close  ");
       lines.push(row(`Discard unsaved changes?  ${discardBtn}   ${keepBtn}`));
     } else {
       if (this.authOnly) {
@@ -750,8 +785,10 @@ class McpPanel {
     const expandIcon = server.expanded ? "▾" : "▸";
     const prefix = isCursor ? fg(t.selected, expandIcon) : fg(t.border, server.expanded ? expandIcon : "·");
 
-    const nameStr = isCursor ? bold(fg(t.selected, server.name)) : server.name;
-    const importLabel = server.source === "import" ? fg(t.description, ` (${server.importKind ?? "import"})`) : "";
+    const serverName = sanitizeDisplayText(server.name);
+    const importKind = sanitizeDisplayText(server.importKind ?? "import");
+    const nameStr = isCursor ? bold(fg(t.selected, serverName)) : serverName;
+    const importLabel = server.source === "import" ? fg(t.description, ` (${importKind})`) : "";
     const statusLabel = this.renderConnectionStatus(server);
 
     if (!server.hasCachedData && !this.authOnly) {
@@ -797,13 +834,15 @@ class McpPanel {
 
     const toggleIcon = tool.isDirect ? fg(t.direct, "●") : fg(t.description, "○");
     const cursor = isCursor ? fg(t.selected, "▸") : " ";
-    const nameStr = isCursor ? bold(fg(t.selected, tool.name)) : tool.name;
+    const toolName = sanitizeDisplayText(tool.name);
+    const description = sanitizeDisplayText(tool.description);
+    const nameStr = isCursor ? bold(fg(t.selected, toolName)) : toolName;
 
-    const prefixLen = 7 + visibleWidth(tool.name);
+    const prefixLen = 7 + visibleWidth(toolName);
     const maxDescLen = Math.max(0, innerW - prefixLen - 8);
     const descStr =
-      maxDescLen > 5 && tool.description
-        ? fg(t.description, "— " + truncateToWidth(tool.description, maxDescLen, "…"))
+      maxDescLen > 5 && description
+        ? fg(t.description, "— " + truncateToWidth(description, maxDescLen, "…"))
         : "";
 
     return `  ${cursor} ${toggleIcon} ${nameStr} ${descStr}`;

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -76,6 +76,7 @@ function fuzzyScore(query: string, text: string): number {
 
 function sanitizeDisplayText(text: string | null | undefined): string {
   return (text ?? "")
+    .replace(/(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x9c))/g, "")
     .replace(/(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/g, "")
     .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
     .replace(/\s+/g, " ")
@@ -87,6 +88,12 @@ function sanitizeRowContent(content: string): string {
   let pendingSpace = false;
   for (let i = 0; i < content.length; i++) {
     const rest = content.slice(i);
+    const osc = rest.match(/^(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x9c))/);
+    if (osc) {
+      i += osc[0].length - 1;
+      continue;
+    }
+
     const ansi = rest.match(/^(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/);
     if (ansi) {
       result += ansi[0];
@@ -430,7 +437,7 @@ class McpPanel {
         const tool = server.tools[item.toolIndex];
         tool.isDirect = !tool.isDirect;
         if (tool.isDirect && server.source === "import") {
-          this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`;
+          this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
         }
         this.updateDirty();
       }
@@ -461,8 +468,9 @@ class McpPanel {
         this.tui.requestRender();
       }).catch((error) => {
         server.connectionStatus = "failed";
-        const message = error instanceof Error ? error.message : String(error);
-        this.authNotice = `Reconnect failed for ${server.name}: ${message}`;
+        const message = sanitizeDisplayText(error instanceof Error ? error.message : String(error));
+        const serverName = sanitizeDisplayText(server.name);
+        this.authNotice = `Reconnect failed for ${serverName}: ${message}`;
         this.tui.requestRender();
       });
       return;
@@ -502,26 +510,28 @@ class McpPanel {
 
   private authenticateServer(server: ServerState): void {
     if (this.authInFlight) return;
+    const serverName = sanitizeDisplayText(server.name);
     if (!this.callbacks.canAuthenticate(server.name)) {
-      this.authNotice = `${server.name} does not use OAuth authentication.`;
+      this.authNotice = `${serverName} does not use OAuth authentication.`;
       return;
     }
 
     this.authInFlight = server.name;
-    this.authNotice = `Authenticating ${server.name}...`;
+    this.authNotice = `Authenticating ${serverName}...`;
     this.tui.requestRender();
 
     this.callbacks.authenticate(server.name).then((result) => {
       server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      const message = sanitizeDisplayText(result.message);
       this.authNotice = result.ok
-        ? `OAuth finished for ${server.name}. Run reconnect if it is still idle.`
-        : `OAuth failed for ${server.name}${result.message ? `: ${result.message}` : ". Check the notification for details."}`;
+        ? `OAuth finished for ${serverName}. Run reconnect if it is still idle.`
+        : `OAuth failed for ${serverName}${message ? `: ${message}` : ". Check the notification for details."}`;
       this.authInFlight = null;
       this.tui.requestRender();
     }).catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = sanitizeDisplayText(error instanceof Error ? error.message : String(error));
       server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
-      this.authNotice = `OAuth failed for ${server.name}: ${message}`;
+      this.authNotice = `OAuth failed for ${serverName}: ${message}`;
       this.authInFlight = null;
       this.tui.requestRender();
     });
@@ -533,14 +543,14 @@ class McpPanel {
     if (item.type === "server") {
       const newState = !server.tools.every((t) => t.isDirect);
       if (server.source === "import" && newState) {
-        this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`;
+        this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
       }
       for (const t of server.tools) t.isDirect = newState;
     } else if (item.toolIndex !== undefined) {
       const tool = server.tools[item.toolIndex];
       tool.isDirect = !tool.isDirect;
       if (tool.isDirect && server.source === "import") {
-        this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`;
+        this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
       }
     }
     this.updateDirty();
@@ -660,7 +670,7 @@ class McpPanel {
     lines.push(emptyRow());
     if (this.noticeLines.length > 0) {
       for (const notice of this.noticeLines) {
-        lines.push(row(fg(t.hint, italic(notice))));
+        lines.push(row(fg(t.hint, italic(sanitizeDisplayText(notice)))));
       }
       lines.push(emptyRow());
     }
@@ -699,11 +709,11 @@ class McpPanel {
       }
 
       if (this.importNotice) {
-        lines.push(row(fg(t.needsAuth, italic(this.importNotice))));
+        lines.push(row(fg(t.needsAuth, italic(sanitizeDisplayText(this.importNotice)))));
         lines.push(emptyRow());
       }
       if (this.authNotice) {
-        lines.push(row(fg(t.needsAuth, italic(this.authNotice))));
+        lines.push(row(fg(t.needsAuth, italic(sanitizeDisplayText(this.authNotice)))));
         lines.push(emptyRow());
       }
     }

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -76,7 +76,7 @@ function fuzzyScore(query: string, text: string): number {
 
 function sanitizeDisplayText(text: string | null | undefined): string {
   return (text ?? "")
-    .replace(/(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x9c))/g, "")
+    .replace(/(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x1b\\|\x9c))/g, "")
     .replace(/(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/g, "")
     .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
     .replace(/\s+/g, " ")
@@ -88,7 +88,7 @@ function sanitizeRowContent(content: string): string {
   let pendingSpace = false;
   for (let i = 0; i < content.length; i++) {
     const rest = content.slice(i);
-    const osc = rest.match(/^(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x9c))/);
+    const osc = rest.match(/^(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x1b\\|\x9c))/);
     if (osc) {
       i += osc[0].length - 1;
       continue;


### PR DESCRIPTION
Fixes #14. This keeps multiline, ANSI, and control-character MCP metadata from breaking the /mcp panel rows, and makes Keep & Close actually close while keeping dirty changes. It also covers the multiline description cases from #134 and #115, and builds on the same sanitization direction as @markokocic's PR #135.