### PR TITLE
Improve startup time: Defer regex safety checker loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 
+### Changed
+- Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.
+
 ### Fixed
 - Collapsed long single-line MCP results according to terminal-wrapped visual lines. Thanks @xz-dev for PR #181.
 - Recovered Streamable HTTP MCP sessions after a server restart invalidates the previous session ID. Thanks @damselem for PR #194.

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,6 +1,6 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
 import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
-import { checkSync } from "recheck";
+import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
@@ -16,6 +16,7 @@ import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
+const require = createRequire(import.meta.url);
 const MAX_REGEX_SEARCH_QUERY_LENGTH = 256;
 const INSTRUCTIONS_PREVIEW_LENGTH = 300;
 const REGEX_SAFETY_CHECK_PARAMS = {
@@ -392,6 +393,7 @@ export function executeSearch(
       pattern = new RegExp(query, "i");
       let safety;
       try {
+        const { checkSync } = require("recheck") as typeof import("recheck");
         safety = checkSync(query, "i", REGEX_SAFETY_CHECK_PARAMS);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Change Brief

At the most basic level: this PR is a startup performance improvement, not a change to regex safety policy.

## Summary

- Defers loading `recheck` until a caller requests regex search.
- Keeps the existing synchronous safety analysis, limits, and rejection behavior unchanged.
- Avoids paying the dependency's initialization cost during ordinary extension startup and non-regex search.

## Why

`index.ts` imports the proxy-mode implementation during extension startup, but `recheck` is only used by `executeSearch` when `regex: true`. The static import therefore adds startup work to every session even when regex search is never used. Loading it inside the regex-only branch moves that cost to the feature that needs it.

## Before / After

Before, importing the extension eagerly loaded `recheck` for all sessions.

After, startup and plain-text search avoid loading `recheck`; the first valid regex search loads it immediately before the existing safety check.

Provided startup benchmark results:

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Isolated overhead (Current) | 133 ms | 93 ms | -40 ms (-30%) |
| Isolated overhead (Home) | 142 ms | 90 ms | -52 ms (-37%) |
| Direct import | ~128 ms | ~87 ms | ~-41 ms (-32%) |

## Specific Changes

- **Module loading**: replaces the top-level `recheck` import with a Node `createRequire` handle.
- **Regex search**: resolves `checkSync` only after the existing length and regex-syntax validation, then applies the same safety parameters and result handling.
- **Scope**: leaves non-regex matching, regex diagnostics, dependencies, and public APIs unchanged.

## Commit Notes

- `perf: lazy-load regex safety checker`
  - Why: `recheck` contributes material startup overhead but serves only regex search.
  - What changed: its synchronous checker is required inside the regex-only execution path.
  - Implication: the first valid regex search pays the one-time module load; all other startup paths avoid it.

## Testing

- `npx tsc --noEmit` — passed.
- `npx vitest run __tests__/proxy-modes-discovery.test.ts` — 7 tests passed.
- `npm test` — 48 test files and 435 tests passed.

No new lazy-loading test is included. A deterministic test would have to inspect Node's module cache, intercept module resolution, or simulate a missing declared dependency, all of which assert implementation details rather than supported behavior. The existing proxy discovery tests cover malformed, oversized, unsafe, safe, and non-regex searches, so they verify that moving the load does not alter regex behavior.

## Risk

Low. The first valid regex search now performs a synchronous CommonJS module load before the same synchronous safety check. Module-load failures remain contained by the existing safety-analysis error path and fail closed.
