### PR TITLE
feat: surface MCP connection failure reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Surfaced MCP connection failure reasons from bounded stdio diagnostics in status output and the `/mcp` panel, with a shortcut to copy the selected failure. Thanks @parkuman for PR #197.
 - Added Codex MCP imports from `.codex/config.toml`, with fallback to the existing JSON config. Thanks @npo-mmenke for PR #31.
 - Added environment-variable interpolation for HTTP MCP server URLs, with missing URL variables failing closed before requests are sent. Thanks @ozeias for PR #206.
 - Added `settings.oauthDir` to store MCP OAuth credentials in a project-specific directory, with `MCP_OAUTH_DIR` still taking precedence. Thanks @Termina1 for PR #105.

--- a/__tests__/commands-status-failure.test.ts
+++ b/__tests__/commands-status-failure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../init.ts", () => ({
+  getFailureAgeSeconds: vi.fn(() => 7),
+  getFailureMessage: vi.fn(() => "stderr says\n\x1b]8;;https://secret.invalid/status\x07server failed\x1b]8;;\x07"),
+  clearFailure: vi.fn(),
+  lazyConnect: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
+  recordFailure: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+describe("MCP status failure reasons", () => {
+  it("includes the bounded failure reason as a safe single-line status", async () => {
+    const { showStatus } = await import("../commands.ts");
+    const ui = { notify: vi.fn() };
+    await showStatus({
+      config: { mcpServers: { demo: { command: "node" } } },
+      manager: { getConnection: () => undefined },
+      toolMetadata: new Map(),
+      failureTracker: new Map([["demo", Date.now()]]),
+    } as any, { hasUI: true, ui } as any);
+
+    expect(ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("demo: failed 7s ago — stderr says server failed"),
+      "info",
+    );
+    expect(ui.notify.mock.calls[0][0]).not.toContain("https://secret.invalid/status");
+  });
+
+  it("sanitizes captured diagnostics in reconnect notifications", async () => {
+    const { reconnectServer } = await import("../commands.ts");
+    const ui = { notify: vi.fn() };
+    await reconnectServer({
+      config: { settings: {}, mcpServers: { demo: { command: "node" } } },
+      manager: {
+        close: vi.fn(async () => {}),
+        connect: vi.fn(async () => {
+          throw new Error("stderr \x1b]52;c;clipboard-secret\x07server failed");
+        }),
+      },
+    } as any, { hasUI: true, ui } as any, "demo");
+
+    expect(ui.notify).toHaveBeenCalledWith("MCP: Failed to reconnect to demo: stderr server failed", "error");
+    expect(ui.notify.mock.calls[0][0]).not.toContain("clipboard-secret");
+  });
+});

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -4,6 +4,7 @@ import { buildToolMetadata } from "../tool-metadata.ts";
 const mocks = vi.hoisted(() => ({
   lazyConnect: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
+  clearFailure: vi.fn(),
   authenticate: vi.fn(),
   supportsOAuth: vi.fn(),
 }));
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../init.ts", () => ({
   lazyConnect: mocks.lazyConnect,
   getFailureAgeSeconds: mocks.getFailureAgeSeconds,
