### PR TITLE
feat: add programmatic MCP source lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 .pi/
 *.log
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a documented `pi-mcp-adapter/programmatic` package API for isolated, session-scoped MCP sources with initial registration, local validation, exact replacement/removal, redacted inspection, cancellation, late launch values, and explicit capability reporting. Existing CLI and file-based extension behavior remain the default.
+
 ## [2.11.0] - 2026-07-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -86,6 +86,85 @@ Note: `args` is a JSON string, not an object.
 
 Two calls instead of 26 tools cluttering the context.
 
+## Programmatic SDK usage
+
+SDK hosts and Pi extensions can contribute isolated, session-scoped MCP sources
+without creating config files or changing process arguments:
+
+```ts
+import { createMcpAdapter } from "pi-mcp-adapter/programmatic";
+
+const adapter = createMcpAdapter({
+  fileDiscovery: "disabled",
+  initialSources: [{
+    source: {
+      identity: {
+        id: "com.example.audit:session-123",
+        revision: "request-456",
+      },
+      servers: {
+        audit: {
+          transport: "streamable-http",
+          requestTimeoutMs: 30_000,
+        },
+      },
+    },
+    launchValues: {
+      // Called only when the server is about to connect. Return a fresh object.
+      resolve: async (_request, signal) => getSessionConnection(signal),
+      // Called after every connection attempt, including failure/cancellation.
+      dispose: async (values) => disposeSessionConnection(values),
+    },
+  }],
+});
+
+// Pass adapter.extension to the SDK's extensionFactories (or invoke it like any
+// other Pi extension). Lifecycle/status operations are available on runtime.
+await adapter.runtime.inspectSources(new AbortController().signal);
+```
+
+See [`examples/programmatic-source.ts`](examples/programmatic-source.ts) for a
+complete typed factory.
+
+### Why sources instead of a config overlay?
+
+A single in-memory config object solves file avoidance, but not coexistence or
+ownership when several extensions contribute servers. A source has a stable
+caller-owned `id`, an opaque `revision`, and source-local server keys. The
+runtime uses those values to provide:
+
+- initial registration before any Pi tool is registered;
+- exact compare-and-replace, so stale callers cannot overwrite a newer revision;
+- exact, idempotent removal that cannot remove another source;
+- source-qualified process/tool identity even when server names collide;
+- local, redacted inspection separate from remote connection health;
+- cancellable operations and callback-scoped launch values that are never kept
+  in source definitions, status, metadata, or diagnostics.
+
+`fileDiscovery: "disabled"` is the isolated composition mode. It does not invoke
+the default file extension, load MCP files/imports, or read the shared metadata
+cache. It registers one `mcp` gateway for the supplied sources. The default is
+`"enabled"`: existing CLI, file discovery, commands, direct tools, and cache
+behavior stay unchanged, with programmatic sources available through a separate
+`mcp_sources` gateway.
+
+The returned `runtime` documents the complete lifecycle boundary:
+
+| Method | Purpose |
+|--------|---------|
+| `capabilities(signal)` | Report explicit environment-aware lifecycle, transport, OAuth, and feature facts. |
+| `validateSource(source, signal)` | Validate and copy a complete secret-free source without connecting. |
+| `replaceSource(request, signal)` | Atomically add or replace one source under an absent/exact precondition. |
+| `removeSource(identity, signal)` | Remove only the exact current identity and drain active work first. |
+| `inspectSource(identity, signal)` | Inspect one exact local source without definitions, launch values, or native causes. |
+| `inspectSources(signal)` | Inspect all local sources in deterministic source/server order. |
+
+`runtimeLeases` are optional on initial/replacement sources. Hosts that manage
+external launch authority can provide `acquire`, `release`, and `drain` hooks;
+simple extensions can omit them. Programmatic Streamable HTTP is exact and does
+not silently fall back to legacy SSE. Check `capabilities()` rather than
+assuming parity with every file-config feature.
+
 ## Config
 
 ### File Layout

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -5,10 +5,35 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8")) as {
+  name?: string;
+  version?: string;
   files?: string[];
+  exports?: Record<string, unknown>;
+  bin?: Record<string, string>;
+  pi?: { extensions?: string[] };
 };
 
 describe("package.json files", () => {
+  it("preserves the package, CLI, and default Pi extension entry", () => {
+    expect(packageJson.name).toBe("pi-mcp-adapter");
+    expect(packageJson.version).toBe("2.11.0");
+    expect(packageJson.bin).toEqual({ "pi-mcp-adapter": "cli.js" });
+    expect(packageJson.pi?.extensions).toEqual(["./index.ts"]);
+  });
+
+  it("exports the compiled extension and programmatic lifecycle", () => {
+    expect(packageJson.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+      "./programmatic": {
+        types: "./dist/programmatic.d.ts",
+        import: "./dist/programmatic.js",
+      },
+    });
+  });
+
   it("publishes every root runtime TypeScript module", () => {
     const publishedFiles = new Set(packageJson.files ?? []);
     const runtimeModules = readdirSync(repoRoot)

--- a/__tests__/packed-package.ts
+++ b/__tests__/packed-package.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const workspace = mkdtempSync(join(tmpdir(), "pi-mcp-adapter-pack-"));
+
+try {
+  const packOutput = execFileSync("npm", ["pack", "--json", "--pack-destination", workspace], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  const packed = JSON.parse(packOutput) as Array<{
+    filename: string;
+    files: Array<{ path: string }>;
+  }>;
+  assert.equal(packed.length, 1);
+  const receipt = packed[0]!;
+  const paths = new Set(receipt.files.map((file) => file.path));
+  for (const required of [
+    "LICENSE",
+    "README.md",
+    "cli.js",
+    "index.ts",
+    "programmatic.ts",
+    "programmatic-types.ts",
+    "examples/programmatic-source.ts",
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/programmatic.js",
+    "dist/programmatic.d.ts",
+  ]) {
+    assert(paths.has(required), `packed package is missing ${required}`);
+  }
+  assert(!paths.has("server-manager.test.ts"));
+
+  execFileSync("npm", ["init", "-y"], { cwd: workspace, stdio: "ignore" });
+  const tarball = join(workspace, receipt.filename);
+  execFileSync("npm", ["install", "--ignore-scripts", tarball], {
+    cwd: workspace,
+    stdio: "pipe",
+  });
+
+  const importReceipt = execFileSync(process.execPath, [
+    "--input-type=module",
+    "-e",
+    `
+      const extension = await import('pi-mcp-adapter');
+      const api = await import('pi-mcp-adapter/programmatic');
+      if (typeof extension.default !== 'function') throw new Error('missing extension export');
+      if (typeof api.createMcpAdapter !== 'function') throw new Error('missing programmatic export');
+      const adapter = api.createMcpAdapter({ fileDiscovery: 'disabled' });
+      if (typeof adapter.extension !== 'function' || typeof adapter.runtime.inspectSources !== 'function') {
+        throw new Error('invalid programmatic factory');
+      }
+      let managerPrivate = false;
+      try { await import('pi-mcp-adapter/server-manager'); }
+      catch (error) { managerPrivate = error?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'; }
+      if (!managerPrivate) throw new Error('manager internals are package-exported');
+      console.log(JSON.stringify({ extension: true, programmatic: true, managerPrivate }));
+    `,
+  ], { cwd: workspace, encoding: "utf8" }).trim();
+  assert.deepEqual(JSON.parse(importReceipt), {
+    extension: true,
+    programmatic: true,
+    managerPrivate: true,
+  });
+
+  const cliHelp = execFileSync(join(workspace, "node_modules", ".bin", "pi-mcp-adapter"), ["--help"], {
+    cwd: workspace,
+    encoding: "utf8",
+  });
+  assert.match(cliHelp, /pi-mcp-adapter helper/);
+
+  const installedManifest = JSON.parse(readFileSync(
+    join(workspace, "node_modules", "pi-mcp-adapter", "package.json"),
+    "utf8",
+  ));
+  assert.equal(installedManifest.name, "pi-mcp-adapter");
+  assert.equal(installedManifest.version, "2.11.0");
+  assert.equal(installedManifest.license, "MIT");
+  assert.deepEqual(installedManifest.pi.extensions, ["./index.ts"]);
+  console.log(`packed package qualification passed: ${receipt.filename}`);
+} finally {
+  rmSync(workspace, { recursive: true, force: true });
+}

--- a/__tests__/programmatic-extension.test.ts
+++ b/__tests__/programmatic-extension.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spies = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({ mcpServers: {} })),
+  loadCache: vi.fn(() => null),
+}));
+
+vi.mock("../config.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config.ts")>();
+  return { ...actual, loadMcpConfig: spies.loadConfig };
+});
+
+vi.mock("../metadata-cache.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../metadata-cache.ts")>();
+  return { ...actual, loadMetadataCache: spies.loadCache };
+});
+
+import mcpAdapter from "../index.ts";
+import { createMcpAdapter } from "../programmatic.ts";
+
+function initialSource() {
+  return {
+    source: {
+      identity: { id: "com.example.ordering:workspace", revision: "revision-1" },
+      servers: {
+        qualified: {
+          transport: "stdio" as const,
+          requestTimeoutMs: 500,
+        },
+      },
+    },
+    launchValues: {
+      resolve: vi.fn(async () => ({ transport: "stdio" as const, command: "command", args: [] })),
+      dispose: vi.fn(async () => undefined),
+    },
+  };
+}
+
+function createPi() {
+  const handlers = new Map<string, (...args: any[]) => unknown>();
+  const tools: any[] = [];
+  const api = {
+    registerTool: vi.fn((tool: unknown) => tools.push(tool)),
+    registerFlag: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: (...args: any[]) => unknown) => handlers.set(event, handler)),
+    getAllTools: vi.fn(() => []),
+    sendMessage: vi.fn(),
+  } as any;
+  return { api, handlers, tools };
+}
+
+beforeEach(() => {
+  spies.loadConfig.mockClear();
+  spies.loadCache.mockClear();
+  spies.loadConfig.mockReturnValue({ mcpServers: {} });
+  spies.loadCache.mockReturnValue(null);
+});
+
+describe("programmatic adapter construction", () => {
+  it("installs initial sources before tool registration without file/cache discovery", async () => {
+    const initial = initialSource();
+    const adapter = createMcpAdapter({ fileDiscovery: "disabled", initialSources: [initial] });
+    expect(await adapter.runtime.inspectSources(new AbortController().signal)).toHaveLength(1);
+    expect(initial.launchValues.resolve).not.toHaveBeenCalled();
+
+    const pi = createPi();
+    adapter.extension(pi.api);
+
+    expect(spies.loadConfig).not.toHaveBeenCalled();
+    expect(spies.loadCache).not.toHaveBeenCalled();
+    expect(pi.api.registerTool).toHaveBeenCalledTimes(1);
+    expect(pi.api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));
+  });
+
+  it("uses the isolated source through the Pi gateway after session startup", async () => {
+    const initial = initialSource();
+    const adapter = createMcpAdapter({ fileDiscovery: "disabled", initialSources: [initial] });
+    const pi = createPi();
+    adapter.extension(pi.api);
+
+    await pi.handlers.get("session_start")?.({}, {
+      cwd: process.cwd(),
+      hasUI: false,
+      signal: new AbortController().signal,
+    });
+    const gateway = pi.tools[0];
+    const result = await gateway.execute("call-1", { action: "status" }, new AbortController().signal);
+
+    expect(result.details).toEqual([
+      expect.objectContaining({ identity: initial.source.identity }),
+    ]);
+  });
+
+  it("serializes rapid session starts so an older completion cannot detach the latest session", async () => {
+    const adapter = createMcpAdapter({ fileDiscovery: "disabled" });
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let firstStarted!: () => void;
+    const firstAttached = new Promise<void>((resolve) => { firstStarted = resolve; });
+    let active: string | undefined;
+    const runtime = adapter.runtime as any;
+    runtime.attachSession = vi.fn(async (context: { name: string }) => {
+      if (context.name === "first") {
+        firstStarted();
+        await firstBlocked;
+      }
+      active = context.name;
+    });
+    runtime.detachSession = vi.fn(async () => { active = undefined; });
+
+    const pi = createPi();
+    adapter.extension(pi.api);
+    const first = pi.handlers.get("session_start")?.({}, { name: "first" });
+    await firstAttached;
+    const second = pi.handlers.get("session_start")?.({}, { name: "second" });
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(active).toBe("second");
+    expect(runtime.attachSession).toHaveBeenCalledTimes(2);
+    expect(runtime.detachSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the ordinary default extension behavior unchanged", () => {
+    const direct = createPi();
+    mcpAdapter(direct.api);
+    const directCalls = {
+      config: spies.loadConfig.mock.calls.length,
+      cache: spies.loadCache.mock.calls.length,
+      flags: direct.api.registerFlag.mock.calls,
+      commands: direct.api.registerCommand.mock.calls.map((call: unknown[]) => call[0]),
+      tools: direct.api.registerTool.mock.calls.map((call: any[]) => call[0].name),
+    };
+
+    spies.loadConfig.mockClear();
+    spies.loadCache.mockClear();
+    const composed = createPi();
+    createMcpAdapter({ fileDiscovery: "enabled" }).extension(composed.api);
+
+    expect(spies.loadConfig).toHaveBeenCalledTimes(directCalls.config);
+    expect(spies.loadCache).toHaveBeenCalledTimes(directCalls.cache);
+    expect(composed.api.registerFlag.mock.calls).toEqual(directCalls.flags);
+    expect(composed.api.registerCommand.mock.calls.map((call: unknown[]) => call[0]))
+      .toEqual(directCalls.commands);
+    expect(composed.api.registerTool.mock.calls.map((call: any[]) => call[0].name))
+      .toEqual([...directCalls.tools, "mcp_sources"]);
+  });
+
+  it("rejects malformed initial sources before any Pi tool can be registered", () => {
+    expect(() => createMcpAdapter({
+      fileDiscovery: "disabled",
+      initialSources: [{
+        source: { identity: { id: "", revision: "" }, servers: {} },
+        launchValues: { resolve: vi.fn(), dispose: vi.fn() },
+      } as any],
+    })).toThrow("MCP programmatic runtime operation failed");
+  });
+});

