### PR TITLE
fix: recover streamable HTTP session after server restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 
 ### Fixed
+- Recovered Streamable HTTP MCP sessions after a server restart invalidates the previous session ID. Thanks @damselem for PR #194.
 - Used server-advertised OAuth protected-resource metadata during authorization so resource servers can point Pi at the correct authorization server. Thanks @jameswarren for issue #173 and PR #174.
 - Dropped inherited HTTP auth when a higher-precedence MCP config repoints a server URL, while preserving explicit OAuth disable flags. Thanks @ductiletoaster for PR #182.
 

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -62,6 +62,13 @@ vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: vi.fn(),
+  StreamableHTTPError: class StreamableHTTPError extends Error {
+    code: number;
+    constructor(code: number, message: string) {
+      super(`Streamable HTTP error: ${message}`);
+      this.code = code;
+    }
+  },
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -54,6 +54,13 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
     mocks.httpTransports.push(transport);
     return transport;
   }),
+  StreamableHTTPError: class StreamableHTTPError extends Error {
+    code: number;
+    constructor(code: number, message: string) {
+      super(`Streamable HTTP error: ${message}`);
+      this.code = code;
+    }
+  },
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({

--- a/__tests__/server-manager-reconnect.test.ts
+++ b/__tests__/server-manager-reconnect.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TransportOptions = {
+  requestInit?: { headers?: Record<string, string> };
+};
+
+type HttpTransportMock = {
+  url: URL;
+  options: TransportOptions;
+  close: () => Promise<void>;
+};
+
+const mocks = vi.hoisted(() => ({
+  clients: [] as any[],
+  httpTransports: [] as HttpTransportMock[],
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation((info: unknown, options: unknown) => {
+    const client: any = {
+      info,
+      options,
+      onclose: undefined,
+      setRequestHandler: vi.fn(),
+      setNotificationHandler: vi.fn(),
+      connect: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => ({ tools: [] })),
+      listResources: vi.fn(async () => ({ resources: [] })),
+      close: vi.fn(async () => undefined),
+    };
+    mocks.clients.push(client);
+    return client;
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
+    const transport = { url, options, close: vi.fn(async () => undefined) };
+    mocks.httpTransports.push(transport);
+    return transport;
+  }),
+  StreamableHTTPError: class StreamableHTTPError extends Error {
+    code: number;
+    constructor(code: number, message: string) {
+      super(`Streamable HTTP error: ${message}`);
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
+describe("McpServerManager.reconnect", () => {
+  beforeEach(() => {
+    mocks.clients.length = 0;
+    mocks.httpTransports.length = 0;
+  });
+
+  // For an HTTP server, connect() creates a probe client+transport and then
+  // a real one; the real client (used as connection.client) is always
+  // mocks.clients[0] for a given connect() call because createClient() runs
+  // before the probe is created inside createHttpTransport().
+  const def = { url: "https://example.test/mcp" };
+
+  it("is single-flight: concurrent reconnects for the same server share one underlying reconnect", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const stale = await manager.connect("remote", def);
+    mocks.clients.length = 0;
+    mocks.httpTransports.length = 0;
+
+    const [c1, c2] = await Promise.all([
+      manager.reconnect("remote", def, stale),
+      manager.reconnect("remote", def, stale),
+    ]);
+
+    expect(c1).toBe(c2);
+    // Exactly one new connection was established (probe client + real
+    // client == 2), not two (which would be 4).
+    expect(mocks.clients.length).toBe(2);
+    expect(manager.getConnection("remote")).toBe(c1);
+  });
+
+  it("identity guard: never tears down a connection it did not prove stale", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const stale = await manager.connect("remote", def);
+    await manager.close("remote");
+    const fresh = await manager.connect("remote", def);
+
+    mocks.clients.length = 0;
+    mocks.httpTransports.length = 0;
+
+    // A caller that captured `stale` before the close/reconnect cycle above
+    // (e.g. a concurrent tool call that lost the race) asks to reconnect
+    // from that now-superseded connection.
+    const result = await manager.reconnect("remote", def, stale);
+
+    expect(result).toBe(fresh);
+    expect(fresh.client.close).not.toHaveBeenCalled();
+    expect(mocks.clients.length).toBe(0); // no new connection attempted
+    expect(manager.getConnection("remote")).toBe(fresh);
+  });
+
+  it("keeps a shared reconnect alive when one caller aborts waiting", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const stale = await manager.connect("remote", def);
+    let releaseClose!: () => void;
+    stale.client.close = vi.fn(() => new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    }));
+    const reason = new Error("stop waiting");
+    const controller = new AbortController();
+
+    const first = manager.reconnect("remote", def, stale, controller.signal);
+    controller.abort(reason);
+    await expect(first).rejects.toBe(reason);
+
+    const second = manager.reconnect("remote", def, stale);
+    releaseClose();
+    const fresh = await second;
+
+    expect(fresh).not.toBe(stale);
+    expect(manager.getConnection("remote")).toBe(fresh);
+  });
+
+  it("carries in-flight work from the stale connection to the fresh connection", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const stale = await manager.connect("remote", def);
+    stale.inFlight = 2;
+
+    const fresh = await manager.reconnect("remote", def, stale);
+
+    expect(fresh).not.toBe(stale);
+    expect(fresh.inFlight).toBe(2);
+    expect(manager.getConnection("remote")).toBe(fresh);
+  });
+
+  it("identity guard: a stale connection's late onclose does not clobber the fresh connection's status", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    const stale = await manager.connect("remote", def);
+    const staleClient = mocks.clients[0];
+
+    mocks.clients.length = 0;
+    mocks.httpTransports.length = 0;
+
+    const fresh = await manager.reconnect("remote", def, stale);
+    const freshClient = mocks.clients[0];
+
+    expect(fresh).not.toBe(stale);
+    expect(manager.getConnection("remote")).toBe(fresh);
+
+    // Late close event from the old (already-replaced) client/transport.
+    staleClient.onclose?.();
+    expect(fresh.status).toBe("connected");
+    expect(manager.getConnection("remote")).toBe(fresh);
+
+    // A close on the current connection's own client still works normally.
+    freshClient.onclose?.();
+    expect(fresh.status).toBe("closed");
+  });
+});

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -34,6 +34,13 @@ vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: vi.fn(),
+  StreamableHTTPError: class StreamableHTTPError extends Error {
+    code: number;
+    constructor(code: number, message: string) {
+      super(`Streamable HTTP error: ${message}`);
+      this.code = code;
+    }
+  },
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({

--- a/__tests__/session-recovery-integration.test.ts
+++ b/__tests__/session-recovery-integration.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// direct-tools.ts calls lazyConnect() before touching the connection; mock
+// it the same way __tests__/direct-tools-auto-auth.test.ts does so we can
+// drive the "already connected" path directly.
+const mocks = vi.hoisted(() => ({
+  lazyConnect: vi.fn(),
+}));
+
+vi.mock("../init.ts", () => ({
+  lazyConnect: mocks.lazyConnect,
+  getFailureAgeSeconds: vi.fn(() => null),
+}));
+
+describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
+  it("recovers a terminated Streamable HTTP session transparently mid tool-call", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected" as const,
+      transport: { sessionId: "session-1" },
+      client: {
+        callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+      },
+    };
+    const fresh = {
+      status: "connected" as const,
+      transport: { sessionId: "session-2" },
+      client: {
+        callTool: vi.fn().mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }] }),
+      },
+    };
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => fresh),
+      getRequestOptions: vi.fn(() => undefined),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: { settings: {}, mcpServers: { demo: { url: "https://api.example.com/mcp" } } },
+      manager,
+      toolMetadata: new Map([
+        ["demo", [{ name: "demo_search", originalName: "search", description: "Search" }]],
+      ]),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", { q: "hello" }, "demo");
+
+    expect(stale.client.callTool).toHaveBeenCalledTimes(1);
+    expect(fresh.client.callTool).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).toHaveBeenCalledWith("demo", state.config.mcpServers.demo, stale);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain("ok");
+  });
+
+  it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected" as const,
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+    };
+    const fresh = {
+      status: "connected" as const,
+      transport: { sessionId: "session-2" },
+      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+    };
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => fresh),
+      getRequestOptions: vi.fn(() => undefined),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: { settings: {}, mcpServers: { demo: { url: "https://api.example.com/mcp" } } },
+      manager,
+      toolMetadata: new Map([
+        ["demo", [{ name: "demo_search", originalName: "search", description: "Search" }]],
+      ]),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "demo_search", {}, "demo");
+
+    expect(stale.client.callTool).toHaveBeenCalledTimes(1);
+    expect(fresh.client.callTool).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+    expect(result.details).toMatchObject({ mode: "call", error: "call_failed" });
+  });
+});
+
+describe("session recovery — direct-tools path (direct-tools.ts createDirectToolExecutor)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.lazyConnect.mockReset().mockResolvedValue(true);
+  });
+
+  it("recovers a terminated Streamable HTTP session transparently for a direct tool call", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected" as const,
+      transport: { sessionId: "session-1" },
+      client: {
+        callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+      },
+    };
+    const fresh = {
+      status: "connected" as const,
+      transport: { sessionId: "session-2" },
+      client: {
+        callTool: vi.fn().mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }] }),
+      },
+    };
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => fresh),
+      getRequestOptions: vi.fn(() => undefined),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: { settings: {}, mcpServers: { demo: { url: "https://api.example.com/mcp" } } },
+      manager,
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(() => state, () => null, {
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Search",
+    });
+
+    const result = await executor("id", { q: "hello" }, undefined, undefined, undefined as any);
+
+    expect(stale.client.callTool).toHaveBeenCalledTimes(1);
+    expect(fresh.client.callTool).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).toHaveBeenCalledWith("demo", state.config.mcpServers.demo, stale);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain("ok");
+  });
+
+  it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected" as const,
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+    };
+    const fresh = {
+      status: "connected" as const,
+      transport: { sessionId: "session-2" },
+      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+    };
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => fresh),
+      getRequestOptions: vi.fn(() => undefined),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    };
+
+    const state = {
+      config: { settings: {}, mcpServers: { demo: { url: "https://api.example.com/mcp" } } },
+      manager,
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const executor = createDirectToolExecutor(() => state, () => null, {
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Search",
+    });
+
+    const result = await executor("id", {}, undefined, undefined, undefined as any);
+
+    expect(stale.client.callTool).toHaveBeenCalledTimes(1);
+    expect(fresh.client.callTool).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+    expect(result.details).toMatchObject({ error: "call_failed", server: "demo" });
+  });
+});

