### PR TITLE
feat: MCP_UI_VIEWER=none to suppress UI window while keeping tool result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ MCP servers can ship interactive UIs via the [MCP UI](https://github.com/MCP-UI-
 3. pi-mcp-adapter fetches the UI HTML and opens it in an iframe
 4. The UI can call MCP tools and send messages back to the agent
 
-**Native rendering:** On macOS, if [Glimpse](https://github.com/hazat/glimpse) is installed (`pi install npm:glimpseui`), UIs open in a native WKWebView window instead of a browser tab. Set `MCP_UI_VIEWER=browser` to force the browser, or `MCP_UI_VIEWER=glimpse` to require native rendering.
+**Native rendering:** On macOS, if [Glimpse](https://github.com/hazat/glimpse) is installed (`pi install npm:glimpseui`), UIs open in a native WKWebView window instead of a browser tab. Set `MCP_UI_VIEWER=browser` to force the browser, `MCP_UI_VIEWER=glimpse` to require native rendering, or `MCP_UI_VIEWER=none` (also accepts `off` / `disabled`) to suppress the window entirely — the tool still runs and its inline result is returned to the agent, but no browser or native window opens. This is useful for headless setups, CI, or users who want the tool output delivered inline as text only. When suppressed, a one-line info notification shows the UI URL so it can still be opened manually if needed.
 
 **Bidirectional communication:** The UI talks back. When it sends a prompt or intent, the message is stored and `triggerTurn()` wakes the agent. The agent retrieves messages via `mcp({ action: "ui-messages" })` and responds, enabling conversational UIs where the app and agent collaborate in real-time.
 

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConsentManager } from "../consent-manager.ts";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { executeCall } from "../proxy-modes.ts";
+import { maybeStartUiSession } from "../ui-session.ts";
+
+const glimpseMocks = vi.hoisted(() => ({
+  isGlimpseAvailable: vi.fn(() => true),
+  openGlimpseWindow: vi.fn(),
+}));
+
+vi.mock("../glimpse-ui.ts", () => glimpseMocks);
+
+function textOf(result: any): string {
+  return result.content.map((entry: any) => entry.text ?? "").join("\n");
+}
+
+function makeState() {
+  const callTool = vi.fn(async () => ({
+    isError: false,
+    content: [{ type: "text" as const, text: "tool output" }],
+  }));
+  const connection = {
+    status: "connected" as const,
+    client: { callTool },
+    tools: [{ name: "app", description: "App", inputSchema: { type: "object" } }],
+    resources: [],
+  };
+  const state = {
+    config: { settings: { toolPrefix: "server" }, mcpServers: { demo: { command: "demo" } } },
+    manager: {
+      getConnection: vi.fn(() => connection),
+      getAllConnections: vi.fn(() => new Map([["demo", connection]])),
+      getRequestOptions: vi.fn(() => undefined),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      registerUiStreamListener: vi.fn(),
+      removeUiStreamListener: vi.fn(),
+    },
+    lifecycle: {},
+    toolMetadata: new Map([
+      ["demo", [{ name: "demo_app", originalName: "app", description: "App", uiResourceUri: "ui://app" }]],
+    ]),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    uiResourceHandler: {
+      readUiResource: vi.fn(async () => ({
+        uri: "ui://app",
+        html: "<main>App</main>",
+        mimeType: "text/html",
+        meta: {},
+      })),
+    },
+    consentManager: new ConsentManager("never"),
+    uiServer: null,
+    completedUiSessions: [],
+    openBrowser: vi.fn(async () => undefined),
+    ui: {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      theme: { fg: (_name: string, value: string) => value },
+    },
+  } as any;
+
+  return { state, callTool };
+}
+
+afterEach(() => {
+  delete process.env.MCP_UI_VIEWER;
+  glimpseMocks.isGlimpseAvailable.mockClear();
+  glimpseMocks.openGlimpseWindow.mockClear();
+});
+
+describe("MCP_UI_VIEWER=none", () => {
+  it.each(["none", "off", "disabled"])("suppresses window opening for %s", async (value) => {
+    process.env.MCP_UI_VIEWER = value;
+    const { state } = makeState();
+
+    const runtime = await maybeStartUiSession(state, {
+      serverName: "demo",
+      toolName: "app",
+      toolArgs: {},
+      uiResourceUri: "ui://app",
+    });
+
+    expect(runtime).toMatchObject({ viewer: "suppressed", windowOpen: false });
+    expect(runtime?.url).toContain("http://localhost:");
+    expect(state.openBrowser).not.toHaveBeenCalled();
+    expect(glimpseMocks.isGlimpseAvailable).not.toHaveBeenCalled();
+    expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("MCP UI window suppressed"), "info");
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.not.stringContaining("Tool still ran"), "info");
+
+    runtime?.close("test-cleanup");
+  });
+
+  it("reports suppressed UI state in proxy tool results", async () => {
+    process.env.MCP_UI_VIEWER = "none";
+    const { state } = makeState();
+
+    const result = await executeCall(state, "demo_app", {}, "demo");
+
+    expect(textOf(result)).toContain("tool output");
+    expect(textOf(result)).toContain("MCP UI window was suppressed");
+    expect(textOf(result)).not.toContain("open in your browser");
+    expect(result.details).toMatchObject({ uiOpen: false, uiViewer: "suppressed" });
+    expect(result.details.uiUrl).toContain("http://localhost:");
+    expect(state.openBrowser).not.toHaveBeenCalled();
+
+    state.uiServer?.close("test-cleanup");
+  });
+
+  it("reports suppressed UI state in direct tool results", async () => {
+    process.env.MCP_UI_VIEWER = "none";
+    const { state } = makeState();
+    const execute = createDirectToolExecutor(
+      () => state,
+      () => null,
+      { serverName: "demo", originalName: "app", prefixedName: "demo_app", description: "App", uiResourceUri: "ui://app" },
+    );
+
+    const result = await execute("call-1", {}, undefined as any, () => {}, undefined as any);
+
+    expect(textOf(result)).toContain("tool output");
+    expect(textOf(result)).toContain("MCP UI window was suppressed");
+    expect(textOf(result)).not.toContain("open in your browser");
+    expect(result.details).toMatchObject({ uiOpen: false, uiViewer: "suppressed" });
+    expect(result.details.uiUrl).toContain("http://localhost:");
+    expect(state.openBrowser).not.toHaveBeenCalled();
+
+    state.uiServer?.close("test-cleanup");
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -9,7 +9,7 @@ import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
-import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
+import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
@@ -446,13 +446,18 @@ export function createDirectToolExecutor(
       const content = resolveMcpResultContent(result as Record<string, unknown>);
       const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
       if (hasUi) {
-        const uiMessage = uiSession?.reused
-          ? "Updated the open UI."
-          : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
-        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}` });
+        const uiSummary = summarizeUiSessionResult(uiSession);
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiSummary.message}` });
         return {
           content: guarded.content,
-          details: { server: spec.serverName, tool: spec.originalName, uiOpen: true, ...guardedMcpDetails(guarded) },
+          details: {
+            server: spec.serverName,
+            tool: spec.originalName,
+            uiOpen: uiSummary.uiOpen,
+            uiViewer: uiSummary.uiViewer,
+            uiUrl: uiSummary.uiUrl,
+            ...guardedMcpDetails(guarded),
+          },
         };
       }
 

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -9,7 +9,7 @@ import { abortable, throwIfAborted } from "./abort.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
-import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
+import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
@@ -970,13 +970,19 @@ export async function executeCall(
 
       const content = resolveMcpResultContent(result as Record<string, unknown>);
       const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
-      const uiMessage = uiSession?.reused
-        ? "Updated the open UI."
-        : "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it.";
-      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiMessage}`, rawMcpResult: result });
+      const uiSummary = summarizeUiSessionResult(uiSession);
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiSummary.message}`, rawMcpResult: result });
       return {
         content: guarded.content,
-        details: { mode: "call", ...guardedMcpDetails(guarded), server: serverName, tool: toolMeta.originalName, uiOpen: true },
+        details: {
+          mode: "call",
+          ...guardedMcpDetails(guarded),
+          server: serverName,
+          tool: toolMeta.originalName,
+          uiOpen: uiSummary.uiOpen,
+          uiViewer: uiSummary.uiViewer,
+          uiUrl: uiSummary.uiUrl,
+        },
       };
     }
 

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -68,6 +68,8 @@ export interface UiServerHandle {
   sessionToken: string;
   serverName: string;
   toolName: string;
+  viewer?: "browser" | "glimpse" | "suppressed";
+  windowOpen?: boolean;
   close: (reason?: string) => void;
   sendToolInput: (args: Record<string, unknown>) => void;
   sendToolResult: (result: CallToolResult) => void;

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -325,30 +325,39 @@ export async function maybeStartUiSession(
 
     state.uiServer = handle;
 
-    const glimpseDetected = isGlimpseAvailable();
     const viewerPref = process.env.MCP_UI_VIEWER?.toLowerCase();
-    const useGlimpse = viewerPref === "glimpse" ||
-      (viewerPref !== "browser" && glimpseDetected);
+    const uiSuppressed = viewerPref === "none" || viewerPref === "off" || viewerPref === "disabled";
 
-    if (useGlimpse) {
-      try {
-        const glimpseHtml = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:0;padding:0;width:100vw;height:100vh;overflow:hidden}iframe{width:100%;height:100%;border:none}</style></head><body><iframe src="${handle.url}"></iframe></body></html>`;
-        activeGlimpseWindow = await openGlimpseWindow(glimpseHtml, {
-          title: `MCP · ${request.serverName} · ${request.toolName}`,
-          width: 1000,
-          height: 800,
-          onClosed: () => {
-            if (active) handle.close("glimpse-closed");
-          },
-        });
-      } catch (error) {
-        log.debug("Glimpse unavailable, using browser", {
-          error: error instanceof Error ? error.message : String(error),
-        });
+    if (uiSuppressed) {
+      // MCP_UI_VIEWER=none: run the tool + UI server (so streaming/results still work)
+      // but do NOT open a browser or native Glimpse window. Notify inline with the URL.
+      state.ui?.notify(`MCP UI suppressed (MCP_UI_VIEWER=${viewerPref}). Tool still ran. UI URL: ${handle.url}`, "info");
+      log.info("Suppressing MCP UI window (MCP_UI_VIEWER=" + viewerPref + ")", { url: handle.url });
+    } else {
+      const glimpseDetected = isGlimpseAvailable();
+      const useGlimpse = viewerPref === "glimpse" ||
+        (viewerPref !== "browser" && glimpseDetected);
+
+      if (useGlimpse) {
+        try {
+          const glimpseHtml = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:0;padding:0;width:100vw;height:100vh;overflow:hidden}iframe{width:100%;height:100%;border:none}</style></head><body><iframe src="${handle.url}"></iframe></body></html>`;
+          activeGlimpseWindow = await openGlimpseWindow(glimpseHtml, {
+            title: `MCP · ${request.serverName} · ${request.toolName}`,
+            width: 1000,
+            height: 800,
+            onClosed: () => {
+              if (active) handle.close("glimpse-closed");
+            },
+          });
+        } catch (error) {
+          log.debug("Glimpse unavailable, using browser", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await openInBrowser(state, handle.url);
+        }
+      } else {
         await openInBrowser(state, handle.url);
       }
-    } else {
-      await openInBrowser(state, handle.url);
     }
 
     return {

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -28,6 +28,8 @@ export interface UiSessionRequest {
   onNeedsAuth?: SessionRecoveryDeps["onNeedsAuth"];
 }
 
+export type UiSessionViewer = "browser" | "glimpse" | "suppressed";
+
 export interface UiSessionRuntime {
   serverName: string;
   toolName: string;
@@ -37,11 +39,48 @@ export interface UiSessionRuntime {
   streamMode?: UiStreamMode;
   requestMeta?: Record<string, unknown>;
   url: string;
+  viewer: UiSessionViewer;
+  windowOpen: boolean;
   isActive: () => boolean;
   sendToolResult: (result: CallToolResult) => void;
   sendResultPatch: (result: CallToolResult) => void;
   sendToolCancelled: (reason: string) => void;
   close: (reason?: string) => void;
+}
+
+export interface UiSessionResultSummary {
+  message: string;
+  uiOpen: boolean;
+  uiViewer?: UiSessionViewer;
+  uiUrl?: string;
+}
+
+export function summarizeUiSessionResult(uiSession: UiSessionRuntime | null): UiSessionResultSummary {
+  if (!uiSession) {
+    return {
+      message: "Interactive UI was unavailable; returning the tool result inline.",
+      uiOpen: false,
+    };
+  }
+
+  if (!uiSession.windowOpen) {
+    const action = uiSession.reused ? "Updated the suppressed MCP UI session." : "MCP UI window was suppressed.";
+    return {
+      message: `${action} Open manually: ${uiSession.url}`,
+      uiOpen: false,
+      uiViewer: uiSession.viewer,
+      uiUrl: uiSession.url,
+    };
+  }
+
+  return {
+    message: uiSession.reused
+      ? "Updated the open UI."
+      : "Interactive UI is open. I'll respond to your prompts and intents as you interact with it.",
+    uiOpen: true,
+    uiViewer: uiSession.viewer,
+    uiUrl: uiSession.url,
+  };
 }
 
 const MAX_COMPLETED_SESSIONS = 10;
@@ -141,6 +180,8 @@ export async function maybeStartUiSession(
         streamMode,
         requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
         url: existingHandle.url,
+        viewer: existingHandle.viewer ?? "browser",
+        windowOpen: existingHandle.windowOpen ?? true,
         isActive: () => active && state.uiServer === existingHandle,
         sendToolResult: (result: CallToolResult) => {
           if (!active || state.uiServer !== existingHandle) return;
@@ -328,10 +369,13 @@ export async function maybeStartUiSession(
     const viewerPref = process.env.MCP_UI_VIEWER?.toLowerCase();
     const uiSuppressed = viewerPref === "none" || viewerPref === "off" || viewerPref === "disabled";
 
+    let viewer: UiSessionViewer = "browser";
+    let windowOpen = true;
+
     if (uiSuppressed) {
-      // MCP_UI_VIEWER=none: run the tool + UI server (so streaming/results still work)
-      // but do NOT open a browser or native Glimpse window. Notify inline with the URL.
-      state.ui?.notify(`MCP UI suppressed (MCP_UI_VIEWER=${viewerPref}). Tool still ran. UI URL: ${handle.url}`, "info");
+      viewer = "suppressed";
+      windowOpen = false;
+      state.ui?.notify(`MCP UI window suppressed (MCP_UI_VIEWER=${viewerPref}). Open manually: ${handle.url}`, "info");
       log.info("Suppressing MCP UI window (MCP_UI_VIEWER=" + viewerPref + ")", { url: handle.url });
     } else {
       const glimpseDetected = isGlimpseAvailable();
@@ -349,16 +393,21 @@ export async function maybeStartUiSession(
               if (active) handle.close("glimpse-closed");
             },
           });
+          viewer = "glimpse";
         } catch (error) {
           log.debug("Glimpse unavailable, using browser", {
             error: error instanceof Error ? error.message : String(error),
           });
           await openInBrowser(state, handle.url);
+          viewer = "browser";
         }
       } else {
         await openInBrowser(state, handle.url);
       }
     }
+
+    handle.viewer = viewer;
+    handle.windowOpen = windowOpen;
 
     return {
       serverName: request.serverName,
@@ -369,6 +418,8 @@ export async function maybeStartUiSession(
       streamMode,
       requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
       url: handle.url,
+      viewer,
+      windowOpen,
       isActive: () => active && state.uiServer === handle,
       sendToolResult: (result: CallToolResult) => {
         if (!active || state.uiServer !== handle) return;


### PR DESCRIPTION
## Summary

Adds a new `MCP_UI_VIEWER=none` value (also accepts `off` / `disabled`) that runs MCP UI tools and their backing UI server while **suppressing the browser/Glimpse window**.

## Why

Currently `MCP_UI_VIEWER` only accepts `browser` or `glimpse` — there's no way to call a UI tool and get its inline `content` result back to the agent without a window popping open. That's a problem for:

- **Headless / CI / remote sessions** where there's no display or you don't want focus-stealing windows
- **Users who prefer inline output** — they want the tool's text result delivered to the conversation, not a browser tab
- **Agent-driven workflows** where the agent calls the tool for its result but the human doesn't need (or want) the interactive UI

Related sentiment is in #121 (auto-open browser without consent), but that issue is specifically about the *OAuth* auth flow (`mcp-auth-flow.ts`). This PR addresses the analogous problem for the MCP **UI tool** path in `ui-session.ts`.

## How it works

When `MCP_UI_VIEWER` is `none` / `off` / `disabled`, `maybeStartUiSession()` now:
- ✅ Still starts the internal UI server (so streaming, `structuredContent`, and the tool's inline result keep working)
- ✅ Still returns the `UiSessionRuntime` so the tool call proceeds normally
- ❌ Does **not** call `openInBrowser()` or `openGlimpseWindow()` — no window opens
- 🔔 Emits a one-line `info` notification with the UI URL, so it can still be opened manually if ever needed

The viewer selection logic is refactored so the new suppressed branch short-circuits before the Glimpse/browser branch. Behavior for `browser` / `glimpse` / unset is unchanged.

## Usage

```bash
# Suppress the window; tool still runs and returns inline result
export MCP_UI_VIEWER=none
pi
```

## Checklist

- [x] Code change in `ui-session.ts`
- [x] README docs updated (the "Native rendering" paragraph)
- [x] Existing UI test suite passes (`ui-integration`, `ui-session-messages`, `ui-streaming` — 36/36)
- [x] No new TypeScript errors introduced (verified against `tsc --noEmit`)

## Notes / Alternatives considered

- I deliberately did **not** add a `settings.ui: false` knob in `McpSettings` — the existing viewer selection is already env-var-driven (`MCP_UI_VIEWER`), so extending that is the smallest, most consistent change. Happy to also add a `settings.ui`/`settings.uiViewer` config key if you'd prefer the JSON-config route.
- I considered also suppressing the "📺 Interactive UI is now open in your browser" suffix message that `proxy-modes.ts` appends to the tool result when `uiResourceUri` is set. I left it as-is for now to keep this change minimal and focused on the window-open behavior, but I can update that message (or skip it when suppressed) in this PR if you'd like.

## Testing

```
__tests__/ui-integration.test.ts  ✓ 10
__tests__/ui-session-messages.test.ts ✓ 6
__tests__/ui-streaming.test.ts ✓ 20
Test Files  3 passed (3)
     Tests  36 passed (36)
```
