### PR TITLE
feat: surface MCP server instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
+- Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 
 ### Fixed
 - Used server-advertised OAuth protected-resource metadata during authorization so resource servers can point Pi at the correct authorization server. Thanks @jameswarren for issue #173 and PR #174.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
+
 ### Fixed
 - Used server-advertised OAuth protected-resource metadata during authorization so resource servers can point Pi at the correct authorization server. Thanks @jameswarren for issue #173 and PR #174.
 - Dropped inherited HTTP auth when a higher-precedence MCP config repoints a server URL, while preserving explicit OAuth disable flags. Thanks @ductiletoaster for PR #182.

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 | List server | `mcp({ server: "name" })` |
 | Search | `mcp({ search: "screenshot navigate" })` |
 | Describe | `mcp({ describe: "tool_name" })` |
+| Instructions | `mcp({ instructions: "name" })` |
 | Call | `mcp({ tool: "...", args: '{"key": "value"}' })` |
 | Connect | `mcp({ connect: "server-name" })` |
 | UI messages | `mcp({ action: "ui-messages" })` |
@@ -401,6 +402,8 @@ MCP proxy and direct-tool results render compactly by default: long text shows t
 Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are OR'd.
 
 Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`.
+
+Servers that provide usage guidance via the MCP `instructions` field get a short preview at the end of `mcp({ server: "name" })` listings; `mcp({ instructions: "name" })` shows the full text. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Search includes both MCP tools and Pi tools (from extensions). Pi tools appear f
 
 Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`.
 
-Servers that provide usage guidance via the MCP `instructions` field get a short preview at the end of `mcp({ server: "name" })` listings; `mcp({ instructions: "name" })` shows the full text. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
+Servers that provide usage guidance via the MCP `instructions` field surface it at three levels: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 
 ## Commands
 

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -31,6 +31,7 @@ function connectedState(client: Record<string, unknown>) {
         ],
       ],
     ]),
+    serverInstructions: new Map(),
     failureTracker: new Map(),
     ui: undefined,
   } as any;

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -96,6 +96,59 @@ describe("buildProxyDescription", () => {
     expect(description).toContain("Servers: figma (1 tools)");
     expect(description).not.toContain("figma (3 tools)");
   });
+
+  it("includes a truncated instructions snippet for servers that provide one", () => {
+    const config: McpConfig = {
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"] },
+      },
+    };
+
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        demo: {
+          configHash: "hash",
+          cachedAt: Date.now(),
+          tools: [{ name: "read_skill", description: "Read a skill" }],
+          resources: [],
+          instructions: `Skills catalog.\n\nAvailable skills:\n${Array.from({ length: 30 }, (_, i) => `- skill-${i}: does thing ${i}`).join("\n")}`,
+        },
+      },
+    };
+
+    const description = buildProxyDescription(config, cache, []);
+
+    expect(description).toContain('Server instructions (truncated - full text via mcp({ instructions: "name" })):');
+    expect(description).toContain("demo: Skills catalog. Available skills: - skill-0:");
+    expect(description).toContain("...");
+    expect(description).not.toContain("skill-29");
+  });
+
+  it("omits the instructions section when no server provides instructions", () => {
+    const config: McpConfig = {
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"] },
+      },
+    };
+
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        demo: {
+          configHash: "hash",
+          cachedAt: Date.now(),
+          tools: [{ name: "read_skill", description: "Read a skill" }],
+          resources: [],
+        },
+      },
+    };
+
+    const description = buildProxyDescription(config, cache, []);
+
+    expect(description).not.toContain("Server instructions");
+    expect(description).toContain('mcp({ instructions: "name" })');
+  });
 });
 
 describe("metadata cache hashing", () => {

--- a/__tests__/elicitation-sdk-integration.test.ts
+++ b/__tests__/elicitation-sdk-integration.test.ts
@@ -41,6 +41,7 @@ function createState(manager: McpServerManager, metadata: ToolMetadata[]): McpEx
     manager,
     config: { settings: {}, mcpServers: { real: definition } },
     toolMetadata: new Map([["real", metadata]]),
+    serverInstructions: new Map(),
     failureTracker: new Map(),
     uiResourceHandler: new UiResourceHandler(manager),
     completedUiSessions: [],

--- a/__tests__/metadata-cache-instructions.test.ts
+++ b/__tests__/metadata-cache-instructions.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadMetadataCache, saveMetadataCache, type ServerCacheEntry } from "../metadata-cache.ts";
+
+describe("metadata cache instructions", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pi-mcp-cache-"));
+    process.env.PI_CODING_AGENT_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips server instructions through the cache file", () => {
+    const entry: ServerCacheEntry = {
+      configHash: "hash",
+      tools: [],
+      resources: [],
+      instructions: "The available skills are listed in this server's instructions.",
+      cachedAt: Date.now(),
+    };
+
+    saveMetadataCache({ version: 1, servers: { demo: entry } });
+
+    expect(loadMetadataCache()?.servers.demo.instructions).toBe(
+      "The available skills are listed in this server's instructions.",
+    );
+  });
+
+  it("omits instructions from the cache file when a server provides none", () => {
+    const entry: ServerCacheEntry = {
+      configHash: "hash",
+      tools: [],
+      resources: [],
+      instructions: undefined,
+      cachedAt: Date.now(),
+    };
+
+    saveMetadataCache({ version: 1, servers: { demo: entry } });
+
+    expect("instructions" in (loadMetadataCache()?.servers.demo ?? {})).toBe(false);
+  });
+});

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -129,6 +129,7 @@ describe("proxy auto auth", () => {
       },
       manager,
       toolMetadata: new Map(),
+      serverInstructions: new Map(),
       failureTracker: new Map(),
       ui: { setStatus: vi.fn() },
     } as any;