--- a/__tests__/session-recovery.test.ts
+++ b/__tests__/session-recovery.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from "vitest";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SessionRecoveryAuthRequiredError, isTerminatedSession, withSessionRecovery } from "../session-recovery.ts";
+import type { ServerConnection } from "../server-manager.ts";
+import type { McpConfig } from "../types.ts";
+
+function makeConnection(sessionId: string | undefined): ServerConnection {
+  return {
+    client: {} as ServerConnection["client"],
+    transport: { sessionId } as unknown as ServerConnection["transport"],
+    definition: { url: "https://example.test/mcp" },
+    tools: [],
+    resources: [],
+    lastUsedAt: Date.now(),
+    inFlight: 0,
+    status: "connected",
+  };
+}
+
+describe("isTerminatedSession", () => {
+  it("is true for a 404 StreamableHTTPError carrying a session id", () => {
+    const err = new StreamableHTTPError(404, "Session not found");
+    expect(isTerminatedSession(err, true)).toBe(true);
+  });
+
+  it("is false for a 404 with no session id (never initialized / wrong URL)", () => {
+    const err = new StreamableHTTPError(404, "Not found");
+    expect(isTerminatedSession(err, false)).toBe(false);
+  });
+
+  it("is false for 400, even with a session id — ambiguous, never treated as expiry", () => {
+    const err = new StreamableHTTPError(400, "Bad request");
+    expect(isTerminatedSession(err, true)).toBe(false);
+  });
+
+  it("is false for a plain Error, even with matching message text", () => {
+    const err = new Error("Streamable HTTP error: 404 session not found");
+    expect(isTerminatedSession(err, true)).toBe(false);
+  });
+
+  it("is false for an AbortError / cancellation", () => {
+    const err = new DOMException("The operation was aborted", "AbortError");
+    expect(isTerminatedSession(err, true)).toBe(false);
+  });
+
+  it("is false for a non-Error thrown value", () => {
+    expect(isTerminatedSession("boom", true)).toBe(false);
+    expect(isTerminatedSession(undefined, true)).toBe(false);
+  });
+});
+
+describe("withSessionRecovery", () => {
+  function makeManager(overrides: {
+    getConnection: () => ServerConnection | undefined;
+    reconnect: (...args: unknown[]) => Promise<ServerConnection>;
+  }) {
+    return {
+      getConnection: vi.fn(overrides.getConnection),
+      reconnect: vi.fn(overrides.reconnect),
+    };
+  }
+
+  const config: McpConfig = {
+    mcpServers: { demo: { url: "https://example.test/mcp" } },
+  };
+
+  it("transparently recovers: fn is retried exactly once against the fresh connection", async () => {
+    const stale = makeConnection("session-1");
+    const fresh = makeConnection("session-2");
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => fresh,
+    });
+
+    const fn = vi.fn(async (conn: ServerConnection) => {
+      if (conn === stale) {
+        throw new StreamableHTTPError(404, "Session not found");
+      }
+      return "ok";
+    });
+
+    const result = await withSessionRecovery({ manager: manager as any, config }, "demo", fn);
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, stale);
+    expect(fn).toHaveBeenNthCalledWith(2, fresh);
+    expect(manager.reconnect).toHaveBeenCalledWith("demo", config.mcpServers.demo, stale);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets an auth callback replace a needs-auth reconnect before retrying", async () => {
+    const stale = makeConnection("session-1");
+    const needsAuth = { ...makeConnection("session-2"), status: "needs-auth" as const };
+    const authed = makeConnection("session-3");
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => needsAuth,
+    });
+    const onNeedsAuth = vi.fn(async () => authed);
+
+    const fn = vi.fn(async (conn: ServerConnection) => {
+      if (conn === stale) {
+        throw new StreamableHTTPError(404, "Session not found");
+      }
+      return conn === authed ? "ok" : "wrong-connection";
+    });
+
+    const result = await withSessionRecovery({ manager: manager as any, config, onNeedsAuth }, "demo", fn);
+
+    expect(result).toBe("ok");
+    expect(onNeedsAuth).toHaveBeenCalledWith("demo");
+    expect(fn).toHaveBeenNthCalledWith(2, authed);
+  });
+
+  it("reports auth required when reconnect cannot produce a connected session", async () => {
+    const stale = makeConnection("session-1");
+    const needsAuth = { ...makeConnection("session-2"), status: "needs-auth" as const };
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => needsAuth,
+    });
+    const fn = vi.fn(async () => {
+      throw new StreamableHTTPError(404, "Session not found");
+    });
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn))
+      .rejects.toBeInstanceOf(SessionRecoveryAuthRequiredError);
+  });
+
+  it("passes the abort signal into reconnect", async () => {
+    const stale = makeConnection("session-1");
+    const fresh = makeConnection("session-2");
+    const signal = new AbortController().signal;
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => fresh,
+    });
+    const fn = vi.fn(async (conn: ServerConnection) => {
+      if (conn === stale) {
+        throw new StreamableHTTPError(404, "Session not found");
+      }
+      return "ok";
+    });
+
+    await expect(withSessionRecovery({ manager: manager as any, config, signal }, "demo", fn)).resolves.toBe("ok");
+
+    expect(manager.reconnect).toHaveBeenCalledWith("demo", config.mcpServers.demo, stale, signal);
+  });
+
+  it("does not reconnect after the caller aborts", async () => {
+    const stale = makeConnection("session-1");
+    const reason = new Error("stop");
+    const controller = new AbortController();
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => makeConnection("session-2"),
+    });
+    const fn = vi.fn(async () => {
+      controller.abort(reason);
+      throw new StreamableHTTPError(404, "Session not found");
+    });
+
+    await expect(withSessionRecovery({ manager: manager as any, config, signal: controller.signal }, "demo", fn))
+      .rejects.toBe(reason);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("retries exactly once: a second 404 propagates unchanged", async () => {
+    const stale = makeConnection("session-1");
+    const fresh = makeConnection("session-2");
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => fresh,
+    });
+
+    const err1 = new StreamableHTTPError(404, "Session not found");
+    const err2 = new StreamableHTTPError(404, "Session not found");
+    const fn = vi.fn().mockRejectedValueOnce(err1).mockRejectedValueOnce(err2);
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err2);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(manager.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recover a resolved tool-result error (isError content is not a thrown error)", async () => {
+    const connection = makeConnection("session-1");
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const fn = vi.fn(async () => ({ isError: true, content: [] }));
+
+    const result = await withSessionRecovery({ manager: manager as any, config }, "demo", fn);
+
+    expect(result).toEqual({ isError: true, content: [] });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("does not recover a 404 without a session id (never initialized / wrong URL)", async () => {
+    const connection = makeConnection(undefined);
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const err = new StreamableHTTPError(404, "Not found");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("does not recover an AbortError", async () => {
+    const connection = makeConnection("session-1");
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const err = new DOMException("aborted", "AbortError");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("does not recover a 400 (ambiguous status, never matched)", async () => {
+    const connection = makeConnection("session-1");
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const err = new StreamableHTTPError(400, "Bad request");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the original error when the server was removed from config before reconnecting", async () => {
+    const connection = makeConnection("session-1");
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const err = new StreamableHTTPError(404, "Session not found");
+    const fn = vi.fn().mockRejectedValue(err);
+    const emptyConfig: McpConfig = { mcpServers: {} };
+
+    await expect(withSessionRecovery({ manager: manager as any, config: emptyConfig }, "demo", fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("concurrency: two simultaneous session failures both replay against the same fresh connection", async () => {
+    const stale = makeConnection("session-1");
+    const fresh = makeConnection("session-2");
+
+    // Simulate McpServerManager.reconnect's real single-flight contract: no
+    // matter how many callers ask, they all get the same in-flight promise
+    // resolving to the same fresh connection.
+    const sharedReconnect = Promise.resolve(fresh);
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: () => sharedReconnect,
+    });
+
+    const fn = vi.fn(async (conn: ServerConnection) => {
+      if (conn === stale) {
+        throw new StreamableHTTPError(404, "Session not found");
+      }
+      return conn === fresh ? "ok" : "unexpected";
+    });
+
+    const [r1, r2] = await Promise.all([
+      withSessionRecovery({ manager: manager as any, config }, "demo", fn),
+      withSessionRecovery({ manager: manager as any, config }, "demo", fn),
+    ]);
+
+    expect(r1).toBe("ok");
+    expect(r2).toBe("ok");
+    // Each caller's own failure triggers its own reconnect() call, but the
+    // manager's single-flight dedupes the underlying work; both resolve to
+    // the identical fresh connection.
+    expect(manager.reconnect).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledTimes(4); // 2 failed stale attempts + 2 successful fresh replays
+  });
+});

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -36,6 +36,47 @@ describe("UiResourceHandler", () => {
       await expect(handler.readUiResource("server", "ui://test/widget")).rejects.toBe(error);
     });
 
+    it("recovers a terminated HTTP session while loading a UI resource", async () => {
+      const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+      const stale = {
+        status: "connected" as const,
+        transport: { sessionId: "session-1" },
+        client: {
+          readResource: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+        },
+        resources: [],
+      };
+      const fresh = {
+        status: "connected" as const,
+        transport: { sessionId: "session-2" },
+        client: {
+          readResource: vi.fn().mockResolvedValue({
+            contents: [{ uri: "ui://test/widget", mimeType: "text/html", text: "<h1>Recovered</h1>" }],
+          }),
+        },
+        resources: [],
+      };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue(stale),
+        reconnect: vi.fn().mockResolvedValue(fresh),
+        getRequestOptions: vi.fn().mockReturnValue(undefined),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      });
+      const config = { mcpServers: { server: { url: "https://example.test/mcp" } } };
+      const handler = new UiResourceHandler(manager);
+
+      const result = await handler.readUiResource("server", "ui://test/widget", { config });
+
+      expect(result.html).toBe("<h1>Recovered</h1>");
+      expect(stale.client.readResource).toHaveBeenCalledTimes(1);
+      expect(fresh.client.readResource).toHaveBeenCalledTimes(1);
+      expect(manager.reconnect).toHaveBeenCalledWith("server", config.mcpServers.server, stale);
+      expect(manager.incrementInFlight).toHaveBeenCalledWith("server");
+      expect(manager.decrementInFlight).toHaveBeenCalledWith("server");
+    });
+
     it("reads and returns HTML from text content", async () => {
       const manager = createMockManager({
         readResource: vi.fn().mockResolvedValue({

--- a/__tests__/ui-server-session-recovery.test.ts
+++ b/__tests__/ui-server-session-recovery.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import http from "node:http";
+import { startUiServer, type UiServerHandle, type UiServerOptions } from "../ui-server.ts";
+import type { McpServerManager, ServerConnection } from "../server-manager.ts";
+import type { ConsentManager } from "../consent-manager.ts";
+import type { UiResourceContent, McpConfig } from "../types.ts";
+
+// Same HTTP helper as __tests__/ui-server.test.ts.
+async function request(
+  url: string,
+  options: { method?: string; body?: unknown } = {}
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method: options.method ?? "GET",
+        headers: { "Content-Type": "application/json" },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf-8");
+          let body: unknown;
+          try {
+            body = JSON.parse(text);
+          } catch {
+            body = text;
+          }
+          resolve({ status: res.statusCode ?? 0, body });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (options.body) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+
+function createMockConsentManager(): ConsentManager {
+  return {
+    requiresPrompt: vi.fn().mockReturnValue(false),
+    shouldCacheConsent: vi.fn().mockReturnValue(true),
+    ensureApproved: vi.fn(),
+    registerDecision: vi.fn(),
+  } as unknown as ConsentManager;
+}
+
+function createMockResource(): UiResourceContent {
+  return {
+    uri: "ui://test/widget",
+    html: "<h1>Test App</h1>",
+    mimeType: "text/html",
+    meta: { permissions: [] },
+  };
+}
+
+describe("UiServer /proxy/tools/call session recovery", () => {
+  let handle: UiServerHandle | null = null;
+
+  afterEach(() => {
+    if (handle) {
+      handle.close("test-cleanup");
+      handle = null;
+    }
+  });
+
+  it("recovers a terminated Streamable HTTP session transparently, when config is supplied", async () => {
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected",
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+    } as unknown as ServerConnection;
+    const fresh = {
+      status: "connected",
+      transport: { sessionId: "session-2" },
+      client: { callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "tool result" }] }) },
+    } as unknown as ServerConnection;
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => fresh),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getRequestOptions: vi.fn(() => undefined),
+    } as unknown as McpServerManager;
+
+    const config: McpConfig = { mcpServers: { "test-server": { url: "https://api.example.com/mcp" } } };
+
+    const options: UiServerOptions = {
+      serverName: "test-server",
+      toolName: "test_tool",
+      toolArgs: {},
+      resource: createMockResource(),
+      manager,
+      config,
+      consentManager: createMockConsentManager(),
+    };
+
+    handle = await startUiServer(options);
+
+    const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+      method: "POST",
+      body: { token: handle.sessionToken, params: { name: "some_tool", arguments: {} } },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "tool result" }] } });
+    expect((stale.client.callTool as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    expect((fresh.client.callTool as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).toHaveBeenCalledWith("test-server", config.mcpServers["test-server"], stale);
+  });
+
+  it("returns auth guidance when recovery reconnect needs auth and no callback can refresh it", async () => {
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected",
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+    } as unknown as ServerConnection;
+    const needsAuth = {
+      status: "needs-auth",
+      transport: { sessionId: "session-2" },
+      client: { callTool: vi.fn() },
+    } as unknown as ServerConnection;
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => needsAuth),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getRequestOptions: vi.fn(() => undefined),
+    } as unknown as McpServerManager;
+
+    handle = await startUiServer({
+      serverName: "test-server",
+      toolName: "test_tool",
+      toolArgs: {},
+      resource: createMockResource(),
+      manager,
+      config: { mcpServers: { "test-server": { url: "https://api.example.com/mcp" } } },
+      consentManager: createMockConsentManager(),
+    });
+
+    const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+      method: "POST",
+      body: { token: handle.sessionToken, params: { name: "some_tool", arguments: {} } },
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      ok: false,
+      error: expect.stringContaining('mcp({ action: "auth-start", server: "test-server" })'),
+    });
+  });
+
+  it("uses the supplied auth callback when recovery reconnect returns needs-auth", async () => {
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected",
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+    } as unknown as ServerConnection;
+    const needsAuth = {
+      status: "needs-auth",
+      transport: { sessionId: "session-2" },
+      client: { callTool: vi.fn() },
+    } as unknown as ServerConnection;
+    const fresh = {
+      status: "connected",
+      transport: { sessionId: "session-3" },
+      client: { callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "after auth" }] }) },
+    } as unknown as ServerConnection;
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(async () => needsAuth),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getRequestOptions: vi.fn(() => undefined),
+    } as unknown as McpServerManager;
+    const onNeedsAuth = vi.fn(async () => fresh);
+
+    handle = await startUiServer({
+      serverName: "test-server",
+      toolName: "test_tool",
+      toolArgs: {},
+      resource: createMockResource(),
+      manager,
+      config: { mcpServers: { "test-server": { url: "https://api.example.com/mcp" } } },
+      onNeedsAuth,
+      consentManager: createMockConsentManager(),
+    });
+
+    const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+      method: "POST",
+      body: { token: handle.sessionToken, params: { name: "some_tool", arguments: {} } },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "after auth" }] } });
+    expect(onNeedsAuth).toHaveBeenCalledWith("test-server");
+    expect((fresh.client.callTool as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs without recovery (unchanged pre-existing behavior) when config is not supplied", async () => {
+    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const stale = {
+      status: "connected",
+      transport: { sessionId: "session-1" },
+      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+    } as unknown as ServerConnection;
+
+    const manager = {
+      getConnection: vi.fn(() => stale),
+      reconnect: vi.fn(),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      getRequestOptions: vi.fn(() => undefined),
+    } as unknown as McpServerManager;
+
+    const options: UiServerOptions = {
+      serverName: "test-server",
+      toolName: "test_tool",
+      toolArgs: {},
+      resource: createMockResource(),
+      manager,
+      // no `config` — recovery must not be attempted
+      consentManager: createMockConsentManager(),
+    };
+
+    handle = await startUiServer(options);
+
+    const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+      method: "POST",
+      body: { token: handle.sessionToken, params: { name: "some_tool", arguments: {} } },
+    });
+
+    expect(res.status).toBe(500);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+    expect((stale.client.callTool as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -14,6 +14,7 @@ import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
+import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
@@ -361,13 +362,40 @@ export function createDirectToolExecutor(
     const requestOptions = state.manager.getRequestOptions?.(spec.serverName, signal) ?? (signal ? { signal } : undefined);
 
     const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
+    const recoverAuthConnection = async () => {
+      const current = state.manager.getConnection(spec.serverName);
+      if (current?.status === "connected") return current;
+
+      if (!autoAuthAttempted) {
+        autoAuthAttempted = true;
+        const autoAuth = await attemptDirectAutoAuth(state, spec.serverName);
+        if (autoAuth.status === "failed") {
+          throw new SessionRecoveryAuthRequiredError(spec.serverName, autoAuth.message);
+        }
+        if (autoAuth.status === "success") {
+          const afterAuth = state.manager.getConnection(spec.serverName);
+          if (afterAuth?.status === "connected") return afterAuth;
+          if (afterAuth?.status === "needs-auth") {
+            await state.manager.close(spec.serverName);
+          }
+          state.failureTracker.delete(spec.serverName);
+          const reconnected = await lazyConnect(state, spec.serverName, signal);
+          return reconnected ? state.manager.getConnection(spec.serverName) : undefined;
+        }
+      }
+      return state.manager.getConnection(spec.serverName);
+    };
 
     try {
       state.manager.touch(spec.serverName);
       state.manager.incrementInFlight(spec.serverName);
 
       if (spec.resourceUri) {
-        const result = await connection.client.readResource({ uri: spec.resourceUri }, requestOptions);
+        const result = await withSessionRecovery(
+          { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+          spec.serverName,
+          (conn) => conn.client.readResource({ uri: spec.resourceUri! }, requestOptions),
+        );
         const content = (result.contents ?? []).map(c => ({
           type: "text" as const,
           text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -387,16 +415,20 @@ export function createDirectToolExecutor(
             toolArgs: params ?? {},
             uiResourceUri: spec.uiResourceUri!,
             streamMode: spec.uiStreamMode,
+            signal,
+            onNeedsAuth: recoverAuthConnection,
           })
         : null;
 
-      const resultPromise = connection.client.callTool({
-        name: spec.originalName,
-        arguments: params ?? {},
-        _meta: uiSession?.requestMeta,
-      }, undefined, requestOptions);
-
-      const result = await abortable(resultPromise, signal);
+      const result = await withSessionRecovery(
+        { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+        spec.serverName,
+        (conn) => abortable(conn.client.callTool({
+          name: spec.originalName,
+          arguments: params ?? {},
+          _meta: uiSession?.requestMeta,
+        }, undefined, requestOptions), signal),
+      );
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
 
       if (result.isError) {
@@ -430,6 +462,14 @@ export function createDirectToolExecutor(
         details: { server: spec.serverName, tool: spec.originalName, ...guardedMcpDetails(guarded) },
       };
     } catch (error) {
+      if (error instanceof SessionRecoveryAuthRequiredError) {
+        const message = error.authMessage ?? getDirectAuthRequiredMessage(state, spec.serverName);
+        uiSession?.sendToolCancelled(message);
+        return {
+          content: [{ type: "text" as const, text: message }],
+          details: { error: "auth_required", server: spec.serverName, message, autoAuthAttempted },
+        };
+      }
       if (error instanceof UrlElicitationRequiredError) {
         const action = await state.manager.handleUrlElicitationRequired(spec.serverName, error);
         const message = action === "accept"

--- a/init.ts
+++ b/init.ts
@@ -60,7 +60,7 @@ export async function initializeMcp(
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
-  const uiResourceHandler = new UiResourceHandler(manager);
+  const uiResourceHandler = new UiResourceHandler(manager, config);
   const consentManager = new ConsentManager("once-per-server");
   const ui = ctx.hasUI ? ctx.ui : undefined;
   const state: McpExtensionState = {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ui-stream-types.ts",
     "config.ts",
     "server-manager.ts",
+    "session-recovery.ts",
     "sampling-handler.ts",
     "elicitation-handler.ts",
     "tool-registrar.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -12,6 +12,7 @@ import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from 
 import { maybeStartUiSession, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
+import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -883,13 +884,42 @@ export async function executeCall(
   const requestOptions = state.manager.getRequestOptions?.(serverName, signal) ?? (signal ? { signal } : undefined);
 
   const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
+  const recoverAuthConnection = async () => {
+    const current = state.manager.getConnection(serverName);
+    if (current?.status === "connected") return current;
+
+    if (!autoAuthAttempted) {
+      autoAuthAttempted = true;
+      const autoAuth = await attemptAutoAuth(state, serverName);
+      if (autoAuth.status === "failed") {
+        throw new SessionRecoveryAuthRequiredError(serverName, autoAuth.message);
+      }
+      if (autoAuth.status === "success") {
+        const definition = state.config.mcpServers[serverName];
+        if (!definition) return undefined;
+        const afterAuth = state.manager.getConnection(serverName);
+        if (afterAuth?.status === "connected") return afterAuth;
+        if (afterAuth?.status === "needs-auth") {
+          await state.manager.close(serverName);
+        }
+        state.failureTracker.delete(serverName);
+        connection = await state.manager.connect(serverName, definition, signal);
+        return connection;
+      }
+    }
+    return state.manager.getConnection(serverName);
+  };
 
   try {
     state.manager.touch(serverName);
     state.manager.incrementInFlight(serverName);
 
     if (toolMeta.resourceUri) {
-      const result = await connection.client.readResource({ uri: toolMeta.resourceUri }, requestOptions);
+      const result = await withSessionRecovery(
+        { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+        serverName,
+        (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
+      );
       const content = (result.contents ?? []).map(c => ({
         type: "text" as const,
         text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
@@ -908,17 +938,22 @@ export async function executeCall(
           toolArgs: args ?? {},
           uiResourceUri: toolMeta.uiResourceUri,
           streamMode: toolMeta.uiStreamMode,
+          signal,
+          onNeedsAuth: recoverAuthConnection,
         })
       : null;
 
-    const resultPromise = connection.client.callTool({
-      name: toolMeta.originalName,
-      arguments: args ?? {},
-      _meta: uiSession?.requestMeta,
-    }, undefined, requestOptions);
+    const result = await withSessionRecovery(
+      { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+      serverName,
+      (conn) => abortable(conn.client.callTool({
+        name: toolMeta.originalName,
+        arguments: args ?? {},
+        _meta: uiSession?.requestMeta,
+      }, undefined, requestOptions), signal),
+    );
 
     if (toolMeta.uiResourceUri) {
-      const result = await abortable(resultPromise, signal);
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
 
       if (result.isError) {
@@ -945,8 +980,6 @@ export async function executeCall(
       };
     }
 
-    const result = await abortable(resultPromise, signal);
-
     if (result.isError) {
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent);
@@ -967,6 +1000,14 @@ export async function executeCall(
       details: { mode: "call", ...guardedMcpDetails(guarded), server: serverName, tool: toolMeta.originalName },
     };
   } catch (error) {
+    if (error instanceof SessionRecoveryAuthRequiredError) {
+      const message = error.authMessage ?? getAuthRequiredMessage(state, serverName);
+      uiSession?.sendToolCancelled(message);
+      return {
+        content: [{ type: "text" as const, text: message }],
+        details: { mode: "call", error: "auth_required", server: serverName, message, autoAuthAttempted },
+      };
+    }
     if (error instanceof UrlElicitationRequiredError) {
       const action = await state.manager.handleUrlElicitationRequired(serverName, error);
       const message = action === "accept"

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -30,7 +30,7 @@ import {
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 
-interface ServerConnection {
+export interface ServerConnection {
   client: Client;
   transport: Transport;
   definition: ServerDefinition;
@@ -47,6 +47,7 @@ type UiStreamListener = (serverName: string, notification: ServerStreamResultPat
 export class McpServerManager {
   private connections = new Map<string, ServerConnection>();
   private connectPromises = new Map<string, Promise<ServerConnection>>();
+  private reconnectPromises = new Map<string, Promise<ServerConnection>>();
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
   private elicitationConfig: ServerElicitationConfig | undefined;
@@ -122,6 +123,57 @@ export class McpServerManager {
     }
   }
 
+  /**
+   * Reconnect a server whose connection was proven stale (e.g. by a 404
+   * "session no longer exists" response). Single-flight per server name —
+   * concurrent callers that raced to the same failure share one reconnect —
+   * and identity-guarded: `staleConnection` is only torn down if it is
+   * still the manager's current connection for `name`. If a concurrent
+   * reconnect (or an unrelated connect()) already replaced it with a fresh
+   * connection, that fresh connection is returned untouched.
+   */
+  async reconnect(
+    name: string,
+    definition: ServerDefinition,
+    staleConnection: ServerConnection,
+    signal?: AbortSignal,
+  ): Promise<ServerConnection> {
+    throwIfAborted(signal);
+    const inFlight = this.reconnectPromises.get(name);
+    if (inFlight) {
+      return abortable(inFlight, signal);
+    }
+
+    const promise = this.doReconnect(name, definition, staleConnection).finally(() => {
+      if (this.reconnectPromises.get(name) === promise) {
+        this.reconnectPromises.delete(name);
+      }
+    });
+    this.reconnectPromises.set(name, promise);
+    return abortable(promise, signal);
+  }
+
+  private async doReconnect(
+    name: string,
+    definition: ServerDefinition,
+    staleConnection: ServerConnection,
+  ): Promise<ServerConnection> {
+    const current = this.connections.get(name);
+
+    // Never tear down a connection we didn't prove stale: if the map no
+    // longer holds the connection we were asked to replace, someone else
+    // already reconnected (or connected) first.
+    if (current !== staleConnection) {
+      return current ?? this.connect(name, definition);
+    }
+
+    const staleInFlight = staleConnection.inFlight;
+    await this.close(name);
+    const fresh = await this.connect(name, definition);
+    fresh.inFlight = Math.max(fresh.inFlight, staleInFlight);
+    return fresh;
+  }
+
   private async createConnection(
     name: string,
     definition: ServerDefinition,
@@ -165,23 +217,43 @@ export class McpServerManager {
       await client.connect(transport, requestOptions);
       this.attachAdapterNotificationHandlers(name, client);
 
-      // Discover tools and resources
-      const [tools, resources] = await Promise.all([
-        this.fetchAllTools(client, requestOptions),
-        this.fetchAllResources(client, requestOptions),
-      ]);
-
-      return {
+      const connection: ServerConnection = {
         client,
         transport,
         definition,
-        tools,
-        resources,
+        tools: [],
+        resources: [],
         instructions: client.getInstructions?.(),
         lastUsedAt: Date.now(),
         inFlight: 0,
         status: "connected",
       };
+
+      // Reflect the SDK's own close signal in connection status, guarded by
+      // identity so a stale connection's late close (e.g. the old
+      // connection from before a session-recovery reconnect) can never
+      // clobber a fresh connection that has since taken its place in
+      // `this.connections`. This intentionally uses `client.onclose`
+      // (Protocol's public hook), not `transport.onclose` — the SDK's
+      // Protocol takes ownership of that one internally for pending-request
+      // rejection, and overwriting it would break that. `client.onerror` is
+      // avoided too: it can fire on benign events (e.g. the optional GET
+      // SSE stream failing) that don't mean the connection is closed.
+      client.onclose = () => {
+        if (this.connections.get(name) === connection) {
+          connection.status = "closed";
+        }
+      };
+
+      // Discover tools and resources
+      const [tools, resources] = await Promise.all([
+        this.fetchAllTools(client, requestOptions),
+        this.fetchAllResources(client, requestOptions),
+      ]);
+      connection.tools = tools;
+      connection.resources = resources;
+
+      return connection;
     } catch (error) {
       // Check for UnauthorizedError - server requires OAuth
       if (error instanceof UnauthorizedError && supportsOAuth(definition)) {

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -1,0 +1,127 @@
+// session-recovery.ts
+//
+// Streamable HTTP session recovery.
+//
+// Per the MCP spec (Streamable HTTP transport):
+//   "When a client receives HTTP 404 in response to a request containing an
+//   Mcp-Session-Id, it MUST start a new session by sending a new
+//   InitializeRequest without a session ID attached."
+//
+// A 404 for a request that carried a session ID is therefore the spec's own
+// definition of "this session no longer exists" (e.g. the remote server
+// process restarted and lost its in-memory session table). Because the spec
+// requires the server to reject the request *before* processing it, retrying
+// the same call against a freshly initialized session cannot double-execute
+// the original request.
+//
+// This module intentionally does NOT:
+//   - match on error message text
+//   - match on any other HTTP status (in particular 400, which is ambiguous
+//     and can mean many things other than "your session is gone")
+//   - treat AbortError/cancellation as a session failure
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { logger } from "./logger.ts";
+import { throwIfAborted } from "./abort.ts";
+import type { McpConfig } from "./types.ts";
+import type { McpServerManager, ServerConnection } from "./server-manager.ts";
+
+/**
+ * True when `err` is the MCP spec's exact definition of "this Streamable
+ * HTTP session no longer exists on the server": a 404 `StreamableHTTPError`
+ * for a request that was sent while carrying an `Mcp-Session-Id`.
+ *
+ * `hadSessionId` must reflect the transport's session id from *before* the
+ * call that produced `err` was made. The installed SDK (1.29.0) happens not
+ * to clear `transport.sessionId` on a 404 response, so checking it at catch
+ * time currently agrees with checking it up front — but callers should
+ * capture it before the call rather than rely on that incidental behavior.
+ */
+export function isTerminatedSession(err: unknown, hadSessionId: boolean): boolean {
+  return err instanceof StreamableHTTPError && err.code === 404 && hadSessionId;
+}
+
+function hasSessionId(connection: ServerConnection): boolean {
+  // Only StreamableHTTPClientTransport exposes `sessionId`; stdio/SSE
+  // transports (and test doubles that omit `transport` entirely) simply
+  // read as `undefined` here.
+  const transport = connection.transport as { sessionId?: string } | undefined;
+  return transport?.sessionId != null;
+}
+
+export class SessionRecoveryAuthRequiredError extends Error {
+  constructor(readonly serverName: string, readonly authMessage?: string) {
+    super(authMessage ?? `MCP server "${serverName}" requires OAuth authentication after reconnect.`);
+    this.name = "SessionRecoveryAuthRequiredError";
+  }
+}
+
+export interface SessionRecoveryDeps {
+  manager: McpServerManager;
+  config: McpConfig;
+  signal?: AbortSignal;
+  onNeedsAuth?: (serverName: string) => Promise<ServerConnection | undefined>;
+}
+
+/**
+ * Runs `fn` against the current connection for `serverName`. If it fails
+ * with a terminated Streamable HTTP session (see `isTerminatedSession`),
+ * reconnects exactly once via `McpServerManager.reconnect` (single-flight,
+ * identity-guarded — see server-manager.ts) and retries `fn` exactly once
+ * against the fresh connection.
+ *
+ * Any other failure — including a second failure after reconnecting, or the
+ * server having been removed from config in the meantime — propagates
+ * unchanged through the caller's existing error handling.
+ */
+export async function withSessionRecovery<T>(
+  deps: SessionRecoveryDeps,
+  serverName: string,
+  fn: (conn: ServerConnection) => Promise<T>,
+): Promise<T> {
+  const connection = deps.manager.getConnection(serverName);
+  if (!connection) {
+    throw new Error(`Server "${serverName}" is not connected`);
+  }
+
+  const hadSessionId = hasSessionId(connection);
+
+  try {
+    return await fn(connection);
+  } catch (err) {
+    if (!isTerminatedSession(err, hadSessionId)) {
+      throw err;
+    }
+
+    // Re-read the live definition rather than reusing the stale
+    // connection's definition, in case config changed since connect. If the
+    // server was removed from config in the meantime there is nothing to
+    // reconnect to, so surface the original error.
+    const definition = deps.config.mcpServers[serverName];
+    if (!definition) {
+      throw err;
+    }
+
+    throwIfAborted(deps.signal);
+    logger.debug(`MCP session for "${serverName}" expired (404 + Mcp-Session-Id); reconnecting`, {
+      server: serverName,
+    });
+    let freshConnection = deps.signal
+      ? await deps.manager.reconnect(serverName, definition, connection, deps.signal)
+      : await deps.manager.reconnect(serverName, definition, connection);
+    throwIfAborted(deps.signal);
+
+    if (freshConnection.status === "needs-auth") {
+      freshConnection = await deps.onNeedsAuth?.(serverName) ?? freshConnection;
+      throwIfAborted(deps.signal);
+    }
+
+    if (freshConnection.status === "needs-auth") {
+      throw new SessionRecoveryAuthRequiredError(serverName);
+    }
+    if (freshConnection.status !== "connected") {
+      throw err;
+    }
+
+    return fn(freshConnection);
+  }
+}

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -2,8 +2,9 @@ import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";
+import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import type { McpServerManager } from "./server-manager.ts";
-import type { UiResourceContent, UiResourceMeta } from "./types.ts";
+import type { McpConfig, UiResourceContent, UiResourceMeta } from "./types.ts";
 
 interface ResourceContentRecord {
   uri?: string;
@@ -13,12 +14,18 @@ interface ResourceContentRecord {
   _meta?: Record<string, unknown>;
 }
 
+interface ReadUiResourceOptions {
+  config?: McpConfig;
+  signal?: AbortSignal;
+  onNeedsAuth?: SessionRecoveryDeps["onNeedsAuth"];
+}
+
 export class UiResourceHandler {
   private log = logger.child({ component: "UiResourceHandler" });
 
-  constructor(private manager: McpServerManager) {}
+  constructor(private manager: McpServerManager, private config?: McpConfig) {}
 
-  async readUiResource(serverName: string, uri: string): Promise<UiResourceContent> {
+  async readUiResource(serverName: string, uri: string, options: ReadUiResourceOptions = {}): Promise<UiResourceContent> {
     const log = this.log.child({ server: serverName, uri });
 
     if (!uri.startsWith("ui://")) {
@@ -29,9 +36,25 @@ export class UiResourceHandler {
 
     let result: ReadResourceResult;
     try {
-      result = await this.manager.readResource(serverName, uri);
+      const config = options.config ?? this.config;
+      if (config) {
+        this.manager.touch(serverName);
+        this.manager.incrementInFlight(serverName);
+        try {
+          result = await withSessionRecovery(
+            { manager: this.manager, config, signal: options.signal, onNeedsAuth: options.onNeedsAuth },
+            serverName,
+            (connection) => connection.client.readResource({ uri }, this.manager.getRequestOptions(serverName, options.signal)),
+          );
+        } finally {
+          this.manager.decrementInFlight(serverName);
+          this.manager.touch(serverName);
+        }
+      } else {
+        result = await this.manager.readResource(serverName, uri, options.signal);
+      }
     } catch (error) {
-      if (error instanceof UrlElicitationRequiredError) throw error;
+      if (error instanceof UrlElicitationRequiredError || error instanceof SessionRecoveryAuthRequiredError) throw error;
       const message = error instanceof Error ? error.message : String(error);
       log.error("Failed to read resource", error instanceof Error ? error : undefined);
       throw new ResourceFetchError(uri, message, {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -9,12 +9,15 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
+import { formatAuthRequiredMessage } from "./utils.ts";
 import { buildHostHtmlTemplate, buildCspMetaContent, applyCspMeta } from "./host-html-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
+import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import {
   extractUiPromptText,
   getVisualizationStreamEnvelope,
+  type McpConfig,
   type UiDisplayMode,
   type UiDisplayModeRequest,
   type UiDisplayModeResult,
@@ -40,6 +43,15 @@ export interface UiServerOptions {
   toolArgs: Record<string, unknown>;
   resource: UiResourceContent;
   manager: McpServerManager;
+  /**
+   * Live extension config, used to re-read the server definition when
+   * recovering a terminated Streamable HTTP session (see
+   * session-recovery.ts). Optional so existing embedders/tests that don't
+   * need session recovery aren't forced to supply it; without it, proxied
+   * tool calls run without recovery (unchanged pre-existing behavior).
+   */
+  config?: McpConfig;
+  onNeedsAuth?: SessionRecoveryDeps["onNeedsAuth"];
   consentManager: ConsentManager;
   hostContext?: UiHostContext;
   initialResultPromise?: Promise<CallToolResult>;
@@ -340,13 +352,20 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         try {
           options.manager.touch(options.serverName);
           options.manager.incrementInFlight(options.serverName);
-          const result = await connection.client.callTool({
+          const callArgs = {
             name: callParams.name,
             arguments:
               callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
                 ? callParams.arguments
                 : {},
-          }, undefined, options.manager.getRequestOptions?.(options.serverName));
+          };
+          const result = options.config
+            ? await withSessionRecovery(
+                { manager: options.manager, config: options.config, onNeedsAuth: options.onNeedsAuth },
+                options.serverName,
+                (conn) => conn.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName)),
+              )
+            : await connection.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName));
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);
@@ -458,6 +477,14 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
       sendJson(res, 404, { ok: false, error: "Not found" });
     } catch (error) {
+      if (error instanceof SessionRecoveryAuthRequiredError) {
+        const fallback = `Server "${options.serverName}" requires OAuth authentication. Run mcp({ action: "auth-start", server: "${options.serverName}" }) to get a browser URL, or /mcp-auth ${options.serverName} in an interactive local session.`;
+        const message = error.authMessage ?? (options.config
+          ? formatAuthRequiredMessage(options.config, options.serverName, fallback)
+          : fallback);
+        sendJson(res, 401, { ok: false, error: message });
+        return;
+      }
       const wrapped = wrapError(error, { server: options.serverName, tool: options.toolName });
       const status = /approval required|denied/i.test(wrapped.message) ? 403 : 500;
       if (status === 500) {

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -14,6 +14,7 @@ import {
 import { logger } from "./logger.ts";
 import { startUiServer, type UiServerHandle } from "./ui-server.ts";
 import { isGlimpseAvailable, openGlimpseWindow } from "./glimpse-ui.ts";
+import type { SessionRecoveryDeps } from "./session-recovery.ts";
 
 let activeGlimpseWindow: { close(): void } | null = null;
 
@@ -23,6 +24,8 @@ export interface UiSessionRequest {
   toolArgs: Record<string, unknown>;
   uiResourceUri: string;
   streamMode?: UiStreamMode;
+  signal?: AbortSignal;
+  onNeedsAuth?: SessionRecoveryDeps["onNeedsAuth"];
 }
 
 export interface UiSessionRuntime {
@@ -170,7 +173,11 @@ export async function maybeStartUiSession(
       };
     }
 
-    const resource = await state.uiResourceHandler.readUiResource(request.serverName, request.uiResourceUri);
+    const resource = await state.uiResourceHandler.readUiResource(request.serverName, request.uiResourceUri, {
+      config: state.config,
+      signal: request.signal,
+      onNeedsAuth: request.onNeedsAuth,
+    });
 
     if (state.uiServer) {
       state.uiServer.close("replaced");
@@ -211,6 +218,8 @@ export async function maybeStartUiSession(
       toolArgs: streamMode === "stream-first" ? {} : request.toolArgs,
       resource,
       manager: state.manager,
+      config: state.config,
+      onNeedsAuth: request.onNeedsAuth,
       consentManager: state.consentManager,
       hostContext,
 


### PR DESCRIPTION
# fix: recover streamable HTTP session after server restart

## Problem

When a streamable HTTP MCP server restarts (deploy, crash, scale-up), it loses its in-memory sessions. The adapter keeps sending its old `Mcp-Session-Id`, the server answers 404, and every tool call fails from then on. The only way out today is restarting the whole Pi process, even though the server is healthy again.

The MCP spec already says what a client must do here:

> When a client receives HTTP 404 in response to a request containing an `Mcp-Session-Id`, it MUST start a new session by sending a new `InitializeRequest`.

The adapter did not implement this. This PR does.

## What the fix does

When a tool call fails with the spec's exact "session is gone" signal, the adapter opens a fresh session and retries that call once. The model and the user never see the error, just a slightly slower call.

Four small pieces:

1. **Exact detection, no guessing** (`session-recovery.ts`):
   ```ts
   err instanceof StreamableHTTPError && err.code === 404 && hadSessionId
   ```
   No message-text matching. No 400 (ambiguous). No match for aborts, or for a 404 when no session was ever established (that is a config problem, not an expired session).

2. **One shared reconnect** (`server-manager.ts`, `reconnect()`): concurrent calls that hit the same dead session share a single reconnect instead of racing. It also never closes a connection that was already replaced by a newer one (identity check), so a slow failing call cannot tear down the fresh connection a faster call just built.

3. **One wrapper at every call site** (`withSessionRecovery`): used by the proxy tool, by direct tools, and by the embedded UI proxy. Retries exactly once. Any second failure goes through the existing error handling unchanged.

4. **Honest connection status**: `client.onclose` now marks the connection `"closed"` (with the same identity check). The SDK's internal `transport.onclose` is left alone on purpose, it owns pending-request cleanup.

## Why retrying is safe

The spec requires the server to reject an unknown session id before processing the request. A 404 therefore means the original call never ran. Retrying it once cannot double-execute anything.

## What this does not change

- Non-session errors behave exactly as before (tool `isError` results, auth errors, aborts, anything else).
- No retry loops, no backoff, no new config options. One reconnect, one retry, done.
- Known gap, on purpose: the manager's own `readResource()` (only used to fetch the UI host page) is not wired up, to keep the diff small. It self-heals on the next tool call.

## Tests

23 new tests across 4 files: the predicate table (what matches and what must not), transparent recovery through the real proxy, direct-tools, and UI-proxy paths, single-retry behavior, concurrency (one shared reconnect, no torn-down fresh connections), and the `onclose` identity guard. Four existing test files that mock the SDK's `streamableHttp.js` needed one added export (`StreamableHTTPError`) in their mock factories, nothing else changed in them.

Full suite green (two pre-existing failures on `main`, unrelated, missing example build artifacts). `tsc --noEmit` clean.

## Related upstream work

`modelcontextprotocol/typescript-sdk` PR #2125 proposes the same spec clause inside the SDK client. It is unmerged, and even merged it would only label the error, not retry. If it ships, this adapter code gets simpler (swap the predicate for the SDK's typed error), with no behavior change.
