### PR TITLE
Add progressive canonical MCP discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added stable canonical MCP tool identities shared by native direct tools, gateway discovery, and Code Mode.
+- Added progressive direct-tool registration and bounded additive schema activation through `mcp` search and describe.
+- Added `toolNaming`, `progressiveDirectTools`, `directActivationLimit`, and `codeModeTool` settings with per-server naming and progressive-loading overrides.
+
+### Changed
+- Reused `@tmustier/code-mode-mcp`'s recall-oriented catalog ranker for non-regex gateway search.
+- Removed proxy execution fields from the model-visible `mcp` schema in progressive mode while retaining the compatibility path outside that mode.
+- Kept unambiguous raw, `server.tool`, and old normalized names as hidden string aliases without registering duplicate schemas.
+
 ## [2.11.0] - 2026-07-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `requestTimeoutMs` | Request timeout in milliseconds for live MCP calls (overrides global; if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
+| `toolNaming` | `"legacy"` or `"canonical"` — override the model-visible naming convention for this server |
+| `progressiveDirectTools` | Override whether this server's direct tools start inactive and load through discovery |
 | `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
 | `debug` | Show server stderr (default: false) |
 
@@ -188,6 +190,10 @@ You can also pass only the `code` query parameter with `args: '{"code":"..."}'`.
 | Setting | Description |
 |---------|-------------|
 | `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
+| `toolNaming` | `"legacy"` (default) or `"canonical"` for stable `mcp__<server>__<tool>` identities |
+| `progressiveDirectTools` | Register configured direct tools inactive and activate matching schemas through `mcp` search/describe (default: false) |
+| `directActivationLimit` | Hard maximum schemas activated by one progressive search (default: 5) |
+| `codeModeTool` | Eager Code Mode control tool that shares canonical names, for example `code_mode_exec` |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
@@ -295,6 +301,45 @@ To exclude specific tools while still using `directTools: true`, add `excludeToo
 Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`.
 
 Direct tools register from the metadata cache in the Pi agent dir (`~/.pi/agent/mcp-cache.json` by default, or `$PI_CODING_AGENT_DIR/mcp-cache.json` when set), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only and the cache populates in the background. To force it: `/mcp reconnect <server>`.
+
+#### Progressive canonical discovery with Code Mode
+
+Large catalogs can register every direct tool without loading every schema into the initial model context:
+
+```json
+{
+  "settings": {
+    "directTools": true,
+    "toolNaming": "canonical",
+    "progressiveDirectTools": true,
+    "directActivationLimit": 5,
+    "codeModeTool": "code_mode_exec"
+  },
+  "mcpServers": {
+    "large-api": {
+      "command": "large-api-mcp"
+    },
+    "code_mode": {
+      "command": "code-mode-mcp",
+      "directTools": ["exec"],
+      "toolNaming": "legacy",
+      "progressiveDirectTools": false
+    }
+  }
+}
+```
+
+With this mode:
+
+- `mcp({ search: "..." })` uses the same recall-oriented ranker as Code Mode, returns a bounded result set and additively activates matching native schemas;
+- `mcp({ describe: "name" })` activates one exact schema;
+- one canonical name works as a native Pi tool and as `tools.<name>(args)` inside Code Mode;
+- unsafe or ambiguous raw identities receive a deterministic 16-hex hash suffix within a 64-character limit;
+- old names remain hidden string aliases only when they resolve unambiguously;
+- the progressive `mcp` schema omits proxy execution fields, so activated tools are called directly;
+- the Code Mode control tool stays eager and is omitted from capability-search results.
+
+Progressive discovery adds a model turn before the first cold call. Use it for large or mixed catalogs where schema savings justify that cost. Keep small, frequently used, interactive or latency-sensitive toolsets eager by setting `progressiveDirectTools: false` on those servers.
 
 When you change direct-tool toggles in `/mcp` or write new config through `/mcp setup`, the extension triggers Pi's normal reload flow automatically. That refreshes extensions, prompts, skills, and MCP tool registration in one shot, so newly configured direct tools can appear without a manual restart.
 

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -264,6 +264,77 @@ describe("excludeTools filtering", () => {
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes"]);
   });
 
+  it("registers one canonical progressive name shared with Code Mode", () => {
+    const definition = {
+      command: "node",
+      directTools: true,
+    };
+    const config: McpConfig = {
+      settings: {
+        toolNaming: "canonical",
+        progressiveDirectTools: true,
+        codeModeTool: "code_mode_exec",
+      },
+      mcpServers: { linear: definition },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        linear: {
+          configHash: computeServerHash(definition),
+          cachedAt: Date.now(),
+          tools: [{ name: "create_issue", description: "Create an issue" }],
+          resources: [],
+        },
+      },
+    };
+
+    const specs = resolveDirectTools(config, cache, "server");
+    expect(specs).toMatchObject([{
+      serverName: "linear",
+      originalName: "create_issue",
+      prefixedName: "mcp__linear__create_issue",
+      progressive: true,
+    }]);
+    const description = buildProxyDescription(config, cache, specs);
+    expect(description).toContain("Discovered MCP tools keep one name everywhere");
+    expect(description).toContain("large reductions, large fan-outs, or long deterministic chains");
+    expect(description).not.toContain('mcp({ tool: "name"');
+    expect(description).toContain("Mode: action > connect > describe > search > server (list) > nothing (status)");
+  });
+
+  it("allows a control-plane server to retain a stable eager legacy name", () => {
+    const definition = {
+      command: "node",
+      directTools: ["exec"],
+      toolNaming: "legacy" as const,
+      progressiveDirectTools: false,
+    };
+    const config: McpConfig = {
+      settings: {
+        toolNaming: "canonical",
+        progressiveDirectTools: true,
+      },
+      mcpServers: { code_mode: definition },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        code_mode: {
+          configHash: computeServerHash(definition),
+          cachedAt: Date.now(),
+          tools: [{ name: "exec", description: "Execute code" }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server")).toMatchObject([{
+      prefixedName: "code_mode_exec",
+      progressive: false,
+    }]);
+  });
+
   it("matches prefixed exclusions even when toolPrefix is none", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "none" },

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -116,6 +116,7 @@ function createState() {
 
 function createPi() {
   const handlers = new Map<string, (...args: any[]) => unknown>();
+  let activeTools: string[] = [];
   return {
     handlers,
     api: {
@@ -126,6 +127,8 @@ function createPi() {
         handlers.set(event, handler);
       }),
       getAllTools: vi.fn(() => []),
+      getActiveTools: vi.fn(() => activeTools),
+      setActiveTools: vi.fn((names: string[]) => { activeTools = names; }),
     } as any,
   };
 }