--- a/__tests__/proxy-modes-instructions.test.ts
+++ b/__tests__/proxy-modes-instructions.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { executeInstructions, executeList } from "../proxy-modes.ts";
+import type { McpExtensionState } from "../state.ts";
+
+const SHORT_INSTRUCTIONS = "Call read_skill with a skill name before answering.";
+const LONG_INSTRUCTIONS = `Available skills: ${Array.from({ length: 40 }, (_, i) => `skill-${i}`).join(", ")}. Call read_skill with a skill name to load one.`;
+
+function createState(overrides: { instructions?: string; connected?: boolean } = {}): McpExtensionState {
+  return {
+    config: {
+      mcpServers: {
+        demo: { command: "npx", args: ["demo"] },
+      },
+    },
+    toolMetadata: new Map([
+      [
+        "demo",
+        [
+          {
+            name: "demo_read_skill",
+            originalName: "read_skill",
+            description: "Read a skill listed in this server's instructions",
+          },
+        ],
+      ],
+    ]),
+    serverInstructions: new Map(overrides.instructions ? [["demo", overrides.instructions]] : []),
+    manager: {
+      getConnection: () => (overrides.connected ? { status: "connected" } : undefined),
+    },
+    failureTracker: new Map(),
+  } as unknown as McpExtensionState;
+}
+
+describe("proxy instructions", () => {
+  it("includes short server instructions in full in the listing", () => {
+    const result = executeList(createState({ instructions: SHORT_INSTRUCTIONS }), "demo");
+
+    expect(result.content[0].text).toContain(`Server instructions:\n${SHORT_INSTRUCTIONS}`);
+    expect(result.content[0].text).not.toContain("mcp({ instructions:");
+    expect(result.details).toMatchObject({ mode: "list", hasInstructions: true });
+  });
+
+  it("truncates long instructions in the listing and points at the instructions mode", () => {
+    const result = executeList(createState({ instructions: LONG_INSTRUCTIONS }), "demo");
+
+    expect(result.content[0].text).toContain("Server instructions:");
+    expect(result.content[0].text).not.toContain(LONG_INSTRUCTIONS);
+    expect(result.content[0].text).toContain('Use mcp({ instructions: "demo" }) for the full text.');
+  });
+
+  it("leaves the listing unchanged when a server has no instructions", () => {
+    const result = executeList(createState(), "demo");
+
+    expect(result.content[0].text).not.toContain("Server instructions");
+    expect(result.details).toMatchObject({ mode: "list", hasInstructions: false });
+  });
+
+  it("returns the full instructions text", () => {
+    const result = executeInstructions(createState({ instructions: LONG_INSTRUCTIONS }), "demo");
+
+    expect(result.content[0].text).toBe(`demo instructions:\n\n${LONG_INSTRUCTIONS}`);
+    expect(result.details).toMatchObject({ mode: "instructions", server: "demo", length: LONG_INSTRUCTIONS.length });
+  });
+
+  it("reports unknown servers", () => {
+    const result = executeInstructions(createState(), "missing");
+
+    expect(result.content[0].text).toContain('Server "missing" not found');
+    expect(result.details).toMatchObject({ mode: "instructions", error: "not_found" });
+  });
+
+  it("reports connected servers that provide no instructions", () => {
+    const result = executeInstructions(createState({ connected: true }), "demo");
+
+    expect(result.content[0].text).toBe('Server "demo" does not provide instructions.');
+    expect(result.details).toMatchObject({ mode: "instructions", error: "no_instructions" });
+  });
+
+  it("suggests connecting when no instructions are cached", () => {
+    const result = executeInstructions(createState(), "demo");
+
+    expect(result.content[0].text).toContain('mcp({ connect: "demo" })');
+    expect(result.details).toMatchObject({ mode: "instructions", error: "not_connected" });
+  });
+});

