### PR TITLE
Respect configured HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added default-on MCP output guarding with temp-file spillover for oversized text results, compact summaries for large proxy result details, and `settings.outputGuard` tuning. Thanks @tmustier for PR #160.
 
 ### Fixed
+- Respected configured HTTP headers before implicit OAuth auto-detection so API-key/custom-header MCP servers do not trigger OAuth DCR.
 - Propagated Pi abort signals into MCP connect, resource, and tool requests so cancelled calls settle promptly. Thanks @xz-dev for PR #159.
 - Re-flagged failed MCP tool calls (`tool_error`/`call_failed`) as errors so they are recorded as failures (`isError: true`) instead of successes. Thanks @ishinder for PR #157.
 - Honored configured `requestTimeoutMs` during MCP connection, discovery, tool, resource, and UI proxy requests. Thanks @mizuikki for PR #155.

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -127,6 +127,19 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(mocks.httpTransports.at(-1)!.options.requestInit?.headers?.Authorization).toBe("Bearer named-env-token");
   });
 
+  it("uses configured headers without implicit OAuth", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+
+    const manager = new McpServerManager();
+    await manager.connect("remote", {
+      url: "https://example.test/mcp",
+      headers: { "X-Goog-Api-Key": "api-key" },
+    });
+
+    expect(mocks.httpTransports.at(-1)!.options.requestInit?.headers?.["X-Goog-Api-Key"]).toBe("api-key");
+    expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
+  });
+
   it("preserves OAuth redirect URI and client metadata for HTTP transports", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
 

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -70,6 +70,23 @@ describe("mcp-auth-flow", () => {
       assert.strictEqual(supportsOAuth(definition), false)
     })
 
+    it("should return false for implicit OAuth when custom headers are configured", () => {
+      const definition: ServerEntry = {
+        url: "https://api.example.com/mcp",
+        headers: { "X-Goog-Api-Key": "api-key" },
+      }
+      assert.strictEqual(supportsOAuth(definition), false)
+    })
+
+    it("should return true for explicit OAuth even when custom headers are configured", () => {
+      const definition: ServerEntry = {
+        url: "https://api.example.com/mcp",
+        auth: "oauth",
+        headers: { "X-Tenant": "tenant-id" },
+      }
+      assert.strictEqual(supportsOAuth(definition), true)
+    })
+
     it("should return false for stdio server", () => {
       const definition: ServerEntry = {
         command: "npx",

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -536,9 +536,13 @@ export function supportsOAuth(definition: ServerEntry): boolean {
   // Explicitly disabled via auth: false or oauth: false
   if (definition.auth === false) return false
   if (definition.oauth === false) return false
+  if (definition.auth === "oauth") return true
   
-  // OAuth is enabled if auth is 'oauth' or not specified (auto-detect)
-  return definition.auth === "oauth" || definition.auth === undefined
+  // Configured custom headers take precedence over implicit OAuth auto-detection.
+  if (definition.headers && Object.keys(definition.headers).length > 0) return false
+
+  // OAuth is enabled when auth is not specified (auto-detect)
+  return definition.auth === undefined
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -294,7 +294,7 @@ export interface ServerEntry {
    * - 'oauth' - Use OAuth 2.1 (auto-discovers endpoints, supports dynamic client registration)
    * - 'bearer' - Use static Bearer token
    * - false - Disable authentication
-   * If not specified and url is present, OAuth will be auto-detected
+   * If not specified and url is present, OAuth will be auto-detected unless custom headers are configured
    */
   auth?: "oauth" | "bearer" | false;
   bearerToken?: string;


### PR DESCRIPTION
This keeps custom header auth ahead of implicit OAuth detection, so API-key HTTP MCP servers use their configured headers instead of getting sent into OAuth DCR. It still preserves explicit OAuth when users set `auth: "oauth"`. Fixes #158.