### PR TITLE
fix(config): bind server auth to url in mergeServerMaps (credential exfiltration)

### DIFF
--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -264,6 +264,81 @@ describe("config discovery", () => {
     expect(JSON.stringify(entry)).not.toContain("LITELLM_API_KEY");
   });
 
+  // Per-field coverage for every member of URL_BOUND_AUTH_FIELDS beyond
+  // headers/bearerTokenEnv — guards against a regression that silently drops a
+  // field from the strip set while the other tests stay green.
+  it("drops an inherited bearerToken when a url-only override repoints the server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-bt-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-bt-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, bearerToken: "secret-bearer-token" },
+      { url: URL_B },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    const entry = config.mcpServers.litellm;
+    expect(entry).toEqual({ url: URL_B });
+    expect(entry.bearerToken).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain("secret-bearer-token");
+  });
+
+  it("drops inherited oauth config when a url-only override repoints the server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-oauth-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-oauth-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, oauth: { clientId: "client", clientSecret: "oauth-client-secret" } },
+      { url: URL_B },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    const entry = config.mcpServers.litellm;
+    expect(entry).toEqual({ url: URL_B });
+    expect(entry.oauth).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain("oauth-client-secret");
+  });
+
+  // Three-source laundering: the accumulated (folded) entry's url — not just a
+  // pairwise base — must drive the strip decision. A middle source re-supplies
+  // the auth WITHOUT a url (so it is inherited against the still-url-A entry),
+  // then the top source repoints the url; the top override must still strip the
+  // accumulated auth.
+  it("does not launder auth across three sources when the top source changes the url", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-3src-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-3src-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    // Lowest precedence (shared-global): baked url + VK header.
+    writeJson(join(home, ".config", "mcp", "mcp.json"), {
+      mcpServers: { litellm: { url: URL_A, headers: { Authorization: "Bearer secret-vk" } } },
+    });
+    // Middle precedence (pi-global): re-supplies auth but NO url — inherited
+    // against the still-url-A accumulated entry.
+    writeJson(join(home, ".pi", "agent", "mcp.json"), {
+      mcpServers: { litellm: { headers: { Authorization: "Bearer secret-vk" } } },
+    });
+    // Highest precedence (shared-project): repoints the url, supplies no auth.
+    writeJson(join(project, ".mcp.json"), {
+      mcpServers: { litellm: { url: URL_B } },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    const entry = config.mcpServers.litellm;
+    expect(entry).toEqual({ url: URL_B });
+    expect(entry.headers).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain("secret-vk");
+  });
+
   it("tracks provenance so project servers write locally and shared/imported servers write to Pi config", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-project-"));

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -154,6 +154,116 @@ describe("config discovery", () => {
     });
   });
 
+  // SECURITY: credential/url binding in mergeServerMaps. A lower-precedence
+  // source (~/.config/mcp/mcp.json) defines an HTTP server with an
+  // Authorization header; a higher-precedence source (~/.pi/agent/mcp.json)
+  // overrides it. Auth material bound to the original url must not follow the
+  // server to a different url. See config.ts mergeServerMaps.
+  const URL_A = "https://litellm.internal/mcp/";
+  const URL_B = "https://attacker.example/mcp/";
+
+  function writeBakedAndOverride(
+    home: string,
+    project: string,
+    baked: Record<string, unknown>,
+    override: Record<string, unknown>,
+  ): void {
+    process.env.HOME = home;
+    process.chdir(project);
+    // Lowest precedence — the baked, credential-bearing definition.
+    writeJson(join(home, ".config", "mcp", "mcp.json"), {
+      mcpServers: { litellm: baked },
+    });
+    // Higher precedence — the (potentially untrusted) override.
+    writeJson(join(home, ".pi", "agent", "mcp.json"), {
+      mcpServers: { litellm: override },
+    });
+  }
+
+  it("preserves inherited auth when a higher-precedence override keeps the same url", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-a-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-a-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, headers: { Authorization: "Bearer secret-vk" } },
+      { url: URL_A, directTools: true },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.litellm).toEqual({
+      url: URL_A,
+      headers: { Authorization: "Bearer secret-vk" },
+      directTools: true,
+    });
+  });
+
+  it("drops inherited auth when a higher-precedence override changes the url without supplying new auth", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-b-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-b-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, headers: { Authorization: "Bearer secret-vk" } },
+      { url: URL_B },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.litellm).toEqual({ url: URL_B });
+    expect(config.mcpServers.litellm.headers).toBeUndefined();
+  });
+
+  it("keeps only the new auth when a higher-precedence override changes both url and headers", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-c-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-c-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, headers: { Authorization: "Bearer secret-vk" } },
+      { url: URL_B, headers: { Authorization: "Bearer override-token" } },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(config.mcpServers.litellm).toEqual({
+      url: URL_B,
+      headers: { Authorization: "Bearer override-token" },
+    });
+  });
+
+  it("does not exfiltrate the baked VK when a url-only override repoints the server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-d-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-d-project-"));
+    // The baked config carries the real VK as an unexpanded interpolation
+    // template; expansion happens at egress. If the header survives a url-only
+    // override, the interpolated VK is shipped to the attacker url.
+    writeBakedAndOverride(
+      home,
+      project,
+      {
+        url: URL_A,
+        headers: { Authorization: "Bearer ${LITELLM_API_KEY}" },
+        bearerTokenEnv: "LITELLM_API_KEY",
+      },
+      { url: URL_B },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    const entry = config.mcpServers.litellm;
+    expect(entry.url).toBe(URL_B);
+    expect(entry.headers).toBeUndefined();
+    expect(entry.bearerTokenEnv).toBeUndefined();
+    // No auth-bearing material of any kind may reference the VK.
+    expect(JSON.stringify(entry)).not.toContain("LITELLM_API_KEY");
+  });
+
   it("tracks provenance so project servers write locally and shared/imported servers write to Pi config", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-provenance-project-"));

--- a/config.ts
+++ b/config.ts
@@ -256,13 +256,38 @@ function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
   };
 }
 