@@ -239,6 +242,69 @@ describe("mcpAdapter session lifecycle", () => {
     });
     expect(directTool.parameters).not.toHaveProperty("$schema");
     expect(directTool.parameters).not.toHaveProperty("additionalProperties");
+  });
+
+  it("keeps progressive discovery primary and constrains the hybrid Code Mode tool", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { command: "node", directTools: true },
+        code_mode: { command: "node", directTools: ["exec"], progressiveDirectTools: false },
+      },
+      settings: {
+        progressiveDirectTools: true,
+        directActivationLimit: 5,
+        codeModeTool: "code_mode_exec",
+      },
+    });
+    mocks.resolveDirectTools.mockReturnValue([
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "mcp__demo__search",
+        description: "Search demo",
+        inputSchema: { type: "object", properties: {} },
+        progressive: true,
+      },
+      {
+        serverName: "code_mode",
+        originalName: "exec",
+        prefixedName: "code_mode_exec",
+        description: "Run JavaScript. Use search() when names are unknown.",
+        inputSchema: { type: "object", properties: { code: { type: "string" } } },
+        progressive: false,
+      },
+    ]);
+    const activeState = createState();
+    mocks.initializeMcp.mockResolvedValue(activeState);
+    mocks.executeSearch.mockResolvedValue({ content: [{ type: "text", text: "found" }] });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const codeTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "code_mode_exec")?.[0];
+    expect(codeTool.description).toContain("Use mcp({ search:");
+    expect(codeTool.description).toContain("Do not use search(), describe(), ALL_TOOLS, or ALL_SERVERS inside this tool");
+    expect(codeTool.promptSnippet).toContain("Use mcp search before Code Mode");
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    expect(proxyTool.parameters.properties).not.toHaveProperty("tool");
+    expect(proxyTool.parameters.properties).not.toHaveProperty("args");
+
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+    await proxyTool.execute("call-1", { search: "demo", limit: 20 });
+
+    expect(mocks.executeSearch).toHaveBeenCalledWith(
+      activeState,
+      "demo",
+      undefined,
+      undefined,
+      false,
+      5,
+      expect.objectContaining({ codeModeTool: "code_mode_exec" }),
+    );
   });
 
   it("skips the proxy tool once direct tools are fully available", async () => {

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { executeCall, executeSearch } from "../proxy-modes.ts";
+import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
 
 function createState(): McpExtensionState {
@@ -59,6 +59,133 @@ describe("proxy discovery", () => {
     const result = executeSearch(createState(), "^demo_[a-z]+$", true);
 
     expect(result.details).toMatchObject({ count: 1, query: "^demo_[a-z]+$" });
+  });
+
+  it("loads canonical direct names and states the one-name Code Mode rule once", () => {
+    const activated: string[][] = [];
+    const state = createState();
+    state.toolMetadata.set("demo", [{
+      name: "mcp__demo__search",
+      originalName: "search",
+      description: "Search demo records",
+      inputSchema: { type: "object", properties: {} },
+    }]);
+
+    const result = executeSearch(state, "search", false, undefined, false, 5, {
+      codeModeTool: "code_mode_exec",
+      activate(names) {
+        activated.push(names);
+        return { added: names, active: names };
+      },
+    });
+
+    expect(activated).toEqual([["mcp__demo__search"]]);
+    expect(result.content[0].text).toContain("mcp__demo__search [activated]");
+    expect(result.content[0].text).toContain("tools.<name>(args)");
+    expect(result.content[0].text.match(/mcp__demo__search/g)).toHaveLength(1);
+    expect(result.details).toMatchObject({
+      added: ["mcp__demo__search"],
+      active: ["mcp__demo__search"],
+      displayed: 1,
+    });
+  });
+
+  it("uses shared recall-oriented ranking before applying the activation cap", () => {
+    const state = createState();
+    state.toolMetadata.set("demo", [
+      {
+        name: "mcp__demo__list_issue_statuses",
+        originalName: "list_issue_statuses",
+        description: "List configured workflow statuses for issues",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "mcp__demo__save_issue",
+        originalName: "save_issue",
+        description: "Create or update an issue including its status and project",
+        inputSchema: { type: "object", properties: { id: { type: "string" }, status: { type: "string" } } },
+      },
+    ]);
+    const activated: string[][] = [];
+
+    const result = executeSearch(state, "update issue status", false, undefined, false, 1, {
+      codeModeTool: "code_mode_exec",
+      activate(names) {
+        activated.push(names);
+        return { added: names, active: names };
+      },
+    });
+
+    expect(activated).toEqual([["mcp__demo__save_issue"]]);
+    expect(result.details).toMatchObject({ count: 2, displayed: 1 });
+    expect(result.content[0].text).toContain('Found 2 tools matching "update issue status" (showing 1)');
+  });
+
+  it("omits the already-active Code Mode control tool from capability search", () => {
+    const state = createState();
+    state.toolMetadata.set("demo", [
+      {
+        name: "mcp__demo__search",
+        originalName: "search",
+        description: "Search demo records",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "code_mode_exec",
+        originalName: "exec",
+        description: "Search and compose tools",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]);
+
+    const result = executeSearch(state, "search", false, undefined, false, 5, {
+      codeModeTool: "code_mode_exec",
+      activate(names) {
+        return { added: names, active: names };
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      count: 1,
+      matches: [{ server: "demo", tool: "mcp__demo__search", originalName: "search" }],
+    });
+    expect(result.content[0].text).not.toContain("code_mode_exec [activated]");
+  });
+
+  it("accepts unambiguous legacy string aliases without exposing duplicate schemas", () => {
+    const state = createState();
+    state.config.settings = { toolPrefix: "server" };
+    state.toolMetadata.set("demo", [{
+      name: "mcp__demo__search",
+      originalName: "search",
+      description: "Search demo records",
+      inputSchema: { type: "object", properties: {} },
+    }]);
+    const activated: string[][] = [];
+
+    const result = executeDescribe(state, "demo_search", {
+      activate(names) {
+        activated.push(names);
+        return { added: names, active: names };
+      },
+    });
+
+    expect(activated).toEqual([["mcp__demo__search"]]);
+    expect(result.details).toMatchObject({ tool: { name: "mcp__demo__search" } });
+  });
+
+  it("rejects ambiguous raw aliases", () => {
+    const state = createState();
+    state.config.mcpServers.other = { command: "npx", args: ["other"] };
+    state.toolMetadata.set("other", [{
+      name: "mcp__other__search",
+      originalName: "search",
+      description: "Search other records",
+      inputSchema: { type: "object", properties: {} },
+    }]);
+
+    const result = executeDescribe(state, "search");
+    expect(result.details).toMatchObject({ error: "tool_not_found", requestedTool: "search" });
   });
 
   it("keeps non-regex searches unaffected by the regex length cap", () => {

--- a/commands.ts
+++ b/commands.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
 import type { McpAuthResult, McpConfig, ServerEntry, McpPanelCallbacks, McpPanelResult, ImportKind } from "./types.ts";
+import { resolveToolNaming } from "./types.ts";
 import {
   ensureCompatibilityImports,
   getMcpDiscoverySummary,
@@ -110,7 +111,14 @@ export async function reconnectServers(
       }
       const prefix = state.config.settings?.toolPrefix ?? "server";
 
-      const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
+      const { metadata, failedTools } = buildToolMetadata(
+        connection.tools,
+        connection.resources,
+        definition,
+        name,
+        prefix,
+        resolveToolNaming(definition, state.config.settings),
+      );
       state.toolMetadata.set(name, metadata);
       updateMetadataCache(state, name);
       state.failureTracker.delete(name);

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -10,7 +10,7 @@ import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
-import { formatToolName, isToolExcluded } from "./types.ts";
+import { formatToolName, isToolExcluded, resolveProgressiveDirectTools, resolveToolNaming } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage } from "./utils.ts";
@@ -129,10 +129,13 @@ export function resolveDirectTools(
 
     if (!toolFilter) continue;
 
+    const naming = resolveToolNaming(definition, config.settings);
+    const progressive = resolveProgressiveDirectTools(definition, config.settings);
+
     for (const tool of serverCache.tools ?? []) {
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
       if (isToolExcluded(tool.name, serverName, prefix, definition.excludeTools)) continue;
-      const prefixedName = formatToolName(tool.name, serverName, prefix);
+      const prefixedName = formatToolName(tool.name, serverName, prefix, naming);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);
         continue;
@@ -146,6 +149,7 @@ export function resolveDirectTools(
         serverName,
         originalName: tool.name,
         prefixedName,
+        progressive,
         description: tool.description ?? "",
         inputSchema: tool.inputSchema,
         uiResourceUri: tool.uiResourceUri,
@@ -158,7 +162,7 @@ export function resolveDirectTools(
         const baseName = `get_${resourceNameToToolName(resource.name)}`;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
         if (isToolExcluded(baseName, serverName, prefix, definition.excludeTools)) continue;
-        const prefixedName = formatToolName(baseName, serverName, prefix);
+        const prefixedName = formatToolName(baseName, serverName, prefix, naming);
         if (BUILTIN_NAMES.has(prefixedName)) {
           console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`);
           continue;
@@ -172,6 +176,7 @@ export function resolveDirectTools(
           serverName,
           originalName: baseName,
           prefixedName,
+          progressive,
           description: resource.description ?? `Read resource: ${resource.uri}`,
           resourceUri: resource.uri,
         });
@@ -211,17 +216,30 @@ export function buildProxyDescription(
   directSpecs: DirectToolSpec[],
 ): string {
   const prefix = config.settings?.toolPrefix ?? "server";
-  let desc = `MCP gateway - connect to MCP servers and call their tools. Non-MCP Pi tools should be called directly, not through mcp.\n`;
+  const progressive = directSpecs.some(spec => spec.progressive);
+  let desc = progressive
+    ? `MCP gateway - search configured MCP capabilities, load matching direct tool schemas, and manage connections/auth.\n`
+    : `MCP gateway - connect to MCP servers and call their tools. Non-MCP Pi tools should be called directly, not through mcp.\n`;
 
   const directByServer = new Map<string, number>();
+  const progressiveByServer = new Map<string, number>();
   for (const spec of directSpecs) {
-    directByServer.set(spec.serverName, (directByServer.get(spec.serverName) ?? 0) + 1);
+    const target = spec.progressive ? progressiveByServer : directByServer;
+    target.set(spec.serverName, (target.get(spec.serverName) ?? 0) + 1);
   }
   if (directByServer.size > 0) {
     const parts = [...directByServer.entries()].map(
       ([server, count]) => `${server} (${count})`,
     );
     desc += `\nDirect tools available (call as normal tools): ${parts.join(", ")}\n`;
+  }
+  if (progressiveByServer.size > 0) {
+    const count = [...progressiveByServer.values()].reduce((sum, value) => sum + value, 0);
+    desc += `\n${count} direct MCP tools are registered inactive. Search for each stage's needed capabilities; matching schemas are loaded additively.\n`;
+    if (config.settings?.codeModeTool) {
+      desc += `Discovered MCP tools keep one name everywhere: call the loaded name directly, or use tools.<name>(args) inside ${config.settings.codeModeTool}. `;
+      desc += `Default to direct calls when you must inspect a result to decide the next step. Use ${config.settings.codeModeTool} when a mechanical stage materially avoids intermediate payload: large reductions, large fan-outs, or long deterministic chains. Keep writes, approvals, rich artifacts, and interactive tools direct. Search each stage as needed, but never rediscover a tool already found.\n`;
+    }
   }
 
   const serverSummaries: string[] = [];
@@ -253,14 +271,18 @@ export function buildProxyDescription(
   desc += `\nUsage:\n`;
   desc += `  mcp({ })                              → Show server status\n`;
   desc += `  mcp({ server: "name" })               → List tools from server\n`;
-  desc += `  mcp({ search: "query" })              → Search MCP tools by name/description\n`;
+  desc += `  mcp({ search: "query", limit: 5 })    → Search MCP tools by name/description and load matching direct schemas\n`;
   desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`;
   desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`;
-  desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`;
+  if (!progressive) {
+    desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`;
+  }
   desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`;
   desc += `  mcp({ action: "auth-start", server: "name" })      → Start manual OAuth and get a browser URL\n`;
   desc += `  mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' }) → Complete manual OAuth\n`;
-  desc += `\nMode: action > tool (call) > connect > describe > search > server (list) > nothing (status)`;
+  desc += progressive
+    ? `\nMode: action > connect > describe > search > server (list) > nothing (status)`
+    : `\nMode: action > tool (call) > connect > describe > search > server (list) > nothing (status)`;
 
   return desc;
 }

--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,27 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         prefix,
         envRaw?.split(",").map(s => s.trim()).filter(Boolean),
       );
+  const progressiveDirectToolNames = new Set(
+    directSpecs.filter(spec => spec.progressive).map(spec => spec.prefixedName),
+  );
+  const progressiveActivation = progressiveDirectToolNames.size > 0
+    ? {
+        codeModeTool: earlyConfig.settings?.codeModeTool,
+        activate(names: string[]) {
+          const requested = names.filter(name => progressiveDirectToolNames.has(name));
+          const current = pi.getActiveTools();
+          const currentSet = new Set(current);
+          const added = requested.filter(name => !currentSet.has(name));
+          if (added.length > 0) {
+            pi.setActiveTools([...new Set([...current, ...added])]);
+          }
+          return {
+            added,
+            active: requested.filter(name => currentSet.has(name) || added.includes(name)),
+          };
+        },
+      }
+    : undefined;
   const missingConfiguredDirectToolServers = getMissingConfiguredDirectToolServers(earlyConfig, earlyCache);
   const shouldRegisterProxyTool =
     earlyConfig.settings?.disableProxyTool !== true
@@ -68,11 +89,22 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     || missingConfiguredDirectToolServers.length > 0;
 
   for (const spec of directSpecs) {
+    const isHybridCodeModeTool = Boolean(
+      progressiveActivation?.codeModeTool
+      && spec.prefixedName === progressiveActivation.codeModeTool,
+    );
+    const description = isHybridCodeModeTool
+      ? `Use mcp({ search: "..." }) to discover each needed capability before calling this tool. Do not use search(), describe(), ALL_TOOLS, or ALL_SERVERS inside this tool for capabilities discoverable through mcp. Use the canonical names returned by mcp directly as tools.<name>(args).\n\n${spec.description || "(no description)"}`
+      : spec.description || "(no description)";
     (pi.registerTool as (tool: unknown) => unknown)({
       name: spec.prefixedName,
-      label: `MCP: ${spec.originalName}`,
-      description: spec.description || "(no description)",
-      promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
+      label: `MCP: ${spec.serverName} / ${spec.originalName}`,
+      description,
+      ...(spec.progressive ? {} : {
+        promptSnippet: isHybridCodeModeTool
+          ? "Use mcp search before Code Mode; reuse returned canonical names and do not rediscover them inside code"
+          : truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
+      }),
       parameters: Type.Unsafe(normalizeDirectToolInputSchema(spec.inputSchema) as never),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
       renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
@@ -88,6 +120,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    if (progressiveDirectToolNames.size > 0) {
+      const initialTools = pi.getActiveTools().filter(name => !progressiveDirectToolNames.has(name));
+      pi.setActiveTools(initialTools);
+    }
+
     const generation = ++lifecycleGeneration;
     const previousState = state;
     state = null;
@@ -256,16 +293,21 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       name: "mcp",
       label: "MCP",
       description: buildProxyDescription(earlyConfig, earlyCache, directSpecs),
-      promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
+      promptSnippet: progressiveActivation
+        ? "Search to load needed MCP tools; never rediscover a tool already found; loaded names also work as tools.<name> in Code Mode"
+        : "MCP gateway - connect to MCP servers and call their tools",
       renderCall: renderMcpProxyToolCall,
       parameters: Type.Object({
-        tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
-        args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),
+        ...(progressiveActivation ? {} : {
+          tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
+          args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),
+        }),
         connect: Type.Optional(Type.String({ description: "Server name to connect (lazy connect + metadata refresh)" })),
         describe: Type.Optional(Type.String({ description: "Tool name to describe (shows parameters)" })),
         search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
         regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
-        includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
+        includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (defaults to false with progressive direct tools)" })),
+        limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 20, description: "Maximum search results and direct schemas to load" })),
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
       }),
@@ -278,6 +320,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         search?: string;
         regex?: boolean;
         includeSchemas?: boolean;
+        limit?: number;
         server?: string;
         action?: string;
       }, signal, _onUpdate, _ctx) {
@@ -350,10 +393,24 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           return executeConnect(state, params.connect, signal);
         }
         if (params.describe) {
-          return executeDescribe(state, params.describe);
+          return executeDescribe(state, params.describe, progressiveActivation);
         }
         if (params.search) {
-          return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas);
+          const activationLimit = earlyConfig.settings?.directActivationLimit ?? 5;
+          const requestedLimit = params.limit ?? activationLimit;
+          const effectiveLimit = progressiveActivation
+            ? Math.min(requestedLimit, activationLimit)
+            : requestedLimit;
+          const includeSchemas = params.includeSchemas ?? !progressiveActivation;
+          return executeSearch(
+            state,
+            params.search,
+            params.regex,
+            params.server,
+            includeSchemas,
+            effectiveLimit,
+            progressiveActivation,
+          );
         }
         if (params.server) {
           return executeList(state, params.server);

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata } from "./types.ts";
+import { resolveToolNaming } from "./types.ts";
 import { existsSync } from "node:fs";
 import { loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
@@ -113,7 +114,13 @@ export async function initializeMcp(
     }
 
     if (cache?.servers?.[name] && isServerCacheValid(cache.servers[name], definition)) {
-      const metadata = reconstructToolMetadata(name, cache.servers[name], prefix, definition);
+      const metadata = reconstructToolMetadata(
+        name,
+        cache.servers[name],
+        prefix,
+        definition,
+        resolveToolNaming(definition, config.settings),
+      );
       toolMetadata.set(name, metadata);
     }
   }
@@ -151,7 +158,14 @@ export async function initializeMcp(
       continue;
     }
 
-    const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
+    const { metadata, failedTools } = buildToolMetadata(
+      connection.tools,
+      connection.resources,
+      definition,
+      name,
+      prefix,
+      resolveToolNaming(definition, config.settings),
+    );
     toolMetadata.set(name, metadata);
     updateMetadataCache(state, name);
 
@@ -189,7 +203,14 @@ export async function initializeMcp(
             if (connection.status === "needs-auth") {
               return { name, ok: false };
             }
-            const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
+            const { metadata } = buildToolMetadata(
+              connection.tools,
+              connection.resources,
+              definition,
+              name,
+              prefix,
+              resolveToolNaming(definition, config.settings),
+            );
             toolMetadata.set(name, metadata);
             updateMetadataCache(state, name);
             return { name, ok: true };
@@ -234,7 +255,14 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
 
   const prefix = state.config.settings?.toolPrefix ?? "server";
 
-  const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
+  const { metadata } = buildToolMetadata(
+    connection.tools,
+    connection.resources,
+    definition,
+    serverName,
+    prefix,
+    resolveToolNaming(definition, state.config.settings),
+  );
   state.toolMetadata.set(serverName, metadata);
 }
 

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
 import { createHash } from "node:crypto";
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { McpTool, McpResource, ServerEntry, ToolMetadata } from "./types.ts";
+import type { McpTool, McpResource, ServerEntry, ToolMetadata, ToolNaming } from "./types.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode, interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
@@ -117,7 +117,8 @@ export function reconstructToolMetadata(
   serverName: string,
   entry: ServerCacheEntry,
   prefix: "server" | "none" | "short",
-  definition: Pick<ServerEntry, "exposeResources" | "excludeTools">
+  definition: Pick<ServerEntry, "exposeResources" | "excludeTools">,
+  naming: ToolNaming = "legacy",
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
 
@@ -128,7 +129,7 @@ export function reconstructToolMetadata(
     }
 
     metadata.push({
-      name: formatToolName(tool.name, serverName, prefix),
+      name: formatToolName(tool.name, serverName, prefix, naming),
       originalName: tool.name,
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
@@ -146,7 +147,7 @@ export function reconstructToolMetadata(
       }
 
       metadata.push({
-        name: formatToolName(baseName, serverName, prefix),
+        name: formatToolName(baseName, serverName, prefix, naming),
         originalName: baseName,
         description: resource.description ?? `Read resource: ${resource.uri}`,
         resourceUri: resource.uri,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "open": "^10.2.0",
         "recheck": "^4.5.0",
         "typebox": "^1.1.24",
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^3.25.0 || ^4.0.0",
+        "@tmustier/code-mode-mcp": "^0.4.0"
       },
       "bin": {
         "pi-mcp-adapter": "cli.js"
@@ -6155,6 +6156,22 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@tmustier/code-mode-mcp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tmustier/code-mode-mcp/-/code-mode-mcp-0.4.0.tgz",
+      "integrity": "sha512-kme02glaJdK5tIiK/ldNNOPqQnKV4euVt+eOhVivbxZ7dH2IK+VrISSStyf11F8vn2q4TgvV2X2YwegMiQdL4g==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0"
+      },
+      "bin": {
+        "code-mode-mcp": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@earendil-works/pi-tui": "^0.74.0",
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "@tmustier/code-mode-mcp": "^0.4.0",
     "open": "^10.2.0",
     "recheck": "^4.5.0",
     "typebox": "^1.1.24",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,12 +1,13 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
 import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
 import { checkSync } from "recheck";
+import { createCatalogSearchPage } from "@tmustier/code-mode-mcp";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
-import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
+import { formatToolName, getServerPrefix, parseUiPromptHandoff, resolveToolNaming } from "./types.ts";
 import { lazyConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
-import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
+import { buildToolMetadata, getToolNames, formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
@@ -14,6 +15,39 @@ import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
+
+export interface ProgressiveToolActivation {
+  activate(names: string[]): { added: string[]; active: string[] };
+  codeModeTool?: string;
+}
+
+function resolveToolReference(
+  state: McpExtensionState,
+  requested: string,
+  serverOverride?: string,
+): { server: string; tool: ToolMetadata } | undefined {
+  const entries = serverOverride
+    ? [[serverOverride, state.toolMetadata.get(serverOverride) ?? []] as const]
+    : [...state.toolMetadata.entries()];
+  const exact = entries.flatMap(([server, tools]) => tools
+    .filter(tool => tool.name === requested || tool.name.replace(/-/g, "_") === requested.replace(/-/g, "_"))
+    .map(tool => ({ server, tool })));
+  if (exact.length === 1) return exact[0];
+  if (exact.length > 1) return undefined;
+
+  const prefix = state.config.settings?.toolPrefix ?? "server";
+  const aliases = entries.flatMap(([server, tools]) => tools
+    .filter(tool => {
+      const candidates = [
+        tool.originalName,
+        `${server}.${tool.originalName}`,
+        formatToolName(tool.originalName, server, prefix, "legacy"),
+      ];
+      return candidates.includes(requested);
+    })
+    .map(tool => ({ server, tool })));
+  return aliases.length === 1 ? aliases[0] : undefined;
+}
 
 const MAX_REGEX_SEARCH_QUERY_LENGTH = 256;
 const REGEX_SAFETY_CHECK_PARAMS = {
@@ -317,18 +351,14 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
   }
 }
 
-export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
-  let serverName: string | undefined;
-  let toolMeta: ToolMetadata | undefined;
-
-  for (const [server, metadata] of state.toolMetadata.entries()) {
-    const found = findToolByName(metadata, toolName);
-    if (found) {
-      serverName = server;
-      toolMeta = found;
-      break;
-    }
-  }
+export function executeDescribe(
+  state: McpExtensionState,
+  toolName: string,
+  activation?: ProgressiveToolActivation,
+): ProxyToolResult {
+  const resolved = resolveToolReference(state, toolName);
+  const serverName = resolved?.server;
+  const toolMeta = resolved?.tool;
 
   if (!serverName || !toolMeta) {
     return {
@@ -337,7 +367,8 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
     };
   }
 
-  let text = `${toolMeta.name}\n`;
+  const activationResult = activation?.activate([toolMeta.name]);
+  let text = `${toolMeta.name}${activationResult?.active.includes(toolMeta.name) ? " [activated]" : ""}\n`;
   text += `Server: ${serverName}\n`;
   if (toolMeta.resourceUri) {
     text += `Type: Resource (reads from ${toolMeta.resourceUri})\n`;
@@ -354,7 +385,12 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "describe", tool: toolMeta, server: serverName },
+    details: {
+      mode: "describe",
+      tool: toolMeta,
+      server: serverName,
+      ...(activationResult ? { added: activationResult.added, active: activationResult.active } : {}),
+    },
   };
 }
 
@@ -364,12 +400,21 @@ export function executeSearch(
   regex?: boolean,
   server?: string,
   includeSchemas?: boolean,
+  limit = 5,
+  activation?: ProgressiveToolActivation,
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 20) {
+    return {
+      content: [{ type: "text" as const, text: "Search limit must be an integer from 1 to 20." }],
+      details: { mode: "search", error: "invalid_limit", query, limit },
+    };
+  }
 
-  const matches: Array<{ server: string; tool: ToolMetadata }> = [];
+  let matches: Array<{ server: string; tool: ToolMetadata }> = [];
+  let totalCount = 0;
 
-  let pattern: RegExp;
+  let pattern: RegExp | undefined;
   try {
     if (regex) {
       if (query.length > MAX_REGEX_SEARCH_QUERY_LENGTH) {
@@ -396,16 +441,11 @@ export function executeSearch(
           details: { mode: "search", error: "unsafe_pattern", query, safetyStatus: safety.status },
         };
       }
-    } else {
-      const terms = query.trim().split(/\s+/).filter(t => t.length > 0);
-      if (terms.length === 0) {
-        return {
-          content: [{ type: "text" as const, text: "Search query cannot be empty" }],
-          details: { mode: "search", error: "empty_query" },
-        };
-      }
-      const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-      pattern = new RegExp(escaped.join("|"), "i");
+    } else if (!query.trim()) {
+      return {
+        content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+        details: { mode: "search", error: "empty_query" },
+      };
     }
   } catch {
     return {
@@ -414,19 +454,48 @@ export function executeSearch(
     };
   }
 
-  for (const [serverName, metadata] of state.toolMetadata.entries()) {
-    if (server && serverName !== server) continue;
-    for (const tool of metadata) {
-      if (pattern.test(tool.name) || pattern.test(tool.description)) {
-        matches.push({
-          server: serverName,
-          tool,
-        });
+  if (regex) {
+    for (const [serverName, metadata] of state.toolMetadata.entries()) {
+      if (server && serverName !== server) continue;
+      for (const tool of metadata) {
+        if (activation?.codeModeTool === tool.name) continue;
+        if (pattern!.test(tool.name) || pattern!.test(tool.originalName) || pattern!.test(tool.description)) {
+          matches.push({ server: serverName, tool });
+        }
       }
     }
+    totalCount = matches.length;
+  } else {
+    const byIdentity = new Map<string, { server: string; tool: ToolMetadata }>();
+    const catalog = [...state.toolMetadata.entries()].flatMap(([serverName, metadata]) => metadata
+      .filter(tool => activation?.codeModeTool !== tool.name)
+      .map(tool => {
+        byIdentity.set(`${serverName}\0${tool.name}`, { server: serverName, tool });
+        return {
+          name: tool.name,
+          server: serverName,
+          tool: tool.originalName,
+          description: tool.description,
+          inputSchema: tool.inputSchema ?? { type: "object", properties: {} },
+        };
+      }));
+    try {
+      const page = createCatalogSearchPage(catalog as Parameters<typeof createCatalogSearchPage>[0])(
+        query,
+        { ...(server ? { server } : {}), limit },
+      );
+      totalCount = page.total;
+      matches = page.items
+        .map(item => byIdentity.get(`${item.server}\0${item.name}`))
+        .filter((item): item is { server: string; tool: ToolMetadata } => item !== undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text" as const, text: message }],
+        details: { mode: "search", error: "invalid_search", query, server, message },
+      };
+    }
   }
-
-  const totalCount = matches.length;
 
   if (totalCount === 0) {
     const msg = server
@@ -438,11 +507,16 @@ export function executeSearch(
     };
   }
 
-  let text = `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}":\n\n`;
+  const displayedMatches = matches.slice(0, limit);
+  const activationResult = activation?.activate(displayedMatches.map(match => match.tool.name));
+  const activeNames = new Set(activationResult?.active ?? []);
+  let text = `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}"`;
+  if (displayedMatches.length < totalCount) text += ` (showing ${displayedMatches.length})`;
+  text += ":\n\n";
 
-  for (const match of matches) {
+  for (const match of displayedMatches) {
     if (showSchemas) {
-      text += `${match.tool.name}\n`;
+      text += `${match.tool.name}${activeNames.has(match.tool.name) ? " [activated]" : ""}\n`;
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
         text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`;
@@ -451,7 +525,7 @@ export function executeSearch(
       }
       text += "\n";
     } else {
-      text += `- ${match.tool.name}`;
+      text += `- ${match.tool.name}${activeNames.has(match.tool.name) ? " [activated]" : ""}`;
       if (match.tool.description) {
         text += ` - ${truncateAtWord(match.tool.description, 50)}`;
       }
@@ -459,13 +533,19 @@ export function executeSearch(
     }
   }
 
+  if (activationResult && activationResult.active.length > 0) {
+    text += `\nLoaded as direct tools. The same names work${activation?.codeModeTool ? ` in ${activation.codeModeTool}` : " in Code Mode"} as tools.<name>(args).`;
+  }
+
   return {
     content: [{ type: "text" as const, text: text.trim() }],
     details: {
       mode: "search",
-      matches: matches.map(m => ({ server: m.server, tool: m.tool.name })),
+      matches: displayedMatches.map(m => ({ server: m.server, tool: m.tool.name, originalName: m.tool.originalName })),
       count: totalCount,
+      displayed: displayedMatches.length,
       query,
+      ...(activationResult ? { added: activationResult.added, active: activationResult.active } : {}),
     },
   };
 }
@@ -561,7 +641,14 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       }
     }
     const prefix = state.config.settings?.toolPrefix ?? "server";
-    const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
+    const { metadata } = buildToolMetadata(
+      connection.tools,
+      connection.resources,
+      definition,
+      serverName,
+      prefix,
+      resolveToolNaming(definition, state.config.settings),
+    );
     state.toolMetadata.set(serverName, metadata);
     updateMetadataCache(state, serverName);
     state.failureTracker.delete(serverName);
@@ -601,23 +688,16 @@ export async function executeCall(
     };
   }
 
-  if (serverName) {
-    toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
-  } else {
-    for (const [server, metadata] of state.toolMetadata.entries()) {
-      const found = findToolByName(metadata, toolName);
-      if (found) {
-        serverName = server;
-        toolMeta = found;
-        break;
-      }
-    }
+  const initiallyResolved = resolveToolReference(state, toolName, serverName);
+  if (initiallyResolved) {
+    serverName = initiallyResolved.server;
+    toolMeta = initiallyResolved.tool;
   }
 
   if (serverName && !toolMeta) {
     const connected = await lazyConnect(state, serverName, signal);
     if (connected) {
-      toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+      toolMeta = resolveToolReference(state, toolName, serverName)?.tool;
     } else {
       const needsAuthConnection = state.manager.getConnection(serverName);
       if (needsAuthConnection?.status === "needs-auth") {
@@ -635,7 +715,7 @@ export async function executeCall(
             state.failureTracker.delete(serverName);
             const connectedAfterAuth = await lazyConnect(state, serverName, signal);
             if (connectedAfterAuth) {
-              toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+              toolMeta = resolveToolReference(state, toolName, serverName)?.tool;
               if (!toolMeta) {
                 return {
                   content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.` }],
@@ -699,7 +779,7 @@ export async function executeCall(
 
       if (!connected) continue;
       if (!prefixMatchedServer) prefixMatchedServer = configuredServer;
-      toolMeta = findToolByName(state.toolMetadata.get(configuredServer), toolName);
+      toolMeta = resolveToolReference(state, toolName, configuredServer)?.tool;
       if (toolMeta) {
         serverName = configuredServer;
         break;
@@ -808,7 +888,7 @@ export async function executeCall(
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
       updateStatusBar(state);
-      toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+      toolMeta = resolveToolReference(state, toolName, serverName)?.tool;
       if (!toolMeta) {
         const available = getToolNames(state, serverName);
         const hint = available.length > 0

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,6 +1,6 @@
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { McpExtensionState } from "./state.ts";
-import type { ToolMetadata, McpTool, McpResource, ServerEntry } from "./types.ts";
+import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolNaming } from "./types.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
@@ -10,7 +10,8 @@ export function buildToolMetadata(
   resources: McpResource[],
   definition: ServerEntry,
   serverName: string,
-  prefix: "server" | "none" | "short"
+  prefix: "server" | "none" | "short",
+  naming: ToolNaming = "legacy",
 ): { metadata: ToolMetadata[]; failedTools: string[] } {
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
@@ -31,7 +32,7 @@ export function buildToolMetadata(
       failedTools.push(tool.name);
     }
     metadata.push({
-      name: formatToolName(tool.name, serverName, prefix),
+      name: formatToolName(tool.name, serverName, prefix, naming),
       originalName: tool.name,
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
@@ -48,7 +49,7 @@ export function buildToolMetadata(
       }
 
       metadata.push({
-        name: formatToolName(baseName, serverName, prefix),
+        name: formatToolName(baseName, serverName, prefix, naming),
         originalName: baseName,
         description: resource.description ?? `Read resource: ${resource.uri}`,
         resourceUri: resource.uri,

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,9 @@ import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
+import { canonicalToolName } from "@tmustier/code-mode-mcp/naming";
+
+export type ToolNaming = "legacy" | "canonical";
 
 // Transport type (stdio + HTTP)
 export type Transport = 
@@ -312,6 +315,10 @@ export interface ServerEntry {
   exposeResources?: boolean;
   // Direct tool registration
   directTools?: boolean | string[];
+  /** Override the model-visible naming convention for this server. */
+  toolNaming?: ToolNaming;
+  /** Override whether this server's direct tools start inactive and load through discovery. */
+  progressiveDirectTools?: boolean;
   // Exclude specific MCP tools/resources by original or prefixed name
   excludeTools?: string[];
   // Debug
@@ -331,6 +338,14 @@ export interface McpOutputGuardSettings {
 // Settings
 export interface McpSettings {
   toolPrefix?: "server" | "none" | "short";
+  /** Use one mcp__<server>__<tool> identity across direct tools, the gateway, and Code Mode. */
+  toolNaming?: ToolNaming;
+  /** Register configured direct tools inactive, then activate matching schemas through search/describe. */
+  progressiveDirectTools?: boolean;
+  /** Maximum matching direct schemas activated by one search. Defaults to 5. */
+  directActivationLimit?: number;
+  /** Active Code Mode control tool whose tools.* namespace uses canonical direct names. */
+  codeModeTool?: string;
   idleTimeout?: number; // minutes, default 10, 0 to disable
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
@@ -378,6 +393,7 @@ export interface DirectToolSpec {
   serverName: string;
   originalName: string;
   prefixedName: string;
+  progressive: boolean;
   description: string;
   inputSchema?: unknown;
   resourceUri?: string;
@@ -431,10 +447,26 @@ export function getServerPrefix(
 export function formatToolName(
   toolName: string,
   serverName: string,
-  prefix: "server" | "none" | "short"
+  prefix: "server" | "none" | "short",
+  naming: ToolNaming = "legacy",
 ): string {
+  if (naming === "canonical") return canonicalToolName(serverName, toolName);
   const p = getServerPrefix(serverName, prefix);
   return p ? `${p}_${toolName}` : toolName;
+}
+
+export function resolveToolNaming(
+  definition: Pick<ServerEntry, "toolNaming">,
+  settings?: Pick<McpSettings, "toolNaming">,
+): ToolNaming {
+  return definition.toolNaming ?? settings?.toolNaming ?? "legacy";
+}
+
+export function resolveProgressiveDirectTools(
+  definition: Pick<ServerEntry, "progressiveDirectTools">,
+  settings?: Pick<McpSettings, "progressiveDirectTools">,
+): boolean {
+  return definition.progressiveDirectTools ?? settings?.progressiveDirectTools ?? false;
 }
 
 function normalizeToolName(value: string): string {
@@ -454,6 +486,7 @@ export function isToolExcluded(
     normalizeToolName(formatToolName(toolName, serverName, prefix)),
     normalizeToolName(formatToolName(toolName, serverName, "server")),
     normalizeToolName(formatToolName(toolName, serverName, "short")),
+    normalizeToolName(formatToolName(toolName, serverName, prefix, "canonical")),
   ]);
 
   for (const excluded of excludeTools) {


### PR DESCRIPTION
## Summary

Add an opt-in hybrid MCP surface that keeps large catalogs out of the initial model context while preserving native direct tools after bounded discovery.

- add deterministic canonical names shared by native tools, gateway discovery and Code Mode
- register configured progressive direct tools inactive, then activate matching schemas additively through `mcp` search or describe
- add `toolNaming`, `progressiveDirectTools`, `directActivationLimit` and `codeModeTool` settings, with per-server naming/loading overrides
- reuse `@tmustier/code-mode-mcp`'s exported naming and recall-oriented catalog search instead of maintaining divergent implementations
- retain raw, `server.tool` and old normalized names as hidden aliases only when unambiguous
- omit proxy execution fields from the model-visible gateway schema in progressive mode

All new behaviour is opt-in. Existing naming, eager direct tools and proxy mode remain the defaults.

## Why

A client should not need to expose hundreds of schemas merely to retain native direct calls. This design starts a hybrid host with the `mcp` discovery plane and an optional eager Code Mode control tool, then loads only the best matching native schemas. The exact same canonical name works directly and as `tools.<name>(args)` inside Code Mode.

`@tmustier/code-mode-mcp` remains a standalone one-tool MCP server. The adapter imports only its pure naming and catalog-search APIs unless a user separately configures its `exec` server.

## Validation

- TypeScript check passes
- 443/443 Vitest tests pass from a clean `npm ci`
- npm audit reports 0 vulnerabilities
- package dry-run includes the declared dependency and updated docs
- final Opus 4.8 campaign: 80/80 exact, 80/80 operationally clean, no naming failures, proxy executions, internal rediscovery, tool-result errors or redundant upstream calls
- catalog campaign: 6/6 exact at 77 and 500 tools; median initial context stayed at 3,366 tokens at both sizes
- a search over 500 matches with `limit: 20` activated only the configured maximum of 5 schemas

## Performance trade-off

Progressive discovery adds one model turn before a cold first call. In the synthetic single-lookup task, the median was 6.89 seconds surface-only versus 4.91 seconds in the earlier eager-direct run. This is why progressive loading defaults to false and can be disabled per server. It is intended for large catalogs where bounded context outweighs roughly two seconds of cold discovery overhead.
