### PR TITLE
fix(windows): resolve npm cache dir via cross-spawn instead of raw spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.
 
 ### Fixed
+- Kept npm cache lookups working on Windows by resolving `npm` through `cross-spawn`. Thanks @zeyadhost for PR #201.
 - Kept direct MCP tool registration working when a host TypeBox shim does not expose `Type.Unsafe`. Thanks @RaviTharuma for PR #198.
 - Kept exact `npx` package specs from reusing a different same-name package version from npm's `_npx` cache. Thanks @danhrahal for issue #178.
 - Kept POST-only Streamable HTTP servers on the Streamable HTTP transport when the optional GET stream returns 405. Thanks @ramhaidar for issue #204.

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -10,6 +10,7 @@ describe("npx-resolver", () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.doUnmock("cross-spawn");
   });
 
   afterEach(() => {
@@ -43,6 +44,64 @@ describe("npx-resolver", () => {
     expect(result).not.toBeNull();
     expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(true);
     expect(existsSync(join(home, ".pi", "agent", "mcp-npx-cache.json"))).toBe(false);
+  });
+
+  it("uses cross-spawn to read npm's cache directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    delete process.env.NPM_CONFIG_CACHE;
+
+    const binPath = writeCachedPackage(npmCache, "demo-pkg");
+    const crossSpawn = vi.fn();
+    const sync = vi.fn(() => ({ status: 0, stdout: `${npmCache}\n` }));
+    Object.assign(crossSpawn, { sync });
+    vi.doMock("cross-spawn", () => ({ default: crossSpawn }));
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
+
+    expect(sync).toHaveBeenCalledWith("npm", ["config", "get", "cache"], { encoding: "utf-8" });
+    expect(crossSpawn).not.toHaveBeenCalled();
+    expect(result?.binPath).toBe(binPath);
+  });
+
+  it("uses cross-spawn to populate npm's npx cache on the slow path", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    delete process.env.NPM_CONFIG_CACHE;
+
+    const proc = {
+      kill: vi.fn(),
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event === "close") queueMicrotask(callback);
+        return proc;
+      }),
+    };
+    const crossSpawn = vi.fn(() => {
+      writeCachedPackage(npmCache, "demo-pkg");
+      return proc;
+    });
+    const sync = vi.fn(() => ({ status: 0, stdout: `${npmCache}\n` }));
+    Object.assign(crossSpawn, { sync });
+    vi.doMock("cross-spawn", () => ({ default: crossSpawn }));
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
+
+    expect(crossSpawn).toHaveBeenCalledWith(
+      "npm",
+      ["exec", "--yes", "--package", "demo-pkg", "--", "node", "-e", "1"],
+      { stdio: "ignore" },
+    );
+    expect(result).not.toBeNull();
   });
 
   it("preserves npx separators for wrapper package arguments", async () => {

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync, realpathSync, readdirSync, statSync, writeFileSync, renameSync, mkdirSync, openSync, readSync, closeSync } from "node:fs";
 import { join, dirname, extname, resolve, sep } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
-import { spawn, spawnSync } from "node:child_process";
+import crossSpawn from "cross-spawn";
 
 const CACHE_VERSION = 1;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -246,7 +246,7 @@ const FORCE_CACHE_TIMEOUT_MS = 30_000;
 async function forceNpxCache(packageSpec: string): Promise<void> {
   try {
     await new Promise<void>((resolve, reject) => {
-      const proc = spawn(
+      const proc = crossSpawn(
         "npm",
         ["exec", "--yes", "--package", packageSpec, "--", "node", "-e", "1"],
         { stdio: "ignore" }
@@ -395,7 +395,7 @@ function getNpmCacheDir(): string | null {
     return npmCacheDirCached;
   }
   try {
-    const result = spawnSync("npm", ["config", "get", "cache"], { encoding: "utf-8" });
+    const result = crossSpawn.sync("npm", ["config", "get", "cache"], { encoding: "utf-8" });
     if (result.status === 0) {
       const path = String(result.stdout).trim();
       npmCacheDirCached = path || null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@earendil-works/pi-tui": "^0.74.0",
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "cross-spawn": "^7.0.6",
         "open": "^10.2.0",
         "recheck": "^4.5.0",
         "typebox": "^1.1.24",
@@ -943,7 +944,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@earendil-works/pi-tui": "^0.74.0",
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "cross-spawn": "^7.0.6",
     "open": "^10.2.0",
     "recheck": "^4.5.0",
     "typebox": "^1.1.24",


### PR DESCRIPTION
Two functions in `npx-resolver.ts` — `getNpmCacheDir()` (line 357) and `forceNpxCache()` (line 236) — use raw `child_process.spawnSync` / `child_process.spawn` to call `npm`. On Windows this fails silently with `ENOENT` because `npm` only exists as `npm.cmd`, not `npm.exe`, and Node's raw spawn can't resolve `.cmd` files.

The result: `getNpmCacheDir()` always returns `null` on Windows, so `resolveFromNpmCache()` never finds cached npx binaries, forcing every npx-based MCP server through a fresh uncached download on every single connection. On a cold cache that can push startup past the 60s default timeout → `-32001` on all servers at once.

Fix replaces both call sites with `cross-spawn`, which correctly resolves `.cmd` shims on Windows. `cross-spawn` was already a transitive dependency (via `@modelcontextprotocol/sdk`); this promotes it to a direct dependency.

Tested on Windows 11 / Node 22:

```
BEFORE (raw child_process.spawnSync): spawnSync npm ENOENT
AFTER  (cross-spawn.sync):            C:\Users\...\npm-cache
```

The three existing `npx-resolver` tests still pass (they set `NPM_CONFIG_CACHE` env var, bypassing the spawn path, but the import change doesn't break module resolution either way).