+// Credential-bearing fields whose value is bound to a specific server `url`.
+// When a higher-precedence config source repoints an existing server at a
+// different url, these MUST NOT be inherited from the lower-precedence entry —
+// otherwise the original endpoint's credentials would be shipped to the new
+// url. See the SECURITY note in mergeServerMaps.
+const URL_BOUND_AUTH_FIELDS = ["headers", "bearerToken", "bearerTokenEnv", "oauth"] as const;
+
 function mergeServerMaps(
   base: Record<string, ServerEntry>,
   next: Record<string, ServerEntry>,
 ): Record<string, ServerEntry> {
   const merged = { ...base };
   for (const [name, definition] of Object.entries(next)) {
-    merged[name] = { ...(merged[name] ?? {}), ...definition };
+    const existing = merged[name];
+    // SECURITY (credential/url binding): the merge is per-field, so a
+    // higher-precedence source that supplies only a new `url` for an existing
+    // server would otherwise retain the lower-precedence entry's auth material
+    // (Authorization header, bearer token, OAuth config) and send it to the new
+    // url — a credential-exfiltration vector when the higher-precedence source
+    // is less trusted than the one that first defined the server. Bind auth to
+    // the url that supplied it: when the url changes, drop inherited auth
+    // material before merging. Auth explicitly re-supplied by `definition` still
+    // applies (it is spread last). Behaviour is unchanged when the url is
+    // identical or the override omits `url` (partial overrides still inherit).
+    let baseEntry: ServerEntry = existing ?? {};
+    if (existing && typeof definition.url === "string" && definition.url !== existing.url) {
+      baseEntry = { ...existing };
+      for (const field of URL_BOUND_AUTH_FIELDS) {
+        delete baseEntry[field];
+      }
+    }
+    merged[name] = { ...baseEntry, ...definition };
   }
   return merged;
 }


### PR DESCRIPTION
## Summary

`mergeServerMaps` (config.ts) merges same-named MCP server entries **per-field** across config-precedence sources:

```js
merged[name] = { ...(merged[name] ?? {}), ...definition };
```

A higher-precedence config source that supplies **only a new `url`** for an already-defined server therefore **retains the lower-precedence entry's auth material** and applies it to the new url:

```
base (lower):     { url: A, headers: { Authorization: "Bearer ${TOKEN}" } }
override (higher):{ url: B }
merged:           { url: B, headers: { Authorization: "Bearer ${TOKEN}" } }   // token now sent to B
```

`resolveHeaders` → `interpolateEnvRecord` then expands `${TOKEN}` from `process.env` and ships the real credential as `Authorization` to whatever the merged `url` ends up being (server-manager.ts).

## Why this is a security issue

Config precedence is `~/.config/mcp/mcp.json` (shared-global, lowest) → `~/.pi/agent/mcp.json` (pi-global) → `<cwd>/.mcp.json` (project) → `<cwd>/.pi/mcp.json` (project-pi, highest). When a **less-trusted** higher-precedence source (a workspace `.mcp.json` from a cloned repo, or `~/.pi/agent/mcp.json` written by a prompt-injected agent) redefines only the `url` of a server whose credentials were baked into a **more-trusted** lower-precedence source, the per-field merge exfiltrates those credentials to an attacker-controlled endpoint. The credential is bound to *a name*, not to *the url it was issued for*.

## The fix

Bind credentials to the url that supplied them. In `mergeServerMaps`, when a higher-precedence override changes an existing server's `url`, drop the inherited url-bound auth fields — `headers`, `bearerToken`, `bearerTokenEnv`, `oauth` — before merging. Auth that the override itself re-supplies still applies (it is spread last).

Behaviour is **unchanged** when:
- the url is identical across sources (partial overrides still inherit auth), or
- the override omits `url` entirely (partial overrides still inherit).

Only the "higher-precedence source repoints the server at a different url" case changes — and there, inherited credentials are dropped rather than forwarded.

## Test plan

Added to `__tests__/config.test.ts` (all green; full suite unaffected apart from the pre-existing `interactive-visualizer` example-artifact tests):

- [x] same url + partial override → base headers preserved
- [x] url changed, no new auth → no `Authorization` on the merged result
- [x] url changed + new headers → only the new headers survive
- [x] exfiltration scenario: baked `{url:A, headers:{Authorization:${TOKEN}}}` + url-only override `{url:B}` → merged carries no token
- [x] `tsc --noEmit` clean