### PR TITLE
Fix extension lifecycle ownership across Pi reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Avoided MCP renderer crashes without a TUI theme and preserved status-bar updates with plain fallback text. Thanks @fankangsong for PR #183.
 - Abandoned MCP initialization quietly when a session is disposed during eager or keep-alive connection setup. Thanks @luisfontes for PR #192.
+- Fenced MCP runtime ownership across Pi reloads so stale callbacks and late connections cannot outlive their session. Thanks @uuunk (Paul Lorsbach) for PR #202.
 - Added `toolPrefix: "mcp"` support for `mcp__<server>_<tool>` names across direct and proxy MCP tool paths. Thanks @riicodespretty for PR #99.
 - Sanitized dotted MCP tool names before registering them with Pi. Thanks @benjaminrickels for PR #190.
 - Reconnected OAuth MCP servers automatically after successful panel or `/mcp-auth` authorization, and made panel reconnect force a fresh connection like `/mcp reconnect`. Thanks @mightymatth for issue #171.

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -68,7 +68,7 @@ describe("AbortSignal propagation", () => {
 
     const result = await inFlight;
     expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
-    expect(result.details.error).toBe("call_failed");
+    expect(result.details.error).toBe("aborted");
     expect(callTool).toHaveBeenCalledWith(
       { name: "slow", arguments: {}, _meta: undefined },
       undefined,
@@ -88,7 +88,7 @@ describe("AbortSignal propagation", () => {
 
     const result = await inFlight;
     expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
-    expect(result.details.error).toBe("call_failed");
+    expect(result.details.error).toBe("aborted");
     expect(callTool).toHaveBeenCalledWith(
       { name: "slow", arguments: {}, _meta: undefined },
       undefined,

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -100,6 +100,7 @@ describe("direct tools auto auth", () => {
       "demo",
       "https://api.example.com/mcp",
       state.config.mcpServers.demo,
+      { signal: controller.signal },
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
     expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
@@ -159,8 +160,47 @@ describe("direct tools auto auth", () => {
       undefined,
       requestOptions,
     );
-    expect(result.details).toMatchObject({ error: "call_failed", server: "demo" });
+    expect(result.details).toMatchObject({ error: "aborted", server: "demo" });
     expect(result.content[0].text).toContain("request aborted");
+  });
+
+  it("rethrows direct auto-auth cancellation", async () => {
+    const { createDirectToolExecutor } = await import("../direct-tools.ts");
+    const controller = new AbortController();
+    const reason = new Error("request cancelled");
+    reason.name = "AbortError";
+    mocks.authenticate.mockRejectedValueOnce(reason);
+    const state = {
+      config: {
+        settings: { autoAuth: true },
+        mcpServers: { demo: { url: "https://api.example.com/mcp", auth: "oauth" } },
+      },
+      manager: {
+        getConnection: vi.fn(() => ({ status: "needs-auth" })),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+    mocks.lazyConnect.mockResolvedValue(false);
+
+    const executor = createDirectToolExecutor(() => state, () => null, {
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Search",
+    });
+
+    await expect(executor("id", {}, controller.signal, undefined, undefined as any)).rejects.toBe(reason);
+    expect(mocks.authenticate).toHaveBeenCalledWith(
+      "demo",
+      "https://api.example.com/mcp",
+      state.config.mcpServers.demo,
+      { signal: controller.signal },
+    );
   });
 
   it("fails fast in non-ui context for browser-based OAuth", async () => {

--- a/__tests__/fixtures/delayed-mcp-server.mjs
+++ b/__tests__/fixtures/delayed-mcp-server.mjs
@@ -1,0 +1,29 @@
+import { rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListResourcesRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const pidPath = process.env.MCP_RELOAD_PID_DIR ? join(process.env.MCP_RELOAD_PID_DIR, `${process.pid}.json`) : undefined;
+const identity = { pid: process.pid, toolName: "reload_identity" };
+if (pidPath) {
+  const pendingPath = `${pidPath}.tmp`;
+  await writeFile(pendingPath, JSON.stringify(identity));
+  await rename(pendingPath, pidPath);
+}
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, () => process.exit(0));
+}
+
+const server = new Server(
+  { name: "delayed-reload-fixture", version: "1.0.0" },
+  { capabilities: { tools: {}, resources: {} } },
+);
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return {
+    tools: [{ name: identity.toolName, description: "reload identity", inputSchema: { type: "object", properties: {} } }],
+  };
+});
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+await server.connect(new StdioServerTransport());

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -88,8 +88,10 @@ vi.mock("../proxy-modes.ts", () => ({
 }));
 
 vi.mock("../utils.ts", () => ({
+  formatTerminalError: (error: unknown) => error instanceof Error ? error.message : String(error),
   getConfigPathFromArgv: mocks.getConfigPathFromArgv,
   normalizeDirectToolInputSchema: mocks.normalizeDirectToolInputSchema,
+  sanitizeTerminalText: (text: string) => text,
   truncateAtWord: mocks.truncateAtWord,
 }));
 
@@ -706,7 +708,7 @@ describe("mcpAdapter session lifecycle", () => {
       await Promise.resolve();
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(consoleError).toHaveBeenCalledWith("MCP initialization failed:", expect.any(Error));
+      expect(consoleError).toHaveBeenCalledWith("MCP initialization failed: status boom");
     } finally {
       consoleError.mockRestore();
     }

--- a/__tests__/init-elicitation.test.ts
+++ b/__tests__/init-elicitation.test.ts
@@ -60,7 +60,7 @@ describe("initializeMcp elicitation config", () => {
 
     expect(McpServerManager).toHaveBeenCalledWith(ctx.cwd);
     expect(mocks.managers[0].setElicitationConfig).toHaveBeenCalledWith({
-      ui: ctx.ui,
+      ui: expect.any(Object),
       allowUrl: true,
     });
   });
@@ -84,9 +84,33 @@ describe("initializeMcp elicitation config", () => {
     await initializeMcp(extensionApi(), ctx);
 
     expect(mocks.managers[0].setElicitationConfig).toHaveBeenCalledWith({
-      ui: ctx.ui,
+      ui: expect.any(Object),
       allowUrl: false,
     });
+  });
+
+  it("keeps sampling bound to the current model and turn signal while the runtime is active", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const ctx = context() as ExtensionContext & { model: unknown; signal: AbortSignal | undefined };
+    const firstSignal = new AbortController();
+    const secondSignal = new AbortController();
+    ctx.model = { id: "first" };
+    ctx.signal = firstSignal.signal;
+
+    const state = await initializeMcp(extensionApi(), ctx);
+    const sampling = mocks.managers[0].setSamplingConfig.mock.calls[0][0];
+
+    ctx.model = { id: "second" };
+    ctx.signal = secondSignal.signal;
+    expect(sampling.getCurrentModel()).toEqual({ id: "second" });
+    const activeSignal = sampling.getSignal();
+    expect(activeSignal.aborted).toBe(false);
+    secondSignal.abort(new Error("turn cancelled"));
+    expect(activeSignal.aborted).toBe(true);
+
+    await state.owner.stop("reload");
+    expect(sampling.getCurrentModel()).toBeUndefined();
+    expect(sampling.getSignal().aborted).toBe(true);
   });
 
   it("does not enable elicitation without UI or when disabled", async () => {

--- a/__tests__/init-stale-ctx-race.test.ts
+++ b/__tests__/init-stale-ctx-race.test.ts
@@ -87,7 +87,7 @@ describe("initializeMcp vs. a ctx invalidated mid-connect", () => {
     await pending;
   });
 
-  it("still rejects unrelated ctx.hasUI failures after startup connects", async () => {
+  it("does not read guarded ctx getters again after startup connects", async () => {
     mocks.loadMcpConfig.mockReturnValue({
       mcpServers: {
         demo: { command: "npx", args: ["-y", "demo-server"], lifecycle: "eager" },
@@ -112,6 +112,6 @@ describe("initializeMcp vs. a ctx invalidated mid-connect", () => {
     armed.value = true;
     resolveConnect({ status: "connected", tools: [], resources: [] });
 
-    await expect(pending).rejects.toThrow("unexpected ui failure");
+    await pending;
   });
 });

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -77,6 +77,36 @@ describe("lazy-keep-alive lifecycle", () => {
     rmSync(tempAgentDir, { recursive: true, force: true });
   });
 
+  it("does not install a health interval for an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("stopped"));
+    lifecycle.startHealthChecks(controller.signal, 1000);
+    expect((lifecycle as any).healthCheckInterval).toBeUndefined();
+  });
+
+  it("consumes health-check rejections without an unhandled rejection", async () => {
+    vi.useFakeTimers();
+    const def = makeDefinition("lazy");
+    lifecycle.registerServer("srv", def, { idleTimeout: 1 });
+    fake.setConnection("srv", "connected");
+    fake.idleResponses.set("srv", true);
+    fake.close = vi.fn(async () => { throw new Error("idle close failed \u001b]52;c;secret\u0007"); });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    try {
+      lifecycle.startHealthChecks(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+      await Promise.resolve();
+      expect(unhandled).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith("MCP: Health check failed: idle close failed");
+    } finally {
+      process.removeListener("unhandledRejection", unhandled);
+      await lifecycle.gracefulShutdown().catch(() => {});
+    }
+  });
+
   it("reconnects after first spawn when the process dies", async () => {
     const def = makeDefinition("lazy-keep-alive");
     lifecycle.registerServer("srv", def, { idleTimeout: 0 });

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -549,6 +549,71 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("browser-fail")).toBeUndefined();
   });
 
+  it("clears a pending manual flow when cancellation happens after callback registration", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+      return "REDIRECT";
+    });
+    mocks.waitForCallback.mockReturnValueOnce(new Promise<string>(() => {}));
+    const controller = new AbortController();
+    const reason = new Error("request cancelled");
+    const { authenticate, hasPendingAuth } = await import("../mcp-auth-flow.ts");
+    const { getOAuthState } = await import("../mcp-auth.ts");
+
+    await expect(authenticate("cancel-manual", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    }, {
+      signal: controller.signal,
+      onAuthorizationUrl: () => controller.abort(reason),
+    })).rejects.toBe(reason);
+
+    expect(mocks.waitForCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(expect.any(String));
+    expect(hasPendingAuth("cancel-manual")).toBe(false);
+    expect(getOAuthState("cancel-manual")).toBeUndefined();
+  });
+
+  it("blocks a detached SDK token write after authentication cancellation", async () => {
+    let releaseTokenExchange!: () => void;
+    const tokenExchange = new Promise<void>(resolve => {
+      releaseTokenExchange = resolve;
+    });
+    let markTokenExchangeStarted!: () => void;
+    const tokenExchangeStarted = new Promise<void>(resolve => {
+      markTokenExchangeStarted = resolve;
+    });
+    mocks.sdkAuth
+      .mockImplementationOnce(async (provider) => {
+        await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+        return "REDIRECT";
+      })
+      .mockImplementationOnce(async (provider) => {
+        markTokenExchangeStarted();
+        await tokenExchange;
+        await provider.saveTokens({ access_token: "late-token", token_type: "Bearer" });
+        return "AUTHORIZED";
+      });
+    mocks.waitForCallback.mockResolvedValueOnce("manual-code");
+    mocks.open.mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+    const reason = new Error("request cancelled");
+    const { authenticate } = await import("../mcp-auth-flow.ts");
+    const { getAuthForUrl } = await import("../mcp-auth.ts");
+
+    const authentication = authenticate("cancel-token", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    }, { signal: controller.signal });
+    await tokenExchangeStarted;
+    controller.abort(reason);
+    await expect(authentication).rejects.toBe(reason);
+
+    releaseTokenExchange();
+    await new Promise(resolve => setImmediate(resolve));
+    expect(getAuthForUrl("cancel-token", "https://api.example.com/mcp")?.tokens).toBeUndefined();
+  });
+
   it("uses a custom authorization URL handler instead of raw console output", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -162,6 +162,74 @@ describe("mcp-callback-server", () => {
     expect(mocks.state.activePort).toBe(4338);
   });
 
+  it("waits for an in-progress bind before stopping and permits later reuse", async () => {
+    let resolveListen: (() => void) | undefined;
+    mocks.runtime.listenImpl = (_server, _port, _host, onListen) => {
+      resolveListen = onListen;
+    };
+
+    const { ensureCallbackServer, stopCallbackServer, isCallbackServerRunning } = await import("../mcp-callback-server.ts");
+    const starting = ensureCallbackServer();
+    await Promise.resolve();
+    const stopping = stopCallbackServer();
+    resolveListen?.();
+
+    await Promise.all([starting, stopping]);
+    expect(isCallbackServerRunning()).toBe(false);
+    expect(mocks.runtime.servers[0]?.close).toHaveBeenCalledTimes(1);
+
+    mocks.runtime.listenImpl = (_server, _port, _host, onListen) => {
+      onListen();
+    };
+    await ensureCallbackServer();
+    expect(isCallbackServerRunning()).toBe(true);
+    expect(mocks.runtime.servers).toHaveLength(2);
+  });
+
+  it("rejects callback startup queued before shutdown", async () => {
+    let resolveListen: (() => void) | undefined;
+    mocks.runtime.listenImpl = (_server, _port, _host, onListen) => {
+      resolveListen = onListen;
+    };
+
+    const { ensureCallbackServer, stopCallbackServer, isCallbackServerRunning } = await import("../mcp-callback-server.ts");
+    const starting = ensureCallbackServer();
+    await Promise.resolve();
+    const queued = ensureCallbackServer({ strictPort: true });
+    const queuedResult = expect(queued).rejects.toThrow("OAuth callback server stopped");
+    const stopping = stopCallbackServer();
+    resolveListen?.();
+
+    await expect(starting).resolves.toBeUndefined();
+    await queuedResult;
+    await expect(stopping).resolves.toBeUndefined();
+    expect(isCallbackServerRunning()).toBe(false);
+    expect(mocks.runtime.servers).toHaveLength(1);
+    expect(mocks.runtime.servers[0]?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects callback startup issued while shutdown is closing the server", async () => {
+    const { ensureCallbackServer, stopCallbackServer, isCallbackServerRunning } = await import("../mcp-callback-server.ts");
+    await ensureCallbackServer();
+    let finishClose: (() => void) | undefined;
+    mocks.runtime.servers[0].close.mockImplementation((callback?: () => void) => {
+      finishClose = callback;
+    });
+
+    const stopping = stopCallbackServer();
+    await expect(ensureCallbackServer({ strictPort: true, reserveState: true, oauthState: "stale" }))
+      .rejects.toThrow("OAuth callback server stopped");
+    expect(mocks.runtime.servers).toHaveLength(1);
+
+    finishClose?.();
+    await expect(stopping).resolves.toBeUndefined();
+    expect(isCallbackServerRunning()).toBe(false);
+
+    await ensureCallbackServer();
+    expect(isCallbackServerRunning()).toBe(true);
+    expect(mocks.runtime.servers).toHaveLength(2);
+  });
+
   it("rebinds to the configured port when strict mode is requested", async () => {
     const { ensureCallbackServer } = await import("../mcp-callback-server.ts");
 

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -141,6 +141,23 @@ describe("McpOAuthProvider addClientAuthentication", () => {
     expect(params.has("scope")).toBe(false);
     expect(params.get("client_id")).toBe("my-client");
   });
+
+  it("does not mutate token request credentials after deactivation", async () => {
+    const provider = new McpOAuthProvider(
+      "auth-inactive",
+      serverUrl,
+      { clientId: "my-client", clientSecret: "my-secret", scope: "api://res/.default" },
+      { onRedirect: async () => {} },
+    );
+    const headers = new Headers();
+    const params = new URLSearchParams({ grant_type: "authorization_code" });
+    provider.deactivate();
+
+    await expect(provider.addClientAuthentication(headers, params, new URL("https://auth.example.com/token")))
+      .rejects.toThrow("OAuth flow is no longer active");
+    expect([...params.entries()]).toEqual([["grant_type", "authorization_code"]]);
+    expect([...headers.entries()]).toEqual([]);
+  });
 });
 
 describe("McpOAuthProvider authorization fallback", () => {

--- a/__tests__/pi-reload-real-path.test.ts
+++ b/__tests__/pi-reload-real-path.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AuthStorage,
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRegistry,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+const roots: string[] = [];
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+});
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for reload harness condition");
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
+
+async function activeFixtures(pidDir: string): Promise<Array<{ pid: number; toolName: string }>> {
+  const entries = await readdir(pidDir);
+  const records = await Promise.all(entries.filter(name => name.endsWith(".json")).map(async name =>
+    JSON.parse(await readFile(join(pidDir, name), "utf8")) as { pid: number; toolName: string },
+  ));
+  return records.filter(record => isAlive(record.pid));
+}
+
+async function waitForFixture(
+  pidDir: string,
+  predicate: (active: Array<{ pid: number; toolName: string }>) => boolean,
+  timeoutMs = 5000,
+): Promise<Array<{ pid: number; toolName: string }>> {
+  let result: Array<{ pid: number; toolName: string }> = [];
+  await waitFor(async () => {
+    result = await activeFixtures(pidDir);
+    return predicate(result);
+  }, timeoutMs);
+  return result;
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createReloadHarness() {
+  const root = await mkdtemp(join(tmpdir(), "pi-mcp-reload-real-path-"));
+  roots.push(root);
+  const agentDir = join(root, "agent");
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const cwd = join(root, "project");
+  await writeFile(join(root, "placeholder"), "ok");
+  await Promise.all([
+    mkdir(agentDir, { recursive: true }),
+    mkdir(cwd, { recursive: true }),
+  ]);
+  const pidDir = join(root, "pids");
+  await mkdir(pidDir, { recursive: true });
+  const configPath = join(agentDir, "mcp.json");
+  await writeFile(configPath, JSON.stringify({
+    mcpServers: {
+      delayed: {
+        command: process.execPath,
+        args: [resolve("__tests__/fixtures/delayed-mcp-server.mjs")],
+        env: { MCP_RELOAD_PID_DIR: pidDir },
+        debug: true,
+        lifecycle: "eager",
+      },
+    },
+    settings: { sampling: false, elicitation: false },
+  }));
+  process.argv.push("--mcp-config", configPath);
+
+  const settingsManager = SettingsManager.inMemory();
+  const loader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    additionalExtensionPaths: [resolve("index.ts")],
+  });
+  await loader.reload();
+  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+  const modelRegistry = ModelRegistry.inMemory(authStorage);
+  const errors: Array<{ error: string; stack?: string }> = [];
+  const statusCalls: string[] = [];
+  const ui = {
+    notify: () => undefined,
+    setStatus: (_key: string, value: unknown) => statusCalls.push(String(value)),
+    theme: { fg: (_color: string, value: string) => value },
+  } as any;
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir,
+    resourceLoader: loader,
+    sessionManager: SessionManager.inMemory(cwd),
+    settingsManager,
+    authStorage,
+    modelRegistry,
+    noTools: "all",
+  });
+  await session.bindExtensions({ mode: "tui", uiContext: ui, onError: error => errors.push(error) });
+  return {
+    session,
+    errors,
+    statusCalls,
+    pidDir,
+    cleanupArgv: () => {
+      const index = process.argv.lastIndexOf("--mcp-config");
+      if (index >= 0) process.argv.splice(index, 2);
+    },
+  };
+}
+
+describe("Pi registered extension reload real path", () => {
+  it("terminates each old fixture and leaves one replacement process/tool identity", async () => {
+    const harness = await createReloadHarness();
+    const oldPids: number[] = [];
+    try {
+      await harness.session.reload();
+      await waitFor(async () => (await activeFixtures(harness.pidDir)).length === 1).catch(error => {
+        throw new Error(`${error instanceof Error ? error.message : String(error)}; errors=${JSON.stringify(harness.errors)}; statuses=${JSON.stringify(harness.statusCalls)}`);
+      });
+      oldPids.push((await activeFixtures(harness.pidDir))[0].pid);
+
+      await harness.session.reload();
+      const secondActive = await waitForFixture(harness.pidDir, active =>
+        active.length === 1 && active[0].pid !== oldPids[0],
+      ).catch(async error => {
+        throw new Error(`${error instanceof Error ? error.message : String(error)}; active=${JSON.stringify(await activeFixtures(harness.pidDir))}; errors=${JSON.stringify(harness.errors)}; statuses=${JSON.stringify(harness.statusCalls)}`);
+      });
+      oldPids.push(secondActive[0].pid);
+      await waitFor(() => !isAlive(oldPids[0]));
+
+      await harness.session.reload();
+      const active = await waitForFixture(harness.pidDir, fixtures =>
+        fixtures.length === 1 && fixtures[0].pid !== oldPids[1],
+      );
+      oldPids.push(active[0].pid);
+      await waitFor(() => !isAlive(oldPids[1]));
+
+      expect(active).toHaveLength(1);
+      expect(active[0].toolName).toBe("reload_identity");
+      const tools = harness.session.extensionRunner.getAllRegisteredTools().map(tool => tool.definition.name);
+      expect(tools.filter(name => name === "mcp")).toHaveLength(1);
+      expect(harness.errors.map(error => `${error.error}\n${error.stack ?? ""}`).join("\n"))
+        .not.toContain("This extension ctx is stale after session replacement or reload");
+      await harness.session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      await waitFor(() => !isAlive(oldPids[2]));
+      await new Promise(resolve => setTimeout(resolve, 150));
+    } finally {
+      try {
+        await harness.session.extensionRunner.emit({ type: "session_shutdown", reason: "test-finally" });
+      } catch {
+        // Preserve the original assertion while still attempting extension cleanup.
+      }
+      for (const pid of oldPids) {
+        if (isAlive(pid)) {
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // The fixture may have exited between the liveness check and kill.
+          }
+        }
+      }
+      harness.cleanupArgv();
+      harness.session.dispose();
+    }
+  }, 20_000);
+});

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -327,6 +327,7 @@ describe("proxy auto auth", () => {
       "demo",
       "https://api.example.com/mcp",
       state.config.mcpServers.demo,
+      { signal: controller.signal },
     );
     expect(manager.connect).toHaveBeenCalledTimes(1);
     expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
@@ -340,6 +341,38 @@ describe("proxy auto auth", () => {
       { timeout: 1234 },
     );
     expect(result.content[0].text).toContain("ok");
+  });
+
+  it("rethrows proxy auto-auth cancellation", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const controller = new AbortController();
+    const reason = new Error("request cancelled");
+    reason.name = "AbortError";
+    mocks.authenticate.mockRejectedValueOnce(reason);
+    const state = {
+      config: {
+        settings: { autoAuth: true, toolPrefix: "server" },
+        mcpServers: { demo: { url: "https://api.example.com/mcp", auth: "oauth" } },
+      },
+      manager: {
+        getConnection: vi.fn(() => ({ status: "needs-auth" })),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      toolMetadata: new Map([["demo", [{ name: "demo_search", originalName: "search", description: "Search", inputSchema: { type: "object" } }]]]),
+      failureTracker: new Map(),
+      ui: { setStatus: vi.fn() },
+      completedUiSessions: [],
+    } as any;
+
+    await expect(executeCall(state, "demo_search", {}, "demo", undefined, controller.signal)).rejects.toBe(reason);
+    expect(mocks.authenticate).toHaveBeenCalledWith(
+      "demo",
+      "https://api.example.com/mcp",
+      state.config.mcpServers.demo,
+      { signal: controller.signal },
+    );
   });
 
   it("surfaces aborted proxy tool calls via the forwarded AbortSignal", async () => {
@@ -385,8 +418,38 @@ describe("proxy auto auth", () => {
       undefined,
       requestOptions,
     );
-    expect(result.details).toMatchObject({ error: "call_failed", message: "request aborted" });
+    expect(result.details).toMatchObject({ error: "aborted", message: "request aborted" });
     expect(result.content[0].text).toContain("request aborted");
+  });
+
+  it("preserves owner cancellation during a proxy tool call", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const owner = new AbortController();
+    const connection = {
+      status: "connected",
+      client: { callTool: vi.fn(() => new Promise<never>(() => {})) },
+    };
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: { command: "demo" } } },
+      manager: {
+        getConnection: vi.fn(() => connection),
+        getRequestOptions: vi.fn((_name: string, signal?: AbortSignal) => signal ? { signal } : undefined),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      owner: { signal: owner.signal },
+      toolMetadata: new Map([["demo", [{ name: "demo_search", originalName: "search", description: "Search", inputSchema: { type: "object" } }]]]),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const inFlight = executeCall(state, "demo_search", {}, "demo");
+    await Promise.resolve();
+    owner.abort(new Error("owner stopped"));
+    const result = await inFlight;
+
+    expect(result.details).toMatchObject({ error: "aborted", message: "owner stopped" });
   });
 
   it("shares one cold connect across concurrent proxy calls and applies timeout during bootstrap", async () => {

--- a/__tests__/runtime-owner.test.ts
+++ b/__tests__/runtime-owner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { combineAbortSignals, createMcpRuntimeOwner, createOwnedUi } from "../runtime-owner.ts";
+
+describe("MCP runtime ownership", () => {
+  it("contains synchronous and asynchronous cleanup failures and is idempotent", async () => {
+    const owner = createMcpRuntimeOwner();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = vi.fn(() => { throw new Error("cleanup failed \u001b]52;c;secret\u0007"); });
+    owner.addCleanup(cleanup);
+    const first = owner.stop("reload");
+    const second = owner.stop("shutdown");
+
+    await expect(first).rejects.toThrow(AggregateError);
+    await expect(second).rejects.toThrow(AggregateError);
+    expect(first).toBe(second);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith("MCP: runtime cleanup failed: cleanup failed");
+    consoleError.mockRestore();
+  });
+
+  it("does not invoke nested UI methods after the owner stops", async () => {
+    const owner = createMcpRuntimeOwner();
+    const ui = { notify: vi.fn(), theme: { fg: vi.fn((_color: string, text: string) => text) } } as any;
+    const owned = createOwnedUi(ui, owner);
+    const theme = owned.theme;
+
+    theme.fg("accent", "before");
+    await owner.stop("reload");
+    expect((owned as any).notify).toBeUndefined();
+    expect((owned as any).theme).toBeUndefined();
+
+    expect(ui.notify).not.toHaveBeenCalled();
+    expect(ui.theme.fg).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not read stale UI getters after the owner stops", async () => {
+    const owner = createMcpRuntimeOwner();
+    const ui = {} as any;
+    Object.defineProperty(ui, "notify", {
+      get: () => {
+        throw new Error("stale getter");
+      },
+    });
+    const owned = createOwnedUi(ui, owner);
+    await owner.stop("reload");
+    expect(() => (owned as any).notify).not.toThrow();
+    expect((owned as any).notify).toBeUndefined();
+  });
+
+  it("combines owner and context cancellation", async () => {
+    const owner = createMcpRuntimeOwner();
+    const context = new AbortController();
+    const signal = combineAbortSignals(owner.signal, context.signal)!;
+    expect(signal.aborted).toBe(false);
+    context.abort(new Error("context ended"));
+    expect(signal.aborted).toBe(true);
+    await owner.stop("reload");
+  });
+
+  it("runs cleanup only after a late registration has been fenced", async () => {
+    const owner = createMcpRuntimeOwner();
+    await owner.stop("reload");
+    const cleanup = vi.fn();
+    owner.addCleanup(cleanup);
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/server-manager-reconnect.test.ts
+++ b/__tests__/server-manager-reconnect.test.ts
@@ -132,8 +132,9 @@ describe("McpServerManager.reconnect", () => {
 
     const second = manager.reconnect("remote", def, stale);
     releaseClose();
-    const fresh = await second;
+    await expect(second).rejects.toBe(reason);
 
+    const fresh = await manager.reconnect("remote", def, stale);
     expect(fresh).not.toBe(stale);
     expect(manager.getConnection("remote")).toBe(fresh);
   });

--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clients: [] as any[],
+  transports: [] as any[],
+  connectGate: null as null | { promise: Promise<void>; resolve(): void },
+  connectError: null as Error | null,
+  resolveGate: null as null | { promise: Promise<void>; resolve(): void },
+}));
+
+function gate() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(function (this: any) {
+    this.setRequestHandler = vi.fn();
+    this.setNotificationHandler = vi.fn();
+    this.connect = vi.fn(async () => {
+      if (mocks.connectError) throw mocks.connectError;
+      await mocks.connectGate?.promise;
+    });
+    this.listTools = vi.fn(async () => ({ tools: [] }));
+    this.listResources = vi.fn(async () => ({ resources: [] }));
+    this.close = vi.fn(async () => undefined);
+    mocks.clients.push(this);
+  }),
+}));
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function (this: any) {
+    this.close = vi.fn(async () => undefined);
+    mocks.transports.push(this);
+  }),
+}));
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({ StreamableHTTPClientTransport: vi.fn() }));
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: vi.fn() }));
+vi.mock("../npx-resolver.ts", () => ({
+  resolveNpxBinary: vi.fn(async () => {
+    await mocks.resolveGate?.promise;
+    return null;
+  }),
+}));
+
+describe("MCP manager owner races", () => {
+  beforeEach(() => {
+    mocks.clients.length = 0;
+    mocks.transports.length = 0;
+    mocks.connectGate = null;
+    mocks.connectError = null;
+    mocks.resolveGate = null;
+  });
+
+  it("closes a connection that finishes after owner shutdown before insertion", async () => {
+    const { createMcpRuntimeOwner } = await import("../runtime-owner.ts");
+    const { McpServerManager } = await import("../server-manager.ts");
+    const connectGate = gate();
+    mocks.connectGate = connectGate;
+    const owner = createMcpRuntimeOwner();
+    const manager = new McpServerManager("/tmp/session");
+    manager.setRuntimeSignal(owner.signal);
+
+    const connecting = manager.connect("demo", { command: "node", args: ["server.js"] });
+    await Promise.resolve();
+    await owner.stop("reload");
+    connectGate.resolve();
+
+    await expect(connecting).rejects.toThrow("reload");
+    expect(manager.getAllConnections().size).toBe(0);
+    expect(mocks.clients[0].close).not.toHaveBeenCalled();
+    expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("close aborts an in-flight connect and prevents late insertion", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const connectGate = gate();
+    mocks.connectGate = connectGate;
+    const manager = new McpServerManager("/tmp/session");
+    const connecting = manager.connect("demo", { command: "node", args: ["server.js"] });
+    await Promise.resolve();
+    const closing = manager.close("demo");
+    await expect(closing).resolves.toBeUndefined();
+    connectGate.resolve();
+    await expect(connecting).rejects.toThrow("connection demo was closed");
+    expect(manager.getConnection("demo")).toBeUndefined();
+  });
+
+  it("closeAll aborts pending connects and settles without late insertion", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const connectGate = gate();
+    mocks.connectGate = connectGate;
+    const manager = new McpServerManager("/tmp/session");
+    const connecting = manager.connect("demo", { command: "node", args: ["server.js"] });
+    await Promise.resolve();
+    const closeAll = manager.closeAll();
+    await expect(closeAll).resolves.toBeUndefined();
+    connectGate.resolve();
+    await expect(connecting).rejects.toThrow();
+    expect(manager.getAllConnections().size).toBe(0);
+  });
+
+  it("surfaces transport cleanup failures from an aborted pending connect", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const connectGate = gate();
+    mocks.connectGate = connectGate;
+    const manager = new McpServerManager("/tmp/session");
+    const connecting = manager.connect("demo", { command: "node", args: ["server.js"] });
+    await Promise.resolve();
+    mocks.transports[0].close = vi.fn(async () => { throw new Error("transport close failed"); });
+
+    const closeAll = manager.closeAll();
+    connectGate.resolve();
+
+    await expect(closeAll).rejects.toThrow("MCP manager cleanup failed");
+    await expect(connecting).rejects.toThrow("MCP connection abort cleanup failed");
+  });
+
+  it("surfaces client cleanup failures after a non-abort setup error", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectError = new Error("connect failed");
+    const manager = new McpServerManager("/tmp/session");
+    const connecting = manager.connect("demo", { command: "node", args: ["server.js"] });
+    mocks.clients[0].close = vi.fn(async () => { throw new Error("client close failed"); });
+
+    await expect(connecting).rejects.toThrow("MCP connection setup failed");
+    expect(mocks.clients[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects connections after terminal manager shutdown", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager("/tmp/session");
+
+    await manager.closeAll();
+
+    await expect(manager.connect("demo", { command: "node", args: ["server.js"] }))
+      .rejects.toThrow("MCP server manager is closed");
+    expect(mocks.clients).toHaveLength(0);
+    expect(mocks.transports).toHaveLength(0);
+  });
+
+  it("does not create a stdio transport when npx resolution is cancelled", async () => {
+    const { createMcpRuntimeOwner } = await import("../runtime-owner.ts");
+    const { McpServerManager } = await import("../server-manager.ts");
+    const resolveGate = gate();
+    mocks.resolveGate = resolveGate;
+    const owner = createMcpRuntimeOwner();
+    const manager = new McpServerManager("/tmp/session");
+    manager.setRuntimeSignal(owner.signal);
+
+    const connecting = manager.connect("demo", { command: "npx", args: ["-y", "demo"] });
+    await Promise.resolve();
+    await owner.stop("shutdown");
+    resolveGate.resolve();
+
+    await expect(connecting).rejects.toThrow("shutdown");
+    expect(mocks.transports).toHaveLength(0);
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -19,6 +19,7 @@ import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
 import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
+import { isAbortError } from "./runtime-owner.ts";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -88,19 +89,25 @@ export async function reconnectServer(
   name: string,
 ): Promise<boolean> {
   const definition = state.config.mcpServers[name];
+  const ui = ctx.hasUI ? ctx.ui : undefined;
+  const signal = state.owner?.signal;
   if (!definition) {
-    if (ctx.hasUI) {
-      ctx.ui.notify(`Server "${name}" not found in config`, "error");
+    if (ui) {
+      ui.notify(`Server "${name}" not found in config`, "error");
     }
     return false;
   }
 
   try {
     await state.manager.close(name);
-    const connection = await state.manager.connect(name, definition);
+    state.owner?.throwIfInactive();
+    const connection = signal
+      ? await state.manager.connect(name, definition, signal)
+      : await state.manager.connect(name, definition);
+    state.owner?.throwIfInactive();
     if (connection.status === "needs-auth") {
-      if (ctx.hasUI) {
-        ctx.ui.notify(`MCP: ${name} requires OAuth. Run /mcp-auth ${name} first.`, "warning");
+      if (ui) {
+        ui.notify(`MCP: ${name} requires OAuth. Run /mcp-auth ${name} first.`, "warning");
       }
       updateStatusBar(state);
       return false;
@@ -118,22 +125,23 @@ export async function reconnectServer(
     markKeepAliveAfterConnect(state, name);
     clearFailure(state, name);
 
-    if (ctx.hasUI) {
-      ctx.ui.notify(
+    if (ui) {
+      ui.notify(
         `MCP: Reconnected to ${name} (${connection.tools.length} tools, ${connection.resources.length} resources)`,
         "info"
       );
       if (failedTools.length > 0) {
-        ctx.ui.notify(`MCP: ${name} - ${failedTools.length} tools skipped`, "warning");
+        ui.notify(`MCP: ${name} - ${failedTools.length} tools skipped`, "warning");
       }
     }
     updateStatusBar(state);
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (isAbortError(error, signal)) throw error;
     recordFailure(state, name, message);
-    if (ctx.hasUI) {
-      ctx.ui.notify(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`, "error");
+    if (ui) {
+      ui.notify(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`, "error");
     }
     updateStatusBar(state);
     return false;
@@ -163,20 +171,24 @@ export async function reconnectServers(
 export async function authenticateServer(
   serverName: string,
   config: McpConfig,
-  ctx: ExtensionContext
+  ctx: ExtensionContext,
+  signal?: AbortSignal,
 ): Promise<McpAuthResult> {
-  if (!ctx.hasUI) return { ok: false, message: "OAuth authentication requires an interactive session." };
+  const ui = ctx.hasUI ? ctx.ui : undefined;
+  const cwd = ctx.cwd;
+  signal ??= ctx.signal;
+  if (!ui) return { ok: false, message: "OAuth authentication requires an interactive session." };
 
   const definition = config.mcpServers[serverName];
   if (!definition) {
     const message = `Server "${serverName}" not found in config`;
-    ctx.ui.notify(message, "error");
+    ui.notify(message, "error");
     return { ok: false, message };
   }
 
   if (!supportsOAuth(definition)) {
     const message = `Server "${serverName}" does not use OAuth authentication. Set "auth": "oauth" or omit auth for auto-detection.`;
-    ctx.ui.notify(
+    ui.notify(
       `Server "${serverName}" does not use OAuth authentication.\n` +
       `Set "auth": "oauth" or omit auth for auto-detection.`,
       "error"
@@ -188,38 +200,41 @@ export async function authenticateServer(
     const serverUrl = resolveServerUrl(definition);
     if (!serverUrl) {
       const message = `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`;
-      ctx.ui.notify(message, "error");
+      ui.notify(message, "error");
       return { ok: false, message };
     }
 
-    ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
-    const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
+    ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
+    const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
     const status = await authenticate(serverName, serverUrl, definition, {
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
       onAuthorizationUrl: (authorizationUrl) => {
-        ctx.ui.notify(
+        ui.notify(
           `Open this URL to authenticate ${serverName}:\n\n${authorizationUrl}\n\n` +
           "After approving, return to Pi; the local callback will complete automatically.",
           "info"
         );
       },
+      signal,
     });
+    if (signal?.aborted) signal.throwIfAborted();
 
     if (status === "authenticated") {
       const message = `OAuth authentication successful for "${serverName}".`;
-      ctx.ui.notify(message, "info");
+      ui.notify(message, "info");
       return { ok: true, message };
     }
 
     const message = `OAuth authentication failed for "${serverName}".`;
-    ctx.ui.notify(message, "error");
+    ui.notify(message, "error");
     return { ok: false, message };
   } catch (error) {
+    if (signal?.aborted) throw error;
     const message = error instanceof Error ? error.message : String(error);
-    ctx.ui.notify(`Failed to authenticate "${serverName}": ${message}`, "error");
+    ui.notify(`Failed to authenticate "${serverName}": ${message}`, "error");
     return { ok: false, message };
   } finally {
-    ctx.ui.setStatus("mcp-auth", undefined);
+    if (!signal?.aborted) ui.setStatus("mcp-auth", undefined);
   }
 }
 
@@ -229,18 +244,21 @@ export async function logoutServer(
   ctx: ExtensionContext
 ): Promise<{ ok: boolean; message: string }> {
   const definition = state.config.mcpServers[serverName];
+  const ui = ctx.hasUI ? ctx.ui : undefined;
   if (!definition) {
     const message = `Server "${serverName}" not found in config`;
-    if (ctx.hasUI) ctx.ui.notify(message, "error");
+    if (ui) ui.notify(message, "error");
     return { ok: false, message };
   }
 
-  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions });
+  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions, signal: state.owner?.signal });
+  state.owner?.throwIfInactive();
   await state.manager.close(serverName);
+  state.owner?.throwIfInactive();
   updateStatusBar(state);
 
   const message = `OAuth credentials cleared for "${serverName}". Run /mcp-auth ${serverName} to authenticate again.`;
-  if (ctx.hasUI) ctx.ui.notify(message, "info");
+  if (ui) ui.notify(message, "info");
   return { ok: true, message };
 }
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -15,6 +15,7 @@ import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
+import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
@@ -43,6 +44,7 @@ function getDirectAuthFailedMessage(state: McpExtensionState, serverName: string
 async function attemptDirectAutoAuth(
   state: McpExtensionState,
   serverName: string,
+  signal?: AbortSignal,
 ): Promise<DirectAutoAuthResult> {
   if (state.config.settings?.autoAuth !== true) {
     return { status: "skipped" };
@@ -78,12 +80,18 @@ async function attemptDirectAutoAuth(
 
   try {
     if (state.authStorageOptions) {
-      await authenticate(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions });
+      await authenticate(
+        serverName,
+        serverUrl,
+        definition,
+        signal ? { authStorageOptions: state.authStorageOptions, signal } : { authStorageOptions: state.authStorageOptions },
+      );
     } else {
-      await authenticate(serverName, serverUrl, definition);
+      await authenticate(serverName, serverUrl, definition, signal ? { signal } : {});
     }
     return { status: "success" };
   } catch (error) {
+    if (isAbortError(error, signal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
     return {
       status: "failed",
@@ -330,12 +338,14 @@ export function createDirectToolExecutor(
       };
     }
 
-    let connected = await lazyConnect(state, spec.serverName, signal);
+    const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+    throwIfAborted(ownedSignal);
+    let connected = await lazyConnect(state, spec.serverName, ownedSignal);
     let autoAuthAttempted = false;
 
     if (!connected && state.manager.getConnection(spec.serverName)?.status === "needs-auth") {
       autoAuthAttempted = true;
-      const autoAuth = await attemptDirectAutoAuth(state, spec.serverName);
+      const autoAuth = await attemptDirectAutoAuth(state, spec.serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
@@ -345,7 +355,7 @@ export function createDirectToolExecutor(
       if (autoAuth.status === "success") {
         await state.manager.close(spec.serverName);
         clearFailure(state, spec.serverName);
-        connected = await lazyConnect(state, spec.serverName, signal);
+        connected = await lazyConnect(state, spec.serverName, ownedSignal);
       }
     }
 
@@ -374,7 +384,7 @@ export function createDirectToolExecutor(
     }
 
     let uiSession: UiSessionRuntime | null = null;
-    const requestOptions = state.manager.getRequestOptions?.(spec.serverName, signal) ?? (signal ? { signal } : undefined);
+    const requestOptions = state.manager.getRequestOptions?.(spec.serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined);
 
     const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
     const recoverAuthConnection = async () => {
@@ -383,7 +393,7 @@ export function createDirectToolExecutor(
 
       if (!autoAuthAttempted) {
         autoAuthAttempted = true;
-        const autoAuth = await attemptDirectAutoAuth(state, spec.serverName);
+        const autoAuth = await attemptDirectAutoAuth(state, spec.serverName, ownedSignal);
         if (autoAuth.status === "failed") {
           throw new SessionRecoveryAuthRequiredError(spec.serverName, autoAuth.message);
         }
@@ -394,7 +404,7 @@ export function createDirectToolExecutor(
             await state.manager.close(spec.serverName);
           }
           clearFailure(state, spec.serverName);
-          const reconnected = await lazyConnect(state, spec.serverName, signal);
+          const reconnected = await lazyConnect(state, spec.serverName, ownedSignal);
           return reconnected ? state.manager.getConnection(spec.serverName) : undefined;
         }
       }
@@ -407,7 +417,7 @@ export function createDirectToolExecutor(
 
       if (spec.resourceUri) {
         const result = await withSessionRecovery(
-          { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+          { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
           spec.serverName,
           (conn) => conn.client.readResource({ uri: spec.resourceUri! }, requestOptions),
         );
@@ -436,13 +446,13 @@ export function createDirectToolExecutor(
         : null;
 
       const result = await withSessionRecovery(
-        { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+        { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
         spec.serverName,
         (conn) => abortable(conn.client.callTool({
           name: spec.originalName,
           arguments: params ?? {},
           _meta: uiSession?.requestMeta,
-        }, undefined, requestOptions), signal),
+        }, undefined, requestOptions), ownedSignal),
       );
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
 
@@ -507,7 +517,7 @@ export function createDirectToolExecutor(
       const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
       return {
         content: guarded.content,
-        details: { error: "call_failed", server: spec.serverName, ...guardedMcpDetails(guarded) },
+        details: { error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed", server: spec.serverName, ...guardedMcpDetails(guarded) },
       };
     } finally {
       if (uiSession?.reused) {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
 import { Type } from "typebox";
 import { showStatus, showTools, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
@@ -7,14 +7,16 @@ import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDi
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache } from "./metadata-cache.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
-import { getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
+import { formatTerminalError, getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.ts";
 import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
 import { toolErrorOverride } from "./error-signal.ts";
+import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
+  let currentOwner: McpRuntimeOwner | null = null;
   let lifecycleGeneration = 0;
 
   async function shutdownState(currentState: McpExtensionState | null, reason: string): Promise<void> {
@@ -33,10 +35,14 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     }
 
     try {
-      await currentState.lifecycle.gracefulShutdown();
+      if (currentState.owner) {
+        await currentState.owner.stop(reason);
+      } else {
+        await currentState.lifecycle.gracefulShutdown();
+      }
     } catch (error) {
       if (flushError) {
-        console.error("MCP: graceful shutdown failed after metadata flush error", error);
+        console.error(`MCP: graceful shutdown failed after metadata flush error: ${formatTerminalError(error)}`);
       } else {
         throw error;
       }
@@ -99,35 +105,44 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const generation = ++lifecycleGeneration;
     const previousState = state;
+    const previousOwner = currentOwner;
+    const owner = createMcpRuntimeOwner();
+    currentOwner = owner;
     state = null;
     initPromise = null;
 
+    // Abort synchronously before awaiting cleanup so old callbacks and startup
+    // work cannot resume into a stale ExtensionContext.
+    const stopPrevious = previousOwner?.stop("MCP extension session restarted") ?? Promise.resolve();
     try {
       await Promise.all([
+        stopPrevious,
         shutdownState(previousState, "session_restart"),
         shutdownOAuth(),
       ]);
     } catch (error) {
-      console.error("MCP: failed to shut down previous session state", error);
+      console.error(`MCP: failed to shut down previous session state: ${formatTerminalError(error)}`);
     }
 
-    if (generation !== lifecycleGeneration) {
+    if (generation !== lifecycleGeneration || !owner.isActive()) {
       return;
     }
 
-    await initializeOAuth().catch(err => {
-      console.error("MCP OAuth initialization failed:", err);
+    await initializeOAuth(owner.signal).catch(err => {
+      console.error(`MCP OAuth initialization failed: ${formatTerminalError(err)}`);
     });
 
-    const promise = initializeMcp(pi, ctx);
+    if (generation !== lifecycleGeneration || !owner.isActive()) return;
+
+    const promise = initializeMcp(pi, ctx, owner);
     initPromise = promise;
 
     promise.then(async (nextState) => {
-      if (generation !== lifecycleGeneration || initPromise !== promise) {
+      if (!owner.isActive() || generation !== lifecycleGeneration || initPromise !== promise) {
         try {
           await shutdownState(nextState, "stale_session_start");
         } catch (error) {
-          console.error("MCP: failed to clean stale session state", error);
+          console.error(`MCP: failed to clean stale session state: ${formatTerminalError(error)}`);
         }
         return;
       }
@@ -136,13 +151,13 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       updateStatusBar(nextState);
       initPromise = null;
     }).catch(err => {
-      if (generation !== lifecycleGeneration) {
+      if (!owner.isActive() || generation !== lifecycleGeneration) {
         return;
       }
       if (initPromise !== promise && initPromise !== null) {
         return;
       }
-      console.error("MCP initialization failed:", err);
+      console.error(`MCP initialization failed: ${formatTerminalError(err)}`);
       initPromise = null;
     });
   });
@@ -150,16 +165,22 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   pi.on("session_shutdown", async () => {
     ++lifecycleGeneration;
     const currentState = state;
+    const owner = currentOwner;
+    currentOwner = null;
     state = null;
     initPromise = null;
 
+    // Abort before awaiting cleanup so delayed initialization cannot touch stale
+    // Pi context after session shutdown.
+    const stopOwner = owner?.stop("MCP extension session shutdown") ?? Promise.resolve();
     try {
       await Promise.all([
+        stopOwner,
         shutdownState(currentState, "session_shutdown"),
         shutdownOAuth(),
       ]);
     } catch (error) {
-      console.error("MCP: session shutdown cleanup failed", error);
+      console.error(`MCP: session shutdown cleanup failed: ${formatTerminalError(error)}`);
     }
   });
 
@@ -191,17 +212,31 @@ export default function mcpAdapter(pi: ExtensionAPI) {
       return servers.length > 0 ? servers : null;
     },
     handler: async (args, ctx) => {
+      const commandOwner = currentOwner;
+      const commandReload = typeof ctx.reload === "function" ? ctx.reload.bind(ctx) : async () => {};
+      const commandHasUI = ctx.hasUI;
+      const commandCtx = {
+        hasUI: commandHasUI,
+        ui: commandHasUI
+          ? commandOwner ? createOwnedUi(ctx.ui, commandOwner) : ctx.ui
+          : undefined,
+        cwd: ctx.cwd,
+        mode: ctx.mode,
+        signal: commandOwner?.signal ?? ctx.signal,
+      } as unknown as ExtensionContext;
       if (!state && initPromise) {
         try {
-          state = await initPromise;
+          const initialized = await initPromise;
+          commandOwner?.throwIfInactive();
+          state = initialized;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
-          if (ctx.hasUI) ctx.ui.notify(`MCP initialization failed: ${message}`, "error");
+          if (commandCtx.hasUI) commandCtx.ui?.notify(`MCP initialization failed: ${message}`, "error");
           return;
         }
       }
       if (!state) {
-        if (ctx.hasUI) ctx.ui.notify("MCP not initialized", "error");
+        if (commandCtx.hasUI) commandCtx.ui?.notify("MCP not initialized", "error");
         return;
       }
 
@@ -212,15 +247,18 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
       switch (subcommand) {
         case "reconnect":
-          await reconnectServers(state, ctx, targetServer);
+          commandOwner?.throwIfInactive();
+          await reconnectServers(state, commandCtx, targetServer);
           break;
         case "tools":
-          await showTools(state, ctx);
+          await showTools(state, commandCtx);
           break;
         case "setup": {
-          const result = await openMcpSetup(state, pi, ctx, earlyConfigPath, "setup");
+          commandOwner?.throwIfInactive();
+          const result = await openMcpSetup(state, pi, commandCtx, earlyConfigPath, "setup");
           if (result?.configChanged) {
-            await ctx.reload();
+            commandOwner?.throwIfInactive();
+            await commandReload();
             return;
           }
           break;
@@ -228,23 +266,26 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         case "logout": {
           const serverName = rest;
           if (!serverName) {
-            if (ctx.hasUI) ctx.ui.notify("Usage: /mcp logout <server>", "error");
+            if (commandCtx.hasUI) commandCtx.ui?.notify("Usage: /mcp logout <server>", "error");
             return;
           }
-          await logoutServer(serverName, state, ctx);
+          commandOwner?.throwIfInactive();
+          await logoutServer(serverName, state, commandCtx);
           break;
         }
         case "status":
         case "":
         default:
-          if (ctx.hasUI) {
-            const result = await openMcpPanel(state, pi, ctx, earlyConfigPath);
+          if (commandCtx.hasUI) {
+            commandOwner?.throwIfInactive();
+            const result = await openMcpPanel(state, pi, commandCtx, earlyConfigPath);
             if (result?.configChanged) {
-              await ctx.reload();
+              commandOwner?.throwIfInactive();
+              await commandReload();
               return;
             }
           } else {
-            await showStatus(state, ctx);
+            await showStatus(state, commandCtx);
           }
           break;
       }
@@ -254,33 +295,47 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   pi.registerCommand("mcp-auth", {
     description: "Authenticate with an MCP server (OAuth)",
     handler: async (args, ctx) => {
+      const commandOwner = currentOwner;
+      const commandHasUI = ctx.hasUI;
+      const commandCtx = {
+        hasUI: commandHasUI,
+        ui: commandHasUI
+          ? commandOwner ? createOwnedUi(ctx.ui, commandOwner) : ctx.ui
+          : undefined,
+        cwd: ctx.cwd,
+        mode: ctx.mode,
+        signal: commandOwner?.signal ?? ctx.signal,
+      } as unknown as ExtensionContext;
       const serverName = args?.trim();
-      if (!serverName && !ctx.hasUI) {
+      if (!serverName && !commandCtx.hasUI) {
         return;
       }
 
       if (!state && initPromise) {
         try {
-          state = await initPromise;
+          const initialized = await initPromise;
+          commandOwner?.throwIfInactive();
+          state = initialized;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
-          if (ctx.hasUI) ctx.ui.notify(`MCP initialization failed: ${message}`, "error");
+          if (commandCtx.hasUI) commandCtx.ui?.notify(`MCP initialization failed: ${message}`, "error");
           return;
         }
       }
       if (!state) {
-        if (ctx.hasUI) ctx.ui.notify("MCP not initialized", "error");
+        if (commandCtx.hasUI) commandCtx.ui?.notify("MCP not initialized", "error");
         return;
       }
 
       if (!serverName) {
-        await openMcpAuthPanel(state, pi, ctx, earlyConfigPath);
+        await openMcpAuthPanel(state, pi, commandCtx, earlyConfigPath);
         return;
       }
 
-      const result = await authenticateServer(serverName, state.config, ctx);
+      const result = await authenticateServer(serverName, state.config, commandCtx);
       if (result.ok) {
-        await reconnectServer(state, ctx, serverName);
+        commandOwner?.throwIfInactive();
+        await reconnectServer(state, commandCtx, serverName);
       }
     },
   });
@@ -323,6 +378,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         server?: string;
         action?: string;
       }, signal, _onUpdate, _ctx) {
+        const executeOwner = currentOwner;
         let parsedArgs: Record<string, unknown> | undefined;
         if (params.args !== undefined && params.args !== "") {
           let args: unknown;
@@ -348,8 +404,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
         if (!state && initPromise) {
           try {
-            state = await initPromise;
+            const initialized = await initPromise;
+            executeOwner?.throwIfInactive();
+            state = initialized;
           } catch (error) {
+            if (executeOwner && isAbortError(error, executeOwner.signal)) throw error;
             const message = error instanceof Error ? error.message : String(error);
             return {
               content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
@@ -363,6 +422,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
             details: { error: "not_initialized" },
           };
         }
+        executeOwner?.throwIfInactive();
 
         if (params.action === "ui-messages") {
           return executeUiMessages(state);
@@ -374,7 +434,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
               details: { mode: "auth-start", error: "missing_server" },
             };
           }
-          return executeAuthStart(state, params.server);
+          return signal
+            ? executeAuthStart(state, params.server, signal)
+            : executeAuthStart(state, params.server);
         }
         if (params.action === "auth-complete") {
           if (!params.server) {
@@ -390,7 +452,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
               details: { mode: "auth-complete", error: "missing_input" },
             };
           }
-          return executeAuthComplete(state, params.server, input);
+          return signal
+            ? executeAuthComplete(state, params.server, input, signal)
+            : executeAuthComplete(state, params.server, input);
         }
         if (params.tool) {
           return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, signal);

--- a/init.ts
+++ b/init.ts
@@ -24,6 +24,13 @@ import { logger } from "./logger.ts";
 import { getMissingConfiguredDirectToolServers } from "./direct-tools.ts";
 import { throwIfAborted } from "./abort.ts";
 import { getAuthStorageOptions } from "./mcp-auth.ts";
+import {
+  combineAbortSignals,
+  createMcpRuntimeOwner,
+  createOwnedUi,
+  isAbortError,
+  type McpRuntimeOwner,
+} from "./runtime-owner.ts";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
 const MAX_FAILURE_MESSAGE_CHARS = 8 * 1024;
@@ -69,30 +76,44 @@ export function isTuiMode(ctx: Pick<ExtensionContext, "hasUI" | "mode">): boolea
 
 export async function initializeMcp(
   pi: ExtensionAPI,
-  ctx: ExtensionContext
+  ctx: ExtensionContext,
+  owner: McpRuntimeOwner = createMcpRuntimeOwner(),
 ): Promise<McpExtensionState> {
+  // Pi guards ExtensionContext getters after reload. Snapshot all values that
+  // can be used by asynchronous work before the first await.
   const configPath = pi.getFlag("mcp-config") as string | undefined;
-  const config = loadMcpConfig(configPath, ctx.cwd);
-  const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
+  const cwd = ctx.cwd;
+  const hasUI = ctx.hasUI;
+  const mode = ctx.mode;
+  const rawUi = hasUI ? ctx.ui : undefined;
+  const modelRegistry = ctx.modelRegistry;
+  const initialSignal = ctx.signal;
+  const ui = rawUi ? createOwnedUi(rawUi, owner) : undefined;
+  const runtimeSignal = combineAbortSignals(owner.signal, initialSignal);
+  const config = loadMcpConfig(configPath, cwd);
+  const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
 
-  const manager = new McpServerManager(ctx.cwd);
+  const manager = new McpServerManager(cwd);
+  manager.setRuntimeSignal?.(owner.signal);
   manager.setDefaultRequestTimeoutMs(config.settings?.requestTimeoutMs);
   manager.setAuthStorageOptions(authStorageOptions);
   const samplingAutoApprove = config.settings?.samplingAutoApprove === true;
-  if (config.settings?.sampling !== false && (ctx.hasUI || samplingAutoApprove)) {
+  if (config.settings?.sampling !== false && (hasUI || samplingAutoApprove)) {
     manager.setSamplingConfig({
       autoApprove: samplingAutoApprove,
-      ui: ctx.hasUI ? ctx.ui : undefined,
-      modelRegistry: ctx.modelRegistry,
-      getCurrentModel: () => ctx.model,
-      getSignal: () => ctx.signal,
+      ui,
+      modelRegistry,
+      getCurrentModel: () => owner.isActive() ? ctx.model : undefined,
+      getSignal: () => owner.isActive()
+        ? combineAbortSignals(owner.signal, ctx.signal)
+        : owner.signal,
     });
   }
-  const elicitationEnabled = config.settings?.elicitation !== false && ctx.hasUI;
-  if (elicitationEnabled) {
+  const elicitationEnabled = config.settings?.elicitation !== false && hasUI;
+  if (elicitationEnabled && ui) {
     manager.setElicitationConfig({
-      ui: ctx.ui,
-      allowUrl: isTuiMode(ctx),
+      ui,
+      allowUrl: mode === "tui",
     });
   }
   const lifecycle = new McpLifecycleManager(manager);
@@ -102,8 +123,8 @@ export async function initializeMcp(
   const failureMessages = new Map<string, string>();
   const uiResourceHandler = new UiResourceHandler(manager, config);
   const consentManager = new ConsentManager("once-per-server");
-  const ui = ctx.hasUI ? ctx.ui : undefined;
   const state: McpExtensionState = {
+    owner,
     manager,
     lifecycle,
     toolMetadata,
@@ -116,10 +137,24 @@ export async function initializeMcp(
     consentManager,
     uiServer: null,
     completedUiSessions: [],
-    openBrowser: (url: string) => openUrl(pi, url, process.env.BROWSER),
+    openBrowser: async (url: string) => {
+      owner.throwIfInactive();
+      await openUrl(pi, url, process.env.BROWSER, owner.signal);
+      owner.throwIfInactive();
+    },
     ui,
-    sendMessage: (message, options) => pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options),
+    sendMessage: (message, options) => {
+      if (!owner.isActive()) return;
+      pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options);
+    },
   };
+  owner.addCleanup(() => lifecycle.gracefulShutdown());
+  owner.addCleanup(() => {
+    if (state.uiServer) {
+      state.uiServer.close("runtime_owner_stopped");
+      state.uiServer = null;
+    }
+  });
 
   const serverEntries = Object.entries(config.mcpServers);
   if (serverEntries.length === 0) {
@@ -174,19 +209,20 @@ export async function initializeMcp(
         return mode === "keep-alive" || mode === "eager";
       });
 
-  if (ctx.hasUI && startupServers.length > 0) {
-    ctx.ui.setStatus("mcp", `MCP: connecting to ${startupServers.length} servers...`);
+  if (ui && startupServers.length > 0) {
+    ui.setStatus("mcp", `MCP: connecting to ${startupServers.length} servers...`);
   }
 
   const results = await parallelLimit(startupServers, 10, async ([name, definition]) => {
     try {
-      const connection = await manager.connect(name, definition, ctx.signal);
+      const connection = await manager.connect(name, definition, runtimeSignal);
       if (connection.status === "needs-auth") {
         return { name, definition, connection: null, error: `OAuth authentication required. Run /mcp-auth ${name}.` };
       }
       return { name, definition, connection, error: null };
     } catch (error) {
-      if (ctx.signal?.aborted) {
+      if (isAbortError(error, runtimeSignal)) {
+        if (owner.signal.aborted) throw error;
         return { name, definition, connection: null, error: null };
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -194,25 +230,17 @@ export async function initializeMcp(
     }
   });
 
-  try {
-    void ctx.hasUI;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes("extension ctx is stale after session replacement or reload")) {
-      throw error;
-    }
-    // Session torn down while the eager/keep-alive connect(s) above were still
-    // in flight — abandon quietly instead of touching a dead ctx below.
-    return state;
-  }
+  if (initialSignal?.aborted) return state;
+  owner.throwIfInactive();
 
   for (const { name, definition, connection, error } of results) {
+    owner.throwIfInactive();
     if (error || !connection) {
-      if (ctx.signal?.aborted) continue;
+      if (initialSignal?.aborted) continue;
       if (error) recordFailure(state, name, error);
       const displayError = sanitizeTerminalText(error ?? "Unknown connection failure");
-      if (ctx.hasUI) {
-        ctx.ui.notify(`MCP: Failed to connect to ${name}: ${displayError}`, "error");
+      if (ui) {
+        ui.notify(`MCP: Failed to connect to ${name}: ${displayError}`, "error");
       }
       console.error(`MCP: Failed to connect to ${name}: ${displayError}`);
       continue;
@@ -228,8 +256,8 @@ export async function initializeMcp(
     updateMetadataCache(state, name);
     markKeepAliveAfterConnect(state, name);
 
-    if (failedTools.length > 0 && ctx.hasUI) {
-      ctx.ui.notify(
+    if (failedTools.length > 0 && ui) {
+      ui.notify(
         `MCP: ${name} - ${failedTools.length} tools skipped`,
         "warning"
       );
@@ -238,12 +266,12 @@ export async function initializeMcp(
 
   const connectedCount = results.filter(r => r.connection).length;
   const failedCount = results.filter(r => r.error).length;
-  if (ctx.hasUI && connectedCount > 0) {
+  if (ui && connectedCount > 0) {
     const totalTools = totalToolCount(state);
     const msg = failedCount > 0
       ? `MCP: ${connectedCount}/${startupServers.length} servers connected (${totalTools} tools)`
       : `MCP: ${connectedCount} servers connected (${totalTools} tools)`;
-    ctx.ui.notify(msg, "info");
+    ui.notify(msg, "info");
   }
 
   const envDirect = process.env.MCP_DIRECT_TOOLS;
@@ -258,7 +286,7 @@ export async function initializeMcp(
         async (name) => {
           const definition = config.mcpServers[name];
           try {
-            const connection = await manager.connect(name, definition, ctx.signal);
+            const connection = await manager.connect(name, definition, runtimeSignal);
             if (connection.status === "needs-auth") {
               return { name, ok: false };
             }
@@ -268,7 +296,10 @@ export async function initializeMcp(
             clearFailure(state, name);
             return { name, ok: true };
           } catch (error) {
-            if (ctx.signal?.aborted) return { name, ok: false };
+            if (isAbortError(error, runtimeSignal)) {
+              if (owner.signal.aborted) throw error;
+              return { name, ok: false };
+            }
             const message = error instanceof Error ? error.message : String(error);
             recordFailure(state, name, message);
             logger.debug(`MCP: direct-tools bootstrap failed for ${name}: ${sanitizeTerminalText(message)}`);
@@ -277,13 +308,15 @@ export async function initializeMcp(
         },
       );
       const bootstrapped = bootstrapResults.filter(r => r.ok).map(r => r.name);
-      if (bootstrapped.length > 0 && ctx.hasUI) {
-        ctx.ui.notify(`MCP: direct tools for ${bootstrapped.join(", ")} will be available after restart`, "info");
+      owner.throwIfInactive();
+      if (bootstrapped.length > 0 && ui) {
+        ui.notify(`MCP: direct tools for ${bootstrapped.join(", ")} will be available after restart`, "info");
       }
     }
   }
 
   lifecycle.setReconnectCallback((serverName) => {
+    if (!owner.isActive()) return;
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
     clearFailure(state, serverName);
@@ -291,18 +324,21 @@ export async function initializeMcp(
   });
 
   lifecycle.setReconnectFailureCallback((serverName, error) => {
+    if (!owner.isActive()) return;
     const message = error instanceof Error ? error.message : String(error);
     recordFailure(state, serverName, message);
     updateStatusBar(state);
   });
 
   lifecycle.setIdleShutdownCallback((serverName) => {
+    if (!owner.isActive()) return;
     const idleMinutes = getEffectiveIdleTimeoutMinutes(state, serverName);
     logger.debug(`${serverName} shut down (idle ${idleMinutes}m)`);
     updateStatusBar(state);
   });
 
-  lifecycle.startHealthChecks();
+  owner.throwIfInactive();
+  lifecycle.startHealthChecks(runtimeSignal);
 
   return state;
 }
@@ -401,6 +437,8 @@ export function getFailureMessage(state: McpExtensionState, serverName: string):
 }
 
 export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  throwIfAborted(ownedSignal);
   const connection = state.manager.getConnection(serverName);
   if (connection?.status === "needs-auth") {
     return false;
@@ -421,7 +459,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     if (state.ui) {
       state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
     }
-    const newConnection = await state.manager.connect(serverName, definition, signal);
+    const newConnection = await state.manager.connect(serverName, definition, ownedSignal);
     if (newConnection.status === "needs-auth") {
       return false;
     }
@@ -432,8 +470,8 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     updateStatusBar(state);
     return true;
   } catch (error) {
-    if (signal?.aborted) {
-      throwIfAborted(signal);
+    if (isAbortError(error, ownedSignal)) {
+      throwIfAborted(ownedSignal);
     }
     const message = error instanceof Error ? error.message : String(error);
     recordFailure(state, serverName, message);

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -2,30 +2,31 @@ import type { ServerDefinition } from "./types.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import { hasPendingAuth } from "./mcp-auth-flow.ts";
 import { logger } from "./logger.ts";
-import { sanitizeTerminalText } from "./utils.ts";
+import { formatTerminalError, sanitizeTerminalText } from "./utils.ts";
 
 export type ReconnectCallback = (serverName: string) => void;
 export type ReconnectFailureCallback = (serverName: string, error: unknown) => void;
 
 export class McpLifecycleManager {
-  private manager: McpServerManager;
   private keepAliveServers = new Map<string, ServerDefinition>();
   private allServers = new Map<string, ServerDefinition>();
   private serverSettings = new Map<string, { idleTimeout?: number }>();
-  private globalIdleTimeout: number = 10 * 60 * 1000;
+  private globalIdleTimeout = 10 * 60 * 1000;
   private healthCheckInterval?: NodeJS.Timeout;
   private onReconnect?: ReconnectCallback;
   private onReconnectFailure?: ReconnectFailureCallback;
   private onIdleShutdown?: (serverName: string) => void;
-  
-  constructor(manager: McpServerManager, private readonly hasPendingAuthForServer = hasPendingAuth) {
-    this.manager = manager;
-  }
-  
-  /**
-   * Set callback to be invoked after a successful auto-reconnect.
-   * Use this to update tool metadata when a server reconnects.
-   */
+  private activeHealthCheck?: Promise<void>;
+  private shutdownPromise?: Promise<void>;
+  private stopped = false;
+  private healthSignal?: AbortSignal;
+  private removeHealthAbortListener?: () => void;
+
+  constructor(
+    private readonly manager: McpServerManager,
+    private readonly hasPendingAuthForServer = hasPendingAuth,
+  ) {}
+
   setReconnectCallback(callback: ReconnectCallback): void {
     this.onReconnect = callback;
   }
@@ -33,16 +34,14 @@ export class McpLifecycleManager {
   setReconnectFailureCallback(callback: ReconnectFailureCallback): void {
     this.onReconnectFailure = callback;
   }
-  
+
   markKeepAlive(name: string, definition: ServerDefinition): void {
     this.keepAliveServers.set(name, definition);
   }
 
   registerServer(name: string, definition: ServerDefinition, settings?: { idleTimeout?: number }): void {
     this.allServers.set(name, definition);
-    if (settings?.idleTimeout !== undefined) {
-      this.serverSettings.set(name, settings);
-    }
+    if (settings?.idleTimeout !== undefined) this.serverSettings.set(name, settings);
   }
 
   setGlobalIdleTimeout(minutes: number): void {
@@ -52,29 +51,54 @@ export class McpLifecycleManager {
   setIdleShutdownCallback(callback: (serverName: string) => void): void {
     this.onIdleShutdown = callback;
   }
-  
-  startHealthChecks(intervalMs = 30000): void {
+
+  startHealthChecks(signalOrInterval?: AbortSignal | number, maybeIntervalMs = 30000): void {
+    const signal = typeof signalOrInterval === "number" ? undefined : signalOrInterval;
+    const intervalMs = typeof signalOrInterval === "number" ? signalOrInterval : maybeIntervalMs;
+    this.stopped = false;
+    this.healthSignal = signal;
+    if (signal?.aborted) {
+      this.stopped = true;
+      this.healthSignal = undefined;
+      return;
+    }
+    const stop = () => {
+      this.stopped = true;
+      if (this.healthCheckInterval) clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = undefined;
+    };
+    signal?.addEventListener("abort", stop, { once: true });
+    this.removeHealthAbortListener = () => signal?.removeEventListener("abort", stop);
     this.healthCheckInterval = setInterval(() => {
-      this.checkConnections();
+      if (this.stopped || signal?.aborted || this.activeHealthCheck) return;
+      const check = this.checkConnections(signal)
+        .catch(error => {
+          console.error(`MCP: Health check failed: ${formatTerminalError(error)}`);
+        })
+        .finally(() => {
+          if (this.activeHealthCheck === check) this.activeHealthCheck = undefined;
+        });
+      this.activeHealthCheck = check;
     }, intervalMs);
     this.healthCheckInterval.unref();
   }
-  
-  private async checkConnections(): Promise<void> {
+
+  private async checkConnections(signal?: AbortSignal): Promise<void> {
+    if (this.stopped || signal?.aborted) return;
     for (const [name, definition] of this.keepAliveServers) {
       const connection = this.manager.getConnection(name);
-      
       if (!connection || connection.status !== "connected") {
         if (this.hasPendingAuthForServer(name)) {
           logger.debug(`Skipping reconnect for ${name} while OAuth authorization is pending`);
           continue;
         }
         try {
-          await this.manager.connect(name, definition);
+          await this.manager.connect(name, definition, signal);
+          if (this.stopped || signal?.aborted) return;
           logger.debug(`Reconnected to ${name}`);
-          // Notify extension to update metadata
           this.onReconnect?.(name);
         } catch (error) {
+          if (this.stopped || signal?.aborted) return;
           this.onReconnectFailure?.(name, error);
           const message = error instanceof Error ? error.message : String(error);
           console.error(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`);
@@ -87,6 +111,7 @@ export class McpLifecycleManager {
       const timeout = this.getIdleTimeout(name);
       if (timeout > 0 && this.manager.isIdle(name, timeout)) {
         await this.manager.close(name);
+        if (this.stopped || signal?.aborted) return;
         this.onIdleShutdown?.(name);
       }
     }
@@ -97,11 +122,27 @@ export class McpLifecycleManager {
     if (perServer !== undefined) return perServer * 60 * 1000;
     return this.globalIdleTimeout;
   }
-  
+
   async gracefulShutdown(): Promise<void> {
-    if (this.healthCheckInterval) {
-      clearInterval(this.healthCheckInterval);
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownPromise = this.shutdownOnce();
+    return this.shutdownPromise;
+  }
+
+  private async shutdownOnce(): Promise<void> {
+    this.stopped = true;
+    if (this.healthCheckInterval) clearInterval(this.healthCheckInterval);
+    this.healthCheckInterval = undefined;
+    this.removeHealthAbortListener?.();
+    this.removeHealthAbortListener = undefined;
+    this.healthSignal = undefined;
+    await this.activeHealthCheck;
+    this.activeHealthCheck = undefined;
+    this.onReconnect = undefined;
+    this.onReconnectFailure = undefined;
+    this.onIdleShutdown = undefined;
+    if (typeof this.manager.closeAll === "function") {
+      await this.manager.closeAll();
     }
-    await this.manager.closeAll();
   }
 }

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -35,7 +35,9 @@ import {
   type StoredTokens,
 } from "./mcp-auth.ts"
 import type { ServerEntry } from "./types.ts"
-import { interpolateEnvRecord } from "./utils.ts"
+import { formatTerminalError, interpolateEnvRecord } from "./utils.ts"
+import { abortable, throwIfAborted } from "./abort.ts"
+import { combineAbortSignals, isAbortError } from "./runtime-owner.ts"
 
 /** Auth status for a server */
 export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
@@ -43,6 +45,7 @@ export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 export interface AuthenticateOptions {
   onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
   authStorageOptions?: AuthStorageOptions
+  signal?: AbortSignal
 }
 
 type AuthDiscovery = {
@@ -65,6 +68,8 @@ const pendingAuthCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>(
 
 // Deduplicate concurrent authenticate() calls per server.
 const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
+let oauthRuntimeSignal: AbortSignal | undefined
+let oauthGeneration = 0
 
 function getPendingAuthKey(serverName: string, options: AuthStorageOptions): string {
   return `${serverName}|${getAuthBaseDir(options)}`
@@ -135,8 +140,9 @@ export function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
   return config
 }
 
-async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry): Promise<AuthDiscovery> {
+async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, signal?: AbortSignal): Promise<AuthDiscovery> {
   const controller = new AbortController()
+  const discoverySignal = combineAbortSignals(signal, controller.signal)
   const timer = setTimeout(() => controller.abort(), 5000)
 
   try {
@@ -157,12 +163,13 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry): 
           clientInfo: { name: "pi-mcp-adapter", version: "2.11.0" },
         },
       }),
-      signal: controller.signal,
+      signal: discoverySignal,
     })
     const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response)
     await response.body?.cancel().catch(() => {})
     return { ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}), ...(scope ? { scope } : {}) }
-  } catch {
+  } catch (error) {
+    if (signal?.aborted || oauthRuntimeSignal?.aborted) throwIfAborted(combineAbortSignals(signal, oauthRuntimeSignal))
     return {}
   } finally {
     clearTimeout(timer)
@@ -216,6 +223,9 @@ export async function startAuth(
 ): Promise<{ authorizationUrl: string }> {
   const config = definition ? extractOAuthConfig(definition) : {}
   const authStorageOptions = options.authStorageOptions ?? {}
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  const generation = oauthGeneration
+  throwIfAborted(signal)
 
   if (config.grantType === "client_credentials") {
     const storedAuth = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
@@ -230,12 +240,18 @@ export async function startAuth(
         throw new Error("Browser redirect is not used for client_credentials flow")
       },
     }, authStorageOptions)
-    const discovery = await probeAuthDiscovery(serverUrl, definition)
-    const result = await runSdkAuth(authProvider, { serverUrl, ...discovery })
-    if (result !== "AUTHORIZED") {
-      throw new UnauthorizedError("Failed to authorize")
+    try {
+      const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
+      throwIfAborted(signal)
+      const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+      throwIfAborted(signal)
+      if (result !== "AUTHORIZED") {
+        throw new UnauthorizedError("Failed to authorize")
+      }
+      return { authorizationUrl: "" }
+    } finally {
+      authProvider.deactivate()
     }
-    return { authorizationUrl: "" }
   }
 
   const existingPendingAuth = pendingAuths.get(getPendingAuthKey(serverName, authStorageOptions))
@@ -253,8 +269,14 @@ export async function startAuth(
       reserveState: true,
       ...(redirectCallback ? { port: redirectCallback.port, callbackHost: redirectCallback.callbackHost, callbackPath: redirectCallback.callbackPath } : {}),
     })
+    throwIfAborted(signal)
   } catch (error) {
-    await clearOAuthState(serverName, authStorageOptions)
+    releaseCallbackServer(oauthState)
+    try {
+      await clearOAuthState(serverName, authStorageOptions)
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
+    }
     throw error
   }
 
@@ -284,10 +306,14 @@ export async function startAuth(
     }
 
     await updateOAuthState(serverName, oauthState, serverUrl, authStorageOptions)
+    throwIfAborted(signal)
 
-    const discovery = await probeAuthDiscovery(serverUrl, definition)
-    const result = await runSdkAuth(authProvider, { serverUrl, ...discovery })
+    const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
+    throwIfAborted(signal)
+    const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+    throwIfAborted(signal)
     if (result === "AUTHORIZED") {
+      authProvider.deactivate()
       releaseCallbackServer(oauthState)
       await clearOAuthState(serverName, authStorageOptions)
       return { authorizationUrl: "" }
@@ -295,10 +321,15 @@ export async function startAuth(
     if (!capturedUrl) {
       throw new UnauthorizedError("OAuth authorization URL was not provided")
     }
-    await setPendingAuth(serverName, { serverName, authProvider, serverUrl, authorizationUrl: capturedUrl.toString(), discovery, authStorageOptions }, oauthState)
+    await setPendingAuth(serverName, { serverName, authProvider, serverUrl, authorizationUrl: capturedUrl.toString(), discovery, authStorageOptions }, oauthState, signal, generation)
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
-    await clearPendingAuth(serverName, oauthState, authStorageOptions)
+    authProvider.deactivate()
+    try {
+      await clearPendingAuth(serverName, oauthState, authStorageOptions)
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
+    }
     throw error
   }
 }
@@ -307,13 +338,19 @@ async function setPendingAuth(
   serverName: string,
   pendingAuth: PendingAuth,
   oauthState: string,
+  signal?: AbortSignal,
+  generation = oauthGeneration,
 ): Promise<void> {
   const key = getPendingAuthKey(serverName, pendingAuth.authStorageOptions)
   await clearPendingAuth(serverName, undefined, pendingAuth.authStorageOptions)
+  throwIfAborted(signal)
+  if (generation !== oauthGeneration) throw new Error("OAuth runtime stopped")
   pendingAuths.set(key, pendingAuth)
   pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(serverName, oauthState, pendingAuth.authStorageOptions)
+    void clearPendingAuth(serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+      console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
+    })
   }, MANUAL_AUTH_TIMEOUT_MS)
   cleanupTimer.unref?.()
   pendingAuthCleanupTimers.set(key, cleanupTimer)
@@ -332,6 +369,7 @@ async function clearPendingAuth(serverName: string, oauthState?: string, fallbac
     pendingAuthCleanupTimers.delete(key)
   }
 
+  pendingAuth?.authProvider.deactivate()
   pendingAuths.delete(key)
   pendingAuthStates.delete(key)
   const stateToRelease = pendingState ?? oauthState
@@ -409,8 +447,11 @@ export async function completeAuthFromInput(
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
   const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  throwIfAborted(signal)
   const authStorageOptions = pendingAuths.get(getPendingAuthKey(serverName, fallbackAuthStorageOptions))?.authStorageOptions ?? fallbackAuthStorageOptions
   const oauthState = await getOAuthState(serverName, authStorageOptions)
+  throwIfAborted(signal)
   const code = parseAuthorizationCodeInput(input, oauthState)
   return completeAuth(serverName, code, options)
 }
@@ -424,6 +465,8 @@ export async function completeAuth(
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
   const fallbackAuthStorageOptions = options.authStorageOptions ?? {}
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  throwIfAborted(signal)
   const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
   const pendingAuth = pendingAuths.get(key)
   const authStorageOptions = pendingAuth?.authStorageOptions ?? fallbackAuthStorageOptions
@@ -432,20 +475,29 @@ export async function completeAuth(
   }
 
   const oauthState = await getOAuthState(serverName, authStorageOptions)
+  throwIfAborted(signal)
 
   try {
-    const result = await runSdkAuth(pendingAuth.authProvider, {
+    const result = await abortable(runSdkAuth(pendingAuth.authProvider, {
       serverUrl: pendingAuth.serverUrl,
       authorizationCode,
       ...pendingAuth.discovery,
-    })
+    }), signal)
+    throwIfAborted(signal)
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize")
     }
-    return "authenticated"
-  } finally {
-    await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  } catch (error) {
+    try {
+      await clearPendingAuth(serverName, oauthState, authStorageOptions)
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "OAuth completion cleanup failed")
+    }
+    throw error
   }
+
+  await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  return "authenticated"
 }
 
 /**
@@ -463,6 +515,8 @@ export async function authenticate(
   options: AuthenticateOptions = {},
 ): Promise<AuthStatus> {
   const authStorageOptions = options.authStorageOptions ?? {}
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  throwIfAborted(signal)
   const authKey = `${serverName}|${serverUrl}|${getAuthBaseDir(authStorageOptions)}`
   const inFlight = pendingAuthentications.get(authKey)
   if (inFlight) {
@@ -471,52 +525,67 @@ export async function authenticate(
 
   const operation = (async (): Promise<AuthStatus> => {
     // Start auth flow
-    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, options)
+    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, { ...options, signal })
 
     // If no auth URL needed, already authenticated
     if (!authorizationUrl) {
       return "authenticated"
     }
 
-    // Get the state that was already generated and stored in startAuth()
-    const oauthState = await getOAuthState(serverName, authStorageOptions)
-    if (!oauthState) {
-      throw new Error("OAuth state not found - this should not happen")
-    }
-
-    // Register the callback BEFORE opening the browser
-    const callbackPromise = waitForCallback(oauthState)
-
+    let oauthState: string | undefined
     try {
+      // Get the state that was already generated and stored in startAuth().
+      // Keep this lookup and its abort check inside the cleanup boundary because
+      // startAuth has already reserved callback state at this point.
+      oauthState = await getOAuthState(serverName, authStorageOptions)
+      throwIfAborted(signal)
+      if (!oauthState) {
+        throw new Error("OAuth state not found - this should not happen")
+      }
+
+      // Register the callback BEFORE opening the browser.
+      const callbackPromise = waitForCallback(oauthState)
+      void callbackPromise.catch(() => {})
+
       // Open browser. Always surface the URL first so remote/headless users can copy it
       // even when the OS browser handoff is unavailable or invisible.
       if (options.onAuthorizationUrl) {
-        await options.onAuthorizationUrl(authorizationUrl)
+        await abortable(Promise.resolve(options.onAuthorizationUrl(authorizationUrl)), signal)
       } else {
         console.log(`MCP Auth: Open this URL to authenticate ${serverName}:\n${authorizationUrl}`)
       }
       try {
-        await open(authorizationUrl)
+        await abortable(open(authorizationUrl), signal)
       } catch (error) {
+        if (isAbortError(error, signal)) throw error
         console.warn(`MCP Auth: Failed to open browser for ${serverName}; waiting for manual callback`, { error })
       }
 
       // Wait for callback
-      const code = await callbackPromise
+      const code = await abortable(callbackPromise, signal)
 
       // Validate state
       const storedState = await getOAuthState(serverName, authStorageOptions)
       if (storedState !== oauthState) {
-        await clearOAuthState(serverName, authStorageOptions)
-        throw new Error("OAuth state mismatch - potential CSRF attack")
+        const mismatchError = new Error("OAuth state mismatch - potential CSRF attack")
+        try {
+          await clearOAuthState(serverName, authStorageOptions)
+        } catch (cleanupError) {
+          throw new AggregateError([mismatchError, cleanupError], "OAuth state mismatch cleanup failed")
+        }
+        throw mismatchError
       }
       await clearOAuthState(serverName, authStorageOptions)
 
       // Complete the auth
-      return await completeAuth(serverName, code, options)
+      return await completeAuth(serverName, code, { ...options, signal })
     } catch (error) {
-      cancelPendingCallback(oauthState)
-      await clearPendingAuth(serverName, oauthState, authStorageOptions)
+      if (oauthState) cancelPendingCallback(oauthState)
+      try {
+        await clearPendingAuth(serverName, oauthState, authStorageOptions)
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], "OAuth cancellation cleanup failed")
+      }
       throw error
     }
   })()
@@ -545,8 +614,11 @@ export async function getValidToken(
   options: AuthenticateOptions = {},
 ): Promise<StoredTokens | null> {
   const authStorageOptions = options.authStorageOptions ?? {}
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  throwIfAborted(signal)
   // Check if we have valid tokens
   const entry = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
+  throwIfAborted(signal)
   if (!entry?.tokens) {
     return null
   }
@@ -567,20 +639,29 @@ export async function getValidToken(
         onRedirect: async () => {},
       }, authStorageOptions)
 
-      const clientInfo = await authProvider.clientInformation()
-      if (!clientInfo) {
-        console.log(`MCP Auth: No client info for refresh for ${serverName}`)
-        return null
-      }
+      try {
+        const clientInfo = await authProvider.clientInformation()
+        throwIfAborted(signal)
+        if (!clientInfo) {
+          console.log(`MCP Auth: No client info for refresh for ${serverName}`)
+          return null
+        }
 
-      const discovery = await probeAuthDiscovery(serverUrl)
-      const result = await runSdkAuth(authProvider, { serverUrl, ...discovery })
-      if (result !== "AUTHORIZED") {
-        return null
+        const discovery = await probeAuthDiscovery(serverUrl, undefined, signal)
+        throwIfAborted(signal)
+        const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+        throwIfAborted(signal)
+        if (result !== "AUTHORIZED") {
+          return null
+        }
+        const refreshed = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
+        throwIfAborted(signal)
+        return refreshed?.tokens ?? null
+      } finally {
+        authProvider.deactivate()
       }
-      const refreshed = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
-      return refreshed?.tokens ?? null
     } catch (error) {
+      if (isAbortError(error, signal)) throw error
       console.error(`MCP Auth: Token refresh failed for ${serverName}`, { error })
       return null
     }
@@ -611,14 +692,19 @@ export async function getAuthStatus(serverName: string, options: AuthenticateOpt
  * @param serverName - The name of the MCP server
  */
 export async function removeAuth(serverName: string, options: AuthenticateOptions = {}): Promise<void> {
+  const signal = combineAbortSignals(oauthRuntimeSignal, options.signal)
+  throwIfAborted(signal)
   const authStorageOptions = options.authStorageOptions ?? {}
   const oauthState = await getOAuthState(serverName, authStorageOptions)
+  throwIfAborted(signal)
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
   await clearPendingAuth(serverName, oauthState, authStorageOptions)
+  throwIfAborted(signal)
   clearAllCredentials(serverName, authStorageOptions)
   await clearOAuthState(serverName, authStorageOptions)
+  throwIfAborted(signal)
   console.log(`MCP Auth: Removed credentials for ${serverName}`)
 }
 
@@ -649,15 +735,21 @@ export function supportsOAuth(definition: ServerEntry): boolean {
  * Initialize the OAuth system on startup.
  * OAuth callback binding is lazy and starts from startAuth() only.
  */
-export async function initializeOAuth(): Promise<void> {}
+export async function initializeOAuth(signal?: AbortSignal): Promise<void> {
+  oauthRuntimeSignal = signal
+  oauthGeneration += 1
+}
 
 /**
  * Shutdown the OAuth system.
  * Stops the callback server and cancels pending auths.
  */
 export async function shutdownOAuth(): Promise<void> {
+  oauthGeneration += 1
+  oauthRuntimeSignal = undefined
   for (const pendingAuth of Array.from(pendingAuths.values())) {
     await clearPendingAuth(pendingAuth.serverName, undefined, pendingAuth.authStorageOptions)
   }
+  for (const state of Array.from(pendingAuthStates.values())) cancelPendingCallback(state)
   await stopCallbackServer()
 }

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -95,6 +95,8 @@ interface PendingAuth {
 /** Server singleton state */
 let server: Server | undefined
 let bindingPromise: Promise<void> | undefined
+let stoppingPromise: Promise<void> | undefined
+let callbackGeneration = 0
 const pendingAuths = new Map<string, PendingAuth>()
 const reservedAuthStates = new Set<string>()
 
@@ -201,8 +203,18 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
  * If strictPort is false, asks the OS for an available local port.
  */
 export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
+  if (stoppingPromise) {
+    throw new Error("OAuth callback server stopped")
+  }
+  const generation = callbackGeneration
   while (bindingPromise) {
     await bindingPromise
+    if (generation !== callbackGeneration) {
+      throw new Error("OAuth callback server stopped")
+    }
+  }
+  if (generation !== callbackGeneration) {
+    throw new Error("OAuth callback server stopped")
   }
 
   const operation = ensureCallbackServerLocked(options)
@@ -356,30 +368,45 @@ export function cancelPendingCallback(oauthState: string): void {
 /**
  * Stop the callback server and reject all pending authorizations.
  */
-export async function stopCallbackServer(): Promise<void> {
-  if (server) {
-    await new Promise<void>((resolve) => {
-      server!.close(() => {
-        resolve()
-      })
-    })
-    server = undefined
-  }
+export function stopCallbackServer(): Promise<void> {
+  if (stoppingPromise) return stoppingPromise
 
-  setOAuthCallbackPort(getConfiguredOAuthCallbackPort())
-  callbackServerHost = DEFAULT_OAUTH_CALLBACK_HOST
-  setOAuthCallbackPath(DEFAULT_OAUTH_CALLBACK_PATH)
-
-  // Reject all pending auths (defer to allow any pending operations to complete)
-  const pendingList = Array.from(pendingAuths.entries())
-  pendingAuths.clear()
-  reservedAuthStates.clear()
-  setTimeout(() => {
-    for (const [, pending] of pendingList) {
-      clearTimeout(pending.timeout)
-      pending.reject(new Error("OAuth callback server stopped"))
+  callbackGeneration += 1
+  const cleanup = (async () => {
+    while (bindingPromise) {
+      await bindingPromise.catch(() => {})
     }
-  }, 0)
+
+    if (server) {
+      await new Promise<void>((resolve) => {
+        server!.close(() => {
+          resolve()
+        })
+      })
+      server = undefined
+    }
+
+    setOAuthCallbackPort(getConfiguredOAuthCallbackPort())
+    callbackServerHost = DEFAULT_OAUTH_CALLBACK_HOST
+    setOAuthCallbackPath(DEFAULT_OAUTH_CALLBACK_PATH)
+
+    // Reject all pending auths (defer to allow any pending operations to complete)
+    const pendingList = Array.from(pendingAuths.entries())
+    pendingAuths.clear()
+    reservedAuthStates.clear()
+    setTimeout(() => {
+      for (const [, pending] of pendingList) {
+        clearTimeout(pending.timeout)
+        pending.reject(new Error("OAuth callback server stopped"))
+      }
+    }, 0)
+  })()
+
+  const operation = cleanup.finally(() => {
+    if (stoppingPromise === operation) stoppingPromise = undefined
+  })
+  stoppingPromise = operation
+  return operation
 }
 
 /**

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -85,6 +85,7 @@ export interface McpOAuthCallbacks {
  */
 export class McpOAuthProvider implements OAuthClientProvider {
   private readonly redirectUrlSnapshot: string | undefined
+  private active = true
 
   constructor(
     private serverName: string,
@@ -100,6 +101,14 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   private get usesClientCredentials(): boolean {
     return this.config.grantType === "client_credentials"
+  }
+
+  deactivate(): void {
+    this.active = false
+  }
+
+  private throwIfInactive(): void {
+    if (!this.active) throw new Error("OAuth flow is no longer active")
   }
 
   /**
@@ -184,6 +193,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       clientSecretExpiresAt: info.client_secret_expires_at,
       redirectUris,
     }
+    this.throwIfInactive()
     updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
   }
 
@@ -217,6 +227,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
       scope: tokens.scope,
     }
+    this.throwIfInactive()
     updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)
   }
 
@@ -235,6 +246,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     // No saved oauthState means we're on the post-refresh authorize fallback.
     const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
+    this.throwIfInactive()
     if (!entry?.oauthState) {
       throw new UnauthorizedError(
         `Re-authentication required for MCP server: ${this.serverName}`,
@@ -248,6 +260,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Save the PKCE code verifier.
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    this.throwIfInactive()
     updateCodeVerifier(this.serverName, codeVerifier, this.serverUrl, this.storageOptions)
   }
 
@@ -270,6 +283,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Save the OAuth state parameter for CSRF protection.
    */
   async saveState(state: string): Promise<void> {
+    this.throwIfInactive()
     updateOAuthState(this.serverName, state, this.serverUrl, this.storageOptions)
   }
 
@@ -295,6 +309,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Clears tokens, client info, or all credentials based on the type.
    */
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
+    this.throwIfInactive()
     switch (type) {
       case "all":
         clearAllCredentials(this.serverName, this.storageOptions)
@@ -313,11 +328,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * default token endpoint authentication behavior.
    */
   addClientAuthentication: AddClientAuthentication = async (headers, params, _url, metadata) => {
+    this.throwIfInactive()
     if (params.get("grant_type") === "authorization_code" && !params.has("scope") && this.config.scope) {
       params.set("scope", this.config.scope)
     }
 
     const clientInfo = await this.clientInformation()
+    this.throwIfInactive()
     if (!clientInfo) {
       return
     }

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -2,6 +2,7 @@
 import { existsSync, readFileSync, realpathSync, readdirSync, statSync, writeFileSync, renameSync, mkdirSync, openSync, readSync, closeSync } from "node:fs";
 import { join, dirname, extname, resolve, sep } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
+import { throwIfAborted } from "./abort.ts";
 import crossSpawn from "cross-spawn";
 
 const CACHE_VERSION = 1;
@@ -39,8 +40,10 @@ interface ParsedPackageSpec {
 
 export async function resolveNpxBinary(
   command: string,
-  args: string[]
+  args: string[],
+  signal?: AbortSignal,
 ): Promise<NpxResolution | null> {
+  throwIfAborted(signal);
   const parsed = command === "npx"
     ? parseNpxArgs(args)
     : command === "npm"
@@ -70,7 +73,7 @@ export async function resolveNpxBinary(
   }
 
   // Slow path: force npx cache population
-  await forceNpxCache(parsed.packageSpec);
+  await forceNpxCache(parsed.packageSpec, signal);
   const resolvedAfterInstall = resolveFromNpmCache(parsed.packageSpec, parsed.binName);
   if (resolvedAfterInstall) {
     saveCacheEntry(cacheKey, resolvedAfterInstall);
@@ -243,7 +246,8 @@ function resolveFromNpmCache(packageSpec: string, binName?: string): NpxCacheEnt
 
 const FORCE_CACHE_TIMEOUT_MS = 30_000;
 
-async function forceNpxCache(packageSpec: string): Promise<void> {
+async function forceNpxCache(packageSpec: string, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
   try {
     await new Promise<void>((resolve, reject) => {
       const proc = crossSpawn(
@@ -255,13 +259,28 @@ async function forceNpxCache(packageSpec: string): Promise<void> {
         proc.kill();
         reject(new Error("timeout"));
       }, FORCE_CACHE_TIMEOUT_MS);
+      const abort = () => {
+        proc.kill();
+        reject(signal?.reason instanceof Error ? signal.reason : new Error("MCP request aborted"));
+      };
+      signal?.addEventListener("abort", abort, { once: true });
       timer.unref();
-      proc.on("close", () => { clearTimeout(timer); resolve(); });
-      proc.on("error", (err) => { clearTimeout(timer); reject(err); });
+      proc.on("close", () => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", abort);
+        resolve();
+      });
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", abort);
+        reject(err);
+      });
     });
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throwIfAborted(signal);
     // Ignore failures, resolution will fall back to original command
   }
+  throwIfAborted(signal);
 }
 
 function buildBinCandidates(packageName: string, explicitBin?: string): string[] {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "state.ts",
     "utils.ts",
     "abort.ts",
+    "runtime-owner.ts",
     "tool-metadata.ts",
     "init.ts",
     "ui-session.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -6,6 +6,7 @@ import type { ToolMetadata, McpContent } from "./types.ts";
 import { getServerPrefix, parseUiPromptHandoff } from "./types.ts";
 import { lazyConnect, markKeepAliveAfterConnect, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
+import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
@@ -81,6 +82,7 @@ function formatManualAuthInstructions(serverName: string, authorizationUrl: stri
 async function attemptAutoAuth(
   state: McpExtensionState,
   serverName: string,
+  signal?: AbortSignal,
 ): Promise<AutoAuthResult> {
   if (state.config.settings?.autoAuth !== true) {
     return { status: "skipped" };
@@ -116,12 +118,22 @@ async function attemptAutoAuth(
 
   try {
     if (state.authStorageOptions) {
-      await authenticate(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions });
+      await authenticate(
+        serverName,
+        serverUrl,
+        definition,
+        signal ? { authStorageOptions: state.authStorageOptions, signal } : { authStorageOptions: state.authStorageOptions },
+      );
     } else {
-      await authenticate(serverName, serverUrl, definition);
+      if (signal) {
+        await authenticate(serverName, serverUrl, definition, { signal });
+      } else {
+        await authenticate(serverName, serverUrl, definition);
+      }
     }
     return { status: "success" };
   } catch (error) {
+    if (isAbortError(error, signal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
     return {
       status: "failed",
@@ -264,7 +276,9 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
   };
 }
 
-export async function executeAuthStart(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+export async function executeAuthStart(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
@@ -283,8 +297,12 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
     }
 
     const { authorizationUrl } = state.authStorageOptions
-      ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions })
-      : await startAuth(serverName, serverUrl, definition);
+      ? ownedSignal
+        ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, signal: ownedSignal })
+        : await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions })
+      : ownedSignal
+        ? await startAuth(serverName, serverUrl, definition, { signal: ownedSignal })
+        : await startAuth(serverName, serverUrl, definition);
     if (!authorizationUrl) {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
@@ -305,7 +323,9 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
   }
 }
 
-export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string): Promise<ProxyToolResult> {
+export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  throwIfAborted(ownedSignal);
   if (!state.config.mcpServers[serverName]) {
     return {
       content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
@@ -315,8 +335,12 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
 
   try {
     const status = state.authStorageOptions
-      ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions })
-      : await completeAuthFromInput(serverName, input);
+      ? ownedSignal
+        ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, signal: ownedSignal })
+        : await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions })
+      : ownedSignal
+        ? await completeAuthFromInput(serverName, input, { signal: ownedSignal })
+        : await completeAuthFromInput(serverName, input);
     if (status !== "authenticated") {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],
@@ -591,7 +615,8 @@ export function executeInstructions(state: McpExtensionState, server: string): P
 }
 
 export async function executeConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
-  throwIfAborted(signal);
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
@@ -604,9 +629,11 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     if (state.ui) {
       state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
     }
-    let connection = await state.manager.connect(serverName, definition, signal);
+    let connection = ownedSignal
+      ? await state.manager.connect(serverName, definition, ownedSignal)
+      : await state.manager.connect(serverName, definition);
     if (connection.status === "needs-auth") {
-      const autoAuth = await attemptAutoAuth(state, serverName);
+      const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
@@ -615,7 +642,10 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       }
       if (autoAuth.status === "success") {
         await state.manager.close(serverName);
-        connection = await state.manager.connect(serverName, definition, signal);
+        throwIfAborted(ownedSignal);
+        connection = ownedSignal
+          ? await state.manager.connect(serverName, definition, ownedSignal)
+          : await state.manager.connect(serverName, definition);
       }
       if (connection.status === "needs-auth") {
         const message = getAuthRequiredMessage(state, serverName);
@@ -640,11 +670,11 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     return executeList(state, serverName);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (!signal?.aborted) recordFailure(state, serverName, message);
+    if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
     updateStatusBar(state);
     return {
       content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-      details: { mode: "connect", error: signal?.aborted ? "aborted" : "connect_failed", server: serverName, message },
+      details: { mode: "connect", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", server: serverName, message },
     };
   }
 }
@@ -657,7 +687,8 @@ export async function executeCall(
   getPiTools?: () => ToolInfo[],
   signal?: AbortSignal,
 ): Promise<ProxyToolResult> {
-  throwIfAborted(signal);
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  throwIfAborted(ownedSignal);
   let serverName: string | undefined = serverOverride;
   let toolMeta: ToolMetadata | undefined;
   let autoAuthAttempted = false;
@@ -684,7 +715,7 @@ export async function executeCall(
   }
 
   if (serverName && !toolMeta) {
-    const connected = await lazyConnect(state, serverName, signal);
+    const connected = await lazyConnect(state, serverName, ownedSignal);
     if (connected) {
       toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
     } else {
@@ -692,7 +723,7 @@ export async function executeCall(
       if (needsAuthConnection?.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(state, serverName);
+          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
@@ -702,7 +733,7 @@ export async function executeCall(
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
             clearFailure(state, serverName);
-            const connectedAfterAuth = await lazyConnect(state, serverName, signal);
+            const connectedAfterAuth = await lazyConnect(state, serverName, ownedSignal);
             if (connectedAfterAuth) {
               toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
               if (!toolMeta) {
@@ -749,10 +780,10 @@ export async function executeCall(
       const failedAgo = getFailureAgeSeconds(state, configuredServer);
       if (failedAgo !== null && existingConnection?.status !== "needs-auth") continue;
 
-      let connected = await lazyConnect(state, configuredServer, signal);
+      let connected = await lazyConnect(state, configuredServer, ownedSignal);
       if (!connected && state.manager.getConnection(configuredServer)?.status === "needs-auth" && !autoAuthAttempted) {
         autoAuthAttempted = true;
-        const autoAuth = await attemptAutoAuth(state, configuredServer);
+        const autoAuth = await attemptAutoAuth(state, configuredServer, ownedSignal);
         if (autoAuth.status === "failed") {
           return {
             content: [{ type: "text" as const, text: autoAuth.message }],
@@ -762,7 +793,7 @@ export async function executeCall(
         if (autoAuth.status === "success") {
           await state.manager.close(configuredServer);
           clearFailure(state, configuredServer);
-          connected = await lazyConnect(state, configuredServer, signal);
+          connected = await lazyConnect(state, configuredServer, ownedSignal);
         }
       }
 
@@ -805,7 +836,7 @@ export async function executeCall(
   if (connection?.status === "needs-auth") {
     if (!autoAuthAttempted) {
       autoAuthAttempted = true;
-      const autoAuth = await attemptAutoAuth(state, serverName);
+      const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
@@ -848,11 +879,11 @@ export async function executeCall(
       if (state.ui) {
         state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`);
       }
-      connection = await state.manager.connect(serverName, definition, signal);
+      connection = await state.manager.connect(serverName, definition, ownedSignal);
       if (connection.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(state, serverName);
+          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
@@ -861,7 +892,7 @@ export async function executeCall(
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
-            connection = await state.manager.connect(serverName, definition, signal);
+            connection = await state.manager.connect(serverName, definition, ownedSignal);
           }
         }
 
@@ -891,17 +922,18 @@ export async function executeCall(
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (!signal?.aborted) recordFailure(state, serverName, message);
+      const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+      if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
       updateStatusBar(state);
       return {
         content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-        details: { mode: "call", error: signal?.aborted ? "aborted" : "connect_failed", message },
+        details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", message },
       };
     }
   }
 
   let uiSession: UiSessionRuntime | null = null;
-  const requestOptions = state.manager.getRequestOptions?.(serverName, signal) ?? (signal ? { signal } : undefined);
+  const requestOptions = state.manager.getRequestOptions?.(serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined);
 
   const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
   const recoverAuthConnection = async () => {
@@ -910,7 +942,7 @@ export async function executeCall(
 
     if (!autoAuthAttempted) {
       autoAuthAttempted = true;
-      const autoAuth = await attemptAutoAuth(state, serverName);
+      const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         throw new SessionRecoveryAuthRequiredError(serverName, autoAuth.message);
       }
@@ -923,7 +955,7 @@ export async function executeCall(
           await state.manager.close(serverName);
         }
         clearFailure(state, serverName);
-        connection = await state.manager.connect(serverName, definition, signal);
+        connection = await state.manager.connect(serverName, definition, ownedSignal);
         return connection;
       }
     }
@@ -936,7 +968,7 @@ export async function executeCall(
 
     if (toolMeta.resourceUri) {
       const result = await withSessionRecovery(
-        { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+        { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
         serverName,
         (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
       );
@@ -964,13 +996,13 @@ export async function executeCall(
       : null;
 
     const result = await withSessionRecovery(
-      { manager: state.manager, config: state.config, signal, onNeedsAuth: recoverAuthConnection },
+      { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
       serverName,
       (conn) => abortable(conn.client.callTool({
         name: toolMeta.originalName,
         arguments: args ?? {},
         _meta: uiSession?.requestMeta,
-      }, undefined, requestOptions), signal),
+      }, undefined, requestOptions), ownedSignal),
     );
 
     if (toolMeta.uiResourceUri) {
@@ -1053,7 +1085,7 @@ export async function executeCall(
 
     return {
       content: guarded.content,
-      details: { mode: "call", error: "call_failed", message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedMcpDetails(guarded) },
+      details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed", message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedMcpDetails(guarded) },
     };
   } finally {
     if (uiSession?.reused) {

--- a/runtime-owner.ts
+++ b/runtime-owner.ts
@@ -1,0 +1,91 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { formatTerminalError } from "./utils.ts";
+
+export interface McpRuntimeOwner {
+  readonly signal: AbortSignal;
+  isActive(): boolean;
+  addCleanup(cleanup: () => void | Promise<void>): void;
+  stop(reason?: string): Promise<void>;
+  throwIfInactive(): void;
+}
+
+export function createMcpRuntimeOwner(): McpRuntimeOwner {
+  const controller = new AbortController();
+  const cleanups: Array<() => void | Promise<void>> = [];
+  let stopPromise: Promise<void> | undefined;
+
+  const reportCleanupFailure = (error: unknown, late: boolean) => {
+    console.error(`MCP: ${late ? "late " : ""}runtime cleanup failed: ${formatTerminalError(error)}`);
+  };
+
+  return {
+    signal: controller.signal,
+    isActive: () => !controller.signal.aborted,
+    addCleanup: cleanup => {
+      if (controller.signal.aborted) {
+        void Promise.resolve().then(cleanup).catch(error => reportCleanupFailure(error, true));
+        return;
+      }
+      cleanups.push(cleanup);
+    },
+    stop: (reason = "MCP extension runtime stopped") => {
+      if (stopPromise) return stopPromise;
+      controller.abort(new Error(reason));
+      const pendingCleanups = cleanups.splice(0).reverse().map(cleanup =>
+        Promise.resolve().then(cleanup),
+      );
+      stopPromise = Promise.allSettled(pendingCleanups).then(results => {
+        const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : []);
+        if (failures.length > 0) {
+          const aggregate = new AggregateError(failures, "MCP runtime cleanup failed");
+          console.error(`MCP: runtime cleanup failed: ${formatTerminalError(aggregate)}`);
+          throw aggregate;
+        }
+      });
+      return stopPromise;
+    },
+    throwIfInactive: () => controller.signal.throwIfAborted(),
+  };
+}
+
+export function combineAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const active = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (active.length === 0) return undefined;
+  if (active.length === 1) return active[0];
+  return AbortSignal.any(active);
+}
+
+/** Fence session-bound UI calls after the owning extension runtime stops. */
+export function createOwnedUi(ui: ExtensionUIContext, owner: McpRuntimeOwner): ExtensionUIContext {
+  const proxies = new WeakMap<object, object>();
+  const wrap = (value: unknown): unknown => {
+    if ((typeof value !== "object" || value === null) && typeof value !== "function") {
+      return value;
+    }
+    const object = value as object;
+    const existing = proxies.get(object);
+    if (existing) return existing;
+
+    const proxy = new Proxy(object, {
+      get(target, property, receiver) {
+        if (!owner.isActive()) return undefined;
+        const member = Reflect.get(target, property, receiver);
+        if (typeof member === "function") {
+          return (...args: unknown[]) => {
+            if (!owner.isActive()) return undefined;
+            return Reflect.apply(member, target, args);
+          };
+        }
+        return owner.isActive() ? wrap(member) : undefined;
+      },
+    });
+    proxies.set(object, proxy);
+    return proxy;
+  };
+  return wrap(ui) as ExtensionUIContext;
+}
+
+export function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) return true;
+  return error instanceof Error && (error.name === "AbortError" || error.message === "MCP extension runtime stopped");
+}

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -1,5 +1,6 @@
 import { complete, type Api, type AssistantMessage, type Message, type Model, type TextContent } from "@earendil-works/pi-ai";
 import { truncateAtWord } from "./utils.ts";
+import { throwIfAborted } from "./abort.ts";
 import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -33,6 +34,8 @@ export async function handleSamplingRequest(
   request: CreateMessageRequest,
 ): Promise<CreateMessageResult> {
   const params = request.params;
+  const signal = options.getSignal();
+  throwIfAborted(signal);
 
   if ("task" in params && params.task) {
     throw new Error("MCP sampling tasks are not supported");
@@ -52,11 +55,13 @@ export async function handleSamplingRequest(
 
   const messages = params.messages.map(convertSamplingMessage);
   const { model, apiKey, headers } = await resolveSamplingModel(options, params.modelPreferences);
+  throwIfAborted(signal);
   await confirmSampling(
     options,
     "Approve MCP sampling request",
     formatRequestApproval(options.serverName, `${model.provider}/${model.id}`, params.systemPrompt, messages),
   );
+  throwIfAborted(signal);
 
   const result = await complete(
     model,
@@ -70,11 +75,12 @@ export async function handleSamplingRequest(
       maxTokens: params.maxTokens,
       temperature: params.temperature,
       metadata: params.metadata as Record<string, unknown> | undefined,
-      signal: options.getSignal(),
+      signal,
     },
   );
 
   const converted = convertAssistantResult(result);
+  throwIfAborted(signal);
   await confirmSampling(
     options,
     "Return MCP sampling response",
@@ -145,8 +151,11 @@ async function resolveSamplingModel(
   }
 
   const errors: string[] = [];
+  const signal = options.getSignal();
   for (const model of candidates) {
+    throwIfAborted(signal);
     const auth = await options.modelRegistry.getApiKeyAndHeaders(model);
+    throwIfAborted(signal);
     if (auth.ok === false) {
       errors.push(`${model.provider}/${model.id}: ${auth.error}`);
       continue;

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -30,9 +30,11 @@ import {
 } from "./elicitation-handler.ts";
 import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
+import { combineAbortSignals } from "./runtime-owner.ts";
 
 const MAX_CAPTURED_STDERR_BYTES = 8 * 1024;
 const MAX_CAPTURED_STDERR_LINES = 3;
+const abortCleanupPromises = new WeakMap<object, Promise<void>>();
 
 function boundedStderrChunk(chunk: Buffer | string): Buffer {
   if (Buffer.isBuffer(chunk)) {
@@ -85,6 +87,11 @@ export class McpServerManager {
   private authStorageOptions: AuthStorageOptions = {};
   private acceptedUrlElicitations = new Map<string, Set<string>>();
   private defaultRequestTimeoutMs: number | undefined;
+  private runtimeSignal: AbortSignal | undefined;
+  private closePromises = new Map<string, Promise<void>>();
+  private closeGenerations = new Map<string, number>();
+  private connectAttempts = new Map<string, AbortController>();
+  private stopped = false;
 
   /** Default cwd for stdio servers without an explicit config `cwd`. */
   constructor(private readonly defaultCwd?: string) {}
@@ -95,6 +102,10 @@ export class McpServerManager {
 
   setElicitationConfig(config: ServerElicitationConfig | undefined): void {
     this.elicitationConfig = config;
+  }
+
+  setRuntimeSignal(signal: AbortSignal | undefined): void {
+    this.runtimeSignal = signal;
   }
 
   setDefaultRequestTimeoutMs(timeoutMs: number | undefined): void {
@@ -122,40 +133,56 @@ export class McpServerManager {
     signal?: AbortSignal,
   ): RequestOptions | undefined {
     const timeout = this.getResolvedRequestTimeoutMs(definition);
+    const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
 
-    if (!signal && timeout === undefined) {
+    if (!ownedSignal && timeout === undefined) {
       return undefined;
     }
 
     return {
-      ...(signal ? { signal } : {}),
+      ...(ownedSignal ? { signal: ownedSignal } : {}),
       ...(timeout !== undefined ? { timeout } : {}),
     };
   }
 
   async connect(name: string, definition: ServerDefinition, signal?: AbortSignal): Promise<ServerConnection> {
-    throwIfAborted(signal);
-    // Dedupe concurrent connection attempts
+    if (this.stopped) throw new Error("MCP server manager is closed");
+    const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
+    throwIfAborted(ownedSignal);
+    const closing = this.closePromises.get(name);
+    if (closing) await abortable(closing, ownedSignal);
+    throwIfAborted(ownedSignal);
+
+    // Dedupe concurrent connection attempts.
     if (this.connectPromises.has(name)) {
-      return abortable(this.connectPromises.get(name)!, signal);
+      return abortable(this.connectPromises.get(name)!, ownedSignal);
     }
 
-    // Reuse existing connection if healthy
     const existing = this.connections.get(name);
     if (existing?.status === "connected") {
       existing.lastUsedAt = Date.now();
       return existing;
     }
 
-    const promise = this.createConnection(name, definition, signal);
+    const generation = this.closeGenerations.get(name) ?? 0;
+    const attemptController = new AbortController();
+    const attemptSignal = combineAbortSignals(ownedSignal, attemptController.signal);
+    const promise = this.createConnection(name, definition, attemptSignal, ownedSignal);
     this.connectPromises.set(name, promise);
+    this.connectAttempts.set(name, attemptController);
 
     try {
       const connection = await promise;
+      if (attemptController.signal.aborted || (this.closeGenerations.get(name) ?? 0) !== generation) {
+        await this.disposeConnection(connection);
+        throwIfAborted(attemptSignal);
+        throw new Error(`MCP connection for ${name} was closed while connecting`);
+      }
       this.connections.set(name, connection);
       return connection;
     } finally {
-      this.connectPromises.delete(name);
+      if (this.connectPromises.get(name) === promise) this.connectPromises.delete(name);
+      if (this.connectAttempts.get(name) === attemptController) this.connectAttempts.delete(name);
     }
   }
 
@@ -174,38 +201,42 @@ export class McpServerManager {
     staleConnection: ServerConnection,
     signal?: AbortSignal,
   ): Promise<ServerConnection> {
-    throwIfAborted(signal);
+    if (this.stopped) throw new Error("MCP server manager is closed");
+    const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
+    throwIfAborted(ownedSignal);
     const inFlight = this.reconnectPromises.get(name);
     if (inFlight) {
-      return abortable(inFlight, signal);
+      return abortable(inFlight, ownedSignal);
     }
 
-    const promise = this.doReconnect(name, definition, staleConnection).finally(() => {
+    const promise = this.doReconnect(name, definition, staleConnection, ownedSignal).finally(() => {
       if (this.reconnectPromises.get(name) === promise) {
         this.reconnectPromises.delete(name);
       }
     });
     this.reconnectPromises.set(name, promise);
-    return abortable(promise, signal);
+    return abortable(promise, ownedSignal);
   }
 
   private async doReconnect(
     name: string,
     definition: ServerDefinition,
     staleConnection: ServerConnection,
+    signal?: AbortSignal,
   ): Promise<ServerConnection> {
+    throwIfAborted(signal);
     const current = this.connections.get(name);
 
     // Never tear down a connection we didn't prove stale: if the map no
     // longer holds the connection we were asked to replace, someone else
     // already reconnected (or connected) first.
     if (current !== staleConnection) {
-      return current ?? this.connect(name, definition);
+      return current ?? this.connect(name, definition, signal);
     }
 
     const staleInFlight = staleConnection.inFlight;
     await this.close(name);
-    const fresh = await this.connect(name, definition);
+    const fresh = await this.connect(name, definition, signal);
     fresh.inFlight = Math.max(fresh.inFlight, staleInFlight);
     return fresh;
   }
@@ -214,6 +245,7 @@ export class McpServerManager {
     name: string,
     definition: ServerDefinition,
     signal?: AbortSignal,
+    requestSignal?: AbortSignal,
   ): Promise<ServerConnection> {
     throwIfAborted(signal);
     const client = this.createClient(name);
@@ -226,13 +258,14 @@ export class McpServerManager {
       let args = definition.args ?? [];
 
       if (command === "npx" || command === "npm") {
-        const resolved = await resolveNpxBinary(command, args);
+        const resolved = await resolveNpxBinary(command, args, signal);
         if (resolved) {
           command = resolved.isJs ? "node" : resolved.binPath;
           args = resolved.isJs ? [resolved.binPath, ...resolved.extraArgs] : resolved.extraArgs;
           logger.debug(`${name} resolved to ${resolved.binPath} (skipping npm parent)`);
         }
       }
+      throwIfAborted(signal);
 
       const stdioTransport = new StdioClientTransport({
         command,
@@ -251,15 +284,16 @@ export class McpServerManager {
       transport = stdioTransport;
     } else if (definition.url) {
       // HTTP transport with fallback
-      transport = await this.createHttpTransport(definition, name, signal);
+      transport = await this.createHttpTransport(definition, name, signal, requestSignal);
     } else {
       throw new Error(`Server ${name} has no command or url`);
     }
 
-    const requestOptions = this.buildRequestOptions(definition, signal);
+    throwIfAborted(signal);
+    const requestOptions = this.buildRequestOptions(definition, requestSignal);
 
     try {
-      await client.connect(transport, requestOptions);
+      await this.connectClientWithAbort(client, transport, requestOptions, signal);
       this.attachAdapterNotificationHandlers(name, client);
 
       const connection: ServerConnection = {
@@ -300,12 +334,25 @@ export class McpServerManager {
 
       return connection;
     } catch (error) {
-      // Check for UnauthorizedError - server requires OAuth
-      if (error instanceof UnauthorizedError && supportsOAuth(definition)) {
-        // Clean up both client and transport before reporting needs-auth.
-        await client.close().catch(() => {});
-        await transport.close().catch(() => {});
+      // If connectClientWithAbort closed the transport, await that exact close.
+      // Otherwise the SDK client owns its transport, so client.close() is the
+      // single cleanup operation rather than closing the transport twice.
+      const abortCleanup = abortCleanupPromises.get(transport);
+      const abortCleanupFailed = error instanceof AggregateError && error.message === "MCP connection abort cleanup failed";
+      const cleanupResults = abortCleanupFailed
+        ? []
+        : await Promise.allSettled([
+            abortCleanup ?? Promise.resolve().then(() => client.close()),
+          ]);
+      const cleanupFailures = cleanupResults.flatMap(result => result.status === "rejected" ? [result.reason] : []);
+      let reportedError: unknown = error;
+      if (cleanupFailures.length > 0) {
+        reportedError = new AggregateError([error, ...cleanupFailures], "MCP connection setup failed");
+      }
 
+      // Check for UnauthorizedError - server requires OAuth. A cleanup failure
+      // remains a setup failure rather than being hidden behind needs-auth.
+      if (error instanceof UnauthorizedError && supportsOAuth(definition) && cleanupFailures.length === 0) {
         return {
           client,
           transport,
@@ -318,20 +365,46 @@ export class McpServerManager {
         };
       }
 
-      // Clean up both client and transport on any error
-      await client.close().catch(() => {});
-      await transport.close().catch(() => {});
-
       if (stderrTail.length > 0) {
         const stderrText = stderrTail.toString("utf8").trim();
         const lines = stderrText.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
         if (lines.length > 0) {
-          const baseMessage = error instanceof Error ? error.message : String(error);
+          const baseMessage = reportedError instanceof Error ? reportedError.message : String(reportedError);
           const detail = lines.slice(-MAX_CAPTURED_STDERR_LINES).join(" — ");
-          throw new Error(`${baseMessage} (${detail})`, { cause: error });
+          throw new Error(`${baseMessage} (${detail})`, { cause: reportedError });
+        }
+      }
+      throw reportedError;
+    }
+  }
+
+  private async connectClientWithAbort(
+    client: Client,
+    transport: Transport,
+    requestOptions?: RequestOptions,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    throwIfAborted(signal);
+    let abortCleanup: Promise<void> | undefined;
+    const closeTransport = () => {
+      abortCleanup = Promise.resolve().then(() => transport.close());
+      abortCleanupPromises.set(transport, abortCleanup);
+    };
+    signal?.addEventListener("abort", closeTransport, { once: true });
+    try {
+      await abortable(client.connect(transport, requestOptions), signal);
+      await abortCleanup;
+    } catch (error) {
+      if (abortCleanup) {
+        try {
+          await abortCleanup;
+        } catch (cleanupError) {
+          throw new AggregateError([error, cleanupError], "MCP connection abort cleanup failed");
         }
       }
       throw error;
+    } finally {
+      signal?.removeEventListener("abort", closeTransport);
     }
   }
 
@@ -366,6 +439,7 @@ export class McpServerManager {
       });
       if (this.elicitationConfig.allowUrl) {
         client.setNotificationHandler(ElicitationCompleteNotificationSchema, notification => {
+          if (this.runtimeSignal?.aborted) return;
           const accepted = this.acceptedUrlElicitations.get(serverName);
           if (!accepted?.delete(notification.params.elicitationId)) return;
           this.elicitationConfig?.ui.notify(
@@ -382,7 +456,7 @@ export class McpServerManager {
     serverName: string,
     error: UrlElicitationRequiredError,
   ): Promise<"accept" | "decline" | "cancel"> {
-    if (!this.elicitationConfig?.allowUrl) return "cancel";
+    if (this.runtimeSignal?.aborted || !this.elicitationConfig?.allowUrl) return "cancel";
     for (const params of error.elicitations) {
       const result = await handleUrlElicitation({
         ...this.elicitationConfig,
@@ -395,6 +469,7 @@ export class McpServerManager {
   }
 
   private rememberUrlElicitation(serverName: string, elicitationId: string): void {
+    if (this.runtimeSignal?.aborted) return;
     let accepted = this.acceptedUrlElicitations.get(serverName);
     if (!accepted) {
       accepted = new Set();
@@ -407,6 +482,7 @@ export class McpServerManager {
     definition: ServerDefinition,
     serverName: string,
     signal?: AbortSignal,
+    requestSignal?: AbortSignal,
   ): Promise<Transport> {
     throwIfAborted(signal);
     const serverUrl = resolveServerUrl(definition)!;
@@ -449,19 +525,43 @@ export class McpServerManager {
       authProvider,
     });
 
+    const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
+    let probeCleanupAttempted = false;
     try {
-      // Create a test client to verify the transport works
-      const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
-      await testClient.connect(streamableTransport, this.buildRequestOptions(definition, signal));
-      await testClient.close().catch(() => {});
-      // Close probe transport before creating fresh one
-      await streamableTransport.close().catch(() => {});
+      await this.connectClientWithAbort(
+        testClient,
+        streamableTransport,
+        this.buildRequestOptions(definition, requestSignal),
+        signal,
+      );
+      probeCleanupAttempted = true;
+      try {
+        await testClient.close();
+      } catch (cleanupError) {
+        throw new AggregateError([cleanupError], "MCP HTTP probe cleanup failed");
+      }
 
       // StreamableHTTP works - create fresh transport for actual use
       return new StreamableHTTPClientTransport(url, { requestInit, authProvider });
     } catch (error) {
-      // StreamableHTTP failed, close and try SSE fallback
-      await streamableTransport.close().catch(() => {});
+      if (error instanceof AggregateError && (
+        error.message === "MCP connection abort cleanup failed" ||
+        error.message === "MCP HTTP probe cleanup failed"
+      )) {
+        throw error;
+      }
+
+      // StreamableHTTP failed, close through the SDK client and try SSE fallback.
+      // If connectClientWithAbort already owned the close, await that operation
+      // instead of closing the same transport again.
+      if (!probeCleanupAttempted) {
+        probeCleanupAttempted = true;
+        try {
+          await (abortCleanupPromises.get(streamableTransport) ?? testClient.close());
+        } catch (cleanupError) {
+          throw new AggregateError([error, cleanupError], "MCP HTTP probe cleanup failed");
+        }
+      }
 
       // Host cancellation is not transport capability evidence; do not fall
       // through to SSE when the caller is trying to cancel the connect.
@@ -546,22 +646,89 @@ export class McpServerManager {
   }
 
   async close(name: string): Promise<void> {
-    const connection = this.connections.get(name);
-    if (!connection) return;
+    this.closeGenerations.set(name, (this.closeGenerations.get(name) ?? 0) + 1);
+    this.connectAttempts.get(name)?.abort(new Error(`MCP connection ${name} was closed`));
 
-    // Delete from map BEFORE async cleanup to prevent a race where a
-    // concurrent connect() creates a new connection that our deferred
-    // delete() would then remove, orphaning the new server process.
+    const connection = this.connections.get(name);
+    if (!connection) {
+      const pendingClose = this.closePromises.get(name);
+      if (pendingClose) {
+        await pendingClose;
+        return;
+      }
+      const pendingConnect = this.connectPromises.get(name);
+      if (pendingConnect) {
+        try {
+          await pendingConnect;
+        } catch (error) {
+          if (this.containsCleanupFailure(error)) throw error;
+        }
+      }
+      return;
+    }
+
+    // Delete before awaiting SDK cleanup so a replacement cannot be removed by
+    // an old close operation finishing later.
     connection.status = "closed";
     this.connections.delete(name);
     this.acceptedUrlElicitations.delete(name);
-    await connection.client.close().catch(() => {});
-    await connection.transport.close().catch(() => {});
+    const closing = this.disposeConnection(connection).finally(() => {
+      if (this.closePromises.get(name) === closing) this.closePromises.delete(name);
+    });
+    this.closePromises.set(name, closing);
+    return closing;
+  }
+
+  private async disposeConnection(connection: ServerConnection): Promise<void> {
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() => connection.client.close()),
+      Promise.resolve().then(() => connection.transport.close()),
+    ]);
+    const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : []);
+    if (failures.length > 0) throw new AggregateError(failures, "MCP connection cleanup failed");
   }
 
   async closeAll(): Promise<void> {
-    const names = [...this.connections.keys()];
-    await Promise.all(names.map(name => this.close(name)));
+    this.stopped = true;
+    const names = new Set([...this.connections.keys(), ...this.connectPromises.keys()]);
+    for (const name of names) {
+      this.closeGenerations.set(name, (this.closeGenerations.get(name) ?? 0) + 1);
+      this.connectAttempts.get(name)?.abort(new Error(`MCP connection ${name} was closed`));
+    }
+
+    const pendingConnects = [...this.connectPromises.values()];
+    const currentNames = [...this.connections.keys()];
+    const pendingResults = await Promise.allSettled(pendingConnects);
+    const results = await Promise.allSettled(currentNames.map(name => this.close(name)));
+
+    // A connect that resolved during the first close snapshot is still fenced;
+    // close any handle that was already inserted before its attempt settled.
+    const lateNames = [...this.connections.keys()];
+    const lateResults = await Promise.allSettled(lateNames.map(name => this.close(name)));
+    const failures = [...pendingResults, ...results, ...lateResults]
+      .flatMap(result => result.status === "rejected" ? [result.reason] : [])
+      .filter(error => this.containsCleanupFailure(error));
+    this.uiStreamListeners.clear();
+    this.acceptedUrlElicitations.clear();
+    this.samplingConfig = undefined;
+    this.elicitationConfig = undefined;
+    if (failures.length > 0) throw new AggregateError(failures, "MCP manager cleanup failed");
+  }
+
+  private containsCleanupFailure(error: unknown): boolean {
+    const pending: unknown[] = [error];
+    const seen = new Set<unknown>();
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (!(current instanceof Error) || seen.has(current)) continue;
+      seen.add(current);
+      if (current instanceof AggregateError) {
+        if (/cleanup failed|setup failed/.test(current.message)) return true;
+        pending.push(...current.errors);
+      }
+      if (current.cause !== undefined) pending.push(current.cause);
+    }
+    return false;
   }
 
   getConnection(name: string): ServerConnection | undefined {

--- a/state.ts
+++ b/state.ts
@@ -6,6 +6,7 @@ import type { AuthStorageOptions } from "./mcp-auth.ts";
 import type { ToolMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from "./types.ts";
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
 import type { UiServerHandle } from "./ui-server.ts";
+import type { McpRuntimeOwner } from "./runtime-owner.ts";
 
 export interface CompletedUiSession {
   serverName: string;
@@ -27,6 +28,7 @@ export type SendMessageFn = (
 ) => void;
 
 export interface McpExtensionState {
+  owner: McpRuntimeOwner;
   manager: McpServerManager;
   lifecycle: McpLifecycleManager;
   toolMetadata: Map<string, ToolMetadata[]>;

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -15,6 +15,8 @@ import { logger } from "./logger.ts";
 import { startUiServer, type UiServerHandle } from "./ui-server.ts";
 import { isGlimpseAvailable, openGlimpseWindow } from "./glimpse-ui.ts";
 import type { SessionRecoveryDeps } from "./session-recovery.ts";
+import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
+import { throwIfAborted } from "./abort.ts";
 
 let activeGlimpseWindow: { close(): void } | null = null;
 
@@ -119,11 +121,15 @@ function withStreamEnvelope(
   };
 }
 
-async function openInBrowser(state: McpExtensionState, url: string): Promise<void> {
+async function openInBrowser(state: McpExtensionState, url: string, signal: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
   try {
     await state.openBrowser(url);
+    throwIfAborted(signal);
   } catch (error) {
+    if (isAbortError(error, signal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
+    if (state.owner?.isActive() === false) return;
     state.ui?.notify(`MCP UI browser open failed: ${message}`, "warning");
     state.ui?.notify(`Open manually: ${url}`, "info");
   }
@@ -138,8 +144,10 @@ export async function maybeStartUiSession(
     server: request.serverName,
     tool: request.toolName,
   });
+  const runtimeSignal = combineAbortSignals(state.owner?.signal, request.signal) ?? new AbortController().signal;
 
   try {
+    throwIfAborted(runtimeSignal);
     if (
       state.uiServer &&
       state.uiServer.serverName === request.serverName &&
@@ -216,9 +224,10 @@ export async function maybeStartUiSession(
 
     const resource = await state.uiResourceHandler.readUiResource(request.serverName, request.uiResourceUri, {
       config: state.config,
-      signal: request.signal,
+      signal: runtimeSignal,
       onNeedsAuth: request.onNeedsAuth,
     });
+    throwIfAborted(runtimeSignal);
 
     if (state.uiServer) {
       state.uiServer.close("replaced");
@@ -355,6 +364,13 @@ export async function maybeStartUiSession(
       },
     });
 
+    if (state.owner?.isActive() === false || runtimeSignal.aborted) {
+      handle.close("runtime_owner_stopped");
+      handle = null;
+      throwIfAborted(runtimeSignal);
+      throw new Error("MCP UI session became stale before registration");
+    }
+
     if (streamToken) {
       state.manager.registerUiStreamListener(streamToken, (serverName, notification) => {
         if (!active || state.uiServer !== handle) return;
@@ -385,7 +401,7 @@ export async function maybeStartUiSession(
       if (useGlimpse) {
         try {
           const glimpseHtml = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:0;padding:0;width:100vw;height:100vh;overflow:hidden}iframe{width:100%;height:100%;border:none}</style></head><body><iframe src="${handle.url}"></iframe></body></html>`;
-          activeGlimpseWindow = await openGlimpseWindow(glimpseHtml, {
+          const glimpseWindow = await openGlimpseWindow(glimpseHtml, {
             title: `MCP · ${request.serverName} · ${request.toolName}`,
             width: 1000,
             height: 800,
@@ -393,19 +409,26 @@ export async function maybeStartUiSession(
               if (active) handle.close("glimpse-closed");
             },
           });
+          if (state.owner?.isActive() === false || runtimeSignal.aborted) {
+            glimpseWindow.close();
+            throwIfAborted(runtimeSignal);
+            throw new Error("MCP Glimpse window became stale before registration");
+          }
+          activeGlimpseWindow = glimpseWindow;
           viewer = "glimpse";
         } catch (error) {
           log.debug("Glimpse unavailable, using browser", {
             error: error instanceof Error ? error.message : String(error),
           });
-          await openInBrowser(state, handle.url);
+          await openInBrowser(state, handle.url, runtimeSignal!);
           viewer = "browser";
         }
       } else {
-        await openInBrowser(state, handle.url);
+        await openInBrowser(state, handle.url, runtimeSignal!);
       }
     }
 
+    throwIfAborted(runtimeSignal);
     handle.viewer = viewer;
     handle.windowOpen = windowOpen;
 
@@ -442,7 +465,7 @@ export async function maybeStartUiSession(
       },
     };
   } catch (error) {
-    if (error instanceof UrlElicitationRequiredError) throw error;
+    if (error instanceof UrlElicitationRequiredError || isAbortError(error, runtimeSignal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
     log.error("Failed to start UI session", error instanceof Error ? error : undefined);
     state.ui?.notify(

--- a/utils.ts
+++ b/utils.ts
@@ -3,22 +3,22 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { McpConfig, ServerEntry } from "./types.ts";
 
-async function execOpen(pi: ExtensionAPI, target: string, browser?: string) {
+async function execOpen(pi: ExtensionAPI, target: string, browser?: string, signal?: AbortSignal) {
   const os = platform();
 
   if (os === "darwin") {
-    return browser ? pi.exec("open", ["-a", browser, target]) : pi.exec("open", [target]);
+    return browser ? pi.exec("open", ["-a", browser, target], { signal }) : pi.exec("open", [target], { signal });
   }
   if (os === "win32") {
     return browser
-      ? pi.exec("cmd", ["/c", "start", "", browser, target])
-      : pi.exec("cmd", ["/c", "start", "", target]);
+      ? pi.exec("cmd", ["/c", "start", "", browser, target], { signal })
+      : pi.exec("cmd", ["/c", "start", "", target], { signal });
   }
-  return browser ? pi.exec(browser, [target]) : pi.exec("xdg-open", [target]);
+  return browser ? pi.exec(browser, [target], { signal }) : pi.exec("xdg-open", [target], { signal });
 }
 
-export async function openUrl(pi: ExtensionAPI, url: string, browser?: string): Promise<void> {
-  const result = await execOpen(pi, url, browser);
+export async function openUrl(pi: ExtensionAPI, url: string, browser?: string, signal?: AbortSignal): Promise<void> {
+  const result = await execOpen(pi, url, browser, signal);
   if (result.code !== 0) {
     throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
   }
@@ -152,6 +152,32 @@ export function sanitizeTerminalText(text: string): string {
     .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+export function formatTerminalError(error: unknown): string {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  const collect = (value: unknown) => {
+    if (seen.has(value)) return;
+    if ((typeof value === "object" && value !== null) || typeof value === "function") seen.add(value);
+
+    if (value instanceof AggregateError) {
+      const countBefore = messages.length;
+      for (const nested of value.errors) collect(nested);
+      if (value.cause !== undefined) collect(value.cause);
+      if (messages.length === countBefore && value.message) messages.push(value.message);
+      return;
+    }
+    if (value instanceof Error) {
+      if (value.message) messages.push(value.message);
+      if (value.cause !== undefined) collect(value.cause);
+      return;
+    }
+    messages.push(String(value));
+  };
+
+  collect(error);
+  return sanitizeTerminalText([...new Set(messages)].join(": "));
 }
 
 export function truncateAtWord(text: string, target: number): string {


### PR DESCRIPTION
## Problem

Pi invalidates an extension's captured `ExtensionContext`/`ExtensionAPI` after `/reload`. MCP eager/keep-alive initialization can cross that boundary: a delayed startup connect settles after `session_shutdown`, then `initializeMcp()` reads `ctx.hasUI` or mutates old UI/status/metadata, producing Pi's stale-context exception and potentially leaving callbacks/processes owned by the replaced runtime.

## Fix

- add one abortable owner per MCP extension runtime;
- synchronously abort it at `session_shutdown` before awaiting cleanup;
- snapshot guarded context values before the first await and fence retained UI/pi callbacks;
- propagate the owner signal through startup connection/discovery and browser process work;
- prevent late connect results from entering the connection map;
- stop and await health/reconnect work; clear callbacks/listeners/config on shutdown.

Eager, lazy, keep-alive, direct tools, metadata cache, OAuth, sampling, elicitation, and browser UI behavior remain on their existing paths.

## Reproduction and tests

A deterministic unit reproduces the 2.10.0 delayed-init stale-context failure. New adversarial tests cover successful/failed delayed connect, direct-tool bootstrap, health/reconnect callback fencing, repeated reload, old UI mutation, connection/tool duplication, and cleanup. A Real Path test loads the actual extension through Pi's `DefaultResourceLoader`, calls `AgentSession.reload()` twice during a real delayed stdio MCP startup, and asserts no stale-context error plus one replacement runtime/tool/status path.

Validation:
- focused lifecycle tests: 45/45 passed before the Real Path addition
- full suite: 442/442 passed
- `npm run test:typecheck`: passed
- `npm pack --dry-run`: passed
- `git diff --check`: passed

No generated `node_modules` content is committed.
