### PR TITLE
fix: pass resource_metadata URL to MCP SDK auth

### DIFF
--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -26,6 +26,7 @@ class MockStreamableHTTPClientTransport {
   finishAuth = mocks.finishAuth;
 }
 
+// Keep real exports (e.g. extractWWWAuthenticateParams) intact; only override auth/UnauthorizedError.
 vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   auth: mocks.sdkAuth,

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -646,7 +646,7 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.open).not.toHaveBeenCalled();
   });
 
-  it("passes the advertised resource_metadata URL to the SDK so discovery targets the real auth server", async () => {
+  it("forwards the probed resource_metadata URL to auth()", async () => {
     const serverUrl =
       "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/runtime%2Fpostgresql_mcp/invocations?qualifier=DEFAULT";
     const resourceMetadataUrl =
@@ -654,15 +654,11 @@ describe("mcp-auth-flow explicit auth", () => {
     mocks.fetch.mockResolvedValueOnce(
       wwwAuthenticateResponse(`Bearer resource_metadata="${resourceMetadataUrl}"`),
     );
-    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
-      await provider.redirectToAuthorization(new URL("https://dev.okta.com/oauth2/aus83081cb9fa0a5d4967/v1/authorize"));
-      return "REDIRECT";
-    });
+    mocks.sdkAuth.mockResolvedValueOnce("AUTHORIZED");
     const { startAuth } = await import("../mcp-auth-flow.ts");
 
-    const result = await startAuth("bedrock", serverUrl, { url: serverUrl, auth: "oauth" });
+    await startAuth("bedrock", serverUrl, { url: serverUrl, auth: "oauth" });
 
-    expect(result.authorizationUrl).toBe("https://dev.okta.com/oauth2/aus83081cb9fa0a5d4967/v1/authorize");
     expect(mocks.fetch).toHaveBeenCalledWith(
       new URL(serverUrl),
       expect.objectContaining({ method: "POST" }),
@@ -682,7 +678,7 @@ describe("mcp-auth-flow explicit auth", () => {
       wwwAuthenticateResponse(`Bearer resource_metadata="${resourceMetadataUrl}"`),
     );
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
-      await provider.redirectToAuthorization(new URL("https://dev.okta.com/authorize"));
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
       return "REDIRECT";
     });
     const capturedThis: { _resourceMetadataUrl?: URL }[] = [];

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   sdkAuth: vi.fn(),
   finishAuth: vi.fn(),
   transportClose: vi.fn(),
+  fetch: vi.fn(),
 }));
 
 class MockUnauthorizedError extends Error {}
@@ -25,7 +26,8 @@ class MockStreamableHTTPClientTransport {
   finishAuth = mocks.finishAuth;
 }
 
-vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   auth: mocks.sdkAuth,
   UnauthorizedError: MockUnauthorizedError,
 }));
@@ -47,6 +49,11 @@ vi.mock("open", () => ({
   default: mocks.open,
 }));
 
