### PR TITLE
Sanitize tool names with dots before format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.
 
 ### Fixed
+- Sanitized dotted MCP tool names before registering them with Pi. Thanks @benjaminrickels for PR #190.
 - Reconnected OAuth MCP servers automatically after successful panel or `/mcp-auth` authorization, and made panel reconnect force a fresh connection like `/mcp reconnect`. Thanks @mightymatth for issue #171.
 - Recovered stale Streamable HTTP MCP sessions that report `-32000 Server not initialized` after a server restart. Thanks @vicary for issue #184.
 - Kept npm cache lookups working on Windows by resolving `npm` through `cross-spawn`. Thanks @zeyadhost for PR #201.

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildToolMetadata } from "../tool-metadata.ts";
 
 const mocks = vi.hoisted(() => ({
   lazyConnect: vi.fn(),
@@ -69,14 +70,23 @@ describe("direct tools auto auth", () => {
       completedUiSessions: [],
     } as any;
 
+    const { metadata } = buildToolMetadata(
+      [{ name: "namespace.tool", description: "Namespaced tool" }] as any,
+      [],
+      state.config.mcpServers.demo,
+      "demo",
+      "server",
+    );
+    const [tool] = metadata;
+
     const executor = createDirectToolExecutor(
       () => state,
       () => null,
       {
         serverName: "demo",
-        originalName: "search",
-        prefixedName: "demo_search",
-        description: "Search",
+        originalName: tool.originalName,
+        prefixedName: tool.name,
+        description: tool.description,
       },
     );
 
@@ -92,7 +102,7 @@ describe("direct tools auto auth", () => {
     expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
     expect(connected.client.callTool).toHaveBeenCalledWith(
       {
-        name: "search",
+        name: "namespace.tool",
         arguments: { q: "hello" },
         _meta: undefined,
       },

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { buildProxyDescription, resolveDirectTools } from "../direct-tools.ts";
 import { computeServerHash, isServerCacheValid, type MetadataCache } from "../metadata-cache.ts";
 import { buildToolMetadata } from "../tool-metadata.ts";
+import { formatToolName } from "../types.ts";
 import type { McpConfig } from "../types.ts";
 import { reconstructToolMetadata } from "../metadata-cache.ts";
 
@@ -23,6 +24,14 @@ afterEach(() => {
       process.env[key] = value;
     }
   }
+});
+
+describe("formatToolName", () => {
+  it("sanitizes dotted MCP tool names for every prefix mode", () => {
+    expect(formatToolName("namespace.tool", "demo", "server")).toBe("demo_namespace_tool");
+    expect(formatToolName("namespace.tool", "demo-mcp", "short")).toBe("demo_namespace_tool");
+    expect(formatToolName("namespace.tool", "demo", "none")).toBe("namespace_tool");
+  });
 });
 
 describe("buildProxyDescription", () => {
@@ -337,6 +346,23 @@ describe("excludeTools filtering", () => {
     );
 
     expect(reconstructed.map((tool) => tool.name)).toEqual(["figma_get_nodes"]);
+  });
+
+  it("sanitizes registered names while preserving raw MCP names", () => {
+    const { metadata } = buildToolMetadata(
+      [{ name: "namespace.tool", description: "Namespaced tool" }] as any,
+      [],
+      { command: "npx", args: ["-y", "demo"] },
+      "demo",
+      "server",
+    );
+
+    expect(metadata).toEqual([
+      expect.objectContaining({
+        name: "demo_namespace_tool",
+        originalName: "namespace.tool",
+      }),
+    ]);
   });
 
   it("filters excluded tools during direct tool registration from cache", () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -365,6 +365,48 @@ describe("excludeTools filtering", () => {
     ]);
   });
 
+  it("keeps the first raw tool when sanitized live metadata names collide", () => {
+    const { metadata } = buildToolMetadata(
+      [
+        { name: "namespace.tool", description: "Dotted" },
+        { name: "namespace_tool", description: "Underscored" },
+        { name: "get_namespace.tool", description: "Tool before colliding resource" },
+      ] as any,
+      [{ name: "namespace.tool", uri: "ui://namespace.tool", description: "Resource" }] as any,
+      { command: "npx", args: ["-y", "demo"] },
+      "demo",
+      "server",
+    );
+
+    expect(metadata.map((tool) => [tool.name, tool.originalName, tool.description])).toEqual([
+      ["demo_namespace_tool", "namespace.tool", "Dotted"],
+      ["demo_get_namespace_tool", "get_namespace.tool", "Tool before colliding resource"],
+    ]);
+  });
+
+  it("keeps the first raw tool when sanitized cached metadata names collide", () => {
+    const reconstructed = reconstructToolMetadata(
+      "demo",
+      {
+        configHash: "hash",
+        cachedAt: Date.now(),
+        tools: [
+          { name: "namespace.tool", description: "Dotted" },
+          { name: "namespace_tool", description: "Underscored" },
+          { name: "get_namespace.tool", description: "Tool before colliding resource" },
+        ],
+        resources: [{ name: "namespace.tool", uri: "ui://namespace.tool", description: "Resource" }],
+      },
+      "server",
+      { command: "npx", args: ["-y", "demo"] },
+    );
+
+    expect(reconstructed.map((tool) => [tool.name, tool.originalName, tool.description])).toEqual([
+      ["demo_namespace_tool", "namespace.tool", "Dotted"],
+      ["demo_get_namespace_tool", "get_namespace.tool", "Tool before colliding resource"],
+    ]);
+  });
+
   it("filters excluded tools during direct tool registration from cache", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "server" },

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -133,6 +133,7 @@ export function reconstructToolMetadata(
   definition: Pick<ServerEntry, "exposeResources" | "excludeTools">
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
+  const seenNames = new Set<string>();
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
@@ -140,8 +141,14 @@ export function reconstructToolMetadata(
       continue;
     }
 
+    const name = formatToolName(tool.name, serverName, prefix);
+    if (seenNames.has(name)) {
+      continue;
+    }
+    seenNames.add(name);
+
     metadata.push({
-      name: formatToolName(tool.name, serverName, prefix),
+      name,
       originalName: tool.name,
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
@@ -158,8 +165,14 @@ export function reconstructToolMetadata(
         continue;
       }
 
+      const name = formatToolName(baseName, serverName, prefix);
+      if (seenNames.has(name)) {
+        continue;
+      }
+      seenNames.add(name);
+
       metadata.push({
-        name: formatToolName(baseName, serverName, prefix),
+        name,
         originalName: baseName,
         description: resource.description ?? `Read resource: ${resource.uri}`,
         resourceUri: resource.uri,

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -14,6 +14,7 @@ export function buildToolMetadata(
 ): { metadata: ToolMetadata[]; failedTools: string[] } {
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
+  const seenNames = new Set<string>();
 
   for (const tool of tools) {
     if (!tool?.name) {
@@ -24,6 +25,12 @@ export function buildToolMetadata(
       continue;
     }
 
+    const name = formatToolName(tool.name, serverName, prefix);
+    if (seenNames.has(name)) {
+      continue;
+    }
+    seenNames.add(name);
+
     let uiResourceUri: string | undefined;
     try {
       uiResourceUri = getToolUiResourceUri({ _meta: tool._meta });
@@ -31,7 +38,7 @@ export function buildToolMetadata(
       failedTools.push(tool.name);
     }
     metadata.push({
-      name: formatToolName(tool.name, serverName, prefix),
+      name,
       originalName: tool.name,
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
@@ -47,8 +54,14 @@ export function buildToolMetadata(
         continue;
       }
 
+      const name = formatToolName(baseName, serverName, prefix);
+      if (seenNames.has(name)) {
+        continue;
+      }
+      seenNames.add(name);
+
       metadata.push({
-        name: formatToolName(baseName, serverName, prefix),
+        name,
         originalName: baseName,
         description: resource.description ?? `Read resource: ${resource.uri}`,
         resourceUri: resource.uri,

--- a/types.ts
+++ b/types.ts
@@ -443,7 +443,8 @@ export function formatToolName(
   prefix: "server" | "none" | "short"
 ): string {
   const p = getServerPrefix(serverName, prefix);
-  return p ? `${p}_${toolName}` : toolName;
+  const sanitized = toolName.replace(/\./g, "_");
+  return p ? `${p}_${sanitized}` : sanitized;
 }
 
 function normalizeToolName(value: string): string {


### PR DESCRIPTION
Some LLMs (looking at you Anthropic) cannot deal with tool names containing dots. So sanitize these tool names by replacing `.` with `_` before assembling the final name.

Ran into the following issue when using an MCP server with `namespace.tool_name` tools and Anthropic models (Opus 4.8, Sonnet 4.6):

`Error: 400 {"errorMessage":"{\"message\":\"tools.295.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'\"}\n","errorCode":"UPSTREAM_LLM_ERROR","date":"2026-07-17T08:44:01.825475829Z","statusCode":400,"errorArgs":{"provider":"anthropic"}}`

Not sure if this is the proper fix, but it worked as a bandaid for me. Just changed `formatToolName()` and left `normalizeToolName()` alone, unsure if that also needs adjusting.