### PR TITLE
fix: make footer status actionable, not an inventory ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Footer status no longer shows a permanent `MCP: 0/N servers` inventory ratio. Healthy idle (lazy, unused) is silent; active connections show server names in dim; `needs-auth` and recent failures surface as actionable `auth:` / `fail:` warnings. Fixes #93.
+
 ## [2.11.0] - 2026-07-03
 
 ### Changed

--- a/__tests__/update-status-bar.test.ts
+++ b/__tests__/update-status-bar.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import { updateStatusBar } from "../init.ts";
+import type { McpExtensionState } from "../state.ts";
+
+function makeUi() {
+  return {
+    setStatus: vi.fn(),
+    theme: {
+      fg: vi.fn((color: string, text: string) => `[${color}]${text}`),
+    },
+  };
+}
+
+function makeState(overrides: {
+  servers?: string[];
+  connections?: Record<string, { status: "connected" | "needs-auth" | "closed" }>;
+  failures?: Record<string, number>;
+  ui?: ReturnType<typeof makeUi> | null;
+}): McpExtensionState {
+  const servers = overrides.servers ?? [];
+  const connections = overrides.connections ?? {};
+  const failures = overrides.failures ?? {};
+  const ui = "ui" in overrides ? overrides.ui ?? undefined : makeUi();
+
+  return {
+    manager: {
+      getConnection: (name: string) => connections[name],
+      getAllConnections: () => new Map(Object.entries(connections)),
+    },
+    config: {
+      mcpServers: Object.fromEntries(servers.map((name) => [name, { command: "true" }])),
+    },
+    failureTracker: new Map(Object.entries(failures)),
+    toolMetadata: new Map(),
+    lifecycle: {} as any,
+    uiResourceHandler: {} as any,
+    consentManager: {} as any,
+    uiServer: null,
+    completedUiSessions: [],
+    openBrowser: async () => {},
+    ui: ui as any,
+  } as unknown as McpExtensionState;
+}
+
+describe("updateStatusBar", () => {
+  it("clears status when no servers are configured", () => {
+    const ui = makeUi();
+    updateStatusBar(makeState({ servers: [], ui }));
+    expect(ui.setStatus).toHaveBeenCalledWith("mcp", undefined);
+    expect(ui.theme.fg).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for healthy idle lazy servers (0 connected, no errors)", () => {
+    const ui = makeUi();
+    updateStatusBar(makeState({ servers: ["figma", "playwright", "atlassian"], ui }));
+    expect(ui.setStatus).toHaveBeenCalledWith("mcp", undefined);
+    expect(ui.theme.fg).not.toHaveBeenCalled();
+  });
+
+  it("shows connected server names in dim (not a permanent inventory ratio)", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["figma", "playwright", "atlassian"],
+        connections: { playwright: { status: "connected" } },
+        ui,
+      }),
+    );
+    expect(ui.theme.fg).toHaveBeenCalledWith("dim", "MCP · playwright");
+    expect(ui.setStatus).toHaveBeenCalledWith("mcp", "[dim]MCP · playwright");
+  });
+
+  it("shows multiple connected names, capped with +N", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["a", "b", "c", "d", "e"],
+        connections: {
+          a: { status: "connected" },
+          b: { status: "connected" },
+          c: { status: "connected" },
+          d: { status: "connected" },
+        },
+        ui,
+      }),
+    );
+    expect(ui.theme.fg).toHaveBeenCalledWith("dim", "MCP · a, b, c +1");
+  });
+
+  it("surfaces needs-auth in warning color", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["figma", "playwright"],
+        connections: { figma: { status: "needs-auth" } },
+        ui,
+      }),
+    );
+    expect(ui.theme.fg).toHaveBeenCalledWith("warning", "MCP · auth: figma");
+  });
+
+  it("surfaces recent failures in error color", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["playwright", "figma"],
+        failures: { playwright: Date.now() },
+        ui,
+      }),
+    );
+    expect(ui.theme.fg).toHaveBeenCalledWith("error", "MCP · fail: playwright");
+  });
+
+  it("prioritizes fail > auth > connected and combines parts", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["playwright", "figma", "atlassian"],
+        connections: {
+          figma: { status: "needs-auth" },
+          atlassian: { status: "connected" },
+        },
+        failures: { playwright: Date.now() },
+        ui,
+      }),
+    );
+    expect(ui.theme.fg).toHaveBeenCalledWith(
+      "error",
+      "MCP · fail: playwright · auth: figma · atlassian",
+    );
+  });
+
+  it("ignores expired failures (outside backoff window)", () => {
+    const ui = makeUi();
+    updateStatusBar(
+      makeState({
+        servers: ["playwright"],
+        failures: { playwright: Date.now() - 120_000 },
+        ui,
+      }),
+    );
+    expect(ui.setStatus).toHaveBeenCalledWith("mcp", undefined);
+  });
+
+  it("is a no-op without UI", () => {
+    expect(() =>
+      updateStatusBar(
+        makeState({
+          servers: ["playwright"],
+          connections: { playwright: { status: "connected" } },
+          ui: null,
+        }),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/init.ts
+++ b/init.ts
@@ -279,16 +279,73 @@ export function flushMetadataCache(state: McpExtensionState): void {
   }
 }
 
+/** Cap list length so the footer stays readable with many servers. */
+function formatNameList(names: string[], max = 3): string {
+  if (names.length <= max) return names.join(", ");
+  const shown = names.slice(0, max).join(", ");
+  return `${shown} +${names.length - max}`;
+}
+
+/**
+ * Footer status: show exceptions and active use, not inventory.
+ *
+ * Lazy servers start disconnected by design, so a permanent `0/N` ratio reads
+ * as broken. Silence is the healthy idle state; connected names, auth needs,
+ * and failures are the only things worth surfacing.
+ *
+ * Priority: fail > auth > connected. Silence when nothing is actionable.
+ * See https://github.com/nicobailon/pi-mcp-adapter/issues/93
+ */
 export function updateStatusBar(state: McpExtensionState): void {
   const ui = state.ui;
   if (!ui) return;
-  const total = Object.keys(state.config.mcpServers).length;
-  if (total === 0) {
+
+  const serverNames = Object.keys(state.config.mcpServers);
+  if (serverNames.length === 0) {
     ui.setStatus("mcp", undefined);
     return;
   }
-  const connectedCount = state.manager.getAllConnections().size;
-  ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`));
+
+  const connected: string[] = [];
+  const needsAuth: string[] = [];
+  const failed: string[] = [];
+
+  for (const name of serverNames) {
+    const connection = state.manager.getConnection(name);
+    if (connection?.status === "connected") {
+      connected.push(name);
+      continue;
+    }
+    if (connection?.status === "needs-auth") {
+      needsAuth.push(name);
+      continue;
+    }
+    if (getFailureAgeSeconds(state, name) !== null) {
+      failed.push(name);
+    }
+  }
+
+  // Healthy idle (lazy, not yet used, no errors): hide the status entirely.
+  if (connected.length === 0 && needsAuth.length === 0 && failed.length === 0) {
+    ui.setStatus("mcp", undefined);
+    return;
+  }
+
+  const parts: string[] = [];
+  if (failed.length > 0) {
+    parts.push(`fail: ${formatNameList(failed)}`);
+  }
+  if (needsAuth.length > 0) {
+    parts.push(`auth: ${formatNameList(needsAuth)}`);
+  }
+  if (connected.length > 0) {
+    parts.push(formatNameList(connected));
+  }
+
+  const text = `MCP · ${parts.join(" · ")}`;
+  const color =
+    failed.length > 0 ? "error" : needsAuth.length > 0 ? "warning" : "dim";
+  ui.setStatus("mcp", ui.theme.fg(color, text));
 }
 
 export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {


### PR DESCRIPTION
## Summary

Fixes #93.

With the default `lazy` lifecycle, servers start disconnected by design. The footer permanently showed `MCP: 0/N servers` in accent color, which reads as broken/incomplete rather than healthy idle.

**New behavior** (show the exception, not the inventory):

| State | Footer |
|-------|--------|
| Healthy idle (0 connected, no errors) | *(hidden)* |
| 1+ connected | `MCP · playwright` (dim) |
| Needs OAuth | `MCP · auth: figma` (warning) |
| Recent failure | `MCP · fail: playwright` (error) |
| Mix | `MCP · fail: a · auth: b · c` (error color if any fail) |

Name lists are capped at 3 (`a, b, c +2`) so many servers stay readable.

## Motivation

`connected/configured` is an ops inventory metric, not a useful agent UI signal. The status bar should answer *"is there something I need to act on?"* / *"what's actively in use?"* — not *"how many sockets are open out of how many I declared?"*.

The detailed inventory remains available via `mcp({ })` / `/mcp` status (unchanged).

## Test plan

- [x] Unit tests for silence / connected / auth / fail / priority / cap / no-UI (`__tests__/update-status-bar.test.ts`, 9 cases)
- [x] Related suites still pass (`index-lifecycle`, `proxy-modes-manual-auth`, `init-elicitation`)
- [ ] Manual: start pi with only lazy servers → footer has no MCP line
- [ ] Manual: call a tool → footer shows `MCP · <server>` in dim
- [ ] Manual: OAuth-required server without credentials → `MCP · auth: <server>` in warning
- [ ] Manual: failed connect within backoff → `MCP · fail: <server>` in error
- [ ] Manual: idle timeout disconnects last server → status clears again