--- a/__tests__/proxy-modes-instructions.test.ts
+++ b/__tests__/proxy-modes-instructions.test.ts
@@ -5,7 +5,7 @@ import type { McpExtensionState } from "../state.ts";
 const SHORT_INSTRUCTIONS = "Call read_skill with a skill name before answering.";
 const LONG_INSTRUCTIONS = `Available skills: ${Array.from({ length: 40 }, (_, i) => `skill-${i}`).join(", ")}. Call read_skill with a skill name to load one.`;
 
-function createState(overrides: { instructions?: string; connected?: boolean } = {}): McpExtensionState {
+function createState(overrides: { instructions?: string; connected?: boolean; noTools?: boolean } = {}): McpExtensionState {
   return {
     config: {
       mcpServers: {
@@ -15,13 +15,15 @@ function createState(overrides: { instructions?: string; connected?: boolean } =
     toolMetadata: new Map([
       [
         "demo",
-        [
-          {
-            name: "demo_read_skill",
-            originalName: "read_skill",
-            description: "Read a skill listed in this server's instructions",
-          },
-        ],
+        overrides.noTools
+          ? []
+          : [
+              {
+                name: "demo_read_skill",
+                originalName: "read_skill",
+                description: "Read a skill listed in this server's instructions",
+              },
+            ],
       ],
     ]),
     serverInstructions: new Map(overrides.instructions ? [["demo", overrides.instructions]] : []),
@@ -54,6 +56,18 @@ describe("proxy instructions", () => {
 
     expect(result.content[0].text).not.toContain("Server instructions");
     expect(result.details).toMatchObject({ mode: "list", hasInstructions: false });
+  });
+
+  it("includes instructions for connected and cached servers with no visible tools", () => {
+    const connected = executeList(createState({ instructions: SHORT_INSTRUCTIONS, connected: true, noTools: true }), "demo");
+    const cached = executeList(createState({ instructions: SHORT_INSTRUCTIONS, noTools: true }), "demo");
+
+    expect(connected.content[0].text).toContain('Server "demo" has no tools');
+    expect(connected.content[0].text).toContain(`Server instructions:\n${SHORT_INSTRUCTIONS}`);
+    expect(connected.details).toMatchObject({ mode: "list", count: 0, hasInstructions: true });
+    expect(cached.content[0].text).toContain('Server "demo" has no cached tools');
+    expect(cached.content[0].text).toContain(`Server instructions:\n${SHORT_INSTRUCTIONS}`);
+    expect(cached.details).toMatchObject({ mode: "list", count: 0, hasInstructions: true });
   });
 
   it("returns the full instructions text", () => {

--- a/__tests__/server-manager-instructions.test.ts
+++ b/__tests__/server-manager-instructions.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clients: [] as any[],
+  instructions: undefined as string | undefined,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
+    this.info = info;
+    this.options = options;
+    this.setRequestHandler = vi.fn();
+    this.setNotificationHandler = vi.fn();
+    this.connect = vi.fn(async () => undefined);
+    this.listTools = vi.fn(async () => ({ tools: [] }));
+    this.listResources = vi.fn(async () => ({ resources: [] }));
+    this.getInstructions = vi.fn(() => mocks.instructions);
+    this.close = vi.fn(async () => undefined);
+    mocks.clients.push(this);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
+    this.options = options;
+    this.close = vi.fn(async () => undefined);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
+describe("McpServerManager instructions", () => {
+  beforeEach(() => {
+    mocks.clients.length = 0;
+    mocks.instructions = undefined;
+  });
+
+  it("captures server instructions from the initialize result at connect time", async () => {
+    mocks.instructions = "Use read_skill to load a skill before answering.";
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    expect(connection.instructions).toBe("Use read_skill to load a skill before answering.");
+  });
+
+  it("leaves instructions undefined when the server provides none", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    expect(connection.instructions).toBeUndefined();
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -112,6 +112,11 @@ export async function reconnectServers(
 
       const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
       state.toolMetadata.set(name, metadata);
+      if (connection.instructions) {
+        state.serverInstructions.set(name, connection.instructions);
+      } else {
+        state.serverInstructions.delete(name);
+      }
       updateMetadataCache(state, name);
       state.failureTracker.delete(name);
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -13,9 +13,10 @@ import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage } from "./utils.ts";
+import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
+const INSTRUCTIONS_SNIPPET_LENGTH = 150;
 
 type DirectAutoAuthResult =
   | { status: "skipped" }
@@ -250,17 +251,29 @@ export function buildProxyDescription(
     desc += `\nServers: ${serverSummaries.join(", ")}\n`;
   }
 
+  const instructionSummaries: string[] = [];
+  for (const serverName of Object.keys(config.mcpServers)) {
+    const instructions = cache?.servers?.[serverName]?.instructions;
+    if (!instructions) continue;
+    const snippet = truncateAtWord(instructions.replace(/\s+/g, " ").trim(), INSTRUCTIONS_SNIPPET_LENGTH);
+    instructionSummaries.push(`  ${serverName}: ${snippet}`);
+  }
+  if (instructionSummaries.length > 0) {
+    desc += `\nServer instructions (truncated - full text via mcp({ instructions: "name" })):\n${instructionSummaries.join("\n")}\n`;
+  }
+
   desc += `\nUsage:\n`;
   desc += `  mcp({ })                              → Show server status\n`;
   desc += `  mcp({ server: "name" })               → List tools from server\n`;
   desc += `  mcp({ search: "query" })              → Search MCP tools by name/description\n`;
   desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`;
+  desc += `  mcp({ instructions: "name" })         → Show full server usage instructions\n`;
   desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`;
   desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`;
   desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`;
   desc += `  mcp({ action: "auth-start", server: "name" })      → Start manual OAuth and get a browser URL\n`;
   desc += `  mcp({ action: "auth-complete", server: "name", args: '{"redirectUrl":"..."}' }) → Complete manual OAuth\n`;
-  desc += `\nMode: action > tool (call) > connect > describe > search > server (list) > nothing (status)`;
+  desc += `\nMode: action > tool (call) > connect > describe > instructions > search > server (list) > nothing (status)`;
 
   return desc;
 }

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { loadMcpConfig } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
-import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
+import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
@@ -263,6 +263,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         args: Type.Optional(Type.String({ description: "Arguments as JSON string (e.g., '{\"key\": \"value\"}')" })),
         connect: Type.Optional(Type.String({ description: "Server name to connect (lazy connect + metadata refresh)" })),
         describe: Type.Optional(Type.String({ description: "Tool name to describe (shows parameters)" })),
+        instructions: Type.Optional(Type.String({ description: "Server name to show that server's usage instructions" })),
         search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
         regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
@@ -275,6 +276,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         args?: string;
         connect?: string;
         describe?: string;
+        instructions?: string;
         search?: string;
         regex?: boolean;
         includeSchemas?: boolean;
@@ -351,6 +353,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         }
         if (params.describe) {
           return executeDescribe(state, params.describe);
+        }
+        if (params.instructions) {
+          return executeInstructions(state, params.instructions);
         }
         if (params.search) {
           return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas);

--- a/init.ts
+++ b/init.ts
@@ -58,6 +58,7 @@ export async function initializeMcp(
   }
   const lifecycle = new McpLifecycleManager(manager);
   const toolMetadata = new Map<string, ToolMetadata[]>();
+  const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
   const uiResourceHandler = new UiResourceHandler(manager);
   const consentManager = new ConsentManager("once-per-server");
@@ -66,6 +67,7 @@ export async function initializeMcp(
     manager,
     lifecycle,
     toolMetadata,
+    serverInstructions,
     config,
     failureTracker,
     uiResourceHandler,
@@ -112,9 +114,13 @@ export async function initializeMcp(
       lifecycle.markKeepAlive(name, definition);
     }
 
-    if (cache?.servers?.[name] && isServerCacheValid(cache.servers[name], definition)) {
-      const metadata = reconstructToolMetadata(name, cache.servers[name], prefix, definition);
+    const cachedEntry = cache?.servers?.[name];
+    if (cachedEntry && isServerCacheValid(cachedEntry, definition)) {
+      const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition);
       toolMetadata.set(name, metadata);
+      if (cachedEntry.instructions) {
+        serverInstructions.set(name, cachedEntry.instructions);
+      }
     }
   }
 
@@ -153,6 +159,11 @@ export async function initializeMcp(
 
     const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
     toolMetadata.set(name, metadata);
+    if (connection.instructions) {
+      serverInstructions.set(name, connection.instructions);
+    } else {
+      serverInstructions.delete(name);
+    }
     updateMetadataCache(state, name);
 
     if (failedTools.length > 0 && ctx.hasUI) {
@@ -189,8 +200,7 @@ export async function initializeMcp(
             if (connection.status === "needs-auth") {
               return { name, ok: false };
             }
-            const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
-            toolMetadata.set(name, metadata);
+            updateServerMetadata(state, name);
             updateMetadataCache(state, name);
             return { name, ok: true };
           } catch (error) {
@@ -236,6 +246,11 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
 
   const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
   state.toolMetadata.set(serverName, metadata);
+  if (connection.instructions) {
+    state.serverInstructions.set(serverName, connection.instructions);
+  } else {
+    state.serverInstructions.delete(serverName);
+  }
 }
 
 export function updateMetadataCache(state: McpExtensionState, serverName: string): void {
@@ -265,6 +280,7 @@ export function updateMetadataCache(state: McpExtensionState, serverName: string
     configHash,
     tools,
     resources,
+    instructions: connection.instructions,
     cachedAt: Date.now(),
   };
 

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -30,6 +30,7 @@ export interface ServerCacheEntry {
   configHash: string;
   tools: CachedTool[];
   resources: CachedResource[];
+  instructions?: string;
   cachedAt: number;
 }
 

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -16,6 +16,7 @@ import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from ".
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
 const MAX_REGEX_SEARCH_QUERY_LENGTH = 256;
+const INSTRUCTIONS_PREVIEW_LENGTH = 300;
 const REGEX_SAFETY_CHECK_PARAMS = {
   attackTimeout: 50,
   incubationTimeout: 50,
@@ -519,9 +520,48 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
     text += "\n";
   }
 
+  const instructions = state.serverInstructions.get(server);
+  if (instructions) {
+    const preview = truncateAtWord(instructions, INSTRUCTIONS_PREVIEW_LENGTH);
+    text += `\nServer instructions:\n${preview}\n`;
+    if (preview !== instructions) {
+      text += `Use mcp({ instructions: "${server}" }) for the full text.\n`;
+    }
+  }
+
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "list", server, tools: toolNames, count: toolNames.length },
+    details: { mode: "list", server, tools: toolNames, count: toolNames.length, hasInstructions: Boolean(instructions) },
+  };
+}
+
+export function executeInstructions(state: McpExtensionState, server: string): ProxyToolResult {
+  if (!state.config.mcpServers[server]) {
+    return {
+      content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "instructions", server, error: "not_found" },
+    };
+  }
+
+  const instructions = state.serverInstructions.get(server);
+  if (instructions) {
+    return {
+      content: [{ type: "text" as const, text: `${server} instructions:\n\n${instructions}` }],
+      details: { mode: "instructions", server, length: instructions.length },
+    };
+  }
+
+  const connection = state.manager.getConnection(server);
+  if (connection?.status === "connected") {
+    return {
+      content: [{ type: "text" as const, text: `Server "${server}" does not provide instructions.` }],
+      details: { mode: "instructions", server, error: "no_instructions" },
+    };
+  }
+
+  return {
+    content: [{ type: "text" as const, text: `No instructions cached for "${server}". Use mcp({ connect: "${server}" }) to connect and refresh.` }],
+    details: { mode: "instructions", server, error: "not_connected" },
   };
 }
 
@@ -563,6 +603,11 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     const prefix = state.config.settings?.toolPrefix ?? "server";
     const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
     state.toolMetadata.set(serverName, metadata);
+    if (connection.instructions) {
+      state.serverInstructions.set(serverName, connection.instructions);
+    } else {
+      state.serverInstructions.delete(serverName);
+    }
     updateMetadataCache(state, serverName);
     state.failureTracker.delete(serverName);
     updateStatusBar(state);

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -482,23 +482,32 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
   const metadata = state.toolMetadata.get(server);
   const toolNames = metadata?.map(m => m.name) ?? [];
   const connection = state.manager.getConnection(server);
+  const instructions = state.serverInstructions.get(server);
+  let instructionsText = "";
+  if (instructions) {
+    const preview = truncateAtWord(instructions, INSTRUCTIONS_PREVIEW_LENGTH);
+    instructionsText = `\n\nServer instructions:\n${preview}`;
+    if (preview !== instructions) {
+      instructionsText += `\nUse mcp({ instructions: "${server}" }) for the full text.`;
+    }
+  }
 
   if (toolNames.length === 0) {
     if (connection?.status === "connected") {
       return {
-        content: [{ type: "text" as const, text: `Server "${server}" has no tools.` }],
-        details: { mode: "list", server, tools: [], count: 0 },
+        content: [{ type: "text" as const, text: `Server "${server}" has no tools.${instructionsText}` }],
+        details: { mode: "list", server, tools: [], count: 0, hasInstructions: Boolean(instructions) },
       };
     }
     if (metadata !== undefined) {
       return {
-        content: [{ type: "text" as const, text: `Server "${server}" has no cached tools (not connected).` }],
-        details: { mode: "list", server, tools: [], count: 0, cached: true },
+        content: [{ type: "text" as const, text: `Server "${server}" has no cached tools (not connected).${instructionsText}` }],
+        details: { mode: "list", server, tools: [], count: 0, cached: true, hasInstructions: Boolean(instructions) },
       };
     }
     return {
-      content: [{ type: "text" as const, text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.` }],
-      details: { mode: "list", server, tools: [], count: 0, error: "not_connected" },
+      content: [{ type: "text" as const, text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.${instructionsText}` }],
+      details: { mode: "list", server, tools: [], count: 0, error: "not_connected", hasInstructions: Boolean(instructions) },
     };
   }
 
@@ -520,14 +529,7 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
     text += "\n";
   }
 
-  const instructions = state.serverInstructions.get(server);
-  if (instructions) {
-    const preview = truncateAtWord(instructions, INSTRUCTIONS_PREVIEW_LENGTH);
-    text += `\nServer instructions:\n${preview}\n`;
-    if (preview !== instructions) {
-      text += `Use mcp({ instructions: "${server}" }) for the full text.\n`;
-    }
-  }
+  text += instructionsText;
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -36,6 +36,7 @@ interface ServerConnection {
   definition: ServerDefinition;
   tools: McpTool[];
   resources: McpResource[];
+  instructions?: string;
   lastUsedAt: number;
   inFlight: number;
   status: "connected" | "closed" | "needs-auth";
@@ -176,6 +177,7 @@ export class McpServerManager {
         definition,
         tools,
         resources,
+        instructions: client.getInstructions?.(),
         lastUsedAt: Date.now(),
         inFlight: 0,
         status: "connected",

--- a/state.ts
+++ b/state.ts
@@ -29,6 +29,7 @@ export interface McpExtensionState {
   manager: McpServerManager;
   lifecycle: McpLifecycleManager;
   toolMetadata: Map<string, ToolMetadata[]>;
+  serverInstructions: Map<string, string>;
   config: McpConfig;
   failureTracker: Map<string, number>;
   uiResourceHandler: UiResourceHandler;


### PR DESCRIPTION
Fixes #188

The MCP spec lets a server return an instructions field in its initialize result, which the TS SDK exposes as client.getInstructions(). Currently the adapter never reads it, so the field is silently dropped. This PR captures instructions at connect time and caches them in mcp-cache.json next to tool metadata, so they survive lazy disconnects and are available without a live connection. Following the adapter's existing pattern of auto-surfacing truncated cached metadata, they show up at three levels: a truncated head per server in the `mcp` tool description (150 chars, whitespace-collapsed, ~40 tokens, only for servers that provide instructions), a longer 300-char preview at the end of `mcp({ server: "name" })` listings, and a new `mcp({ instructions: "name" })` mode that returns the full text.

State syncs wherever tool metadata is already refreshed (startup, lazy connect, `mcp({ connect })`, `/mcp reconnect`), including clearing stale instructions when a server stops providing them. Like the existing tool-count summaries, the description head appears once a server has connected at least once.

The tool description gets this new section, and its usage list and mode precedence line now document the new mode:

```
Server instructions (truncated - full text via mcp({ instructions: "name" })):
  skills-server: This server exposes a catalog of agent skills. Load a skill before acting on a related task. Available skills: - code-review: Review a diff for...
```

`mcp({ instructions: "skills-server" })` returns the full untruncated text.

Tests cover capture at connect time, the cache round-trip, the listing preview, all instructions-mode outcomes, and the description snippet. Three existing fixtures gained a one-line serverInstructions map for the new state field. npx tsc --noEmit is clean and the full suite passes.