### PR TITLE
fix: prevent crash when rendering MCP tool calls/results without theme

### DIFF
--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -1,9 +1,11 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import {
+  createMcpDirectToolCallRenderer,
   formatMcpDirectToolCallLines,
   formatMcpProxyToolCallLines,
   formatMcpToolResultLines,
+  renderMcpProxyToolCall,
   renderMcpToolResult,
 } from "../tool-result-renderer.ts";
 
@@ -143,5 +145,31 @@ describe("MCP tool result renderer", () => {
     expect(output).toContain("line 4");
     expect(output).not.toContain("Ctrl+O to expand");
     expect(output).not.toContain("…");
+  });
+
+  it("does not throw when theme is undefined (headless mode)", () => {
+    const output = renderMcpToolResult(
+      result([{ type: "text", text: "hello world" }]),
+      collapsedOptions,
+    ).render(80).join("\n");
+
+    expect(output).toContain("hello world");
+  });
+});
+
+describe("MCP tool call renderer with theme fallback", () => {
+  it("renderMcpProxyToolCall does not throw when theme is undefined", () => {
+    const component = renderMcpProxyToolCall(
+      { tool: "test_tool", server: "test-server", args: JSON.stringify({ key: "value" }) },
+    );
+    const output = component.render(80).join("\n");
+    expect(output).toContain("mcp call test_tool @ test-server");
+  });
+
+  it("createMcpDirectToolCallRenderer does not throw when theme is undefined", () => {
+    const renderer = createMcpDirectToolCallRenderer("test_tool");
+    const component = renderer({ key: "value" });
+    const output = component.render(80).join("\n");
+    expect(output).toContain("test_tool");
   });
 });

--- a/init.ts
+++ b/init.ts
@@ -281,7 +281,7 @@ export function flushMetadataCache(state: McpExtensionState): void {
 
 export function updateStatusBar(state: McpExtensionState): void {
   const ui = state.ui;
-  if (!ui) return;
+  if (!ui || !ui.theme) return;
   const total = Object.keys(state.config.mcpServers).length;
   if (total === 0) {
     ui.setStatus("mcp", undefined);

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -5,7 +5,9 @@ type McpToolResultDetails = Record<string, unknown> & { error?: unknown };
 type McpToolContentBlock = AgentToolResult<McpToolResultDetails>["content"][number];
 
 interface RenderTheme {
+  /** Colorize text using a named semantic color (e.g. "toolTitle", "muted", "warning"). */
   fg: (name: string, text: string) => string;
+  /** Optional bold wrapper — applied to the title line. */
   bold?: (text: string) => string;
 }
 
@@ -31,6 +33,11 @@ export interface McpToolResultDisplay {
 }
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
+
+// Plain pass-through theme used as default when no theme is provided.
+// theme parameters are optional across all render functions to support
+// callers that don't depend on TUI styling (e.g. tests, headless mode).
+const plainTheme: RenderTheme = { fg: (_name: string, text: string) => text };
 
 function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
@@ -96,23 +103,26 @@ export function formatMcpDirectToolCallLines(
   return [displayName, formatJsonish(args, maxInputChars)];
 }
 
-function renderToolCallLines(lines: string[], theme: RenderTheme) {
+/** Shared rendering core for tool call display — styles the title and detail lines. */
+function renderToolCallLines(lines: string[], theme?: RenderTheme) {
+  const activeTheme = theme ?? plainTheme;
   const [title = "mcp", ...rest] = lines;
-  const styledTitle = theme.fg("toolTitle", theme.bold ? theme.bold(title) : title);
-  const styledRest = rest.map(line => theme.fg("muted", line));
+  const styledTitle = activeTheme.fg("toolTitle", activeTheme.bold ? activeTheme.bold(title) : title);
+  const styledRest = rest.map(line => activeTheme.fg("muted", line));
   return new Text([styledTitle, ...styledRest].join("\n"), 0, 0);
 }
 
-export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme: RenderTheme) {
+export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme?: RenderTheme) {
   return renderToolCallLines(formatMcpProxyToolCallLines(args), theme);
 }
 
 export function createMcpDirectToolCallRenderer(displayName: string) {
-  return (args: Record<string, unknown>, theme: RenderTheme) => {
+  return (args: Record<string, unknown>, theme?: RenderTheme) => {
     return renderToolCallLines(formatMcpDirectToolCallLines(displayName, args), theme);
   };
 }
 
+/** Convert MCP content blocks (text or image) into display lines. */
 function blockToLines(block: McpToolContentBlock): string[] {
   if (block.type === "text") {
     return block.text.split("\n");
@@ -120,6 +130,7 @@ function blockToLines(block: McpToolContentBlock): string[] {
   return [`[image: ${block.mimeType}]`];
 }
 
+/** Format MCP content blocks into display lines, collapsing long output when not expanded. */
 export function formatMcpToolResultLines(
   result: Pick<AgentToolResult<McpToolResultDetails>, "content">,
   expanded: boolean,
@@ -141,20 +152,25 @@ export function formatMcpToolResultLines(
 export function renderMcpToolResult(
   result: AgentToolResult<McpToolResultDetails>,
   options: ToolRenderResultOptions,
-  theme: RenderTheme,
+  theme?: RenderTheme,
   context?: McpToolRenderContext,
 ) {
+  const activeTheme = theme ?? plainTheme;
+
+  // Stream partial → show a simple "running" indicator.
   if (options.isPartial) {
-    return new Text(theme.fg("warning", "Running MCP tool..."), 0, 0);
+    return new Text(activeTheme.fg("warning", "Running MCP tool..."), 0, 0);
   }
 
+  // Auto-expand the result when the tool reported an error or the caller
+  // signals an error context, so the user can see failure details immediately.
   const hasErrorDetails = Boolean(result.details.error);
   const display = formatMcpToolResultLines(result, options.expanded || context?.isError === true || hasErrorDetails);
   const output = display.lines
-    .map((line) => line === "…" ? theme.fg("muted", line) : theme.fg("toolOutput", line))
+    .map((line) => line === "…" ? activeTheme.fg("muted", line) : activeTheme.fg("toolOutput", line))
     .join("\n");
   const hint = display.truncated && !options.expanded
-    ? `\n${theme.fg("muted", "(Ctrl+O to expand)")}`
+    ? `\n${activeTheme.fg("muted", "(Ctrl+O to expand)")}`
     : "";
 
   return new Text(`${output}${hint}`, 0, 0);


### PR DESCRIPTION
## Summary

Fix a `TypeError: theme.fg is not a function` crash that occurs in headless mode when MCP tool calls/results are rendered without a TUI theme.

## Changes

- `tool-result-renderer.ts`: Make `theme` parameters optional across all render functions (`renderMcpProxyToolCall`, `createMcpDirectToolCallRenderer`, `renderMcpToolResult`) with a `plainTheme` pass-through fallback. Rename shorthand `t` to `activeTheme` for clarity. Add explanatory comments at key code positions.
- `init.ts`: Guard `updateStatusBar` against undefined `ui.theme`.
- `__tests__/tool-result-renderer.test.ts`: Add tests verifying that renderers do not throw when called without a theme.