### PR TITLE
fix: initialize MCP at extension load for eager/keep-alive servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declared Pi host packages as optional peer dependencies with exact development pins, reducing extension install footprint and avoiding host version conflicts. Thanks @t0dorakis for PR #200.
 
 ### Fixed
+- Started MCP initialization at extension load when any server is configured with `lifecycle: "eager"` or `"keep-alive"`, so hosts that drive Pi programmatically without `session_start` still connect startup servers. Thanks Brian Gebel (@ductiletoaster) for PR #170.
 - Enforced normalized standard `_meta.ui.csp` and OpenAI-compatible `_meta["openai/widgetCSP"]` metadata with response headers while preserving provider HTML. Thanks @IdoHadar for PR #195.
 - Avoided MCP renderer crashes without a TUI theme and preserved status-bar updates with plain fallback text. Thanks @fankangsong for PR #183.
 - Abandoned MCP initialization quietly when a session is disposed during eager or keep-alive connection setup. Thanks @luisfontes for PR #192.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ You can also pass only the `code` query parameter with `args: { code: "..." }`. 
 - **`keep-alive`** — Connect at startup. Auto-reconnect via health checks. No idle timeout. Use for servers you always need available.
 - **`lazy-keep-alive`** — Don't connect at startup. Connect on first tool call (like `lazy`). Once spawned, never idle-shut down and auto-reconnect via health checks if the process dies (like `keep-alive`). Use for servers that are expensive to start but should stay resident after their first use.
 