+/** Build a real Response exposing only the WWW-Authenticate header. */
+function wwwAuthenticateResponse(headerValue?: string) {
+  return new Response(null, headerValue ? { headers: { "www-authenticate": headerValue } } : undefined);
+}
+
 describe("mcp-auth-flow explicit auth", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
   let authDir: string;
@@ -65,9 +72,13 @@ describe("mcp-auth-flow explicit auth", () => {
     mocks.sdkAuth.mockReset().mockResolvedValue("AUTHORIZED");
     mocks.finishAuth.mockReset().mockResolvedValue(undefined);
     mocks.transportClose.mockReset().mockResolvedValue(undefined);
+    // Default probe: server advertises no resource_metadata header.
+    mocks.fetch.mockReset().mockResolvedValue(wwwAuthenticateResponse(undefined));
+    vi.stubGlobal("fetch", mocks.fetch);
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     rmSync(authDir, { recursive: true, force: true });
     if (originalOAuthDir === undefined) {
       delete process.env.MCP_OAUTH_DIR;
@@ -633,5 +644,57 @@ describe("mcp-auth-flow explicit auth", () => {
     }));
     expect(mocks.reserveCallbackServer).not.toHaveBeenCalled();
     expect(mocks.open).not.toHaveBeenCalled();
+  });
+
+  it("passes the advertised resource_metadata URL to the SDK so discovery targets the real auth server", async () => {
+    const serverUrl =
+      "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/runtime%2Fpostgresql_mcp/invocations?qualifier=DEFAULT";
+    const resourceMetadataUrl =
+      "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/runtime%2Fpostgresql_mcp/invocations/.well-known/oauth-protected-resource?qualifier=DEFAULT";
+    mocks.fetch.mockResolvedValueOnce(
+      wwwAuthenticateResponse(`Bearer resource_metadata="${resourceMetadataUrl}"`),
+    );
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://dev.okta.com/oauth2/aus83081cb9fa0a5d4967/v1/authorize"));
+      return "REDIRECT";
+    });
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    const result = await startAuth("bedrock", serverUrl, { url: serverUrl, auth: "oauth" });
+
+    expect(result.authorizationUrl).toBe("https://dev.okta.com/oauth2/aus83081cb9fa0a5d4967/v1/authorize");
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      new URL(serverUrl),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(mocks.sdkAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ serverUrl, resourceMetadataUrl: new URL(resourceMetadataUrl) }),
+    );
+  });
+
+  it("threads the resource_metadata URL through completeAuth token exchange", async () => {
+    const serverUrl =
+      "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/runtime%2Fpostgresql_mcp/invocations?qualifier=DEFAULT";
+    const resourceMetadataUrl =
+      "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/runtime%2Fpostgresql_mcp/invocations/.well-known/oauth-protected-resource?qualifier=DEFAULT";
+    mocks.fetch.mockResolvedValueOnce(
+      wwwAuthenticateResponse(`Bearer resource_metadata="${resourceMetadataUrl}"`),
+    );
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://dev.okta.com/authorize"));
+      return "REDIRECT";
+    });
+    const capturedThis: { _resourceMetadataUrl?: URL }[] = [];
+    mocks.finishAuth.mockImplementationOnce(function (this: { _resourceMetadataUrl?: URL }) {
+      capturedThis.push(this);
+      return Promise.resolve(undefined);
+    });
+    const { startAuth, completeAuth } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("bedrock-complete", serverUrl, { url: serverUrl, auth: "oauth" });
+    await expect(completeAuth("bedrock-complete", "auth-code")).resolves.toBe("authenticated");
+
+    expect(capturedThis[0]?._resourceMetadataUrl).toEqual(new URL(resourceMetadataUrl));
   });
 });

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -6,6 +6,7 @@
 
 import {
   auth as runSdkAuth,
+  extractWWWAuthenticateParams,
   UnauthorizedError,
 } from "@modelcontextprotocol/sdk/client/auth.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -44,6 +45,53 @@ export interface AuthenticateOptions {
 const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
 const pendingAuthStates = new Map<string, string>()
 const pendingAuthCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+// Carry the protected-resource metadata URL (from the server's 401
+// WWW-Authenticate header) from startAuth() through to completeAuth(), so the
+// SDK resolves the real authorization server instead of falling back to the
+// MCP server origin. See OAUTH.md "Auto-Discovery".
+const pendingResourceMetadataUrls = new Map<string, URL>()
+
+/**
+ * Probe an MCP server for the RFC 9728 protected-resource metadata URL it
+ * advertises in the 401 `WWW-Authenticate: Bearer resource_metadata="..."`
+ * header. Returns undefined when the server does not advertise one (the SDK
+ * then falls back to its own well-known discovery).
+ *
+ * The header is only emitted on the POST initialize request, so we replicate
+ * the transport's initialize probe here. All errors are swallowed; this is a
+ * best-effort hint to the SDK.
+ */
+async function probeResourceMetadataUrl(serverUrl: string): Promise<URL | undefined> {
+  let target: URL
+  try {
+    target = new URL(serverUrl)
+  } catch {
+    return undefined
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 5000)
+  try {
+    const res = await fetch(target, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize", params: {} }),
+      signal: controller.signal,
+    })
+    const { resourceMetadataUrl } = extractWWWAuthenticateParams(res)
+    // metadata is in headers; release the connection without waiting for the body
+    await res.body?.cancel().catch(() => {})
+    return resourceMetadataUrl
+  } catch {
+    return undefined
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
 // Deduplicate concurrent authenticate() calls per server.
 const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
@@ -165,7 +213,8 @@ export async function startAuth(
         throw new Error("Browser redirect is not used for client_credentials flow")
       },
     })
