### PR TITLE
Fix collapsing single-line MCP output

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 | Auth start | `mcp({ action: "auth-start", server: "name" })` |
 | Auth complete | `mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' })` |
 
-MCP proxy and direct-tool results render compactly by default: long text shows the first three lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
+MCP proxy and direct-tool results render compactly by default: long text shows up to the first three lines (each capped at 500 characters) plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
 
 Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are OR'd.
 

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -84,6 +84,17 @@ describe("MCP tool result renderer", () => {
     });
   });
 
+  it("collapses a long newline-free result", () => {
+    const display = formatMcpToolResultLines(result([
+      { type: "text", text: "x".repeat(20) },
+    ]), false, 3, 10);
+
+    expect(display).toEqual({
+      lines: ["xxxxxxxxx…"],
+      truncated: true,
+    });
+  });
+
   it("shows full text when expanded", () => {
     const display = formatMcpToolResultLines(result([
       { type: "text", text: "one\ntwo\nthree\nfour" },

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -31,6 +31,7 @@ export interface McpToolResultDisplay {
 }
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
+const DEFAULT_MAX_COLLAPSED_LINE_CHARS = 500;
 
 function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
@@ -124,16 +125,27 @@ export function formatMcpToolResultLines(
   result: Pick<AgentToolResult<McpToolResultDetails>, "content">,
   expanded: boolean,
   maxCollapsedLines = 3,
+  maxCollapsedLineChars = DEFAULT_MAX_COLLAPSED_LINE_CHARS,
 ): McpToolResultDisplay {
   const allLines = result.content.flatMap(blockToLines);
   const lines = allLines.length > 0 ? allLines : ["(empty result)"];
 
-  if (expanded || lines.length <= maxCollapsedLines) {
+  if (expanded) {
+    return { lines, truncated: false };
+  }
+
+  const collapsedLines = lines.slice(0, maxCollapsedLines);
+  const hasLongLine = collapsedLines.some(line => line.length > maxCollapsedLineChars);
+  const hasMoreLines = lines.length > maxCollapsedLines;
+  if (!hasLongLine && !hasMoreLines) {
     return { lines, truncated: false };
   }
 
   return {
-    lines: [...lines.slice(0, maxCollapsedLines), "…"],
+    lines: [
+      ...collapsedLines.map(line => truncateText(line, maxCollapsedLineChars)),
+      ...(hasMoreLines ? ["…"] : []),
+    ],
     truncated: true,
   };
 }


### PR DESCRIPTION
## Problem
- My mcp servers return payloads in huge one-line minified json strings. The mcp adapter extension doesn't truncate that because it takes up only a single line.

## Summary
- collapse single-line MCP result text (such as minified JSON)
- keep the full result available with Ctrl+O
- cover the behavior with a regression test

## Testing
- `git diff --check`
- Not run: `npm test -- --run __tests__/tool-result-renderer.test.ts` (`vitest` is not installed in this checkout)
- manually ran some mcp commands that return minified json with no newlines, and the result is properly truncated