--- a/__tests__/programmatic-runtime.test.ts
+++ b/__tests__/programmatic-runtime.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  McpConfigSource,
+  McpLaunchValueProvider,
+  McpRuntimeLease,
+  McpRuntimeLeaseProvider,
+  McpSourceIdentity,
+} from "../programmatic-types.ts";
+
+const managerMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  close: vi.fn().mockResolvedValue(undefined),
+  closeAll: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../server-manager.ts", () => ({
+  McpServerManager: class {
+    setSamplingConfig() {}
+    setElicitationConfig() {}
+    getConnection() { return undefined; }
+    connect(...args: unknown[]) { return managerMocks.connect(...args); }
+    close(...args: unknown[]) { return managerMocks.close(...args); }
+    closeAll(...args: unknown[]) { return managerMocks.closeAll(...args); }
+  },
+}));
+
+import { ProgrammaticMcpRuntime } from "../programmatic-runtime.ts";
+
+const serverKey = (token: string) => `server-${token}`;
+
+function identity(token: string, id = `example.extension:${token}`): McpSourceIdentity {
+  return { id, revision: `revision-${token}` };
+}
+
+function source(sourceIdentity: McpSourceIdentity, keys = [serverKey("a")]): McpConfigSource {
+  return {
+    identity: sourceIdentity,
+    servers: Object.fromEntries(keys.map((key) => [key, {
+      transport: "stdio" as const,
+      requestTimeoutMs: 500,
+      deniedTools: ["hidden"],
+    }])),
+  };
+}
+
+function providers(options: {
+  values?: Awaited<ReturnType<McpLaunchValueProvider["resolve"]>>;
+  abort?: AbortController;
+  failDrain?: boolean;
+} = {}) {
+  const counters = { resolved: 0, disposed: 0, acquired: 0, released: 0, drained: 0 };
+  const active = new WeakSet<object>();
+  const launchValues: McpLaunchValueProvider = {
+    async resolve() {
+      counters.resolved += 1;
+      options.abort?.abort(new Error("cancelled at launch"));
+      return options.values ?? {
+        transport: "stdio",
+        command: "CANARY_COMMAND",
+        args: ["CANARY_ARG"],
+        env: { TOKEN: "CANARY_SECRET" },
+      };
+    },
+    async dispose() { counters.disposed += 1; },
+  };
+  const runtimeLeases: McpRuntimeLeaseProvider = {
+    async acquire() {
+      counters.acquired += 1;
+      const lease = Object.freeze({}) as McpRuntimeLease;
+      active.add(lease);
+      return lease;
+    },
+    async release(lease) {
+      if (!active.has(lease)) throw new Error("lease ownership mismatch");
+      active.delete(lease);
+      counters.released += 1;
+    },
+    async drain() {
+      counters.drained += 1;
+      if (options.failDrain) throw new Error("drain failed");
+    },
+  };
+  return { counters, launchValues, runtimeLeases };
+}
+
+function runtime() {
+  return new ProgrammaticMcpRuntime({ fileDiscovery: "disabled" });
+}
+
+beforeEach(() => {
+  managerMocks.connect.mockReset();
+  managerMocks.connect.mockResolvedValue({
+    status: "connected",
+    tools: [
+      { name: "echo", description: "Echo" },
+      { name: "hidden", description: "Hidden" },
+    ],
+    resources: [],
+    client: {
+      callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+      readResource: vi.fn(),
+    },
+  });
+  managerMocks.close.mockClear();
+  managerMocks.closeAll.mockClear();
+});
+
+describe("programmatic source lifecycle", () => {
+  it("installs initial sources synchronously and isolates colliding server keys", async () => {
+    const subject = runtime();
+    const first = providers();
+    const second = providers();
+    const firstSource = source(identity("1"));
+    const secondSource = source(identity("2"));
+    subject.installInitialSources([
+      { source: firstSource, ...first },
+      { source: secondSource, ...second },
+    ]);
+
+    const statuses = await subject.inspectSources(new AbortController().signal);
+    expect(statuses.map((status) => status.identity.id)).toEqual([
+      "example.extension:1",
+      "example.extension:2",
+    ]);
+    expect(statuses.every((status) => status.servers[0]?.key === "server-a")).toBe(true);
+    expect(first.counters.resolved).toBe(0);
+    expect(second.counters.resolved).toBe(0);
+  });
+
+  it("validates and copies the complete secret-free source locally", async () => {
+    const subject = runtime();
+    const input = source(identity("1"), ["zulu", "alpha"]);
+    const validated = await subject.validateSource(input, new AbortController().signal);
+    expect(validated).toEqual({ ok: true, value: input, diagnostics: [] });
+    if (!validated.ok) throw new Error("valid source rejected");
+    expect(validated.value).not.toBe(input);
+
+    await expect(subject.validateSource({
+      ...input,
+      servers: {},
+    }, new AbortController().signal)).resolves.toMatchObject({ ok: false });
+  });
+
+  it("uses exact compare-and-replace and preserves the old source when cleanup rejects", async () => {
+    const subject = runtime();
+    const oldProviders = providers({ failDrain: true });
+    const oldIdentity = identity("1", "example.extension:shared");
+    subject.installInitialSources([{ source: source(oldIdentity), ...oldProviders }]);
+
+    const nextIdentity = identity("2", "example.extension:shared");
+    const nextProviders = providers();
+    const rejected = await subject.replaceSource({
+      source: source(nextIdentity),
+      expected: { kind: "exact", identity: oldIdentity },
+      ...nextProviders,
+    }, new AbortController().signal);
+
+    expect(rejected.kind).toBe("rejected");
+    expect(await subject.inspectSource(oldIdentity, new AbortController().signal)).toBeDefined();
+    expect(await subject.inspectSource(nextIdentity, new AbortController().signal)).toBeUndefined();
+  });
+
+  it("removes only the exact current identity", async () => {
+    const subject = runtime();
+    const current = identity("1", "example.extension:shared");
+    const stale = identity("2", "example.extension:shared");
+    subject.installInitialSources([{ source: source(current), ...providers() }]);
+
+    expect(await subject.removeSource(stale, new AbortController().signal)).toEqual({
+      kind: "ownership-mismatch",
+      requestedIdentity: stale,
+      currentIdentity: current,
+    });
+    expect(await subject.removeSource(current, new AbortController().signal)).toEqual({ kind: "removed" });
+    expect(await subject.removeSource(current, new AbortController().signal)).toEqual({ kind: "absent" });
+  });
+
+  it("resolves launch values only at connect, disposes them, and never retains them in inspection", async () => {
+    const subject = runtime();
+    const sourceIdentity = identity("1");
+    const sourceProviders = providers();
+    subject.installInitialSources([{ source: source(sourceIdentity), ...sourceProviders }]);
+    await subject.attachSession({ cwd: process.cwd(), hasUI: false } as any);
+
+    const execution = await subject.openExecution(sourceIdentity, serverKey("a"), new AbortController().signal);
+    expect(sourceProviders.counters).toMatchObject({ resolved: 1, disposed: 1, acquired: 1, released: 0 });
+    expect(managerMocks.connect).toHaveBeenCalledWith(
+      expect.stringMatching(/^programmatic:[0-9a-f]{64}$/),
+      expect.objectContaining({ command: "CANARY_COMMAND", env: { TOKEN: "CANARY_SECRET" } }),
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        allowLegacySseFallback: false,
+        values: "resolved",
+        retainedDefinition: expect.not.objectContaining({ command: "CANARY_COMMAND" }),
+      }),
+    );
+    const statusJson = JSON.stringify(await subject.inspectSources(new AbortController().signal));
+    expect(statusJson).not.toMatch(/CANARY_COMMAND|CANARY_ARG|CANARY_SECRET/);
+
+    await execution.close();
+    expect(sourceProviders.counters.released).toBe(1);
+  });
+
+  it("supports optional runtime leases for simple extensions", async () => {
+    const subject = runtime();
+    const sourceIdentity = identity("1");
+    const sourceProviders = providers();
+    subject.installInitialSources([{
+      source: source(sourceIdentity),
+      launchValues: sourceProviders.launchValues,
+    }]);
+    await subject.attachSession({ cwd: process.cwd(), hasUI: false } as any);
+
+    const execution = await subject.openExecution(sourceIdentity, serverKey("a"), new AbortController().signal);
+    await expect(execution.close()).resolves.toBeUndefined();
+  });
+
+  it("redacts provider failures from errors and status", async () => {
+    const subject = runtime();
+    const sourceIdentity = identity("1");
+    const sourceProviders = providers();
+    sourceProviders.launchValues.resolve = async () => {
+      throw new Error("CANARY_NATIVE_CAUSE");
+    };
+    subject.installInitialSources([{ source: source(sourceIdentity), ...sourceProviders }]);
+    await subject.attachSession({ cwd: process.cwd(), hasUI: false } as any);
+
+    await expect(subject.openExecution(sourceIdentity, serverKey("a"), new AbortController().signal))
+      .rejects.toThrow("MCP programmatic runtime operation failed");
+    const status = JSON.stringify(await subject.inspectSources(new AbortController().signal));
+    expect(status).not.toContain("CANARY_NATIVE_CAUSE");
+    expect(status).toContain("ADAPTER_FAILED");
+    expect(sourceProviders.counters).toMatchObject({ acquired: 1, released: 1, disposed: 0 });
+  });
+
+  it("disposes values and releases authority when cancellation happens after resolve", async () => {
+    const subject = runtime();
+    const controller = new AbortController();
+    const sourceIdentity = identity("1");
+    const sourceProviders = providers({ abort: controller });
+    subject.installInitialSources([{ source: source(sourceIdentity), ...sourceProviders }]);
+    await subject.attachSession({ cwd: process.cwd(), hasUI: false } as any);
+
+    await expect(subject.openExecution(sourceIdentity, serverKey("a"), controller.signal))
+      .rejects.toThrow("cancelled at launch");
+    expect(sourceProviders.counters).toMatchObject({ resolved: 1, disposed: 1, acquired: 1, released: 1 });
+    expect(managerMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe launch values after disposal without reaching the transport", async () => {
+    const subject = runtime();
+    const sourceIdentity = identity("1");
+    const sourceProviders = providers({
+      values: { transport: "stdio", command: "unsafe\0command", args: [] },
+    });
+    subject.installInitialSources([{ source: source(sourceIdentity), ...sourceProviders }]);
+    await subject.attachSession({ cwd: process.cwd(), hasUI: false } as any);
+
+    await expect(subject.openExecution(sourceIdentity, serverKey("a"), new AbortController().signal))
+      .rejects.toThrow("MCP programmatic runtime operation failed");
+    expect(sourceProviders.counters).toMatchObject({ resolved: 1, disposed: 1, acquired: 1, released: 1 });
+    expect(managerMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it("releases a cancelled queue slot without deadlocking later lifecycle work", async () => {
+    const subject = runtime();
+    const oldIdentity = identity("1", "example.extension:shared");
+    const oldProviders = providers();
+    let startDrain!: () => void;
+    const drainStarted = new Promise<void>((resolve) => { startDrain = resolve; });
+    let unblockDrain!: () => void;
+    const drainBlocked = new Promise<void>((resolve) => { unblockDrain = resolve; });
+    oldProviders.runtimeLeases.drain = async () => {
+      startDrain();
+      await drainBlocked;
+    };
+    subject.installInitialSources([{ source: source(oldIdentity), ...oldProviders }]);
+
+    const nextIdentity = identity("2", "example.extension:shared");
+    const nextProviders = providers();
+    const first = subject.replaceSource({
+      source: source(nextIdentity),
+      expected: { kind: "exact", identity: oldIdentity },
+      ...nextProviders,
+    }, new AbortController().signal);
+    await drainStarted;
+
+    const queuedController = new AbortController();
+    const queued = subject.removeSource(nextIdentity, queuedController.signal);
+    const reason = new Error("cancelled while queued");
+    queuedController.abort(reason);
+    await expect(queued).rejects.toBe(reason);
+
+    unblockDrain();
+    expect((await first).kind).toBe("applied");
+    await expect(subject.removeSource(nextIdentity, new AbortController().signal))
+      .resolves.toEqual({ kind: "removed" });
+  });
+
+  it("reports complete explicit capabilities and honors pre-aborted operations", async () => {
+    const subject = runtime();
+    const signal = new AbortController().signal;
+    const capabilities = await subject.capabilities(signal);
+    expect(Object.values(capabilities.sourceLifecycle).every((value) => typeof value === "boolean")).toBe(true);
+    expect(Object.values(capabilities.transports).every((value) => typeof value === "boolean")).toBe(true);
+    expect(Object.values(capabilities.oauth).every((value) => typeof value === "boolean")).toBe(true);
+    expect(Object.values(capabilities.features).every((value) => typeof value === "boolean")).toBe(true);
+    expect(capabilities.transports).toEqual({
+      stdio: true,
+      streamableHttp: true,
+      legacySse: false,
+      websocket: false,
+    });
+    expect(capabilities.features).toMatchObject({ resources: false, directTools: false });
+
+    const controller = new AbortController();
+    const reason = new Error("pre-aborted");
+    controller.abort(reason);
+    await expect(subject.inspectSources(controller.signal)).rejects.toBe(reason);
+  });
+});

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -25,6 +25,8 @@ type HttpTransportMock = {
 const mocks = vi.hoisted(() => ({
   clients: [] as any[],
   httpTransports: [] as HttpTransportMock[],
+  sseTransports: [] as HttpTransportMock[],
+  failStreamableProbe: false,
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
@@ -34,7 +36,11 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
       options,
       setRequestHandler: vi.fn(),
       setNotificationHandler: vi.fn(),
-      connect: vi.fn(async () => undefined),
+      connect: vi.fn(async () => {
+        if ((info as { name?: string })?.name === "pi-mcp-probe" && mocks.failStreamableProbe) {
+          throw new Error("streamable probe failed");
+        }
+      }),
       listTools: vi.fn(async () => ({ tools: [] })),
       listResources: vi.fn(async () => ({ resources: [] })),
       close: vi.fn(async () => undefined),
@@ -57,7 +63,11 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
-  SSEClientTransport: vi.fn(),
+  SSEClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
+    const transport = { url, options, close: vi.fn(async () => undefined) };
+    mocks.sseTransports.push(transport);
+    return transport;
+  }),
 }));
 
 vi.mock("../npx-resolver.ts", () => ({
@@ -73,6 +83,8 @@ describe("McpServerManager HTTP bearer auth", () => {
   beforeEach(() => {
     mocks.clients.length = 0;
     mocks.httpTransports.length = 0;
+    mocks.sseTransports.length = 0;
+    mocks.failStreamableProbe = false;
   });
 
   afterEach(() => {
@@ -173,5 +185,53 @@ describe("McpServerManager HTTP bearer auth", () => {
 
     expect(mocks.clients[1].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
     expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[1], { timeout: 5000 });
+  });
+
+  it("uses callback-resolved HTTP values without consulting process.env", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    process.env.MCP_TEST_BEARER_TOKEN = "PROCESS_GLOBAL_CANARY";
+
+    const manager = new McpServerManager();
+    await manager.connect("qualified-source-server", {
+      url: "https://example.test/mcp",
+      auth: "bearer",
+      bearerToken: "CALLBACK_TOKEN",
+      headers: { "X-Source": "CALLBACK_HEADER" },
+    }, undefined, {
+      values: "resolved",
+      allowLegacySseFallback: false,
+      retainedDefinition: { requestTimeoutMs: 1000 },
+    });
+
+    expect(mocks.httpTransports.at(-1)!.options.requestInit?.headers).toEqual({
+      "X-Source": "CALLBACK_HEADER",
+      Authorization: "Bearer CALLBACK_TOKEN",
+    });
+    expect(JSON.stringify(mocks.httpTransports.at(-1)!.options)).not.toContain("PROCESS_GLOBAL_CANARY");
+  });
+
+  it("does not silently turn exact Streamable HTTP into legacy SSE", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.failStreamableProbe = true;
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("qualified-source-server", {
+      url: "https://example.test/mcp",
+    }, undefined, {
+      values: "resolved",
+      allowLegacySseFallback: false,
+    })).rejects.toThrow("streamable probe failed");
+
+    expect(mocks.sseTransports).toHaveLength(0);
+  });
+
+  it("preserves legacy SSE fallback for ordinary file configuration", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.failStreamableProbe = true;
+
+    const manager = new McpServerManager();
+    await manager.connect("file-server", { url: "https://example.test/mcp" });
+
+    expect(mocks.sseTransports).toHaveLength(1);
   });
 });

--- a/__tests__/server-manager-programmatic-stdio.test.ts
+++ b/__tests__/server-manager-programmatic-stdio.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  stdioOptions: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    setRequestHandler: vi.fn(),
+    setNotificationHandler: vi.fn(),
+    connect: vi.fn(async () => undefined),
+    listTools: vi.fn(async () => ({ tools: [] })),
+    listResources: vi.fn(async () => ({ resources: [] })),
+    close: vi.fn(async () => undefined),
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+    mocks.stdioOptions.push(options);
+    return { close: vi.fn(async () => undefined) };
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
+describe("McpServerManager programmatic stdio values", () => {
+  const previous = process.env.PROGRAMMATIC_PROCESS_CANARY;
+
+  beforeEach(() => {
+    mocks.stdioOptions.length = 0;
+    process.env.PROGRAMMATIC_PROCESS_CANARY = "must-not-be-inherited";
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.PROGRAMMATIC_PROCESS_CANARY;
+    else process.env.PROGRAMMATIC_PROCESS_CANARY = previous;
+  });
+
+  it("launches with only callback-resolved environment and retains only structural policy", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager("/session");
+    const connection = await manager.connect("programmatic:qualified", {
+      command: "/resolved/bin/server",
+      args: ["--resolved"],
+      cwd: "/resolved/cwd",
+      env: { CALLBACK_ONLY: "resolved" },
+    }, undefined, {
+      values: "resolved",
+      retainedDefinition: { requestTimeoutMs: 750 },
+    });
+
+    expect(mocks.stdioOptions).toEqual([{
+      command: "/resolved/bin/server",
+      args: ["--resolved"],
+      cwd: "/resolved/cwd",
+      env: { CALLBACK_ONLY: "resolved" },
+      stderr: "ignore",
+    }]);
+    expect(JSON.stringify(mocks.stdioOptions)).not.toContain("PROGRAMMATIC_PROCESS_CANARY");
+    expect(connection.definition).toEqual({ requestTimeoutMs: 750 });
+  });
+});

--- a/examples/programmatic-source.ts
+++ b/examples/programmatic-source.ts
@@ -1,0 +1,36 @@
+import {
+  createMcpAdapter,
+  type McpLaunchValues,
+} from "pi-mcp-adapter/programmatic";
+
+export interface SessionMcpContext {
+  readonly id: string;
+  readonly revision: string;
+  resolveConnection(signal: AbortSignal): Promise<McpLaunchValues>;
+  disposeConnection(values: McpLaunchValues): void | Promise<void>;
+}
+
+/** Create one isolated adapter instance for an SDK-managed Pi session. */
+export function createSessionMcpAdapter(session: SessionMcpContext) {
+  return createMcpAdapter({
+    fileDiscovery: "disabled",
+    initialSources: [{
+      source: {
+        identity: {
+          id: `com.example.audit:${session.id}`,
+          revision: session.revision,
+        },
+        servers: {
+          audit: {
+            transport: "streamable-http",
+            requestTimeoutMs: 30_000,
+          },
+        },
+      },
+      launchValues: {
+        resolve: (_request, signal) => session.resolveConnection(signal),
+        dispose: (values) => session.disposeConnection(values),
+      },
+    }],
+  });
+}

--- a/package.json
+++ b/package.json
@@ -5,14 +5,29 @@
   "type": "module",
   "license": "MIT",
   "author": "Nico Bailon",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./programmatic": {
+      "types": "./dist/programmatic.d.ts",
+      "import": "./dist/programmatic.js"
+    }
+  },
   "bin": {
     "pi-mcp-adapter": "cli.js"
   },
   "scripts": {
+    "clean:dist": "node -e \"import('node:fs/promises').then(fs => fs.rm('dist', { recursive: true, force: true }))\"",
+    "build": "npm run clean:dist && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:oauth-provider": "node --import tsx --test mcp-oauth-provider.test.ts"
+    "test:package": "node --import tsx __tests__/packed-package.ts",
+    "test:oauth-provider": "node --import tsx --test mcp-oauth-provider.test.ts",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -39,6 +54,10 @@
     "cli.js",
     "agent-dir.ts",
     "index.ts",
+    "programmatic.ts",
+    "programmatic-types.ts",
+    "programmatic-runtime.ts",
+    "programmatic-extension.ts",
     "error-signal.ts",
     "state.ts",
     "utils.ts",
@@ -79,6 +98,8 @@
     "logger.ts",
     "errors.ts",
     "app-bridge.bundle.js",
+    "dist",
+    "examples/programmatic-source.ts",
     "banner.png",
     "README.md",
     "CHANGELOG.md",

--- a/programmatic-extension.ts
+++ b/programmatic-extension.ts
@@ -1,0 +1,121 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { McpSourceIdentity } from "./programmatic-types.ts";
+import { ProgrammaticMcpRuntime } from "./programmatic-runtime.ts";
+
+function textResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: typeof value === "string" ? value : JSON.stringify(value, null, 2) }],
+    details: value,
+  };
+}
+
+function safeFailure(error: unknown, signal?: AbortSignal) {
+  const code = signal?.aborted
+    ? "MCP_LAUNCH_CANCELLED"
+    : error !== null && typeof error === "object" && "code" in error && typeof error.code === "string"
+      ? error.code
+      : "ADAPTER_FAILED";
+  return {
+    content: [{ type: "text" as const, text: "MCP programmatic runtime operation failed" }],
+    details: { error: code },
+  };
+}
+
+function parseIdentity(value: string | undefined): McpSourceIdentity {
+  if (value === undefined) throw new Error("source identity is required");
+  const parsed = JSON.parse(value);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("source identity must be an object");
+  }
+  return parsed as McpSourceIdentity;
+}
+
+/** Register the source-qualified proxy used by programmatic adapter instances. */
+export function registerProgrammaticExtension(
+  pi: ExtensionAPI,
+  runtime: ProgrammaticMcpRuntime,
+  toolName: "mcp" | "mcp_sources",
+): void {
+  let generation = 0;
+  let sessionTail = Promise.resolve();
+
+  function enqueueSession(operation: () => Promise<void>): Promise<void> {
+    const queued = sessionTail.then(operation, operation);
+    sessionTail = queued.catch(() => undefined);
+    return queued;
+  }
+
+  pi.on("session_start", (_event, context) => {
+    const current = ++generation;
+    return enqueueSession(async () => {
+      if (current !== generation) return;
+      await runtime.attachSession(context);
+      if (current !== generation) await runtime.detachSession();
+    });
+  });
+
+  pi.on("session_shutdown", () => {
+    const current = ++generation;
+    return enqueueSession(async () => {
+      if (current === generation) await runtime.detachSession();
+    });
+  });
+
+  (pi.registerTool as (tool: unknown) => unknown)({
+    name: toolName,
+    label: toolName === "mcp" ? "MCP" : "MCP Sources",
+    description: "Source-qualified MCP gateway for programmatic configuration sources",
+    promptSnippet: "MCP gateway for isolated programmatic sources",
+    parameters: Type.Object({
+      action: Type.Optional(Type.Union([
+        Type.Literal("status"),
+        Type.Literal("capabilities"),
+        Type.Literal("list"),
+        Type.Literal("call"),
+      ])),
+      source: Type.Optional(Type.String({
+        description: "Exact McpSourceIdentity encoded as JSON",
+      })),
+      server: Type.Optional(Type.String({ description: "Source-local server key" })),
+      tool: Type.Optional(Type.String({ description: "Native MCP tool name" })),
+      args: Type.Optional(Type.String({ description: "Tool arguments encoded as a JSON object" })),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: {
+        action?: "status" | "capabilities" | "list" | "call";
+        source?: string;
+        server?: string;
+        tool?: string;
+        args?: string;
+      },
+      signal?: AbortSignal,
+    ) {
+      const operationSignal = signal ?? new AbortController().signal;
+      try {
+        operationSignal.throwIfAborted();
+        const action = params.action ?? "status";
+        if (action === "status") return textResult(await runtime.inspectSources(operationSignal));
+        if (action === "capabilities") return textResult(await runtime.capabilities(operationSignal));
+        const identity = parseIdentity(params.source);
+        if (params.server === undefined) throw new Error("server key is required");
+        if (action === "list") {
+          return textResult(await runtime.listTools(identity, params.server, operationSignal));
+        }
+        if (params.tool === undefined) throw new Error("tool name is required");
+        let args: Record<string, unknown> = {};
+        if (params.args !== undefined) {
+          const parsed = JSON.parse(params.args);
+          if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new Error("tool arguments must be an object");
+          }
+          args = parsed as Record<string, unknown>;
+        }
+        return textResult(await runtime.callTool(identity, params.server, params.tool, args, operationSignal));
+      } catch (error) {
+        return safeFailure(error, operationSignal);
+      }
+    },
+  });
+}

