### PR TITLE
fix: initializeMcp abandons quietly instead of throwing when the session is disposed mid-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Avoided MCP renderer crashes without a TUI theme and preserved status-bar updates with plain fallback text. Thanks @fankangsong for PR #183.
+- Abandoned MCP initialization quietly when a session is disposed during eager or keep-alive connection setup. Thanks @luisfontes for PR #192.
 - Sanitized dotted MCP tool names before registering them with Pi. Thanks @benjaminrickels for PR #190.
 - Reconnected OAuth MCP servers automatically after successful panel or `/mcp-auth` authorization, and made panel reconnect force a fresh connection like `/mcp reconnect`. Thanks @mightymatth for issue #171.
 - Recovered stale Streamable HTTP MCP sessions that report `-32000 Server not initialized` after a server restart. Thanks @vicary for issue #184.

--- a/__tests__/init-stale-ctx-race.test.ts
+++ b/__tests__/init-stale-ctx-race.test.ts
@@ -14,6 +14,7 @@ vi.mock("../config.ts", async (importOriginal) => ({
 vi.mock("../server-manager.ts", () => ({
   McpServerManager: vi.fn().mockImplementation(function (this: any) {
     this.setDefaultRequestTimeoutMs = vi.fn();
+    this.setAuthStorageOptions = vi.fn();
     this.setSamplingConfig = vi.fn();
     this.setElicitationConfig = vi.fn();
     this.getConnection = vi.fn();
@@ -81,10 +82,8 @@ describe("initializeMcp vs. a ctx invalidated mid-connect", () => {
     armed.value = true;
     resolveConnect({ status: "connected", tools: [], resources: [] });
 
-    // Desired/fixed behavior: a session torn down mid-connect is an ordinary,
-    // expected race — initializeMcp should abandon quietly, not reject. On
-    // today's code this promise rejects with the "extension ctx is stale" error
-    // instead, so this assertion currently fails.
+    // A session torn down mid-connect is an ordinary, expected race:
+    // initializeMcp should abandon quietly instead of rejecting.
     await pending;
   });
 });

--- a/__tests__/init-stale-ctx-race.test.ts
+++ b/__tests__/init-stale-ctx-race.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const mocks = vi.hoisted(() => ({
+  loadMcpConfig: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock("../config.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config.ts")>()),
+  loadMcpConfig: mocks.loadMcpConfig,
+}));
+
+vi.mock("../server-manager.ts", () => ({
+  McpServerManager: vi.fn().mockImplementation(function (this: any) {
+    this.setDefaultRequestTimeoutMs = vi.fn();
+    this.setSamplingConfig = vi.fn();
+    this.setElicitationConfig = vi.fn();
+    this.getConnection = vi.fn();
+    this.connect = mocks.connect;
+  }),
+}));
+
+function extensionApi(): ExtensionAPI {
+  return { getFlag: vi.fn() } as unknown as ExtensionAPI;
+}
+
+// Mirrors pi-coding-agent's real ExtensionContext getters: each one re-checks
+// runner.assertActive() on every read, so a session torn down mid-connect makes
+// the *next* read throw — not just future ones. `armed` flips true to simulate
+// session.dispose() firing while the eager connect below is still in flight.
+function contextThatGoesStale(armed: { value: boolean }): ExtensionContext {
+  return {
+    cwd: "/tmp/project",
+    get hasUI() {
+      if (armed.value) {
+        throw new Error(
+          "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload()."
+        );
+      }
+      return true;
+    },
+    mode: "tui",
+    ui: { notify: vi.fn(), setStatus: vi.fn() },
+    modelRegistry: {},
+    model: undefined,
+    signal: undefined,
+  } as unknown as ExtensionContext;
+}
+
+describe("initializeMcp vs. a ctx invalidated mid-connect", () => {
+  it("does not reject once the session is disposed mid-connect — it should abandon quietly", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"], lifecycle: "eager" },
+      },
+      settings: {},
+    });
+
+    let resolveConnect!: (value: unknown) => void;
+    mocks.connect.mockImplementation(
+      () => new Promise((resolve) => { resolveConnect = resolve; })
+    );
+
+    const { initializeMcp } = await import("../init.ts");
+
+    const armed = { value: false };
+    const ctx = contextThatGoesStale(armed);
+
+    const pending = initializeMcp(extensionApi(), ctx);
+
+    // Let the synchronous prefix (config load, manager construction, the
+    // pre-connect ctx.hasUI reads, and the connect() call itself) run first.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Simulate session.dispose() firing while the "eager" server's connect is
+    // still in flight — the exact race from the bug report: a fast, no-MCP-tool
+    // turn completes (and the harness disposes the session) before an eager
+    // server finishes connecting.
+    armed.value = true;
+    resolveConnect({ status: "connected", tools: [], resources: [] });
+
+    // Desired/fixed behavior: a session torn down mid-connect is an ordinary,
+    // expected race — initializeMcp should abandon quietly, not reject. On
+    // today's code this promise rejects with the "extension ctx is stale" error
+    // instead, so this assertion currently fails.
+    await pending;
+  });
+});

--- a/__tests__/init-stale-ctx-race.test.ts
+++ b/__tests__/init-stale-ctx-race.test.ts
@@ -30,13 +30,13 @@ function extensionApi(): ExtensionAPI {
 // runner.assertActive() on every read, so a session torn down mid-connect makes
 // the *next* read throw — not just future ones. `armed` flips true to simulate
 // session.dispose() firing while the eager connect below is still in flight.
-function contextThatGoesStale(armed: { value: boolean }): ExtensionContext {
+function contextThatGoesStale(armed: { value: boolean }, message?: string): ExtensionContext {
   return {
     cwd: "/tmp/project",
     get hasUI() {
       if (armed.value) {
         throw new Error(
-          "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload()."
+          message ?? "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload()."
         );
       }
       return true;
@@ -85,5 +85,33 @@ describe("initializeMcp vs. a ctx invalidated mid-connect", () => {
     // A session torn down mid-connect is an ordinary, expected race:
     // initializeMcp should abandon quietly instead of rejecting.
     await pending;
+  });
+
+  it("still rejects unrelated ctx.hasUI failures after startup connects", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"], lifecycle: "eager" },
+      },
+      settings: {},
+    });
+
+    let resolveConnect!: (value: unknown) => void;
+    mocks.connect.mockImplementation(
+      () => new Promise((resolve) => { resolveConnect = resolve; })
+    );
+
+    const { initializeMcp } = await import("../init.ts");
+
+    const armed = { value: false };
+    const ctx = contextThatGoesStale(armed, "unexpected ui failure");
+
+    const pending = initializeMcp(extensionApi(), ctx);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    armed.value = true;
+    resolveConnect({ status: "connected", tools: [], resources: [] });
+
+    await expect(pending).rejects.toThrow("unexpected ui failure");
   });
 });