+When any enabled server uses `eager` or `keep-alive`, initialization also starts when the extension loads. This supports hosts that embed Pi programmatically and never emit `session_start`; if a session does start later, the session-owned runtime supersedes the load-time runtime.
+
 ### Settings
 
 ```json

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -716,6 +716,181 @@ describe("mcpAdapter session lifecycle", () => {
     expect(staleState.lifecycle.gracefulShutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("initializes MCP at extension load when a server requests startup connection", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "eager" },
+      },
+    });
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeStatus.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+    const loadCtx = mocks.initializeMcp.mock.calls[0][1];
+    expect(loadCtx.hasUI).toBe(false);
+    expect(loadCtx.mode).toBe("print");
+    expect(loadCtx.cwd).toBe(process.cwd());
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    expect(proxyTool).toBeDefined();
+
+    await proxyTool.execute("call-1", {});
+    expect(mocks.executeStatus).toHaveBeenCalledWith(state);
+  });
+
+  it("does not initialize at load when startup servers are absent or disabled", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        lazy: { command: "npx", args: ["-y", "demo-server"] },
+        disabledEager: { url: "http://localhost:3999/mcp", lifecycle: "eager", disabled: true },
+      },
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mocks.initializeMcp).not.toHaveBeenCalled();
+  });
+
+  it("lets session_start supersede an in-flight load-time init", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "keep-alive" },
+      },
+    });
+    const loadInit = createDeferred<any>();
+    const sessionInit = createDeferred<any>();
+    mocks.initializeMcp
+      .mockReturnValueOnce(loadInit.promise)
+      .mockReturnValueOnce(sessionInit.promise);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+    const loadRuntime = mocks.createOAuthRuntime.mock.results[0].value;
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, { hasUI: false });
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(2);
+    expect(loadRuntime.signal.aborted).toBe(true);
+    expect(mocks.shutdownOAuth).toHaveBeenCalledWith(loadRuntime);
+
+    const sessionState = createState();
+    sessionInit.resolve(sessionState);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.updateStatusBar).toHaveBeenCalledWith(sessionState);
+
+    const staleState = createState();
+    loadInit.resolve(staleState);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.updateStatusBar).not.toHaveBeenCalledWith(staleState);
+    expect(mocks.flushMetadataCache).toHaveBeenCalledWith(staleState);
+    expect(staleState.lifecycle.gracefulShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips load-time initialization when session_start fires first", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "eager" },
+      },
+    });
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, { hasUI: false });
+    await new Promise((resolve) => setImmediate(resolve));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuts down an unresolved load-time initialization during session_shutdown", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "eager" },
+      },
+    });
+    const loadInit = createDeferred<any>();
+    mocks.initializeMcp.mockReturnValue(loadInit.promise);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+    const loadRuntime = mocks.createOAuthRuntime.mock.results[0].value;
+
+    const sessionShutdown = handlers.get("session_shutdown");
+    await sessionShutdown?.();
+    expect(loadRuntime.signal.aborted).toBe(true);
+    expect(mocks.shutdownOAuth).toHaveBeenCalledWith(loadRuntime);
+
+    const staleState = createState();
+    loadInit.resolve(staleState);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.updateStatusBar).not.toHaveBeenCalledWith(staleState);
+    expect(mocks.flushMetadataCache).toHaveBeenCalledWith(staleState);
+    expect(staleState.lifecycle.gracefulShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the proxy tool wait when initialization stalls", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "eager" },
+      },
+    });
+    const never = createDeferred<any>();
+    mocks.initializeMcp.mockReturnValue(never.promise);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    try {
+      const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+      expect(proxyTool).toBeDefined();
+
+      const resultPromise = proxyTool.execute("call-1", { search: "demo" });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await resultPromise;
+
+      expect(result.details).toEqual({ error: "init_timeout", timeoutMs: 30_000 });
+      expect(mocks.executeSearch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("shuts down OAuth on session_shutdown", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,24 @@ import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwne
 
 export type { McpAdapterOptions } from "./types.ts";
 
+const INIT_WAIT_TIMEOUT_MS = 30_000;
+const INIT_WAIT_TIMED_OUT: unique symbol = Symbol("init-wait-timed-out");
+
+async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof INIT_WAIT_TIMED_OUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof INIT_WAIT_TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(INIT_WAIT_TIMED_OUT), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const sessionConfig = options.config !== undefined ? cloneMcpConfig(options.config) : undefined;
   const programmaticConfig = sessionConfig !== undefined;
@@ -202,6 +220,69 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     type: "string",
   });
 
+  function startInitialization(ctx: ExtensionContext, owner: McpRuntimeOwner, oauthRuntime: McpOAuthRuntime, generation: number, staleReason: string): void {
+    const promise = initializeMcp(pi, ctx, owner, {
+      ...(programmaticConfig || options.configPath !== undefined
+        ? { configPath: earlyConfigPath, config: sessionConfig }
+        : {}),
+      oauthRuntime,
+    });
+    initPromise = promise;
+
+    promise.then(async (nextState) => {
+      if (!owner.isActive() || generation !== lifecycleGeneration || initPromise !== promise) {
+        try {
+          await shutdownState(nextState, staleReason);
+        } catch (error) {
+          console.error(`MCP: failed to clean stale initialization state: ${formatTerminalError(error)}`);
+        }
+        return;
+      }
+
+      state = nextState;
+      nextState.onToolMetadataUpdated = (_serverName, _reason) => {
+        if (state !== nextState || !owner.isActive()) return;
+        syncToolSurface(ctx);
+      };
+      syncToolSurface(ctx);
+      updateStatusBar(nextState);
+      initPromise = null;
+    }).catch(err => {
+      if (!owner.isActive() || generation !== lifecycleGeneration) {
+        return;
+      }
+      if (initPromise !== promise && initPromise !== null) {
+        return;
+      }
+      console.error(`MCP initialization failed: ${formatTerminalError(err)}`);
+      initPromise = null;
+    });
+  }
+
+  function startLoadTimeInitialization(): void {
+    const hasStartupServer = Object.values(earlyConfig.mcpServers).some((definition) => {
+      if (definition.disabled === true) return false;
+      return definition.lifecycle === "eager" || definition.lifecycle === "keep-alive";
+    });
+    if (!hasStartupServer) return;
+    setImmediate(() => {
+      if (lifecycleGeneration !== 0 || state || initPromise) return;
+      const generation = ++lifecycleGeneration;
+      const owner = createMcpRuntimeOwner();
+      const oauthRuntime = createOAuthRuntime(owner.signal);
+      currentOwner = owner;
+      currentOAuthRuntime = oauthRuntime;
+      startInitialization({
+        mode: "print",
+        hasUI: false,
+        cwd: process.cwd(),
+        model: undefined,
+        modelRegistry: undefined,
+        signal: undefined,
+      } as unknown as ExtensionContext, owner, oauthRuntime, generation, "stale_load_time_initialization");
+    });
+  }
+
   pi.on("session_start", async (_event, ctx) => {
     const generation = ++lifecycleGeneration;
     const previousState = state;
@@ -227,49 +308,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       console.error(`MCP: failed to shut down previous session state: ${formatTerminalError(error)}`);
     }
 
-    if (generation !== lifecycleGeneration || !owner.isActive()) {
-      return;
-    }
-
     if (generation !== lifecycleGeneration || !owner.isActive()) return;
 
-    const initOptions = {
-      ...(programmaticConfig || options.configPath !== undefined
-        ? { configPath: earlyConfigPath, config: sessionConfig }
-        : {}),
-      oauthRuntime,
-    };
-    const promise = initializeMcp(pi, ctx, owner, initOptions);
-    initPromise = promise;
-
-    promise.then(async (nextState) => {
-      if (!owner.isActive() || generation !== lifecycleGeneration || initPromise !== promise) {
-        try {
-          await shutdownState(nextState, "stale_session_start");
-        } catch (error) {
-          console.error(`MCP: failed to clean stale session state: ${formatTerminalError(error)}`);
-        }
-        return;
-      }
-
-      state = nextState;
-      nextState.onToolMetadataUpdated = (_serverName, _reason) => {
-        if (state !== nextState || !owner.isActive()) return;
-        syncToolSurface(ctx);
-      };
-      syncToolSurface(ctx);
-      updateStatusBar(nextState);
-      initPromise = null;
-    }).catch(err => {
-      if (!owner.isActive() || generation !== lifecycleGeneration) {
-        return;
-      }
-      if (initPromise !== promise && initPromise !== null) {
-        return;
-      }
-      console.error(`MCP initialization failed: ${formatTerminalError(err)}`);
-      initPromise = null;
-    });
+    startInitialization(ctx, owner, oauthRuntime, generation, "stale_session_start");
   });
 
   pi.on("session_shutdown", async () => {
@@ -558,7 +599,13 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
         if (!state && initPromise) {
           try {
-            const initialized = await initPromise;
+            const initialized = await awaitWithTimeout(initPromise, INIT_WAIT_TIMEOUT_MS);
+            if (initialized === INIT_WAIT_TIMED_OUT) {
+              return {
+                content: [{ type: "text" as const, text: "MCP initialization is still in progress. Try again shortly." }],
+                details: { error: "init_timeout", timeoutMs: INIT_WAIT_TIMEOUT_MS },
+              };
+            }
             executeOwner?.throwIfInactive();
             state = initialized;
           } catch (error) {
@@ -668,6 +715,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   const initialDirectTools = syncDirectTools(earlyConfig, earlyCache).specs;
   syncProxyTool(earlyConfig, earlyCache, initialDirectTools);
+  startLoadTimeInitialization();
 }
 
 export function createMcpAdapter(options: McpAdapterOptions = {}) {


### PR DESCRIPTION
## Problem

`initializeMcp()` is only ever called from the `pi.on("session_start")` handler. In pi-coding-agent, `session_start` is emitted from `AgentSession.bindExtensions()` (called by the interactive, print, and RPC modes) and from `reload()`. Host apps that embed pi programmatically and drive sessions through the session service (e.g. web harnesses built on pi that construct sessions via `createAgentSessionFromServices`) never call `bindExtensions`, so `session_start` never fires.

Under such hosts the adapter loads, registers the proxy tool / direct tools / commands — the tool surface looks perfectly healthy — but initialization never runs, and every call returns `MCP not initialized` (`details.error: "not_initialized"`) for the lifetime of the process. `lifecycle: "eager"` doesn't help: it only controls connect timing *inside* `initializeMcp`, not when `initializeMcp` itself runs.

Reproduction: load the extension in a host that never emits `session_start`, configure any server with `lifecycle: "eager"`, and call `mcp({ search: "..." })` — the result is always `MCP not initialized`, with no connection attempt ever made (the target server is reachable and answers a raw `initialize` in <100ms from the same environment).

## Fix

- When any configured server requests a startup connection (`lifecycle: "eager"` or `"keep-alive"`), kick off initialization at extension load using a minimal headless context (`hasUI: false`, `cwd: process.cwd()`). Everything UI-dependent in `initializeMcp` is already gated on `ctx.hasUI`, so the headless context takes the same path as a non-UI session.
- `session_start` behavior is unchanged: it still shuts down previous state and re-initializes with the real session context. If it fires while (or after) a load-time init is running, the existing generation handoff supersedes the load-time state and gracefully shuts it down — interactive, print, and RPC modes behave as before, aside from eager/keep-alive servers beginning their startup connection slightly earlier.
- Lazy-only configs are untouched — no init happens at load, exactly as today.
- The proxy tool's wait on an in-flight init is now bounded (30s → `init_timeout` result with a "try again shortly" message) instead of blocking indefinitely.

## Notes

- No new dependencies; the change is contained to `index.ts` plus tests/docs.
- Added coverage in `__tests__/index-lifecycle.test.ts`: load-time init for eager/keep-alive, no load-time init for lazy-only configs, `session_start` superseding an in-flight load-time init (both orderings), and the bounded wait.
- `npx tsc --noEmit` clean; `npm test` passes (the only failures on my machine are the pre-existing `interactive-visualizer` dist checks, which require building the example locally).

Happy to adjust the trigger condition (e.g. eager-only, or a settings opt-in) or the timeout if you'd prefer different semantics — whatever fits the project best. Thanks for the adapter!