### PR TITLE
fix: collapse MCP results by visual lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 
 ### Fixed
+- Collapsed long single-line MCP results according to terminal-wrapped visual lines. Thanks @xz-dev for PR #181.
 - Recovered Streamable HTTP MCP sessions after a server restart invalidates the previous session ID. Thanks @damselem for PR #194.
 - Used server-advertised OAuth protected-resource metadata during authorization so resource servers can point Pi at the correct authorization server. Thanks @jameswarren for issue #173 and PR #174.
 - Dropped inherited HTTP auth when a higher-precedence MCP config repoints a server URL, while preserving explicit OAuth disable flags. Thanks @ductiletoaster for PR #182.

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 | Auth start | `mcp({ action: "auth-start", server: "name" })` |
 | Auth complete | `mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' })` |
 
-MCP proxy and direct-tool results render compactly by default: long text shows the first three lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
+MCP proxy and direct-tool results render compactly by default: long text shows the first three terminal-wrapped lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
 
 Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are OR'd.
 

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -119,6 +119,38 @@ describe("MCP tool result renderer", () => {
     expect(display.truncated).toBe(false);
   });
 
+  it("collapses a single line that wraps beyond the compact viewport height", () => {
+    const output = renderMcpToolResult(
+      result([{
+        type: "text",
+        text: "segment-1 segment-2 segment-3 segment-4 segment-5 segment-6 segment-7 segment-8",
+      }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false },
+    ).render(20).join("\n");
+
+    expect(output).toContain("segment-1");
+    expect(output).toContain("…");
+    expect(output).toContain("Ctrl+O to expand");
+    expect(output).not.toContain("segment-8");
+  });
+
+  it("shows the full wrapped single line when expanded", () => {
+    const output = renderMcpToolResult(
+      result([{
+        type: "text",
+        text: "segment-1 segment-2 segment-3 segment-4 segment-5 segment-6 segment-7 segment-8",
+      }]),
+      { expanded: true, isPartial: false },
+      plainTheme,
+      { isError: false },
+    ).render(20).join("\n");
+
+    expect(output).toContain("segment-8");
+    expect(output).not.toContain("Ctrl+O to expand");
+  });
+
   it("renders long error results expanded even when the row is collapsed", () => {
     const output = renderMcpToolResult(
       result([{ type: "text", text: "Error: failed\nline 2\nline 3\nline 4" }]),
@@ -130,6 +162,21 @@ describe("MCP tool result renderer", () => {
     expect(output).toContain("line 4");
     expect(output).not.toContain("Ctrl+O to expand");
     expect(output).not.toContain("…");
+  });
+
+  it("does not collapse a long single-line error", () => {
+    const output = renderMcpToolResult(
+      result([{
+        type: "text",
+        text: "Error: segment-1 segment-2 segment-3 segment-4 segment-5 segment-6 segment-7 segment-8",
+      }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: true },
+    ).render(20).join("\n");
+
+    expect(output).toContain("segment-8");
+    expect(output).not.toContain("Ctrl+O to expand");
   });
 
   it("renders adapter error details expanded even when Pi context is not marked as an error", () => {

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { type Component, Text } from "@earendil-works/pi-tui";
 
 type McpToolResultDetails = Record<string, unknown> & { error?: unknown };
 type McpToolContentBlock = AgentToolResult<McpToolResultDetails>["content"][number];
@@ -31,6 +31,29 @@ export interface McpToolResultDisplay {
 }
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
+const DEFAULT_MAX_COLLAPSED_LINES = 3;
+
+class CollapsibleText implements Component {
+  constructor(
+    private readonly text: string,
+    private readonly expanded: boolean,
+    private readonly maxCollapsedLines: number,
+    private readonly ellipsis: string,
+    private readonly expandHint: string,
+  ) {}
+
+  render(width: number): string[] {
+    const lines = new Text(this.text, 0, 0).render(width);
+    if (this.expanded || lines.length <= this.maxCollapsedLines) return lines;
+
+    return [
+      ...lines.slice(0, this.maxCollapsedLines),
+      ...new Text(`${this.ellipsis}\n${this.expandHint}`, 0, 0).render(width),
+    ];
+  }
+
+  invalidate(): void {}
+}
 
 function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
@@ -149,13 +172,15 @@ export function renderMcpToolResult(
   }
 
   const hasErrorDetails = Boolean(result.details.error);
-  const display = formatMcpToolResultLines(result, options.expanded || context?.isError === true || hasErrorDetails);
-  const output = display.lines
-    .map((line) => line === "…" ? theme.fg("muted", line) : theme.fg("toolOutput", line))
-    .join("\n");
-  const hint = display.truncated && !options.expanded
-    ? `\n${theme.fg("muted", "(Ctrl+O to expand)")}`
-    : "";
+  const expanded = options.expanded || context?.isError === true || hasErrorDetails;
+  const display = formatMcpToolResultLines(result, true);
+  const output = display.lines.map((line) => theme.fg("toolOutput", line)).join("\n");
 
-  return new Text(`${output}${hint}`, 0, 0);
+  return new CollapsibleText(
+    output,
+    expanded,
+    DEFAULT_MAX_COLLAPSED_LINES,
+    theme.fg("muted", "…"),
+    theme.fg("muted", "(Ctrl+O to expand)"),
+  );
 }


### PR DESCRIPTION
## Summary

- collapse MCP result output after three terminal-wrapped visual lines instead of only counting newline-delimited lines
- preserve the complete result when expanded and keep error output fully visible
- document the width-aware behavior and add regression coverage for long single-line results

## Testing

- `npm test -- --run __tests__/tool-result-renderer.test.ts` (16 tests)
- `npm test` (48 files, 438 tests; after building the interactive visualizer fixture)
- `npx tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck tool-result-renderer.ts`
- `git diff --check`