--- a/programmatic-runtime.ts
+++ b/programmatic-runtime.ts
@@ -1,0 +1,794 @@
+import { createHash } from "node:crypto";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { McpServerManager } from "./server-manager.ts";
+import type { ServerDefinition } from "./types.ts";
+import type {
+  McpConfigSource,
+  McpDiagnostic,
+  McpInitialSource,
+  McpLaunchValueProvider,
+  McpLaunchValues,
+  McpProgrammaticRuntime,
+  McpRuntimeCapabilities,
+  McpRuntimeLease,
+  McpRuntimeLeaseProvider,
+  McpRuntimeServerBinding,
+  McpSourceIdentity,
+  McpSourceRemoveResult,
+  McpSourceReplaceRequest,
+  McpSourceReplaceResult,
+  McpSourceServer,
+  McpSourceServerStatus,
+  McpSourceStatus,
+  McpSourceValidationResult,
+} from "./programmatic-types.ts";
+
+const INVALID_SOURCE = "SOURCE_INVALID";
+const ADAPTER_FAILED = "ADAPTER_FAILED";
+const CANCELLED = "MCP_LAUNCH_CANCELLED";
+const CLEANUP_FAILED = "MCP_LAUNCH_CLEANUP_FAILED";
+const SOURCE_DIGEST_PREFIX = "mcp-programmatic-source-v1\0";
+
+interface ProgrammaticConnection {
+  client: {
+    callTool(
+      params: { name: string; arguments?: Record<string, unknown> },
+      resultSchema?: unknown,
+      options?: RequestOptions,
+    ): Promise<CallToolResult>;
+  };
+  tools: readonly { name: string; description?: string; inputSchema?: unknown }[];
+  status: "connected" | "closed" | "needs-auth";
+}
+
+type ServerRuntimeStatus = {
+  state: McpSourceServerStatus["state"];
+  toolCount?: number;
+  errorCode?: string;
+};
+
+type ExecutionState = {
+  controller: AbortController;
+  lease: McpRuntimeLease;
+  closed: boolean;
+};
+
+type SourceRecord = {
+  source: McpConfigSource;
+  sourceDigest: string;
+  launchValues: McpLaunchValueProvider;
+  runtimeLeases: McpRuntimeLeaseProvider;
+  serverStatus: Map<string, ServerRuntimeStatus>;
+  executions: Set<ExecutionState>;
+};
+
+export interface ProgrammaticExecution {
+  readonly connection: ProgrammaticConnection;
+  readonly signal: AbortSignal;
+  close(signal?: AbortSignal): Promise<void>;
+}
+
+class ProgrammaticMcpError extends Error {
+  constructor(readonly code: string) {
+    super("MCP programmatic runtime operation failed");
+    this.name = "ProgrammaticMcpError";
+  }
+}
+
+const textEncoder = new TextEncoder();
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function compareUtf8(left: string, right: string): number {
+  const leftBytes = textEncoder.encode(left);
+  const rightBytes = textEncoder.encode(right);
+  const length = Math.min(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = leftBytes[index]! - rightBytes[index]!;
+    if (difference !== 0) return difference;
+  }
+  return leftBytes.length - rightBytes.length;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") {
+    if (hasLoneSurrogate(value)) throw new TypeError("invalid string");
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("invalid number");
+    return JSON.stringify(value);
+  }
+  if (typeof value === "boolean") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value !== "object") throw new TypeError("not JSON");
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort(compareUtf8).map((key) => {
+    if (hasLoneSurrogate(key)) throw new TypeError("invalid key");
+    return `${JSON.stringify(key)}:${canonicalJson(object[key])}`;
+  }).join(",")}}`;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !hasLoneSurrogate(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function identityIsValid(identity: unknown): identity is McpSourceIdentity {
+  return isRecord(identity) && hasOnlyKeys(identity, ["id", "revision"]) &&
+    isNonEmptyString(identity.id) && isNonEmptyString(identity.revision);
+}
+
+function stringListIsValid(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every(isNonEmptyString) &&
+    new Set(value).size === value.length;
+}
+
+function serverIsValid(server: unknown): server is McpSourceServer {
+  return isRecord(server) && hasOnlyKeys(server, [
+    "transport", "requestTimeoutMs", "allowedTools", "deniedTools",
+  ]) && (server.transport === "stdio" || server.transport === "streamable-http") &&
+    (server.requestTimeoutMs === undefined ||
+      typeof server.requestTimeoutMs === "number" && Number.isFinite(server.requestTimeoutMs) &&
+      server.requestTimeoutMs > 0) &&
+    (server.allowedTools === undefined || stringListIsValid(server.allowedTools)) &&
+    (server.deniedTools === undefined || stringListIsValid(server.deniedTools));
+}
+
+function sourceIsValid(source: unknown): source is McpConfigSource {
+  if (!isRecord(source) || !hasOnlyKeys(source, ["identity", "servers"]) ||
+      !identityIsValid(source.identity) || !isRecord(source.servers) ||
+      Object.keys(source.servers).length === 0) return false;
+  return Object.entries(source.servers)
+    .every(([key, server]) => isNonEmptyString(key) && serverIsValid(server));
+}
+
+function sourceDigest(source: McpConfigSource): string {
+  const bytes = `${SOURCE_DIGEST_PREFIX}${canonicalJson(source)}`;
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function launchValuesAreValid(values: unknown, transport: McpSourceServer["transport"]): values is McpLaunchValues {
+  if (!isRecord(values) || values.transport !== transport) return false;
+  if (transport === "stdio") {
+    return hasOnlyKeys(values, ["transport", "command", "args", "cwd", "env"]) &&
+      isNonEmptyString(values.command) && !values.command.includes("\0") && Array.isArray(values.args) &&
+      values.args.every((value) => typeof value === "string" &&
+        !hasLoneSurrogate(value) && !value.includes("\0")) &&
+      (values.cwd === undefined || typeof values.cwd === "string" && !values.cwd.includes("\0")) &&
+      (values.env === undefined || isRecord(values.env) &&
+        Object.entries(values.env).every(([key, value]) =>
+          isNonEmptyString(key) && !/[=\0]/.test(key) && typeof value === "string" &&
+          !hasLoneSurrogate(value) && !value.includes("\0")));
+  }
+  if (!hasOnlyKeys(values, ["transport", "url", "headers", "bearerToken"]) ||
+      !isNonEmptyString(values.url) || /[\u0000-\u001f\u007f]/.test(values.url) ||
+      (values.headers !== undefined && (!isRecord(values.headers) ||
+        Object.entries(values.headers).some(([key, value]) =>
+          !isNonEmptyString(key) || /[\r\n\0]/.test(key) ||
+          typeof value !== "string" || /[\r\n\0]/.test(value)))) ||
+      (values.bearerToken !== undefined &&
+        (typeof values.bearerToken !== "string" || /[\r\n\0]/.test(values.bearerToken)))) return false;
+  try {
+    const url = new URL(values.url);
+    return (url.protocol === "http:" || url.protocol === "https:") &&
+      url.username.length === 0 && url.password.length === 0;
+  } catch {
+    return false;
+  }
+}
+
+function launchProviderIsValid(provider: unknown): provider is McpLaunchValueProvider {
+  return isRecord(provider) && typeof provider.resolve === "function" &&
+    typeof provider.dispose === "function";
+}
+
+function leaseProviderIsValid(provider: unknown): provider is McpRuntimeLeaseProvider {
+  return isRecord(provider) && typeof provider.acquire === "function" &&
+    typeof provider.release === "function" && typeof provider.drain === "function";
+}
+
+const NO_RUNTIME_LEASES: McpRuntimeLeaseProvider = Object.freeze({
+  async acquire() { return Object.freeze({}); },
+  async release() {},
+  async drain() {},
+});
+
+function providersAreValid(request: McpSourceReplaceRequest | McpInitialSource): boolean {
+  return launchProviderIsValid(request.launchValues) &&
+    (request.runtimeLeases === undefined || leaseProviderIsValid(request.runtimeLeases));
+}
+
+function invalidDiagnostic(operation: string, code = INVALID_SOURCE): McpDiagnostic {
+  return {
+    code,
+    severity: "error",
+    operation,
+    message: "MCP source operation was rejected",
+    details: { sourceOperation: operation },
+  };
+}
+
+function ownerKey(identity: McpSourceIdentity): string {
+  return identity.id;
+}
+
+function exactIdentityKey(identity: McpSourceIdentity): string {
+  return canonicalJson(identity);
+}
+
+function qualifiedServerKey(identity: McpSourceIdentity, serverKey: string): string {
+  return `programmatic:${createHash("sha256")
+    .update(`${exactIdentityKey(identity)}\0${serverKey}`)
+    .digest("hex")}`;
+}
+
+function copyIdentity(identity: McpSourceIdentity): McpSourceIdentity {
+  return cloneJson(identity);
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw signal.reason;
+}
+
+function statusFor(record: SourceRecord): McpSourceStatus {
+  return {
+    identity: copyIdentity(record.source.identity),
+    sourceDigest: record.sourceDigest,
+    state: "registered",
+    servers: Object.entries(record.source.servers)
+      .sort(([left], [right]) => compareText(left, right))
+      .map(([key, server]) => {
+        const runtime = record.serverStatus.get(key) ?? { state: "registered" as const };
+        return {
+          key,
+          transport: server.transport,
+          state: runtime.state,
+          ...(runtime.toolCount === undefined ? {} : { toolCount: runtime.toolCount }),
+          ...(runtime.errorCode === undefined ? {} : { errorCode: runtime.errorCode }),
+        };
+      }),
+  };
+}
+
+function serverDefinition(server: McpSourceServer, values: McpLaunchValues): ServerDefinition {
+  const common: ServerDefinition = {
+    requestTimeoutMs: server.requestTimeoutMs,
+    exposeResources: false,
+    excludeTools: [...(server.deniedTools ?? [])],
+    auth: values.transport === "streamable-http" && values.bearerToken !== undefined
+      ? "bearer"
+      : false,
+  };
+  if (values.transport === "stdio") {
+    return {
+      ...common,
+      command: values.command,
+      args: [...values.args],
+      ...(values.cwd === undefined ? {} : { cwd: values.cwd }),
+      ...(values.env === undefined ? {} : { env: { ...values.env } }),
+    };
+  }
+  return {
+    ...common,
+    url: values.url,
+    ...(values.headers === undefined ? {} : { headers: { ...values.headers } }),
+    ...(values.bearerToken === undefined ? {} : { bearerToken: values.bearerToken }),
+  };
+}
+
+function retainedDefinition(server: McpSourceServer): ServerDefinition {
+  return {
+    requestTimeoutMs: server.requestTimeoutMs,
+    exposeResources: false,
+    excludeTools: [...(server.deniedTools ?? [])],
+  };
+}
+
+/**
+ * Source authority used by the public factory and its Pi extension. The class
+ * itself is package-internal; callers receive the narrow lifecycle interface.
+ */
+export class ProgrammaticMcpRuntime implements McpProgrammaticRuntime {
+  private readonly records = new Map<string, SourceRecord>();
+  private manager: McpServerManager | undefined;
+  private context: ExtensionContext | undefined;
+  private operationTail: Promise<void> = Promise.resolve();
+
+  constructor(readonly options: { readonly fileDiscovery: "enabled" | "disabled" }) {
+    // Initial registration is deliberately synchronous. The returned extension
+    // cannot register a tool until every source has been validated and stored.
+  }
+
+  installInitialSources(initialSources: readonly McpInitialSource[]): void {
+    for (const initial of initialSources) {
+      if (!sourceIsValid(initial.source) || !providersAreValid(initial)) {
+        throw new ProgrammaticMcpError(INVALID_SOURCE);
+      }
+      const source = cloneJson(initial.source);
+      const key = ownerKey(source.identity);
+      if (this.records.has(key)) throw new ProgrammaticMcpError(INVALID_SOURCE);
+      this.records.set(key, this.createRecord(source, initial.launchValues, initial.runtimeLeases));
+    }
+  }
+
+  private createRecord(
+    source: McpConfigSource,
+    launchValues: McpLaunchValueProvider,
+    runtimeLeases?: McpRuntimeLeaseProvider,
+  ): SourceRecord {
+    return {
+      source,
+      sourceDigest: sourceDigest(source),
+      launchValues,
+      runtimeLeases: runtimeLeases ?? NO_RUNTIME_LEASES,
+      serverStatus: new Map(Object.keys(source.servers)
+        .map((key) => [key, { state: "registered" as const }])),
+      executions: new Set(),
+    };
+  }
+
+  async attachSession(context: ExtensionContext): Promise<void> {
+    if (this.manager !== undefined) await this.detachSession();
+    this.context = context;
+    const manager = new McpServerManager(context.cwd);
+    manager.setSamplingConfig(context.hasUI ? {
+      autoApprove: false,
+      ui: context.ui,
+      modelRegistry: context.modelRegistry,
+      getCurrentModel: () => context.model,
+      getSignal: () => context.signal,
+    } : undefined);
+    manager.setElicitationConfig(context.hasUI ? {
+      ui: context.ui,
+      allowUrl: context.mode === "tui",
+    } : undefined);
+    this.manager = manager;
+    for (const record of this.records.values()) {
+      for (const key of Object.keys(record.source.servers)) {
+        record.serverStatus.set(key, { state: "registered" });
+      }
+    }
+  }
+
+  async detachSession(): Promise<void> {
+    const manager = this.manager;
+    this.manager = undefined;
+    this.context = undefined;
+    for (const record of this.records.values()) {
+      for (const execution of [...record.executions]) execution.controller.abort(new ProgrammaticMcpError(CANCELLED));
+      await this.closeExecutions(record);
+      for (const key of Object.keys(record.source.servers)) {
+        record.serverStatus.set(key, { state: "registered" });
+      }
+    }
+    if (manager !== undefined) await manager.closeAll();
+  }
+
+  async capabilities(signal: AbortSignal): Promise<McpRuntimeCapabilities> {
+    throwIfAborted(signal);
+    const context = this.context;
+    return {
+      sourceLifecycle: {
+        initialSourcesBeforeToolRegistration: true,
+        isolatedFileDiscovery: true,
+        localValidation: true,
+        atomicReplace: true,
+        exactRemove: true,
+        inspect: true,
+        cancellable: true,
+        lateLaunchValues: true,
+        runtimeLeases: true,
+      },
+      transports: {
+        stdio: true,
+        streamableHttp: true,
+        legacySse: false,
+        websocket: false,
+      },
+      oauth: {
+        authorizationCode: false,
+        clientCredentials: false,
+      },
+      features: {
+        sampling: context?.hasUI === true,
+        elicitationForm: context?.hasUI === true,
+        elicitationUrl: context?.hasUI === true && context.mode === "tui",
+        toolApproval: false,
+        resources: false,
+        directTools: false,
+      },
+    };
+  }
+
+  async validateSource(
+    source: McpConfigSource,
+    signal: AbortSignal,
+  ): Promise<McpSourceValidationResult> {
+    throwIfAborted(signal);
+    if (!sourceIsValid(source)) {
+      return { ok: false, diagnostics: [invalidDiagnostic("validateMcpSource")] };
+    }
+    const copy = cloneJson(source);
+    throwIfAborted(signal);
+    return { ok: true, value: copy, diagnostics: [] };
+  }
+
+  private async exclusive<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> {
+    throwIfAborted(signal);
+    const previous = this.operationTail;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    this.operationTail = previous.catch(() => undefined).then(() => gate);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+        previous.then(
+          () => {
+            signal.removeEventListener("abort", onAbort);
+            resolve();
+          },
+          (error) => {
+            signal.removeEventListener("abort", onAbort);
+            reject(error);
+          },
+        );
+      });
+      throwIfAborted(signal);
+      return await operation();
+    } finally {
+      // An operation cancelled while queued must still release its queue slot.
+      release();
+    }
+  }
+
+  async replaceSource(
+    request: McpSourceReplaceRequest,
+    signal: AbortSignal,
+  ): Promise<McpSourceReplaceResult> {
+    return this.exclusive(signal, async () => {
+      const validation = await this.validateSource(request.source, signal);
+      if (!validation.ok) return { kind: "rejected", diagnostics: validation.diagnostics };
+      const expectedValid = isRecord(request.expected) &&
+        (request.expected.kind === "absent" && hasOnlyKeys(request.expected, ["kind"]) ||
+          request.expected.kind === "exact" && hasOnlyKeys(request.expected, ["kind", "identity"]) &&
+          identityIsValid(request.expected.identity));
+      if (!providersAreValid(request) || !expectedValid) {
+        return { kind: "rejected", diagnostics: [invalidDiagnostic("replaceMcpSource")] };
+      }
+
+      const source = validation.value;
+      const key = ownerKey(source.identity);
+      const previous = this.records.get(key);
+      const expectedMatches = request.expected.kind === "absent"
+        ? previous === undefined
+        : previous !== undefined &&
+          exactIdentityKey(previous.source.identity) === exactIdentityKey(request.expected.identity);
+      if (!expectedMatches) {
+        if (previous !== undefined) {
+          return { kind: "stale", currentIdentity: copyIdentity(previous.source.identity) };
+        }
+        return { kind: "rejected", diagnostics: [invalidDiagnostic("replaceMcpSource")] };
+      }
+
+      const replacement = this.createRecord(
+        cloneJson(source),
+        request.launchValues,
+        request.runtimeLeases,
+      );
+      if (previous !== undefined) {
+        try {
+          await this.closeRecord(previous, signal);
+        } catch (error) {
+          if (signal.aborted) throw signal.reason;
+          return { kind: "rejected", diagnostics: [invalidDiagnostic("replaceMcpSource", CLEANUP_FAILED)] };
+        }
+      }
+      // Cleanup is the commit threshold. Once the old runtime authority has
+      // drained, publish the complete replacement even if cancellation arrives
+      // concurrently; this avoids exposing a half-reconciled source.
+      this.records.set(key, replacement);
+      return {
+        kind: "applied",
+        status: statusFor(replacement),
+        ...(previous === undefined ? {} : {
+          previousIdentity: copyIdentity(previous.source.identity),
+        }),
+      };
+    });
+  }
+
+  async removeSource(
+    identity: McpSourceIdentity,
+    signal: AbortSignal,
+  ): Promise<McpSourceRemoveResult> {
+    return this.exclusive(signal, async () => {
+      if (!identityIsValid(identity)) throw new ProgrammaticMcpError(INVALID_SOURCE);
+      const requested = cloneJson(identity);
+      const key = ownerKey(requested);
+      const current = this.records.get(key);
+      if (current === undefined) return { kind: "absent" };
+      if (exactIdentityKey(current.source.identity) !== exactIdentityKey(requested)) {
+        return {
+          kind: "ownership-mismatch",
+          requestedIdentity: requested,
+          currentIdentity: copyIdentity(current.source.identity),
+        };
+      }
+      await this.closeRecord(current, signal);
+      // As with replacement, exact removal commits after cleanup has drained.
+      this.records.delete(key);
+      return { kind: "removed" };
+    });
+  }
+
+  async inspectSource(
+    identity: McpSourceIdentity,
+    signal: AbortSignal,
+  ): Promise<McpSourceStatus | undefined> {
+    throwIfAborted(signal);
+    if (!identityIsValid(identity)) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    const record = this.records.get(ownerKey(identity));
+    if (record === undefined || exactIdentityKey(record.source.identity) !== exactIdentityKey(identity)) {
+      return undefined;
+    }
+    return cloneJson(statusFor(record));
+  }
+
+  async inspectSources(signal: AbortSignal): Promise<readonly McpSourceStatus[]> {
+    throwIfAborted(signal);
+    return [...this.records.entries()]
+      .sort(([left], [right]) => compareText(left, right))
+      .map(([, record]) => cloneJson(statusFor(record)));
+  }
+
+  private recordFor(identity: McpSourceIdentity): SourceRecord {
+    if (!identityIsValid(identity)) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    const record = this.records.get(ownerKey(identity));
+    if (record === undefined || exactIdentityKey(record.source.identity) !== exactIdentityKey(identity)) {
+      throw new ProgrammaticMcpError(INVALID_SOURCE);
+    }
+    return record;
+  }
+
+  private bindingFor(record: SourceRecord, serverKey: string): McpRuntimeServerBinding {
+    const server = record.source.servers[serverKey];
+    if (server === undefined) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    return {
+      source: copyIdentity(record.source.identity),
+      serverKey,
+      transport: server.transport,
+    };
+  }
+
+  async openExecution(
+    identity: McpSourceIdentity,
+    serverKey: string,
+    signal: AbortSignal,
+  ): Promise<ProgrammaticExecution> {
+    throwIfAborted(signal);
+    const record = this.recordFor(identity);
+    const server = record.source.servers[serverKey];
+    if (server === undefined) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    const binding = this.bindingFor(record, serverKey);
+    let lease: McpRuntimeLease | undefined;
+    let values: McpLaunchValues | undefined;
+    let connection: ProgrammaticConnection | undefined;
+    let primaryFailure: unknown;
+    record.serverStatus.set(serverKey, { state: "connecting" });
+
+    try {
+      lease = await record.runtimeLeases.acquire(binding, signal);
+      throwIfAborted(signal);
+      const manager = this.manager;
+      if (manager === undefined) throw new ProgrammaticMcpError(ADAPTER_FAILED);
+      const internalKey = qualifiedServerKey(identity, serverKey);
+      const existing = manager.getConnection(internalKey) as ProgrammaticConnection | undefined;
+      if (existing?.status === "connected") {
+        connection = existing;
+      } else {
+        values = await record.launchValues.resolve(binding, signal);
+        throwIfAborted(signal);
+        if (!launchValuesAreValid(values, server.transport)) {
+          throw new ProgrammaticMcpError(INVALID_SOURCE);
+        }
+        connection = await manager.connect(
+          internalKey,
+          serverDefinition(server, values),
+          signal,
+          {
+            allowLegacySseFallback: false,
+            retainedDefinition: retainedDefinition(server),
+            values: "resolved",
+          },
+        ) as ProgrammaticConnection;
+      }
+      throwIfAborted(signal);
+    } catch (error) {
+      primaryFailure = signal.aborted ? signal.reason : error;
+    } finally {
+      if (values !== undefined) {
+        try {
+          await record.launchValues.dispose(values);
+        } catch {
+          if (!signal.aborted) primaryFailure = new ProgrammaticMcpError(CLEANUP_FAILED);
+        }
+      }
+      if (primaryFailure !== undefined && lease !== undefined) {
+        try {
+          await record.runtimeLeases.release(lease, new AbortController().signal);
+        } catch {
+          if (!signal.aborted) primaryFailure = new ProgrammaticMcpError(CLEANUP_FAILED);
+        }
+      }
+    }
+
+    if (primaryFailure !== undefined) {
+      if (connection !== undefined && this.manager !== undefined) {
+        await this.manager.close(qualifiedServerKey(identity, serverKey));
+      }
+      record.serverStatus.set(serverKey, {
+        state: "failed",
+        errorCode: signal.aborted ? CANCELLED : primaryFailure instanceof ProgrammaticMcpError
+          ? primaryFailure.code
+          : ADAPTER_FAILED,
+      });
+      throw primaryFailure instanceof ProgrammaticMcpError || signal.aborted
+        ? primaryFailure
+        : new ProgrammaticMcpError(ADAPTER_FAILED);
+    }
+    if (lease === undefined || connection === undefined) throw new ProgrammaticMcpError(CLEANUP_FAILED);
+    if (connection.status === "needs-auth") {
+      await record.runtimeLeases.release(lease, new AbortController().signal);
+      record.serverStatus.set(serverKey, { state: "needs-auth" });
+      throw new ProgrammaticMcpError(ADAPTER_FAILED);
+    }
+
+    const executionController = new AbortController();
+    const execution: ExecutionState = {
+      controller: executionController,
+      lease,
+      closed: false,
+    };
+    record.executions.add(execution);
+    record.serverStatus.set(serverKey, {
+      state: "connected",
+      toolCount: connection.tools.length,
+    });
+
+    return {
+      connection,
+      signal: AbortSignal.any([signal, executionController.signal]),
+      close: async (closeSignal = new AbortController().signal) => {
+        if (execution.closed) return;
+        execution.closed = true;
+        try {
+          await record.runtimeLeases.release(execution.lease, closeSignal);
+          record.executions.delete(execution);
+        } catch (error) {
+          execution.closed = false;
+          throw error;
+        }
+      },
+    };
+  }
+
+  async callTool(
+    identity: McpSourceIdentity,
+    serverKey: string,
+    tool: string,
+    args: Record<string, unknown>,
+    signal: AbortSignal,
+  ): Promise<CallToolResult> {
+    const record = this.recordFor(identity);
+    const server = record.source.servers[serverKey];
+    if (server === undefined) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    const allowed = server.allowedTools === undefined
+      ? undefined
+      : new Set(server.allowedTools);
+    const denied = server.deniedTools === undefined
+      ? undefined
+      : new Set(server.deniedTools);
+    if ((allowed !== undefined && !allowed.has(tool)) || denied?.has(tool)) {
+      throw new ProgrammaticMcpError(INVALID_SOURCE);
+    }
+    const execution = await this.openExecution(identity, serverKey, signal);
+    try {
+      return await execution.connection.client.callTool(
+        { name: tool, arguments: args },
+        undefined,
+        { signal: execution.signal },
+      );
+    } finally {
+      await execution.close(new AbortController().signal);
+    }
+  }
+
+  async listTools(
+    identity: McpSourceIdentity,
+    serverKey: string,
+    signal: AbortSignal,
+  ): Promise<readonly { identity: string; name: string; description?: string; inputSchema?: unknown }[]> {
+    const record = this.recordFor(identity);
+    const server = record.source.servers[serverKey];
+    if (server === undefined) throw new ProgrammaticMcpError(INVALID_SOURCE);
+    const execution = await this.openExecution(identity, serverKey, signal);
+    try {
+      const allowed = server.allowedTools === undefined
+        ? undefined
+        : new Set(server.allowedTools);
+      const denied = new Set(server.deniedTools ?? []);
+      const qualifier = qualifiedServerKey(identity, serverKey);
+      return execution.connection.tools
+        .filter((tool) => (allowed === undefined || allowed.has(tool.name)) && !denied.has(tool.name))
+        .map((tool) => ({
+          identity: `${qualifier}:${tool.name}`,
+          name: tool.name,
+          ...(tool.description === undefined ? {} : { description: tool.description }),
+          ...(tool.inputSchema === undefined ? {} : { inputSchema: tool.inputSchema }),
+        }));
+    } finally {
+      await execution.close(new AbortController().signal);
+    }
+  }
+
+  private async closeExecutions(record: SourceRecord): Promise<void> {
+    for (const execution of [...record.executions]) execution.controller.abort(new ProgrammaticMcpError(CANCELLED));
+    for (const execution of [...record.executions]) {
+      if (!execution.closed) {
+        execution.closed = true;
+        try {
+          await record.runtimeLeases.release(execution.lease, new AbortController().signal);
+          record.executions.delete(execution);
+        } catch {
+          execution.closed = false;
+          throw new ProgrammaticMcpError(CLEANUP_FAILED);
+        }
+      }
+    }
+    await record.runtimeLeases.drain(new AbortController().signal);
+  }
+
+  private async closeRecord(record: SourceRecord, signal: AbortSignal): Promise<void> {
+    throwIfAborted(signal);
+    await this.closeExecutions(record);
+    throwIfAborted(signal);
+    const manager = this.manager;
+    if (manager !== undefined) {
+      await Promise.all(Object.keys(record.source.servers).map((serverKey) =>
+        manager.close(qualifiedServerKey(record.source.identity, serverKey))));
+    }
+  }
+}

--- a/programmatic-types.ts
+++ b/programmatic-types.ts
@@ -1,0 +1,225 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | Readonly<{ [key: string]: JsonValue }>;
+
+export type McpSourceTransport = "stdio" | "streamable-http";
+
+/**
+ * Stable caller-owned source name plus an opaque revision used for exact
+ * compare-and-replace. Names should be globally unique to the contributing
+ * extension, for example `com.example.search:workspace`.
+ */
+export interface McpSourceIdentity {
+  readonly id: string;
+  readonly revision: string;
+}
+
+/** Secret-free policy retained by the adapter between connection attempts. */
+export interface McpSourceServer {
+  readonly transport: McpSourceTransport;
+  readonly requestTimeoutMs?: number;
+  readonly allowedTools?: readonly string[];
+  readonly deniedTools?: readonly string[];
+}
+
+export interface McpConfigSource {
+  readonly identity: McpSourceIdentity;
+  /** Server keys are source-local and remain qualified by `identity` internally. */
+  readonly servers: Readonly<Record<string, McpSourceServer>>;
+}
+
+export type McpSourcePrecondition =
+  | Readonly<{ kind: "absent" }>
+  | Readonly<{ kind: "exact"; identity: McpSourceIdentity }>;
+
+export interface McpRuntimeServerBinding {
+  readonly source: McpSourceIdentity;
+  readonly serverKey: string;
+  readonly transport: McpSourceTransport;
+}
+
+export type McpLaunchValueRequest = McpRuntimeServerBinding;
+
+/**
+ * Plaintext launch values exist only for one immediate launch/connect attempt.
+ * The runtime never places them in source records, status, cache metadata, or
+ * diagnostics and always calls the provider's `dispose` hook.
+ */
+export type McpLaunchValues =
+  | Readonly<{
+      transport: "stdio";
+      command: string;
+      args: readonly string[];
+      cwd?: string;
+      env?: Readonly<Record<string, string>>;
+    }>
+  | Readonly<{
+      transport: "streamable-http";
+      url: string;
+      headers?: Readonly<Record<string, string>>;
+      bearerToken?: string;
+    }>;
+
+export interface McpLaunchValueProvider {
+  resolve(request: McpLaunchValueRequest, signal: AbortSignal): Promise<McpLaunchValues>;
+  dispose(values: McpLaunchValues): void | Promise<void>;
+}
+
+/** Opaque caller-owned authority retained only for one active execution. */
+export type McpRuntimeLease = Readonly<Record<PropertyKey, unknown>>;
+
+/**
+ * Optional lifetime hooks for callers that must keep launch authority alive
+ * while a tool is executing. `drain` completes before a source is replaced or
+ * removed.
+ */
+export interface McpRuntimeLeaseProvider {
+  acquire(binding: McpRuntimeServerBinding, signal: AbortSignal): Promise<McpRuntimeLease>;
+  release(lease: McpRuntimeLease, signal: AbortSignal): Promise<void>;
+  drain(signal: AbortSignal): Promise<void>;
+}
+
+export type McpSourceReplaceRequest = Readonly<{
+  source: McpConfigSource;
+  expected: McpSourcePrecondition;
+  launchValues: McpLaunchValueProvider;
+  runtimeLeases?: McpRuntimeLeaseProvider;
+}>;
+
+export interface McpDiagnostic {
+  readonly code: string;
+  readonly severity: "error" | "warning";
+  readonly operation: string;
+  readonly message: string;
+  readonly details?: Readonly<Record<string, JsonValue>>;
+}
+
+export type McpSourceValidationResult =
+  | Readonly<{
+      ok: true;
+      value: McpConfigSource;
+      diagnostics: readonly McpDiagnostic[];
+    }>
+  | Readonly<{
+      ok: false;
+      diagnostics: readonly McpDiagnostic[];
+    }>;
+
+export interface McpSourceServerStatus {
+  readonly key: string;
+  readonly transport: McpSourceTransport;
+  readonly state: "registered" | "connecting" | "connected" | "needs-auth" | "failed";
+  readonly toolCount?: number;
+  readonly errorCode?: string;
+}
+
+export interface McpSourceStatus {
+  readonly identity: McpSourceIdentity;
+  /** SHA-256 of the canonical, secret-free source definition. */
+  readonly sourceDigest: string;
+  readonly state: "registered" | "replacing" | "removing" | "failed";
+  readonly servers: readonly McpSourceServerStatus[];
+}
+
+export type McpSourceReplaceResult =
+  | Readonly<{
+      kind: "applied";
+      status: McpSourceStatus;
+      previousIdentity?: McpSourceIdentity;
+    }>
+  | Readonly<{
+      kind: "stale";
+      currentIdentity: McpSourceIdentity;
+    }>
+  | Readonly<{
+      kind: "rejected";
+      diagnostics: readonly McpDiagnostic[];
+    }>;
+
+export type McpSourceRemoveResult =
+  | Readonly<{ kind: "removed" }>
+  | Readonly<{ kind: "absent" }>
+  | Readonly<{
+      kind: "ownership-mismatch";
+      requestedIdentity: McpSourceIdentity;
+      currentIdentity: McpSourceIdentity;
+    }>;
+
+/** Complete, environment-aware facts for the programmatic adapter instance. */
+export interface McpRuntimeCapabilities {
+  readonly sourceLifecycle: Readonly<{
+    initialSourcesBeforeToolRegistration: boolean;
+    isolatedFileDiscovery: boolean;
+    localValidation: boolean;
+    atomicReplace: boolean;
+    exactRemove: boolean;
+    inspect: boolean;
+    cancellable: boolean;
+    lateLaunchValues: boolean;
+    runtimeLeases: boolean;
+  }>;
+  readonly transports: Readonly<{
+    stdio: boolean;
+    streamableHttp: boolean;
+    legacySse: boolean;
+    websocket: boolean;
+  }>;
+  readonly oauth: Readonly<{
+    authorizationCode: boolean;
+    clientCredentials: boolean;
+  }>;
+  readonly features: Readonly<{
+    sampling: boolean;
+    elicitationForm: boolean;
+    elicitationUrl: boolean;
+    toolApproval: boolean;
+    resources: boolean;
+    directTools: boolean;
+  }>;
+}
+
+/** Documented package boundary. Transport and manager internals stay private. */
+export interface McpProgrammaticRuntime {
+  capabilities(signal: AbortSignal): Promise<McpRuntimeCapabilities>;
+  validateSource(
+    source: McpConfigSource,
+    signal: AbortSignal,
+  ): Promise<McpSourceValidationResult>;
+  replaceSource(
+    request: McpSourceReplaceRequest,
+    signal: AbortSignal,
+  ): Promise<McpSourceReplaceResult>;
+  removeSource(
+    identity: McpSourceIdentity,
+    signal: AbortSignal,
+  ): Promise<McpSourceRemoveResult>;
+  inspectSource(
+    identity: McpSourceIdentity,
+    signal: AbortSignal,
+  ): Promise<McpSourceStatus | undefined>;
+  inspectSources(signal: AbortSignal): Promise<readonly McpSourceStatus[]>;
+}
+
+export type McpInitialSource = Readonly<{
+  source: McpConfigSource;
+  launchValues: McpLaunchValueProvider;
+  runtimeLeases?: McpRuntimeLeaseProvider;
+}>;
+
+export interface McpAdapterOptions {
+  /** Installed synchronously before the returned extension can register tools. */
+  readonly initialSources?: readonly McpInitialSource[];
+  /** Existing standalone behavior remains the default. */
+  readonly fileDiscovery?: "enabled" | "disabled";
+}
+
+export interface McpAdapterInstance {
+  readonly extension: (pi: ExtensionAPI) => void;
+  readonly runtime: McpProgrammaticRuntime;
+}

--- a/programmatic.ts
+++ b/programmatic.ts
@@ -1,0 +1,62 @@
+import mcpAdapter from "./index.ts";
+import { registerProgrammaticExtension } from "./programmatic-extension.ts";
+import { ProgrammaticMcpRuntime } from "./programmatic-runtime.ts";
+import type { McpAdapterInstance, McpAdapterOptions } from "./programmatic-types.ts";
+
+/**
+ * Create an MCP adapter with an exported, source-qualified lifecycle.
+ *
+ * Initial sources are synchronously validated and installed before the returned
+ * extension can register any Pi tool. `fileDiscovery: "disabled"` is the
+ * isolated composition mode: it never invokes the standalone file extension,
+ * reads MCP files/imports, or loads the shared metadata cache. The default
+ * remains `"enabled"`, preserving the ordinary extension and CLI behavior.
+ */
+export function createMcpAdapter(options: McpAdapterOptions = {}): McpAdapterInstance {
+  const fileDiscovery = options.fileDiscovery ?? "enabled";
+  if (fileDiscovery !== "enabled" && fileDiscovery !== "disabled") {
+    throw new TypeError("fileDiscovery must be enabled or disabled");
+  }
+
+  const runtime = new ProgrammaticMcpRuntime({ fileDiscovery });
+  runtime.installInitialSources(options.initialSources ?? []);
+
+  return Object.freeze({
+    runtime,
+    extension(pi) {
+      if (fileDiscovery === "enabled") {
+        mcpAdapter(pi);
+        registerProgrammaticExtension(pi, runtime, "mcp_sources");
+      } else {
+        registerProgrammaticExtension(pi, runtime, "mcp");
+      }
+    },
+  });
+}
+
+export type {
+  JsonValue,
+  McpAdapterInstance,
+  McpAdapterOptions,
+  McpConfigSource,
+  McpDiagnostic,
+  McpInitialSource,
+  McpLaunchValueProvider,
+  McpLaunchValueRequest,
+  McpLaunchValues,
+  McpProgrammaticRuntime,
+  McpRuntimeCapabilities,
+  McpRuntimeLease,
+  McpRuntimeLeaseProvider,
+  McpRuntimeServerBinding,
+  McpSourceIdentity,
+  McpSourcePrecondition,
+  McpSourceRemoveResult,
+  McpSourceReplaceRequest,
+  McpSourceReplaceResult,
+  McpSourceServer,
+  McpSourceTransport,
+  McpSourceServerStatus,
+  McpSourceStatus,
+  McpSourceValidationResult,
+} from "./programmatic-types.ts";

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -43,6 +43,15 @@ interface ServerConnection {
 
 type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void;
 
+interface ConnectOptions {
+  /** Programmatic Streamable HTTP sources must never silently become legacy SSE. */
+  allowLegacySseFallback?: boolean;
+  /** Secret-free definition retained after launch for request/runtime policy. */
+  retainedDefinition?: ServerDefinition;
+  /** Programmatic values are callback-resolved and must not consult process.env. */
+  values?: "config" | "resolved";
+}
+
 export class McpServerManager {
   private connections = new Map<string, ServerConnection>();
   private connectPromises = new Map<string, Promise<ServerConnection>>();
@@ -95,7 +104,12 @@ export class McpServerManager {
     };
   }
 
-  async connect(name: string, definition: ServerDefinition, signal?: AbortSignal): Promise<ServerConnection> {
+  async connect(
+    name: string,
+    definition: ServerDefinition,
+    signal?: AbortSignal,
+    options: ConnectOptions = {},
+  ): Promise<ServerConnection> {
     throwIfAborted(signal);
     // Dedupe concurrent connection attempts
     if (this.connectPromises.has(name)) {
@@ -109,7 +123,7 @@ export class McpServerManager {
       return existing;
     }
 
-    const promise = this.createConnection(name, definition, signal);
+    const promise = this.createConnection(name, definition, signal, options);
     this.connectPromises.set(name, promise);
 
     try {
@@ -125,6 +139,7 @@ export class McpServerManager {
     name: string,
     definition: ServerDefinition,
     signal?: AbortSignal,
+    options: ConnectOptions = {},
   ): Promise<ServerConnection> {
     throwIfAborted(signal);
     const client = this.createClient(name);
@@ -147,13 +162,16 @@ export class McpServerManager {
       transport = new StdioClientTransport({
         command,
         args,
-        env: resolveEnv(definition.env),
-        cwd: resolveConfigPath(definition.cwd) ?? this.defaultCwd,
+        env: options.values === "resolved" ? definition.env : resolveEnv(definition.env),
+        cwd: options.values === "resolved"
+          ? definition.cwd ?? this.defaultCwd
+          : resolveConfigPath(definition.cwd) ?? this.defaultCwd,
         stderr: definition.debug ? "inherit" : "ignore",
       });
     } else if (definition.url) {
-      // HTTP transport with fallback
-      transport = await this.createHttpTransport(definition, name, signal);
+      // HTTP transport with fallback for file-config users. Programmatic
+      // Streamable HTTP sources explicitly disable fallback.
+      transport = await this.createHttpTransport(definition, name, signal, options);
     } else {
       throw new Error(`Server ${name} has no command or url`);
     }
@@ -173,7 +191,7 @@ export class McpServerManager {
       return {
         client,
         transport,
-        definition,
+        definition: options.retainedDefinition ?? definition,
         tools,
         resources,
         lastUsedAt: Date.now(),
@@ -190,7 +208,7 @@ export class McpServerManager {
         return {
           client,
           transport,
-          definition,
+          definition: options.retainedDefinition ?? definition,
           tools: [],
           resources: [],
           lastUsedAt: Date.now(),
@@ -278,16 +296,21 @@ export class McpServerManager {
     definition: ServerDefinition,
     serverName: string,
     signal?: AbortSignal,
+    options: ConnectOptions = {},
   ): Promise<Transport> {
     throwIfAborted(signal);
     const url = new URL(definition.url!);
 
     // Build headers first (including any bearer token)
-    const headers = resolveHeaders(definition.headers) ?? {};
+    const headers = options.values === "resolved"
+      ? { ...(definition.headers ?? {}) }
+      : resolveHeaders(definition.headers) ?? {};
 
     // For bearer auth, add the token to headers BEFORE creating requestInit
     if (definition.auth === "bearer") {
-      const token = resolveBearerToken(definition);
+      const token = options.values === "resolved"
+        ? definition.bearerToken
+        : resolveBearerToken(definition);
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
       }
@@ -338,12 +361,13 @@ export class McpServerManager {
         throwIfAborted(signal);
       }
 
-      // If this was an UnauthorizedError, don't try SSE - the server needs auth
-      if (error instanceof UnauthorizedError) {
+      // If this was an UnauthorizedError, don't try SSE - the server needs auth.
+      // Programmatic Streamable HTTP declarations are exact and never fall back.
+      if (error instanceof UnauthorizedError || options.allowLegacySseFallback === false) {
         throw error;
       }
 
-      // SSE is the legacy transport
+      // SSE is the legacy transport for ordinary file configuration only.
       return new SSEClientTransport(url, { requestInit, authProvider });
     }
   }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "rewriteRelativeImportExtensions": true,
+    "sourceMap": false
+  },
+  "include": ["*.ts"],
+  "exclude": ["*.test.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a documented, typed `pi-mcp-adapter/programmatic` API for SDK hosts and Pi extensions that need session-scoped MCP configuration without temporary files or process-global arguments.

The API is source-oriented rather than a one-off config overlay:

- initial sources are validated and installed before Pi tool registration;
- `fileDiscovery: "disabled"` avoids all MCP file/import/cache discovery;
- stable source IDs plus opaque revisions provide exact compare-and-replace and exact removal;
- server keys, processes, tools, and status remain source-qualified, so equal server names do not collide;
- launch values are resolved only immediately before connect, receive an `AbortSignal`, and are disposed on success, failure, and cancellation;
- local redacted inventory is inspectable separately from remote connection health;
- complete capabilities report supported and unsupported lifecycle, transport, OAuth, and Pi feature facts explicitly.

This addresses #85. It builds on the extension-provider direction explored in #56 and the in-memory SDK overlay in #86, but keeps source ownership and runtime lifecycle explicit. In particular, it does not persist extension-contributed values into user config and does not expose `McpServerManager` internals as the public contract.

## Public API

```ts
import { createMcpAdapter } from "pi-mcp-adapter/programmatic";