--- a/init.ts
+++ b/init.ts
@@ -153,6 +153,14 @@ export async function initializeMcp(
     }
   });
 
+  try {
+    void ctx.hasUI;
+  } catch {
+    // Session torn down while the eager/keep-alive connect(s) above were still
+    // in flight — abandon quietly instead of touching a dead ctx below.
+    return state;
+  }
+
   for (const { name, definition, connection, error } of results) {
     if (error || !connection) {
       if (ctx.hasUI) {

--- a/init.ts
+++ b/init.ts
@@ -155,7 +155,11 @@ export async function initializeMcp(
 
   try {
     void ctx.hasUI;
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("extension ctx is stale after session replacement or reload")) {
+      throw error;
+    }
     // Session torn down while the eager/keep-alive connect(s) above were still
     // in flight — abandon quietly instead of touching a dead ctx below.
     return state;


### PR DESCRIPTION
## Summary

`session_start` kicks off `initializeMcp()` fire-and-forget (`index.ts:113`) — never
awaited by the handler itself. If the host disposes the `AgentSession` (invalidating the
extension ctx) before the eager/keep-alive connect step resolves, the next `ctx.hasUI`
read throws pi-coding-agent's stale-ctx error. It's caught by the `.catch` in `index.ts`
and logged via `console.error("MCP initialization failed:", err)` — non-fatal, but it
reads exactly like a crash (`console.error` renders the `Error`'s stack).

Repro: a host that calls `bindExtensions()` (fires `session_start`) then `dispose()`
right after a turn that never calls an MCP tool — e.g. a fast, pure-text response — can
lose the race against an `"eager"`/`"keep-alive"` server's connect. Exit code stays 0;
this is a caught rejection, not an uncaught exception, but it's frequent (any no-tool-call
turn on a host with a create-session-per-turn lifecycle) and misleading in logs.

## Root cause

Every `ExtensionContext` member (`ui`, `mode`, `hasUI`, `cwd`, `sessionManager`,
`modelRegistry`, `model`, `isIdle()`, `isProjectTrusted()`, `signal`, `abort()`,
`hasPendingMessages()`, `shutdown()`, `getContextUsage()`, `compact()`,
`getSystemPrompt()`) calls the identical `runner.assertActive()` guard first
(pi-coding-agent's `createContext()`) — there's no non-throwing liveness check anywhere
on `ctx`, and extensions never get a reference to the underlying `ExtensionRunner` (which
does hold a plain `staleMessage` field) to check some other way.

## Fix

A `try`/`catch` around one cheap, side-effect-free `ctx` touch — not a string match on
the caught error's message, which would be fragile and wouldn't distinguish this from any
other failure — placed once right after the only `await` that matters, ahead of every
`ctx.hasUI` touch that follows it in the rest of the function:

```diff
   });

+  try {
+    void ctx.hasUI;
+  } catch {
+    // Session torn down while the eager/keep-alive connect(s) above were still
+    // in flight — abandon quietly instead of touching a dead ctx below.
+    return state;
+  }
+
   for (const { name, definition, connection, error } of results) {
     if (error || !connection) {
       if (ctx.hasUI) {
```

`state` is already a fully-constructed `McpExtensionState` by this point — the early
return just skips populating it with connections/tool metadata a torn-down session has
no use for.

## Test plan

- [x] New test (`__tests__/init-stale-ctx-race.test.ts`, following the existing
      `init-elicitation.test.ts` pattern) drives `initializeMcp` directly with a `ctx`
      whose `hasUI` getter flips to throwing mid-connect — confirmed red on `main` at the
      exact line the crash's stack trace cites, confirmed green with this fix.
- [x] Full suite (`npx vitest run`): 434/436 passing — the 2 failures
      (`interactive-visualizer-server.test.ts`) are the pre-existing unbuilt-example-bundle
      gap already noted by #170's own author, unrelated to this change.
- [x] `npx tsc --noEmit` clean.

Relates to #170 (same neighborhood of code — `session_start`/`initializeMcp` — but a
different bug: a host that never calls `bindExtensions()` never gets `session_start` at
all, so init never runs there). Not a duplicate of any open issue I could find.