+  clearFailure: mocks.clearFailure,
 }));
 
 vi.mock("../mcp-auth-flow.ts", () => ({
@@ -23,6 +25,7 @@ describe("direct tools auto auth", () => {
     vi.resetModules();
     mocks.lazyConnect.mockReset();
     mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
+    mocks.clearFailure.mockReset();
     mocks.authenticate.mockReset().mockResolvedValue("authenticated");
     mocks.supportsOAuth.mockReset().mockReturnValue(true);
   });

--- a/__tests__/init-failure-state.test.ts
+++ b/__tests__/init-failure-state.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearFailure, getFailureAgeSeconds, getFailureMessage, recordFailure } from "../init.ts";
+
+describe("MCP failure state", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("bounds messages and removes diagnostics after the backoff TTL", () => {
+    vi.useFakeTimers();
+    const state = {
+      failureTracker: new Map<string, number>(),
+      failureMessages: new Map<string, string>(),
+    } as any;
+
+    recordFailure(state, "demo", "x".repeat(100_000));
+
+    expect(state.failureMessages.get("demo")).toHaveLength(8 * 1024);
+    expect(getFailureAgeSeconds(state, "demo")).toBe(0);
+    expect(getFailureMessage(state, "demo")).toHaveLength(8 * 1024);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(state.failureTracker.has("demo")).toBe(false);
+    expect(state.failureMessages.has("demo")).toBe(false);
+    expect(getFailureAgeSeconds(state, "demo")).toBeNull();
+  });
+
+  it("clears a prior expiry timer when a failure recovers", () => {
+    vi.useFakeTimers();
+    const state = {
+      failureTracker: new Map<string, number>(),
+      failureMessages: new Map<string, string>(),
+    } as any;
+
+    recordFailure(state, "demo", "failed");
+    clearFailure(state, "demo");
+    vi.advanceTimersByTime(60_000);
+
+    expect(state.failureTracker.size).toBe(0);
+    expect(state.failureMessages.size).toBe(0);
+  });
+});

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -98,6 +98,7 @@ describe("lazy-keep-alive initializeMcp integration", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalDirectTools === undefined) {
       delete process.env.MCP_DIRECT_TOOLS;
     } else {
@@ -121,6 +122,104 @@ describe("lazy-keep-alive initializeMcp integration", () => {
     await (state.lifecycle as any).checkConnections();
 
     expect(mocks.manager.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("records direct-tool bootstrap failures", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: {},
+      mcpServers: { srv: { command: "demo", lifecycle: "lazy", directTools: true } },
+    };
+    mocks.getMissingConfiguredDirectToolServers.mockReturnValue(["srv"]);
+    mocks.manager.connect.mockRejectedValueOnce(new Error("bootstrap failed"));
+    const { initializeMcp } = await import("../init.ts");
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+      signal: undefined,
+    } as any);
+
+    expect(state.failureTracker.has("srv")).toBe(true);
+    expect(state.failureMessages.get("srv")).toBe("bootstrap failed");
+  });
+
+  it("clears stale startup diagnostics when direct-tool bootstrap recovers", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: {},
+      mcpServers: { srv: { command: "demo", lifecycle: "keep-alive", directTools: true } },
+    };
+    mocks.getMissingConfiguredDirectToolServers.mockReturnValue(["srv"]);
+    mocks.manager.connect.mockRejectedValueOnce(new Error("startup failed"));
+    const { initializeMcp } = await import("../init.ts");
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+      signal: undefined,
+    } as any);
+
+    expect(mocks.manager.connect).toHaveBeenCalledTimes(2);
+    expect(state.failureTracker.has("srv")).toBe(false);
+    expect(state.failureMessages.has("srv")).toBe(false);
+  });
+
+  it("sanitizes captured diagnostics in startup notifications and terminal logs", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: {},
+      mcpServers: { srv: { command: "demo", lifecycle: "eager" } },
+    };
+    mocks.manager.connect.mockRejectedValueOnce(new Error("stderr \x1b]52;c;clipboard-secret\x07startup failed"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { setStatus: vi.fn(), notify: vi.fn() };
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: true,
+      mode: "tui",
+      ui,
+      signal: undefined,
+    } as any);
+
+    expect(state.failureMessages.get("srv")).toContain("clipboard-secret");
+    expect(ui.notify).toHaveBeenCalledWith("MCP: Failed to connect to srv: stderr startup failed", "error");
+    expect(consoleError).toHaveBeenCalledWith("MCP: Failed to connect to srv: stderr startup failed");
+  });
+
+  it("does not record or notify an aborted eager startup", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: {},
+      mcpServers: { srv: { command: "demo", lifecycle: "eager" } },
+    };
+    const controller = new AbortController();
+    mocks.manager.connect.mockImplementationOnce(async () => {
+      controller.abort(new Error("startup cancelled"));
+      throw new Error("startup cancelled");
+    });
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { setStatus: vi.fn(), notify: vi.fn() };
+
+    const state = await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: true,
+      mode: "tui",
+      ui,
+      signal: controller.signal,
+    } as any);
+
+    expect(state.failureTracker.size).toBe(0);
+    expect(state.failureMessages.size).toBe(0);
+    expect(ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("Failed to connect"), "error");
   });
 
   it("marks direct-tool metadata bootstrap spawns for health-check reconnects", async () => {

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -17,6 +17,7 @@ class FakeManager {
   connectCalls: string[] = [];
   closeCalls: string[] = [];
   idleResponses = new Map<string, boolean>();
+  connectError: Error | undefined;
 
   setConnection(name: string, status: FakeConnection["status"] | null): void {
     if (status === null) {
@@ -32,6 +33,7 @@ class FakeManager {
 
   async connect(name: string): Promise<FakeConnection> {
     this.connectCalls.push(name);
+    if (this.connectError) throw this.connectError;
     const connection: FakeConnection = { status: "connected" };
     this.connections.set(name, connection);
     return connection;
@@ -65,6 +67,7 @@ describe("lazy-keep-alive lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     if (originalAgentDir === undefined) {
       delete process.env.PI_CODING_AGENT_DIR;
@@ -89,6 +92,29 @@ describe("lazy-keep-alive lifecycle", () => {
     await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
 
     expect(fake.connectCalls).toContain("srv");
+  });
+
+  it("records reconnect failures and clears them after a later success", async () => {
+    const def = makeDefinition("keep-alive");
+    lifecycle.markKeepAlive("srv", def);
+    const onFailure = vi.fn();
+    const onSuccess = vi.fn();
+    lifecycle.setReconnectFailureCallback(onFailure);
+    lifecycle.setReconnectCallback(onSuccess);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    fake.connectError = new Error("server exited \x1b]52;c;clipboard-secret\x07safely");
+
+    await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
+
+    expect(onFailure).toHaveBeenCalledWith("srv", fake.connectError);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("MCP: Failed to reconnect to srv: server exited safely");
+    expect(consoleError.mock.calls[0][0]).not.toContain("clipboard-secret");
+
+    fake.connectError = undefined;
+    await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
+
+    expect(onSuccess).toHaveBeenCalledWith("srv");
   });
 
   it("does not reconnect keep-alive servers while OAuth authorization is pending", async () => {

--- a/__tests__/mcp-panel-copy-error.test.ts
+++ b/__tests__/mcp-panel-copy-error.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(async (_text: string) => undefined),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({ copyToClipboard: mocks.copyToClipboard }));
+
+function stripAnsi(input: string): string {
+  return input.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("mcp-panel failure copy", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("copies a sanitized selected failure reason and shows a notice", async () => {
+    const { createMcpPanel } = await import("../mcp-panel.ts");
+    const { computeServerHash } = await import("../metadata-cache.ts");
+    const config = { mcpServers: { demo: { command: "node", args: ["server.js"] } } };
+    const cache = {
+      version: 1 as const,
+      servers: {
+        demo: { configHash: computeServerHash(config.mcpServers.demo), cachedAt: Date.now(), tools: [], resources: [] },
+      },
+    };
+    const panel = createMcpPanel(
+      config as any,
+      cache as any,
+      new Map(),
+      {
+        reconnect: async () => true,
+        canAuthenticate: () => false,
+        authenticate: async () => ({ ok: false }),
+        getConnectionStatus: () => "failed",
+        getFailureMessage: () => "connection failed\n\x1b]8;;https://secret.invalid\x07details\x1b]8;;\x07",
+        refreshCacheAfterReconnect: () => null,
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    panel.handleInput("\x19");
+    await flush();
+
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith("connection failed details");
+    const output = stripAnsi(panel.render(80).join("\n"));
+    expect(output).toContain("Copied error");
+    expect(output).not.toContain("https://secret.invalid");
+    panel.dispose();
+  });
+
+  it("does nothing when the selected server has no failure reason", async () => {
+    const { createMcpPanel } = await import("../mcp-panel.ts");
+    const config = { mcpServers: { demo: { command: "node" } } };
+    const panel = createMcpPanel(
+      config as any,
+      null,
+      new Map(),
+      {
+        reconnect: async () => true,
+        canAuthenticate: () => false,
+        authenticate: async () => ({ ok: false }),
+        getConnectionStatus: () => "idle",
+        getFailureMessage: () => null,
+        refreshCacheAfterReconnect: () => null,
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    panel.handleInput("\x19");
+    await flush();
+    expect(mocks.copyToClipboard).not.toHaveBeenCalled();
+    panel.dispose();
+  });
+});

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -25,6 +25,23 @@ function createConfig(): McpConfig {
   };
 }
 
+function createFailedPanel(
+  connectionStatus: "failed" | "idle",
+  failureMessage: string | null,
+  width: number,
+): string {
+  const config = createConfig();
+  const callbacks: McpPanelCallbacks = {
+    ...createCallbacks(),
+    getConnectionStatus: () => connectionStatus,
+    getFailureMessage: () => failureMessage,
+  };
+  const panel = createMcpPanel(config, createCache(config), new Map(), callbacks, { requestRender: () => {} }, () => {});
+  const output = stripAnsi(panel.render(width).join("\n"));
+  panel.dispose();
+  return output;
+}
+
 function createCache(config: McpConfig): MetadataCache {
   return {
     version: 1,
@@ -90,6 +107,39 @@ describe("mcp-panel rendering", () => {
     expect(output).not.toContain("\x1b]");
     expect(output).not.toContain("https://example.invalid/notice");
     panel.dispose();
+  });
+
+  it("strips an unterminated OSC payload from notices", () => {
+    const config = createConfig();
+    const panel = createMcpPanel(
+      config,
+      createCache(config),
+      new Map(),
+      createCallbacks(),
+      { requestRender: () => {} },
+      () => {},
+      { noticeLines: ["Open \x1b]8;;https://secret.invalid/truncated"] },
+    );
+
+    const output = stripAnsi(panel.render(120).join("\n"));
+
+    expect(output).toContain("Open");
+    expect(output).not.toContain("https://secret.invalid/truncated");
+    panel.dispose();
+  });
+
+  it("renders the selected failure reason wrapped without truncating useful context", () => {
+    const reason = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is it running?";
+    const output = createFailedPanel("failed", reason, 60);
+
+    expect(output).toContain("failed");
+    for (const word of reason.split(/\s+/)) expect(output).toContain(word);
+    expect(output.split("\n").filter((line) => /docker/i.test(line)).length).toBeGreaterThan(1);
+    expect(output).not.toContain("…");
+  });
+
+  it("does not render a failure reason when the server is not failed", () => {
+    expect(createFailedPanel("idle", "should not appear", 60)).not.toContain("should not appear");
   });
 
   it("keeps dirty changes and closes when Keep & Close is confirmed", () => {

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   markKeepAliveAfterConnect: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
   updateStatusBar: vi.fn(),
+  clearFailure: vi.fn(),
+  recordFailure: vi.fn(),
   clients: [] as any[],
   transports: [] as any[],
   connectImpl: vi.fn(),
@@ -29,6 +31,8 @@ vi.mock("../init.ts", () => ({
   markKeepAliveAfterConnect: mocks.markKeepAliveAfterConnect,
   getFailureAgeSeconds: mocks.getFailureAgeSeconds,
   updateStatusBar: mocks.updateStatusBar,
+  clearFailure: mocks.clearFailure,
+  recordFailure: mocks.recordFailure,
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
@@ -92,6 +96,8 @@ describe("proxy auto auth", () => {
     mocks.markKeepAliveAfterConnect.mockReset();
     mocks.getFailureAgeSeconds.mockReset().mockReturnValue(null);
     mocks.updateStatusBar.mockReset();
+    mocks.clearFailure.mockReset();
+    mocks.recordFailure.mockReset();
     mocks.clients.length = 0;
     mocks.transports.length = 0;
     mocks.connectImpl.mockReset().mockResolvedValue(undefined);

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   markKeepAliveAfterConnect: vi.fn(),
   getFailureAgeSeconds: vi.fn(),
   updateStatusBar: vi.fn(),
+  clearFailure: vi.fn(),
 }));
 
 vi.mock("../mcp-auth-flow.ts", () => ({
@@ -26,6 +27,7 @@ vi.mock("../init.ts", () => ({
   markKeepAliveAfterConnect: mocks.markKeepAliveAfterConnect,
   getFailureAgeSeconds: mocks.getFailureAgeSeconds,
   updateStatusBar: mocks.updateStatusBar,
+  clearFailure: mocks.clearFailure,
 }));
 
 function createState(overrides: Record<string, unknown> = {}) {
@@ -40,6 +42,7 @@ function createState(overrides: Record<string, unknown> = {}) {
     manager: { close: vi.fn(async () => {}) },
     toolMetadata: new Map(),
     failureTracker: new Map([["demo", Date.now()]]),
+    failureMessages: new Map([["demo", "stale failure"]]),
     ...overrides,
   } as any;
 }
@@ -53,6 +56,10 @@ describe("manual OAuth proxy actions", () => {
     });
     mocks.supportsOAuth.mockReset().mockImplementation((definition) => definition.auth === "oauth");
     mocks.updateStatusBar.mockReset();
+    mocks.clearFailure.mockReset().mockImplementation((state: any, serverName: string) => {
+      state.failureTracker.delete(serverName);
+      state.failureMessages?.delete(serverName);
+    });
   });
 
   it("returns copyable instructions and authorization URL", async () => {

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PassThrough } from "node:stream";
+
+const mocks = vi.hoisted(() => ({
+  transports: [] as any[],
+  connectImpl: null as null | ((transport: any) => Promise<void>),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(function (this: any) {
+    this.setRequestHandler = vi.fn();
+    this.setNotificationHandler = vi.fn();
+    this.connect = vi.fn(async (transport: any) => {
+      if (mocks.connectImpl) return mocks.connectImpl(transport);
+    });
+    this.listTools = vi.fn(async () => ({ tools: [] }));
+    this.listResources = vi.fn(async () => ({ resources: [] }));
+    this.close = vi.fn(async () => undefined);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: any) {
+    this.options = options;
+    this.stderr = options?.stderr === "pipe" ? new PassThrough() : null;
+    this.close = vi.fn(async () => undefined);
+    mocks.transports.push(this);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation(function (this: any) {
+    this.close = vi.fn(async () => undefined);
+    mocks.transports.push(this);
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn().mockImplementation(function (this: any) {
+    this.close = vi.fn(async () => undefined);
+    mocks.transports.push(this);
+  }),
+}));
+
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => null),
+}));
+
+describe("McpServerManager stderr capture", () => {
+  beforeEach(() => {
+    mocks.transports.length = 0;
+    mocks.connectImpl = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pipes stderr for normal stdio servers and preserves inherit for debug", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+    expect(mocks.transports[0].options.stderr).toBe("pipe");
+
+    await manager.connect("debug", { command: "node", args: ["server.js"], debug: true });
+    expect(mocks.transports[1].options.stderr).toBe("inherit");
+  });
+
+  it("appends captured stderr to the connection error", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    mocks.connectImpl = async (transport) => {
+      transport.stderr.write("Cannot connect to the Docker daemon at unix:///var/run/docker.sock.\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      throw new Error("MCP error -32000: Connection closed");
+    };
+
+    await expect(manager.connect("loki", { command: "docker" })).rejects.toThrow(
+      /MCP error -32000: Connection closed \(Cannot connect to the Docker daemon/,
+    );
+  });
+
+  it("bounds oversized string stderr chunks before retaining their tail", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connectionError = new Error("connection failed");
+    mocks.connectImpl = async (transport) => {
+      transport.stderr.emit("data", "x".repeat(1_000_000));
+      await new Promise((resolve) => setImmediate(resolve));
+      throw connectionError;
+    };
+
+    let capturedError: Error | undefined;
+    try {
+      await manager.connect("demo", { command: "node" });
+    } catch (error) {
+      capturedError = error as Error;
+    }
+    expect(capturedError?.cause).toBe(connectionError);
+    expect(Buffer.byteLength(capturedError?.message ?? "", "utf8")).toBeLessThanOrEqual(8_192 + 100);
+  });
+
+  it("keeps empty stderr and non-stdio errors unchanged", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    mocks.connectImpl = async () => {
+      throw new Error("MCP error -32000: Connection closed");
+    };
+
+    await expect(manager.connect("stdio", { command: "node" })).rejects.toThrow(/^MCP error -32000: Connection closed$/);
+    await expect(manager.connect("http", { url: "https://example.com/mcp" })).rejects.toThrow(/^MCP error -32000: Connection closed$/);
+  });
+
+  it("bounds captured stderr and keeps only its final three lines", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connectionError = new Error("connection failed");
+    mocks.connectImpl = async (transport) => {
+      transport.stderr.write("x".repeat(8_192));
+      transport.stderr.write("\nline-1\nline-2\nline-3\nline-4\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      throw connectionError;
+    };
+
+    let capturedError: Error | undefined;
+    try {
+      await manager.connect("demo", { command: "node" });
+    } catch (error) {
+      capturedError = error as Error;
+    }
+
+    expect(Buffer.byteLength(capturedError?.message ?? "", "utf8")).toBeLessThan(8_192 + 200);
+    expect(capturedError?.message).toContain("line-2 — line-3 — line-4");
+    expect(capturedError?.message).not.toContain("line-1");
+    expect(capturedError?.cause).toBe(connectionError);
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -12,13 +12,13 @@ import {
   writeSharedServerEntry,
   writeStarterProjectConfig,
 } from "./config.ts";
-import { markKeepAliveAfterConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds } from "./init.ts";
+import { markKeepAliveAfterConnect, updateMetadataCache, updateStatusBar, getFailureAgeSeconds, getFailureMessage, clearFailure, recordFailure } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
 import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
-import { openPath, resolveServerUrl } from "./utils.ts";
+import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -41,7 +41,8 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
       status = "needs auth";
       statusIcon = "⚠";
     } else if (failedAgo !== null) {
-      status = `failed ${failedAgo}s ago`;
+      const reason = sanitizeTerminalText(getFailureMessage(state, name) ?? "");
+      status = reason ? `failed ${failedAgo}s ago — ${reason}` : `failed ${failedAgo}s ago`;
       statusIcon = "✗";
       failed = true;
     } else if (metadata !== undefined) {
@@ -115,7 +116,7 @@ export async function reconnectServer(
     }
     updateMetadataCache(state, name);
     markKeepAliveAfterConnect(state, name);
-    state.failureTracker.delete(name);
+    clearFailure(state, name);
 
     if (ctx.hasUI) {
       ctx.ui.notify(
@@ -130,9 +131,9 @@ export async function reconnectServer(
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    state.failureTracker.set(name, Date.now());
+    recordFailure(state, name, message);
     if (ctx.hasUI) {
-      ctx.ui.notify(`MCP: Failed to reconnect to ${name}: ${message}`, "error");
+      ctx.ui.notify(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`, "error");
     }
     updateStatusBar(state);
     return false;
@@ -364,6 +365,7 @@ function buildMcpPanelCallbacks(
       if (getFailureAgeSeconds(state, serverName) !== null) return "failed";
       return "idle";
     },
+    getFailureMessage: (serverName: string) => getFailureMessage(state, serverName),
     refreshCacheAfterReconnect: (serverName: string) => {
       const freshCache = loadMetadataCache();
       return freshCache?.servers?.[serverName] ?? null;

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -3,7 +3,7 @@ import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js"
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
-import { lazyConnect, getFailureAgeSeconds } from "./init.ts";
+import { lazyConnect, getFailureAgeSeconds, clearFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { isServerCacheValid } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
@@ -344,7 +344,7 @@ export function createDirectToolExecutor(
       }
       if (autoAuth.status === "success") {
         await state.manager.close(spec.serverName);
-        state.failureTracker.delete(spec.serverName);
+        clearFailure(state, spec.serverName);
         connected = await lazyConnect(state, spec.serverName, signal);
       }
     }
@@ -393,7 +393,7 @@ export function createDirectToolExecutor(
           if (afterAuth?.status === "needs-auth") {
             await state.manager.close(spec.serverName);
           }
-          state.failureTracker.delete(spec.serverName);
+          clearFailure(state, spec.serverName);
           const reconnected = await lazyConnect(state, spec.serverName, signal);
           return reconnected ? state.manager.getConnection(spec.serverName) : undefined;
         }

--- a/init.ts
+++ b/init.ts
@@ -19,13 +19,49 @@ import {
 import { McpServerManager } from "./server-manager.ts";
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.ts";
 import { UiResourceHandler } from "./ui-resource-handler.ts";
-import { openUrl, parallelLimit } from "./utils.ts";
+import { openUrl, parallelLimit, sanitizeTerminalText } from "./utils.ts";
 import { logger } from "./logger.ts";
 import { getMissingConfiguredDirectToolServers } from "./direct-tools.ts";
 import { throwIfAborted } from "./abort.ts";
 import { getAuthStorageOptions } from "./mcp-auth.ts";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
+const MAX_FAILURE_MESSAGE_CHARS = 8 * 1024;
+const failureExpiryTimers = new WeakMap<McpExtensionState, Map<string, ReturnType<typeof setTimeout>>>();
+
+function getFailureExpiryTimers(state: McpExtensionState): Map<string, ReturnType<typeof setTimeout>> {
+  let timers = failureExpiryTimers.get(state);
+  if (!timers) {
+    timers = new Map();
+    failureExpiryTimers.set(state, timers);
+  }
+  return timers;
+}
+
+export function clearFailure(state: McpExtensionState, serverName: string): void {
+  state.failureTracker.delete(serverName);
+  state.failureMessages?.delete(serverName);
+  const timers = failureExpiryTimers.get(state);
+  const timer = timers?.get(serverName);
+  if (timer) clearTimeout(timer);
+  timers?.delete(serverName);
+}
+
+export function recordFailure(state: McpExtensionState, serverName: string, message: string): void {
+  clearFailure(state, serverName);
+  const failedAt = Date.now();
+  state.failureTracker.set(serverName, failedAt);
+  state.failureMessages?.set(serverName, message.slice(0, MAX_FAILURE_MESSAGE_CHARS));
+  const timer = setTimeout(() => {
+    if (state.failureTracker.get(serverName) === failedAt) {
+      state.failureTracker.delete(serverName);
+      state.failureMessages?.delete(serverName);
+    }
+    getFailureExpiryTimers(state).delete(serverName);
+  }, FAILURE_BACKOFF_MS);
+  timer.unref?.();
+  getFailureExpiryTimers(state).set(serverName, timer);
+}
 
 export function isTuiMode(ctx: Pick<ExtensionContext, "hasUI" | "mode">): boolean {
   return ctx.hasUI && ctx.mode === "tui";
@@ -63,6 +99,7 @@ export async function initializeMcp(
   const toolMetadata = new Map<string, ToolMetadata[]>();
   const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
+  const failureMessages = new Map<string, string>();
   const uiResourceHandler = new UiResourceHandler(manager, config);
   const consentManager = new ConsentManager("once-per-server");
   const ui = ctx.hasUI ? ctx.ui : undefined;
@@ -74,6 +111,7 @@ export async function initializeMcp(
     config,
     authStorageOptions,
     failureTracker,
+    failureMessages,
     uiResourceHandler,
     consentManager,
     uiServer: null,
@@ -148,6 +186,9 @@ export async function initializeMcp(
       }
       return { name, definition, connection, error: null };
     } catch (error) {
+      if (ctx.signal?.aborted) {
+        return { name, definition, connection: null, error: null };
+      }
       const message = error instanceof Error ? error.message : String(error);
       return { name, definition, connection: null, error: message };
     }
@@ -167,10 +208,13 @@ export async function initializeMcp(
 
   for (const { name, definition, connection, error } of results) {
     if (error || !connection) {
+      if (ctx.signal?.aborted) continue;
+      if (error) recordFailure(state, name, error);
+      const displayError = sanitizeTerminalText(error ?? "Unknown connection failure");
       if (ctx.hasUI) {
-        ctx.ui.notify(`MCP: Failed to connect to ${name}: ${error}`, "error");
+        ctx.ui.notify(`MCP: Failed to connect to ${name}: ${displayError}`, "error");
       }
-      console.error(`MCP: Failed to connect to ${name}: ${error}`);
+      console.error(`MCP: Failed to connect to ${name}: ${displayError}`);
       continue;
     }
 
@@ -221,10 +265,13 @@ export async function initializeMcp(
             updateServerMetadata(state, name);
             updateMetadataCache(state, name);
             markKeepAliveAfterConnect(state, name);
+            clearFailure(state, name);
             return { name, ok: true };
           } catch (error) {
+            if (ctx.signal?.aborted) return { name, ok: false };
             const message = error instanceof Error ? error.message : String(error);
-            logger.debug(`MCP: direct-tools bootstrap failed for ${name}: ${message}`);
+            recordFailure(state, name, message);
+            logger.debug(`MCP: direct-tools bootstrap failed for ${name}: ${sanitizeTerminalText(message)}`);
             return { name, ok: false };
           }
         },
@@ -239,7 +286,13 @@ export async function initializeMcp(
   lifecycle.setReconnectCallback((serverName) => {
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
-    state.failureTracker.delete(serverName);
+    clearFailure(state, serverName);
+    updateStatusBar(state);
+  });
+
+  lifecycle.setReconnectFailureCallback((serverName, error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    recordFailure(state, serverName, message);
     updateStatusBar(state);
   });
 
@@ -342,6 +395,11 @@ export function getFailureAgeSeconds(state: McpExtensionState, serverName: strin
   return Math.round(ageMs / 1000);
 }
 
+export function getFailureMessage(state: McpExtensionState, serverName: string): string | null {
+  if (getFailureAgeSeconds(state, serverName) === null) return null;
+  return state.failureMessages?.get(serverName) ?? null;
+}
+
 export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {
   const connection = state.manager.getConnection(serverName);
   if (connection?.status === "needs-auth") {
@@ -367,7 +425,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     if (newConnection.status === "needs-auth") {
       return false;
     }
-    state.failureTracker.delete(serverName);
+    clearFailure(state, serverName);
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
     markKeepAliveAfterConnect(state, serverName);
@@ -377,9 +435,9 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     if (signal?.aborted) {
       throwIfAborted(signal);
     }
-    state.failureTracker.set(serverName, Date.now());
     const message = error instanceof Error ? error.message : String(error);
-    logger.debug(`MCP: lazy connect failed for ${serverName}: ${message}`);
+    recordFailure(state, serverName, message);
+    logger.debug(`MCP: lazy connect failed for ${serverName}: ${sanitizeTerminalText(message)}`);
     updateStatusBar(state);
     return false;
   }

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -2,8 +2,10 @@ import type { ServerDefinition } from "./types.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import { hasPendingAuth } from "./mcp-auth-flow.ts";
 import { logger } from "./logger.ts";
+import { sanitizeTerminalText } from "./utils.ts";
 
 export type ReconnectCallback = (serverName: string) => void;
+export type ReconnectFailureCallback = (serverName: string, error: unknown) => void;
 
 export class McpLifecycleManager {
   private manager: McpServerManager;
@@ -13,6 +15,7 @@ export class McpLifecycleManager {
   private globalIdleTimeout: number = 10 * 60 * 1000;
   private healthCheckInterval?: NodeJS.Timeout;
   private onReconnect?: ReconnectCallback;
+  private onReconnectFailure?: ReconnectFailureCallback;
   private onIdleShutdown?: (serverName: string) => void;
   
   constructor(manager: McpServerManager, private readonly hasPendingAuthForServer = hasPendingAuth) {
@@ -25,6 +28,10 @@ export class McpLifecycleManager {
    */
   setReconnectCallback(callback: ReconnectCallback): void {
     this.onReconnect = callback;
+  }
+
+  setReconnectFailureCallback(callback: ReconnectFailureCallback): void {
+    this.onReconnectFailure = callback;
   }
   
   markKeepAlive(name: string, definition: ServerDefinition): void {
@@ -68,7 +75,9 @@ export class McpLifecycleManager {
           // Notify extension to update metadata
           this.onReconnect?.(name);
         } catch (error) {
-          console.error(`MCP: Failed to reconnect to ${name}:`, error);
+          this.onReconnectFailure?.(name, error);
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`);
         }
       }
     }

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,8 +1,10 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { copyToClipboard } from "@earendil-works/pi-coding-agent";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import { isToolExcluded } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
+import { sanitizeTerminalText, stripOscSequences } from "./utils.ts";
 import type { MetadataCache, ServerCacheEntry, CachedTool } from "./metadata-cache.ts";
 
 interface PanelTheme {
@@ -75,25 +77,15 @@ function fuzzyScore(query: string, text: string): number {
 }
 
 function sanitizeDisplayText(text: string | null | undefined): string {
-  return (text ?? "")
-    .replace(/(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x1b\\|\x9c))/g, "")
-    .replace(/(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/g, "")
-    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return sanitizeTerminalText(text ?? "");
 }
 
 function sanitizeRowContent(content: string): string {
+  const withoutOsc = stripOscSequences(content);
   let result = "";
   let pendingSpace = false;
-  for (let i = 0; i < content.length; i++) {
-    const rest = content.slice(i);
-    const osc = rest.match(/^(?:\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x9d[\s\S]*?(?:\x07|\x1b\\|\x9c))/);
-    if (osc) {
-      i += osc[0].length - 1;
-      continue;
-    }
-
+  for (let i = 0; i < withoutOsc.length; i++) {
+    const rest = withoutOsc.slice(i);
     const ansi = rest.match(/^(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/);
     if (ansi) {
       result += ansi[0];
@@ -101,7 +93,7 @@ function sanitizeRowContent(content: string): string {
       continue;
     }
 
-    const code = content.charCodeAt(i);
+    const code = withoutOsc.charCodeAt(i);
     if (code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
       pendingSpace = true;
       continue;
@@ -111,7 +103,7 @@ function sanitizeRowContent(content: string): string {
       result += " ";
     }
     pendingSpace = false;
-    result += content[i];
+    result += withoutOsc[i];
   }
   return result;
 }
@@ -140,6 +132,7 @@ interface ServerState {
   excludeTools?: string[];
   exposeResources: boolean;
   connectionStatus: ConnectionStatus;
+  failureMessage?: string | null;
   tools: ToolState[];
   hasCachedData: boolean;
 }
@@ -239,6 +232,7 @@ class McpPanel {
       }
 
       const status = callbacks.getConnectionStatus(serverName);
+      const failureMessage = callbacks.getFailureMessage?.(serverName) ?? null;
 
       this.servers.push({
         name: serverName,
@@ -248,6 +242,7 @@ class McpPanel {
         excludeTools: definition.excludeTools,
         exposeResources: definition.exposeResources !== false,
         connectionStatus: status,
+        failureMessage,
         tools,
         hasCachedData: !!serverCache,
       });
@@ -457,6 +452,24 @@ class McpPanel {
       return;
     }
 
+    if (matchesKey(data, "ctrl+y")) {
+      const item = this.visibleItems[this.cursorIndex];
+      if (!item) return;
+      const server = this.servers[item.serverIndex];
+      if (server.connectionStatus !== "failed" || !server.failureMessage) return;
+      const serverName = sanitizeDisplayText(server.name);
+      const failureMessage = sanitizeDisplayText(server.failureMessage);
+      copyToClipboard(failureMessage).then(() => {
+        this.authNotice = `Copied error for ${serverName} to clipboard`;
+        this.tui.requestRender();
+      }).catch((error) => {
+        const message = sanitizeDisplayText(error instanceof Error ? error.message : String(error));
+        this.authNotice = `Failed to copy error for ${serverName}: ${message}`;
+        this.tui.requestRender();
+      });
+      return;
+    }
+
     if (data === "?") {
       if (this.authOnly) return;
       this.descSearchActive = true;
@@ -533,6 +546,7 @@ class McpPanel {
 
     this.callbacks.reconnect(server.name).then((connected) => {
       server.connectionStatus = this.callbacks.getConnectionStatus(server.name);
+      server.failureMessage = this.callbacks.getFailureMessage?.(server.name) ?? null;
       if (server.connectionStatus === "connected") {
         const entry = this.callbacks.refreshCacheAfterReconnect(server.name);
         if (entry) {
@@ -712,6 +726,11 @@ class McpPanel {
 
         if (item.type === "server") {
           lines.push(row(this.renderServerRow(server, isCursor)));
+          if (isCursor && server.connectionStatus === "failed" && server.failureMessage) {
+            for (const line of this.wrapText(sanitizeDisplayText(server.failureMessage), innerW - 6)) {
+              lines.push(row(`    ${fg(t.cancel, line)}`));
+            }
+          }
         } else if (item.toolIndex !== undefined) {
           lines.push(row(this.renderToolRow(server.tools[item.toolIndex], isCursor, innerW)));
         }
@@ -776,6 +795,7 @@ class McpPanel {
           italic("⏎") + " expand/auth",
           italic("ctrl+a") + " auth",
           italic("ctrl+r") + " reconnect",
+          ...(this.selectedServerHasFailureMessage() ? [italic("ctrl+y") + " copy error"] : []),
           italic("?") + " desc search",
           italic("ctrl+s") + " save",
           italic("esc") + " clear/close",
@@ -842,6 +862,47 @@ class McpPanel {
     }
 
     return `${prefix} ${toggleIcon} ${nameStr}${importLabel}  ${toolInfo}${statusLabel}`;
+  }
+
+  private selectedServerHasFailureMessage(): boolean {
+    const item = this.visibleItems[this.cursorIndex];
+    if (!item) return false;
+    const server = this.servers[item.serverIndex];
+    return server.connectionStatus === "failed" && !!server.failureMessage;
+  }
+
+  private wrapText(text: string, width: number): string[] {
+    const max = Math.max(8, width);
+    const words = text.split(/\s+/).filter(Boolean);
+    const lines: string[] = [];
+    let current = "";
+    const splitLongWord = (word: string): string => {
+      let rest = word;
+      while (visibleWidth(rest) > max) {
+        let take = "";
+        let index = 0;
+        while (index < rest.length && visibleWidth(take + rest[index]) <= max) {
+          take += rest[index];
+          index++;
+        }
+        if (!take) take = rest[0];
+        lines.push(take);
+        rest = rest.slice(take.length);
+      }
+      return rest;
+    };
+
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (visibleWidth(candidate) <= max) {
+        current = candidate;
+      } else {
+        if (current) lines.push(current);
+        current = splitLongWord(word);
+      }
+    }
+    if (current) lines.push(current);
+    return lines.length > 0 ? lines : [text];
   }
 
   private renderConnectionStatus(server: ServerState): string {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -4,7 +4,7 @@ import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
-import { lazyConnect, markKeepAliveAfterConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar } from "./init.ts";
+import { lazyConnect, markKeepAliveAfterConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
@@ -325,7 +325,7 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
     }
 
     await state.manager.close(serverName);
-    state.failureTracker.delete(serverName);
+    clearFailure(state, serverName);
     updateStatusBar(state);
     return {
       content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.` }],
@@ -635,15 +635,13 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     }
     updateMetadataCache(state, serverName);
     markKeepAliveAfterConnect(state, serverName);
-    state.failureTracker.delete(serverName);
+    clearFailure(state, serverName);
     updateStatusBar(state);
     return executeList(state, serverName);
   } catch (error) {
-    if (!signal?.aborted) {
-      state.failureTracker.set(serverName, Date.now());
-    }
-    updateStatusBar(state);
     const message = error instanceof Error ? error.message : String(error);
+    if (!signal?.aborted) recordFailure(state, serverName, message);
+    updateStatusBar(state);
     return {
       content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
       details: { mode: "connect", error: signal?.aborted ? "aborted" : "connect_failed", server: serverName, message },
@@ -703,7 +701,7 @@ export async function executeCall(
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
-            state.failureTracker.delete(serverName);
+            clearFailure(state, serverName);
             const connectedAfterAuth = await lazyConnect(state, serverName, signal);
             if (connectedAfterAuth) {
               toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
@@ -763,7 +761,7 @@ export async function executeCall(
         }
         if (autoAuth.status === "success") {
           await state.manager.close(configuredServer);
-          state.failureTracker.delete(configuredServer);
+          clearFailure(state, configuredServer);
           connected = await lazyConnect(state, configuredServer, signal);
         }
       }
@@ -816,7 +814,7 @@ export async function executeCall(
       }
       if (autoAuth.status === "success") {
         await state.manager.close(serverName);
-        state.failureTracker.delete(serverName);
+        clearFailure(state, serverName);
         connection = state.manager.getConnection(serverName);
       }
     }
@@ -875,7 +873,7 @@ export async function executeCall(
           };
         }
       }
-      state.failureTracker.delete(serverName);
+      clearFailure(state, serverName);
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
       markKeepAliveAfterConnect(state, serverName);
@@ -892,11 +890,9 @@ export async function executeCall(
         };
       }
     } catch (error) {
-      if (!signal?.aborted) {
-        state.failureTracker.set(serverName, Date.now());
-      }
-      updateStatusBar(state);
       const message = error instanceof Error ? error.message : String(error);
+      if (!signal?.aborted) recordFailure(state, serverName, message);
+      updateStatusBar(state);
       return {
         content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
         details: { mode: "call", error: signal?.aborted ? "aborted" : "connect_failed", message },
@@ -926,7 +922,7 @@ export async function executeCall(
         if (afterAuth?.status === "needs-auth") {
           await state.manager.close(serverName);
         }
-        state.failureTracker.delete(serverName);
+        clearFailure(state, serverName);
         connection = await state.manager.connect(serverName, definition, signal);
         return connection;
       }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -31,6 +31,36 @@ import {
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 
+const MAX_CAPTURED_STDERR_BYTES = 8 * 1024;
+const MAX_CAPTURED_STDERR_LINES = 3;
+
+function boundedStderrChunk(chunk: Buffer | string): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    const start = Math.max(0, chunk.byteLength - MAX_CAPTURED_STDERR_BYTES);
+    return Buffer.from(chunk.subarray(start));
+  }
+
+  // Limit string conversion before encoding; Buffer.from(largeString) would
+  // otherwise allocate the entire stderr event before applying the cap.
+  const suffix = chunk.length > MAX_CAPTURED_STDERR_BYTES
+    ? chunk.slice(-MAX_CAPTURED_STDERR_BYTES)
+    : chunk;
+  const bytes = Buffer.from(suffix, "utf8");
+  return bytes.byteLength > MAX_CAPTURED_STDERR_BYTES
+    ? Buffer.from(bytes.subarray(bytes.byteLength - MAX_CAPTURED_STDERR_BYTES))
+    : bytes;
+}
+
+function appendStderrTail(tail: Buffer, chunk: Buffer | string): Buffer {
+  const bytes = boundedStderrChunk(chunk);
+  if (bytes.length === 0) return tail;
+  if (tail.length === 0) return bytes;
+  const combined = Buffer.concat([tail, bytes]);
+  return combined.length > MAX_CAPTURED_STDERR_BYTES
+    ? Buffer.from(combined.subarray(combined.length - MAX_CAPTURED_STDERR_BYTES))
+    : combined;
+}
+
 export interface ServerConnection {
   client: Client;
   transport: Transport;
@@ -189,6 +219,7 @@ export class McpServerManager {
     const client = this.createClient(name);
 
     let transport: Transport;
+    let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 
     if (definition.command) {
       let command = definition.command;
@@ -203,13 +234,21 @@ export class McpServerManager {
         }
       }
 
-      transport = new StdioClientTransport({
+      const stdioTransport = new StdioClientTransport({
         command,
         args,
         env: resolveEnv(definition.env),
         cwd: resolveConfigPath(definition.cwd) ?? this.defaultCwd,
-        stderr: definition.debug ? "inherit" : "ignore",
+        stderr: definition.debug ? "inherit" : "pipe",
       });
+      // Keep non-debug child diagnostics available for connection failures without
+      // retaining an unbounded stream or changing the existing debug behavior.
+      if (stdioTransport.stderr) {
+        stdioTransport.stderr.on("data", (chunk: Buffer | string) => {
+          stderrTail = appendStderrTail(stderrTail, chunk);
+        });
+      }
+      transport = stdioTransport;
     } else if (definition.url) {
       // HTTP transport with fallback
       transport = await this.createHttpTransport(definition, name, signal);
@@ -282,6 +321,16 @@ export class McpServerManager {
       // Clean up both client and transport on any error
       await client.close().catch(() => {});
       await transport.close().catch(() => {});
+
+      if (stderrTail.length > 0) {
+        const stderrText = stderrTail.toString("utf8").trim();
+        const lines = stderrText.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+        if (lines.length > 0) {
+          const baseMessage = error instanceof Error ? error.message : String(error);
+          const detail = lines.slice(-MAX_CAPTURED_STDERR_LINES).join(" — ");
+          throw new Error(`${baseMessage} (${detail})`, { cause: error });
+        }
+      }
       throw error;
     }
   }

--- a/state.ts
+++ b/state.ts
@@ -34,6 +34,7 @@ export interface McpExtensionState {
   config: McpConfig;
   authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;
+  failureMessages: Map<string, string>;
   uiResourceHandler: UiResourceHandler;
   consentManager: ConsentManager;
   uiServer: UiServerHandle | null;

--- a/types.ts
+++ b/types.ts
@@ -412,6 +412,7 @@ export interface McpPanelCallbacks {
   canAuthenticate: (serverName: string) => boolean;
   authenticate: (serverName: string) => Promise<McpAuthResult>;
   getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth";
+  getFailureMessage?: (serverName: string) => string | null;
   refreshCacheAfterReconnect: (serverName: string) => import("./metadata-cache.ts").ServerCacheEntry | null;
 }
 

--- a/utils.ts
+++ b/utils.ts
@@ -121,6 +121,39 @@ export function resolveBearerToken(definition: Pick<ServerEntry, "bearerToken" |
   return definition.bearerTokenEnv ? process.env[definition.bearerTokenEnv] : undefined;
 }
 
+/** Remove OSC control strings, including payloads that have no terminator. */
+export function stripOscSequences(text: string): string {
+  let result = "";
+  let index = 0;
+  while (index < text.length) {
+    const isEscOsc = text.charCodeAt(index) === 0x1b && text[index + 1] === "]";
+    const isC1Osc = text.charCodeAt(index) === 0x9d;
+    if (!isEscOsc && !isC1Osc) {
+      result += text[index++];
+      continue;
+    }
+
+    index += isEscOsc ? 2 : 1;
+    while (index < text.length) {
+      const code = text.charCodeAt(index++);
+      if (code === 0x07 || code === 0x9c) break;
+      if (code === 0x1b && text[index] === "\\") {
+        index++;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+export function sanitizeTerminalText(text: string): string {
+  return stripOscSequences(text)
+    .replace(/(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_])/g, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function truncateAtWord(text: string, target: number): string {
   if (!text || text.length <= target) return text;
 


### PR DESCRIPTION
Persist the failure message and display it in the `/mcp` panel when that mcp server is under the cursor. This helps quickly diagnose issues with connecting to MCP servers rather than taking a guess at the failure reason. Users can use `ctrl+y` when the cursor is on the failed server to copy the error message for later use.

Captures stdio child stderr so failures show the real cause (e.g. `Cannot connect to the Docker daemon`) instead of a bare `MCP error -32000: Connection closed`. Addresses #196.

**Before**

https://github.com/user-attachments/assets/f0cf1850-804d-42a1-abf1-b122d7f91a65

**After**

https://github.com/user-attachments/assets/23b3626b-f68c-4840-a41f-d40f27ae57d2