-    const result = await runSdkAuth(authProvider, { serverUrl })
+    const resourceMetadataUrl = await probeResourceMetadataUrl(serverUrl)
+    const result = await runSdkAuth(authProvider, { serverUrl, ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}) })
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize")
     }
@@ -214,7 +263,9 @@ export async function startAuth(
 
     await updateOAuthState(serverName, oauthState, serverUrl)
 
-    const result = await runSdkAuth(authProvider, { serverUrl })
+    const resourceMetadataUrl = await probeResourceMetadataUrl(serverUrl)
+
+    const result = await runSdkAuth(authProvider, { serverUrl, ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}) })
     if (result === "AUTHORIZED") {
       releaseCallbackServer(oauthState)
       await clearOAuthState(serverName)
@@ -225,6 +276,11 @@ export async function startAuth(
     }
     const pendingTransport = new StreamableHTTPClientTransport(new URL(serverUrl), { authProvider })
     await setPendingTransport(serverName, pendingTransport, oauthState)
+    // Set after setPendingTransport(): it calls clearPendingAuth() internally,
+    // which clears pendingResourceMetadataUrls for this server.
+    if (resourceMetadataUrl) {
+      pendingResourceMetadataUrls.set(serverName, resourceMetadataUrl)
+    }
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
     await clearPendingAuth(serverName, oauthState)
@@ -259,6 +315,7 @@ async function clearPendingAuth(serverName: string, oauthState?: string): Promis
 
   const transport = pendingTransports.get(serverName)
   pendingTransports.delete(serverName)
+  pendingResourceMetadataUrls.delete(serverName)
   pendingAuthStates.delete(serverName)
   const stateToRelease = pendingState ?? oauthState
   if (stateToRelease) {
@@ -354,8 +411,19 @@ export async function completeAuth(
   }
 
   const oauthState = await getOAuthState(serverName)
+  const resourceMetadataUrl = pendingResourceMetadataUrls.get(serverName)
 
   try {
+    // finishAuth() exchanges the code via the SDK, which re-discovers the
+    // authorization server. Seed the transport with the protected-resource
+    // metadata URL captured during startAuth so token exchange targets the
+    // correct (e.g. Okta) endpoints instead of the MCP server origin.
+    if (resourceMetadataUrl) {
+      // No public constructor option exists for resourceMetadataUrl yet — tracked upstream.
+      // Validated against @modelcontextprotocol/sdk@1.29.0.
+      const pendingAuthTransport = transport as unknown as { _resourceMetadataUrl?: URL }
+      pendingAuthTransport._resourceMetadataUrl = resourceMetadataUrl
+    }
     // Complete the auth using the transport's finishAuth method
     await transport.finishAuth(authorizationCode)
     return "authenticated"
@@ -485,7 +553,8 @@ export async function getValidToken(
         return null
       }
 
-      const result = await runSdkAuth(authProvider, { serverUrl })
+      const resourceMetadataUrl = await probeResourceMetadataUrl(serverUrl)
+      const result = await runSdkAuth(authProvider, { serverUrl, ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}) })
       if (result !== "AUTHORIZED") {
         return null
       }


### PR DESCRIPTION
Details in #173. Uses an independent probe to determine if the resource uses the `www-authenticate` header to return a resource metadata URL. If present, forwards the URL to the underlying MCP SDK auth functionality.