### PR TITLE
fix: tolerate OMP typebox shim missing Type.Unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.
 
 ### Fixed
+- Kept direct MCP tool registration working when a host TypeBox shim does not expose `Type.Unsafe`. Thanks @RaviTharuma for PR #198.
 - Kept exact `npx` package specs from reusing a different same-name package version from npm's `_npx` cache. Thanks @danhrahal for issue #178.
 - Kept POST-only Streamable HTTP servers on the Streamable HTTP transport when the optional GET stream returns 405. Thanks @ramhaidar for issue #204.
 - Kept manual OAuth `auth-start` / `auth-complete` flows from being invalidated by keep-alive health checks, and made reserved manual callback states show a manual completion page instead of a CSRF error. Thanks @oozle for issue #207.

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -136,6 +136,7 @@ describe("mcpAdapter session lifecycle", () => {
   beforeEach(() => {
     delete process.env.MCP_DIRECT_TOOLS;
     vi.resetModules();
+    vi.doUnmock("typebox");
     for (const value of Object.values(mocks)) {
       if (typeof value === "function" && "mockReset" in value) {
         value.mockReset();
@@ -194,6 +195,34 @@ describe("mcpAdapter session lifecycle", () => {
       name: "mcp",
       renderResult: expect.any(Function),
     }));
+  });
+
+  it("registers direct MCP tools when the host TypeBox shim omits Unsafe", async () => {
+    vi.doMock("typebox", () => ({
+      Type: {
+        Object: (properties: Record<string, unknown>, options?: Record<string, unknown>) => ({ type: "object", properties, ...options }),
+        String: (options?: Record<string, unknown>) => ({ type: "string", ...options }),
+        Boolean: (options?: Record<string, unknown>) => ({ type: "boolean", ...options }),
+        Optional: (schema: Record<string, unknown>) => ({ ...schema, optional: true }),
+        Union: (schemas: unknown[], options?: Record<string, unknown>) => ({ anyOf: schemas, ...options }),
+      },
+    }));
+    mocks.resolveDirectTools.mockReturnValue([
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search demo",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      },
+    ]);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    const directTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "demo_search")?.[0];
+    expect(directTool.parameters).toEqual({ type: "object", properties: { query: { type: "string" } } });
   });
 
   it("normalizes direct MCP tool schemas before registration", async () => {

--- a/index.ts
+++ b/index.ts
@@ -67,13 +67,22 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     || directSpecs.length === 0
     || missingConfiguredDirectToolServers.length > 0;
 
+  // OMP remaps `typebox` to a host shim that historically lacked Type.Unsafe.
+  // Prefer Unsafe when present (real TypeBox / fixed OMP shim); otherwise pass
+  // the normalized JSON Schema through as a plain object so toolWireSchema and
+  // validateToolArguments still treat it as JSON Schema.
+  const toToolParameters = (schema: Record<string, unknown>) =>
+    typeof (Type as { Unsafe?: (value: never) => unknown }).Unsafe === "function"
+      ? (Type as { Unsafe: (value: never) => unknown }).Unsafe(schema as never)
+      : schema;
+
   for (const spec of directSpecs) {
     (pi.registerTool as (tool: unknown) => unknown)({
       name: spec.prefixedName,
       label: `MCP: ${spec.originalName}`,
       description: spec.description || "(no description)",
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
-      parameters: Type.Unsafe(normalizeDirectToolInputSchema(spec.inputSchema) as never),
+      parameters: toToolParameters(normalizeDirectToolInputSchema(spec.inputSchema)),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
       renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
       renderResult: renderMcpToolResult,


### PR DESCRIPTION
## Summary
- Oh My Pi (OMP) remaps `typebox` imports onto a host shim.
- Older OMP shims lacked `Type.Unsafe`, so direct MCP tool registration crashed during extension load with `Type.Unsafe is not a function`.
- `toolWireSchema` / argument validation already accept plain JSON Schema objects.

## Change
- Prefer `Type.Unsafe(...)` when present (real TypeBox or fixed OMP shim).
- Otherwise pass the normalized MCP `inputSchema` object through unchanged.

## Test plan
- [x] Local OMP 17.0.6 + defensive adapter: extension load succeeds.
- [x] Real TypeBox hosts still use `Type.Unsafe` when available.
- [ ] Adapter unit/integration tests if present.
- [ ] Confirm no schema regression on pi-coding-agent with real TypeBox.

## Context
Companion to OMP shim fix adding `Type.Unsafe`. Defense-in-depth so the adapter keeps loading on hosts with incomplete TypeBox shims.