const adapter = createMcpAdapter({
  fileDiscovery: "disabled",
  initialSources: [{
    source: {
      identity: { id: "com.example.audit:session-123", revision: "request-456" },
      servers: {
        audit: { transport: "streamable-http", requestTimeoutMs: 30_000 },
      },
    },
    launchValues: {
      resolve: (_request, signal) => getSessionConnection(signal),
      dispose: (values) => disposeSessionConnection(values),
    },
  }],
});
```

The returned instance contains:

- `extension`: the Pi extension factory;
- `runtime.capabilities(signal)`;
- `runtime.validateSource(source, signal)`;
- `runtime.replaceSource(request, signal)`;
- `runtime.removeSource(identity, signal)`;
- `runtime.inspectSource(identity, signal)`;
- `runtime.inspectSources(signal)`.

Optional runtime-lease hooks let a host keep external launch authority alive for an execution and drain it before replacement/removal. Simple extensions can omit them. The source shape itself is deliberately generic and secret-free: `id`, `revision`, source-local servers, transport, timeout, and tool allow/deny policy only.

The lifecycle lands as one usable contract rather than splitting registration from replacement/removal/status/cancellation/late values across releases.

## Design and compatibility

- Package name and version are unchanged in this contribution.
- The existing default export, `pi.extensions: ["./index.ts"]`, CLI bin, file precedence, commands, direct tools, imports, and metadata-cache path remain unchanged.
- `createMcpAdapter()` defaults to `fileDiscovery: "enabled"` and parity-tests the ordinary extension registrations. Programmatic sources use a separate `mcp_sources` gateway in that mode.
- Isolated mode invokes no file loader or shared metadata cache and registers one `mcp` gateway.
- Existing file-config HTTP continues to use Streamable HTTP with legacy SSE fallback. Programmatic `streamable-http` is exact and never silently changes transport.
- Callback-resolved stdio values do not inherit/interpolate process environment; callback-resolved HTTP values do not consult process environment.
- Status and failures contain stable codes and structural inventory only—never command/argument/environment/header/bearer values or native causes.
- Compiled root and `./programmatic` exports are packed and import-tested. The default Pi source entry remains unchanged.
- README rationale, a complete typed example, changelog entry, and package/API tests are included.

## Verification

Current upstream base and submitted head:

- base `upstream/main`: `82724dccc13a49310530898f922bafff12b7f3fe`
- head: `4f1a2af656f48581e0d9d8c9a5719e7dbf83fb55`

Both hashes were verified against their remote branch refs immediately before submission.

Commands run on Node `v24.17.0`:

- `npm --prefix examples/interactive-visualizer run build`
- `npm run typecheck`
- `npm test` — 51 files, 457 tests passed
- `npm run test:oauth-provider` — 30 tests passed
- `npm run build` plus direct imports of `dist/index.js` and `dist/programmatic.js`
- `npm run test:package` — packed tarball installed into an isolated consumer; root/programmatic imports, CLI help, license, package identity/version, default Pi entry, and private manager subpath all verified
- `npm pack --dry-run` — 143 files; required source, compiled declarations/runtime, example, README, changelog, and MIT license included
- unchanged downstream portable lifecycle conformance through the generic public API — 1 contract test passed

Focused tests cover Pi registration order, rapid session-start serialization, file/cache isolation, colliding source-local server names, exact replacement/removal, failed-replacement rollback, queue and launch cancellation, late-value disposal, runtime-lease drain, deterministic redacted status, callback-resolved stdio/HTTP values, explicit Streamable HTTP behavior, capability completeness, default-extension parity, and unsafe launch-value rejection.

## Release request

If this API direction is accepted, please include the complete lifecycle and the compiled `pi-mcp-adapter/programmatic` export in the next release. No package version bump is included here so release numbering remains maintainer-owned.
