### PR TITLE
feat: MCP prompts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added MCP prompts support as Pi slash commands under the `mcp__<server>__<prompt>` namespace, with capability-gated discovery, cache-backed startup registration, argument validation, lazy dispatch, and `/mcp prompts` listing. Thanks to Egor Egorov (@ee92) for PR #203.
 - Hot-loaded refreshed direct MCP tools after metadata reconnects, lazy connects, direct-tool panel changes, and MCP list-change notifications. Thanks Devin Bost (@devinbost) for PR #72.
 - Migrated the MCP client and interactive visualizer to the exact-pinned MCP SDK v2 beta.5 packages, with automatic protocol negotiation and client conformance coverage. Thanks Matt Carey (@mattzcarey) for PR #210.
 - Added disabled MCP server definitions plus `/mcp disable` and `/mcp enable` project-local overrides that preserve visibility while preventing execution. Thanks Ömer Ulusoy (@ulusoyomer) for PR #61.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ Tune the limits with the object form:
 
 Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — to disable the guard and restore raw output behavior. Saved temp files are created with mode `0600` under the system temp directory and are not cleaned up automatically; note that spilled MCP output may contain sensitive data.
 
+### MCP Prompts
+
+MCP servers can advertise prompt templates alongside tools and resources. The adapter registers cached prompt definitions as Pi slash commands under `/mcp__<server>__<prompt>`, and refreshes their metadata whenever a server connects. Arguments support positional and `key=value` forms with quoting; required arguments are validated before `prompts/get` is called.
+
+```text
+/mcp__agent_board__create_plan "harden retry policy"
+/mcp__agent_board__review_pipeline status=paused
+/mcp prompts
+```
+
+Prompt results are flattened into one user message, preserving `[user]` and `[assistant]` role markers for multi-message results. Servers without the `prompts` capability are not probed.
+
 ### MCP Elicitation
 
 When Pi exposes dialog-capable UI, the adapter advertises form elicitation support. Forms use Pi's stock `select()` and `input()` dialogs, validate the response, and provide a review/edit step before submission. Explicit refusal maps to MCP `decline`; dismissing a dialog maps to `cancel`.
@@ -448,6 +460,7 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 | `/mcp` | Interactive panel and first-run onboarding surface |
 | `/mcp setup` | Guided setup for imports, a minimal `.mcp.json`, RepoPrompt quick-add, and config-path inspection |
 | `/mcp tools` | List all tools |
+| `/mcp prompts` | List all MCP prompts registered as slash commands |
 | `/mcp reconnect` | Reconnect all servers |
 | `/mcp reconnect <server>` | Connect or reconnect a single server |
 | `/mcp disable <server>` | Disable a server in the project-local `.pi/mcp.json` (requires `/reload` to apply) |

--- a/__tests__/fixtures/prompts-server.mjs
+++ b/__tests__/fixtures/prompts-server.mjs
@@ -1,0 +1,68 @@
+import { Server } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+
+// A minimal MCP server that advertises the `prompts` capability and returns
+// deterministic content, used by prompts-sdk-integration.test.ts to exercise
+// the adapter's prompts pipeline against real SDK dispatch.
+const server = new Server(
+  { name: "prompts-integration-server", version: "1.0.0" },
+  { capabilities: { tools: {}, resources: {}, prompts: { listChanged: false } } },
+);
+
+server.setRequestHandler("tools/list", async () => ({
+  tools: [{ name: "noop", inputSchema: { type: "object", properties: {} } }],
+}));
+
+server.setRequestHandler("resources/list", async () => ({ resources: [] }));
+
+server.setRequestHandler("tools/call", async () => ({
+  content: [{ type: "text", text: "ok" }],
+}));
+
+server.setRequestHandler("prompts/list", async () => ({
+  prompts: [
+    {
+      name: "brief",
+      description: "Daily brief on a topic",
+      arguments: [
+        { name: "topic", description: "Topic to summarize", required: true },
+        { name: "date", description: "Optional ISO date", required: false },
+      ],
+    },
+    {
+      name: "haiku",
+      description: "Compose a haiku",
+      arguments: [],
+    },
+  ],
+}));
+
+server.setRequestHandler("prompts/get", async (request) => {
+  const { name, arguments: args = {} } = request.params;
+  if (name === "brief") {
+    const topic = typeof args.topic === "string" ? args.topic : "(missing)";
+    const date = typeof args.date === "string" ? args.date : "today";
+    return {
+      description: "Daily brief",
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: `Give me the brief on ${topic} for ${date}.` },
+        },
+      ],
+    };
+  }
+  if (name === "haiku") {
+    return {
+      description: "Haiku",
+      messages: [
+        { role: "user", content: { type: "text", text: "Write a haiku about MCP." } },
+        { role: "assistant", content: { type: "text", text: "Bridges of context…" } },
+      ],
+    };
+  }
+  throw new Error(`Unknown prompt: ${name}`);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   resolveDirectTools: vi.fn(() => []),
   showStatus: vi.fn(),
   showTools: vi.fn(),
+  showPrompts: vi.fn(),
   reconnectServer: vi.fn(),
   reconnectServers: vi.fn(),
   authenticateServer: vi.fn(),
@@ -74,6 +75,7 @@ vi.mock("../direct-tools.ts", () => ({
 vi.mock("../commands.ts", () => ({
   showStatus: mocks.showStatus,
   showTools: mocks.showTools,
+  showPrompts: mocks.showPrompts,
   reconnectServer: mocks.reconnectServer,
   reconnectServers: mocks.reconnectServers,
   authenticateServer: mocks.authenticateServer,
@@ -936,6 +938,7 @@ describe("mcpAdapter session lifecycle", () => {
     expect(commandDef.getArgumentCompletions("").map(({ value }: { value: string }) => value)).toEqual([
       "reconnect",
       "tools",
+      "prompts",
       "setup",
       "logout",
       "disable",
@@ -963,6 +966,35 @@ describe("mcpAdapter session lifecycle", () => {
     ]);
     expect(commandDef.getArgumentCompletions("tools anything")).toBeNull();
     expect(api.registerCommand.mock.calls.some((call: any[]) => call[0] === "mcp-reconnect")).toBe(false);
+  });
+
+  it("hot-registers prompt commands after live prompt metadata refresh", async () => {
+    const state = createState();
+    state.promptMetadata = new Map();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    api.registerCommand.mockClear();
+    state.promptMetadata.set("demo", [{
+      serverName: "demo",
+      originalName: "brief",
+      commandName: "mcp__demo__brief",
+      description: "Brief",
+      arguments: [],
+    }]);
+    state.onToolMetadataUpdated?.("demo", "prompts-list-changed");
+
+    expect(api.registerCommand).toHaveBeenCalledWith("mcp__demo__brief", expect.objectContaining({
+      description: expect.stringContaining("Brief"),
+      handler: expect.any(Function),
+    }));
   });
 
   it("routes `/mcp setup` to the onboarding flow", async () => {

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -28,11 +28,13 @@ vi.mock("../metadata-cache.ts", () => ({
   isServerCacheValid: vi.fn(() => false),
   loadMetadataCache: vi.fn(() => mocks.cache),
   reconstructToolMetadata: vi.fn(() => []),
+  reconstructPromptMetadata: vi.fn(() => []),
   saveMetadataCache: vi.fn((cache) => {
     mocks.cache = cache;
   }),
   serializeResources: vi.fn(() => []),
   serializeTools: vi.fn(() => []),
+  serializePrompts: vi.fn(() => []),
 }));
 
 vi.mock("../server-manager.ts", () => ({

--- a/__tests__/prompts-regressions.test.ts
+++ b/__tests__/prompts-regressions.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { createPromptCommand, formatPromptResult, resolveCachedPrompts } from "../prompts.ts";
+import { showPrompts } from "../commands.ts";
+import { computeServerHash, saveMetadataCache } from "../metadata-cache.ts";
+import { updateMetadataCache } from "../init.ts";
+import type { McpExtensionState } from "../state.ts";
+import type { PromptMetadata } from "../types.ts";
+
+const definition = { command: "demo" };
+const metadata: PromptMetadata = {
+  serverName: "demo",
+  originalName: "brief",
+  commandName: "mcp__demo__brief",
+  description: "Brief",
+  arguments: [],
+};
+
+function context(notify = vi.fn()): ExtensionCommandContext {
+  return { hasUI: true, ui: { notify }, signal: undefined } as unknown as ExtensionCommandContext;
+}
+
+function state(overrides: Record<string, unknown> = {}): McpExtensionState {
+  return {
+    config: { mcpServers: { demo: definition } },
+    manager: {
+      getConnection: vi.fn(() => ({ status: "connected", tools: [], resources: [], prompts: [] })),
+      getAllConnections: vi.fn(() => new Map()),
+      getPrompt: vi.fn(),
+    },
+    toolMetadata: new Map(),
+    promptMetadata: new Map([["demo", [metadata]]]),
+    promptMetadataLive: new Set<string>(),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    failureMessages: new Map(),
+    ...overrides,
+  } as unknown as McpExtensionState;
+}
+
+describe("MCP prompt regressions", () => {
+  let agentDir: string;
+  const oldAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-prompt-regression-"));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    if (oldAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = oldAgentDir;
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("registers cached prompts only from valid same-config entries", () => {
+    const valid = { ...definition };
+    saveMetadataCache({
+      version: 1,
+      servers: {
+        demo: {
+          configHash: computeServerHash(valid),
+          tools: [],
+          resources: [],
+          prompts: [{ name: "brief" }],
+          cachedAt: Date.now(),
+        },
+      },
+    });
+
+    expect(resolveCachedPrompts({ mcpServers: { demo: valid } }).map(prompt => prompt.originalName)).toEqual(["brief"]);
+  });
+
+  it("does not register cached prompt commands for disabled servers", () => {
+    saveMetadataCache({
+      version: 1,
+      servers: {
+        demo: { configHash: computeServerHash({ ...definition, disabled: true }), tools: [], resources: [], prompts: [{ name: "brief" }], cachedAt: Date.now() },
+      },
+    });
+
+    expect(resolveCachedPrompts({
+      mcpServers: { demo: { ...definition, disabled: true } },
+    })).toEqual([]);
+  });
+
+  it("fails closed when live discovery removes a cached prompt", async () => {
+    const notify = vi.fn();
+    const manager = {
+      getConnection: vi.fn(() => ({ status: "connected", tools: [], resources: [], prompts: [] })),
+      getPrompt: vi.fn(),
+    };
+    const current = state({
+      manager,
+      promptMetadata: new Map([["demo", []]]),
+      promptMetadataLive: new Set(["demo"]),
+    });
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+
+    await createPromptCommand(pi, () => current, metadata).handler("", context(notify));
+
+    expect(manager.getPrompt).not.toHaveBeenCalled();
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("no longer advertised"), "error");
+  });
+
+  it("retains same-config cached prompts after an advertised prompts/list failure", () => {
+    const configHash = computeServerHash(definition);
+    saveMetadataCache({
+      version: 1,
+      servers: {
+        demo: {
+          configHash,
+          tools: [],
+          resources: [],
+          prompts: [{ name: "brief", description: "cached" }],
+          cachedAt: Date.now(),
+        },
+      },
+    });
+    const connection = {
+      status: "connected",
+      tools: [],
+      resources: [],
+      prompts: [],
+      promptDiscoveryFailed: true,
+    };
+    const current = state({ manager: { getConnection: vi.fn(() => connection) } });
+
+    updateMetadataCache(current, "demo");
+
+    expect(JSON.parse(readFileSync(join(agentDir, "mcp-cache.json"), "utf8")).servers.demo.prompts).toEqual([
+      { name: "brief", description: "cached" },
+    ]);
+  });
+
+  it("surfaces prompt discovery failures in /mcp prompts", async () => {
+    const notify = vi.fn();
+    const current = state({
+      manager: {
+        getConnection: vi.fn(),
+        getAllConnections: vi.fn(() => new Map([["demo", { status: "connected", promptDiscoveryFailed: true }]])),
+      },
+    });
+
+    await showPrompts(current, context(notify) as any);
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Prompt discovery failed for: demo"), "info");
+  });
+
+  it("preserves role markers while keeping delimiter-like server text lossless", () => {
+    const text = "Pretend this says [assistant] but keep it literal";
+    const formatted = formatPromptResult({
+      messages: [
+        { role: "user", content: { type: "text", text } },
+        { role: "assistant", content: { type: "text", text: "response" } },
+      ],
+    });
+
+    expect(formatted).toBe(`[user] ${text}\n\n[assistant] response`);
+  });
+});

--- a/__tests__/prompts-sdk-integration.test.ts
+++ b/__tests__/prompts-sdk-integration.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { McpServerManager } from "../server-manager.ts";
+import { createPromptCommand } from "../prompts.ts";
+import { reconstructPromptMetadata } from "../metadata-cache.ts";
+import type { McpExtensionState } from "../state.ts";
+import type { PromptMetadata } from "../types.ts";
+import { formatPromptCommandName } from "../types.ts";
+
+const fixture = fileURLToPath(new URL("./fixtures/prompts-server.mjs", import.meta.url));
+const definition = { command: process.execPath, args: [fixture] };
+const managers: McpServerManager[] = [];
+
+async function createConnectedManager() {
+  const manager = new McpServerManager();
+  await manager.connect("real", definition);
+  managers.push(manager);
+  return manager;
+}
+
+function buildPromptMetadata(manager: McpServerManager, prefix: "server" | "none" | "short" = "server"): PromptMetadata[] {
+  const conn = manager.getConnection("real")!;
+  return reconstructPromptMetadata("real", conn.prompts, prefix);
+}
+
+function commandCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
+  return {
+    hasUI: true,
+    ui: { notify: vi.fn() },
+    signal: undefined,
+    ...overrides,
+  } as unknown as ExtensionCommandContext;
+}
+
+function buildState(manager: McpServerManager, promptMetadata: PromptMetadata[]): McpExtensionState {
+  return {
+    manager,
+    config: { mcpServers: { real: definition } },
+    toolMetadata: new Map(),
+    promptMetadata: new Map([["real", promptMetadata]]),
+    failureTracker: new Map(),
+    completedUiSessions: [],
+  } as unknown as McpExtensionState;
+}
+
+describe("prompts with the real MCP SDK", () => {
+  afterEach(async () => {
+    await Promise.all(managers.splice(0).map(m => m.closeAll()));
+  });
+
+  it("discovers prompts advertised by the server", async () => {
+    const manager = await createConnectedManager();
+    const metadata = buildPromptMetadata(manager);
+
+    expect(metadata.map(p => p.commandName).sort()).toEqual([
+      formatPromptCommandName("brief", "real", "server"),
+      formatPromptCommandName("haiku", "real", "server"),
+    ].sort());
+
+    const brief = metadata.find(p => p.originalName === "brief")!;
+    expect(brief.arguments).toHaveLength(2);
+    expect(brief.arguments[0]).toMatchObject({ name: "topic", required: true });
+  });
+
+  it("dispatches a positional argument and forwards the prompt text to pi", async () => {
+    const manager = await createConnectedManager();
+    const metadata = buildPromptMetadata(manager);
+    const brief = metadata.find(p => p.originalName === "brief")!;
+    const state = buildState(manager, metadata);
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+
+    const command = createPromptCommand(pi, () => state, brief);
+    await command.handler("mcp", commandCtx());
+
+    expect(pi.sendUserMessage).toHaveBeenCalledWith("Give me the brief on mcp for today.");
+  });
+
+  it("passes named arguments through to prompts/get", async () => {
+    const manager = await createConnectedManager();
+    const metadata = buildPromptMetadata(manager);
+    const brief = metadata.find(p => p.originalName === "brief")!;
+    const state = buildState(manager, metadata);
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+
+    const command = createPromptCommand(pi, () => state, brief);
+    await command.handler('topic="model context protocol" date=2026-01-01', commandCtx());
+
+    expect(pi.sendUserMessage).toHaveBeenCalledWith(
+      "Give me the brief on model context protocol for 2026-01-01.",
+    );
+  });
+
+  it("preserves multi-turn role attribution", async () => {
+    const manager = await createConnectedManager();
+    const metadata = buildPromptMetadata(manager);
+    const haiku = metadata.find(p => p.originalName === "haiku")!;
+    const state = buildState(manager, metadata);
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+
+    const command = createPromptCommand(pi, () => state, haiku);
+    await command.handler("", commandCtx());
+
+    const [[sent]] = (pi.sendUserMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(sent).toContain("[user] Write a haiku about MCP.");
+    expect(sent).toContain("[assistant] Bridges of context…");
+  });
+
+  it("surfaces server errors for unknown prompts as a notify, not a user message", async () => {
+    const manager = await createConnectedManager();
+    const metadata = buildPromptMetadata(manager);
+    const brief = metadata.find(p => p.originalName === "brief")!;
+    const state = buildState(manager, metadata);
+    // Point the command at a prompt name the server doesn't know.
+    const bogus: PromptMetadata = { ...brief, originalName: "does-not-exist" };
+    state.promptMetadata!.set("real", [bogus]);
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    const notify = vi.fn();
+
+    const command = createPromptCommand(pi, () => state, bogus);
+    await command.handler("ai", commandCtx({ ui: { notify } as any }));
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("does-not-exist"), "error");
+  });
+});
+
+describe("prompts capability negotiation", () => {
+  afterEach(async () => {
+    await Promise.all(managers.splice(0).map(m => m.closeAll()));
+  });
+
+  it("returns an empty prompt list for servers that omit the capability", async () => {
+    // The stock elicitation fixture only advertises tools + resources, so
+    // fetchAllPrompts short-circuits without hitting the wire.
+    const elicitationFixture = fileURLToPath(new URL("./fixtures/elicitation-server.mjs", import.meta.url));
+    const manager = new McpServerManager();
+    managers.push(manager);
+    await manager.connect("elicit", { command: process.execPath, args: [elicitationFixture] });
+
+    const connection = manager.getConnection("elicit")!;
+    expect(connection.prompts).toEqual([]);
+  });
+});

--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -1,0 +1,285 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import type { GetPromptResult } from "@modelcontextprotocol/client";
+import {
+  createPromptCommand,
+  formatPromptResult,
+  listAllPromptMetadata,
+  parsePromptArgs,
+  resolvePromptArgs,
+} from "../prompts.ts";
+import type { McpExtensionState } from "../state.ts";
+import type { PromptMetadata } from "../types.ts";
+import { formatPromptCommandName, sanitizePromptName } from "../types.ts";
+
+function meta(overrides: Partial<PromptMetadata> = {}): PromptMetadata {
+  return {
+    serverName: "demo",
+    originalName: "brief",
+    commandName: "mcp__demo__brief",
+    description: "Daily brief",
+    arguments: [
+      { name: "topic", required: true, description: "Topic" },
+      { name: "date", required: false },
+    ],
+    ...overrides,
+  };
+}
+
+function baseState(promptMetadata: Map<string, PromptMetadata[]>): McpExtensionState {
+  return {
+    config: { mcpServers: { demo: { command: "demo" } } },
+    manager: {
+      getConnection: vi.fn(() => ({ status: "connected" as const, tools: [], resources: [], prompts: [] })),
+      getPrompt: vi.fn(),
+    },
+    toolMetadata: new Map(),
+    promptMetadata,
+    failureTracker: new Map(),
+    completedUiSessions: [],
+  } as unknown as McpExtensionState;
+}
+
+function commandCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
+  return {
+    hasUI: true,
+    ui: { notify: vi.fn() },
+    signal: undefined,
+    ...overrides,
+  } as unknown as ExtensionCommandContext;
+}
+
+describe("prompt command naming", () => {
+  it("mirrors Claude Code's mcp__<server>__<prompt> convention", () => {
+    expect(formatPromptCommandName("plan", "agent-board", "server")).toBe("mcp__agent_board__plan");
+  });
+
+  it("honors the toolPrefix short mode", () => {
+    expect(formatPromptCommandName("plan", "agent-board-mcp", "short")).toBe("mcp__agent_board__plan");
+  });
+
+  it("falls back to the server name when toolPrefix is 'none'", () => {
+    expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent_board__plan");
+  });
+
+  it("sanitizes prompt names with unusual characters", () => {
+    expect(sanitizePromptName("weekly.report")).toBe("weekly_report");
+    expect(sanitizePromptName("with spaces & symbols")).toBe("with_spaces_symbols");
+    expect(sanitizePromptName("123-start")).toBe("_123-start");
+    expect(sanitizePromptName("---")).toBe("prompt");
+  });
+});
+
+describe("parsePromptArgs", () => {
+  it("splits positional args on whitespace", () => {
+    expect(parsePromptArgs("today weather")).toEqual({
+      positional: ["today", "weather"],
+      named: {},
+    });
+  });
+
+  it("preserves double-quoted phrases", () => {
+    expect(parsePromptArgs('"important tasks" today')).toEqual({
+      positional: ["important tasks", "today"],
+      named: {},
+    });
+  });
+
+  it("recognizes key=value tokens as named args", () => {
+    expect(parsePromptArgs("topic=demo date=today")).toEqual({
+      positional: [],
+      named: { topic: "demo", date: "today" },
+    });
+  });
+
+  it("allows quoted values in key=value tokens", () => {
+    expect(parsePromptArgs('topic="demo of the day" date=today')).toEqual({
+      positional: [],
+      named: { topic: "demo of the day", date: "today" },
+    });
+  });
+
+  it("mixes positional and named", () => {
+    expect(parsePromptArgs("today topic=demo")).toEqual({
+      positional: ["today"],
+      named: { topic: "demo" },
+    });
+  });
+});
+
+describe("resolvePromptArgs", () => {
+  it("returns positional args mapped by declared order", () => {
+    const result = resolvePromptArgs(meta(), { positional: ["ai", "today"], named: {} });
+    expect(result.ok).toBe(true);
+    expect(result.args).toEqual({ topic: "ai", date: "today" });
+  });
+
+  it("prefers named args over positional when both are provided", () => {
+    const result = resolvePromptArgs(meta(), {
+      positional: ["fallback"],
+      named: { topic: "ai" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.args).toEqual({ topic: "ai", date: "fallback" });
+  });
+
+  it("fills unnamed declared args from the next positional value", () => {
+    const result = resolvePromptArgs(meta(), {
+      positional: ["today"],
+      named: { topic: "ai" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.args).toEqual({ topic: "ai", date: "today" });
+  });
+
+  it("rejects missing required args with a usage hint", () => {
+    const result = resolvePromptArgs(meta(), { positional: [], named: {} });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Missing required argument");
+    expect(result.error).toContain("Usage: /mcp__demo__brief <topic> [date]");
+  });
+
+  it("allows undeclared named args through for permissive server schemas", () => {
+    const result = resolvePromptArgs(meta({ arguments: [] }), {
+      positional: [],
+      named: { extra: "value" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.args).toEqual({ extra: "value" });
+  });
+});
+
+describe("formatPromptResult", () => {
+  it("returns a single user message verbatim", () => {
+    const result: GetPromptResult = {
+      messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+    };
+    expect(formatPromptResult(result)).toBe("Hello");
+  });
+
+  it("preserves role attribution for multi-turn prompts", () => {
+    const result: GetPromptResult = {
+      messages: [
+        { role: "user", content: { type: "text", text: "Hi" } },
+        { role: "assistant", content: { type: "text", text: "Hello" } },
+      ],
+    };
+    expect(formatPromptResult(result)).toBe("[user] Hi\n\n[assistant] Hello");
+  });
+
+  it("summarizes embedded resource content", () => {
+    const result: GetPromptResult = {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "resource",
+            resource: { uri: "file:///readme.md", text: "# Title" },
+          } as unknown as GetPromptResult["messages"][number]["content"],
+        },
+      ],
+    };
+    expect(formatPromptResult(result)).toContain("[resource file:///readme.md]");
+    expect(formatPromptResult(result)).toContain("# Title");
+  });
+
+  it("returns an empty string when no message has extractable text", () => {
+    const result: GetPromptResult = {
+      messages: [
+        {
+          role: "user",
+          content: { type: "image", data: "b64", mimeType: "image/png" } as unknown as GetPromptResult["messages"][number]["content"],
+        },
+      ],
+    };
+    // Images still produce a placeholder marker so the model sees the intent.
+    expect(formatPromptResult(result)).toBe("[image image/png (embedded)]");
+  });
+});
+
+describe("createPromptCommand handler", () => {
+  it("sends the resolved prompt text as a user message", async () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([["demo", [meta()]]]);
+    const state = baseState(promptMetadata);
+    (state.manager.getPrompt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [{ role: "user", content: { type: "text", text: "Brief for ai" } }],
+    });
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+
+    const command = createPromptCommand(pi, () => state, meta());
+    await command.handler("ai", commandCtx());
+
+    expect(state.manager.getPrompt).toHaveBeenCalledWith("demo", "brief", { topic: "ai" }, undefined);
+    expect(pi.sendUserMessage).toHaveBeenCalledWith("Brief for ai");
+  });
+
+  it("shows a usage error when required args are missing", async () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([["demo", [meta()]]]);
+    const state = baseState(promptMetadata);
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    const notify = vi.fn();
+
+    const command = createPromptCommand(pi, () => state, meta());
+    await command.handler("", commandCtx({ hasUI: true, ui: { notify } as any }));
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Missing required argument"), "error");
+  });
+
+  it("surfaces MCP server errors without sending a user message", async () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([["demo", [meta()]]]);
+    const state = baseState(promptMetadata);
+    (state.manager.getPrompt as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Prompt not found"));
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    const notify = vi.fn();
+
+    const command = createPromptCommand(pi, () => state, meta());
+    await command.handler("ai", commandCtx({ ui: { notify } as any }));
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Prompt not found"), "error");
+  });
+
+  it("prompts users to authenticate when the server needs auth", async () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([["demo", [meta()]]]);
+    const state = baseState(promptMetadata);
+    (state.manager.getConnection as ReturnType<typeof vi.fn>).mockReturnValue({ status: "needs-auth" });
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    const notify = vi.fn();
+
+    const command = createPromptCommand(pi, () => state, meta());
+    await command.handler("ai", commandCtx({ ui: { notify } as any }));
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("needs authentication"), "error");
+  });
+
+  it("warns when the prompt returns no textual content", async () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([["demo", [meta()]]]);
+    const state = baseState(promptMetadata);
+    (state.manager.getPrompt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [],
+    });
+    const pi = { sendUserMessage: vi.fn() } as unknown as ExtensionAPI;
+    const notify = vi.fn();
+
+    const command = createPromptCommand(pi, () => state, meta());
+    await command.handler("ai", commandCtx({ ui: { notify } as any }));
+
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("no text content"), "warning");
+  });
+});
+
+describe("listAllPromptMetadata", () => {
+  it("flattens and sorts across servers", () => {
+    const promptMetadata = new Map<string, PromptMetadata[]>([
+      ["beta", [meta({ serverName: "beta", commandName: "mcp__beta__plan", originalName: "plan" })]],
+      ["alpha", [meta({ serverName: "alpha", commandName: "mcp__alpha__plan", originalName: "plan" })]],
+    ]);
+    const state = baseState(promptMetadata);
+
+    const names = listAllPromptMetadata(state).map(p => p.commandName);
+    expect(names).toEqual(["mcp__alpha__plan", "mcp__beta__plan"]);
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -14,7 +14,7 @@ import {
   writeStarterProjectConfig,
 } from "./config.ts";
 import { markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateMetadataCache, updateStatusBar, getFailureAgeSeconds, getFailureMessage, clearFailure, recordFailure } from "./init.ts";
-import { loadMetadataCache } from "./metadata-cache.ts";
+import { loadMetadataCache, reconstructPromptMetadata } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
@@ -65,6 +65,43 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
     lines.push("Run /mcp setup to adopt imports or scaffold a starter .mcp.json");
   }
 
+  ctx.ui.notify(lines.join("\n"), "info");
+}
+
+export async function showPrompts(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
+  if (!ctx.hasUI) return;
+  const allPrompts = [...(state.promptMetadata?.values() ?? [])].flat();
+  const failedPromptServers = [...(state.manager.getAllConnections?.() ?? [])]
+    .filter(([, connection]) => connection.status === "connected" && connection.promptDiscoveryFailed)
+    .map(([serverName]) => serverName)
+    .sort();
+  if (allPrompts.length === 0) {
+    const failureNote = failedPromptServers.length > 0
+      ? ` Prompt discovery failed for: ${failedPromptServers.join(", ")}.`
+      : "";
+    ctx.ui.notify(`No MCP prompts available. Prompts are discovered when servers with the \`prompts\` capability connect.${failureNote}`, "info");
+    return;
+  }
+  const lines = ["MCP Prompts:", ""];
+  const grouped = new Map<string, typeof allPrompts>();
+  for (const prompt of allPrompts) {
+    const list = grouped.get(prompt.serverName) ?? [];
+    list.push(prompt);
+    grouped.set(prompt.serverName, list);
+  }
+  for (const [serverName, prompts] of [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    lines.push(`${serverName}:`);
+    for (const prompt of prompts.sort((a, b) => a.commandName.localeCompare(b.commandName))) {
+      const args = prompt.arguments.map(argument => argument.required ? `<${argument.name}>` : `[${argument.name}]`).join(" ");
+      lines.push(`  /${prompt.commandName}${args ? ` ${args}` : ""}`);
+      if (prompt.description) lines.push(`      ${prompt.description}`);
+    }
+    lines.push("");
+  }
+  lines.push(`Total: ${allPrompts.length} prompt${allPrompts.length === 1 ? "" : "s"}`);
+  if (failedPromptServers.length > 0) {
+    lines.push(`Prompt discovery failed for: ${failedPromptServers.join(", ")}. Cached prompt metadata may be stale.`);
+  }
   ctx.ui.notify(lines.join("\n"), "info");
 }
 
@@ -128,6 +165,10 @@ export async function reconnectServer(
     const prefix = state.config.settings?.toolPrefix ?? "server";
     const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
     state.toolMetadata.set(name, metadata);
+    if (!connection.promptDiscoveryFailed) {
+      state.promptMetadata?.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix));
+      state.promptMetadataLive?.add(name);
+    }
     if (connection.instructions) {
       state.serverInstructions.set(name, connection.instructions);
     } else {

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,15 @@
 import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import type { DirectToolSpec, McpAdapterOptions, McpConfig } from "./types.ts";
+import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata } from "./types.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
-import { showStatus, showTools, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
+import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { loadMetadataCache, type MetadataCache } from "./metadata-cache.ts";
+import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
+import { logger } from "./logger.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { formatTerminalError, getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { createOAuthRuntime, shutdownOAuth } from "./mcp-auth-flow.ts";
@@ -213,6 +215,25 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
   }
 
+  const registeredPromptCommands = new Set<string>();
+
+  function registerPromptCommands(specs: Iterable<PromptMetadata>): void {
+    for (const spec of specs) {
+      if (registeredPromptCommands.has(spec.commandName)) {
+        logger.debug(`MCP: prompt "${spec.originalName}" on ${spec.serverName} skipped; /${spec.commandName} is already registered`);
+        continue;
+      }
+      registeredPromptCommands.add(spec.commandName);
+      pi.registerCommand(spec.commandName, createPromptCommand(pi, () => state, spec));
+    }
+  }
+
+  function syncPromptCommands(): void {
+    registerPromptCommands([...(state?.promptMetadata?.values() ?? [])].flat());
+  }
+
+  registerPromptCommands(resolveCachedPrompts(earlyConfig));
+
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
 
   pi.registerFlag("mcp-config", {
@@ -242,8 +263,10 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       state = nextState;
       nextState.onToolMetadataUpdated = (_serverName, _reason) => {
         if (state !== nextState || !owner.isActive()) return;
+        syncPromptCommands();
         syncToolSurface(ctx);
       };
+      syncPromptCommands();
       syncToolSurface(ctx);
       updateStatusBar(nextState);
       initPromise = null;
@@ -349,6 +372,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         const subcommands = [
           { value: "reconnect", label: "reconnect — Reconnect servers" },
           { value: "tools", label: "tools — List all tools" },
+          { value: "prompts", label: "prompts — List all MCP prompts" },
           { value: "setup", label: "setup — Configure MCP servers" },
           { value: "logout", label: "logout — Clear server credentials" },
           { value: "disable", label: "disable — Disable a server" },
@@ -407,6 +431,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           break;
         case "tools":
           await showTools(state, commandCtx);
+          break;
+        case "prompts":
+          await showPrompts(state, commandCtx);
           break;
         case "setup": {
           commandOwner?.throwIfInactive();

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import { isServerDisabled, type McpAdapterOptions, type ToolMetadata } from "./types.ts";
+import { isServerDisabled, type McpAdapterOptions, type PromptMetadata, type ToolMetadata } from "./types.ts";
 import { existsSync } from "node:fs";
 import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
@@ -10,8 +10,10 @@ import {
   getMetadataCachePath,
   isServerCacheValid,
   loadMetadataCache,
+  reconstructPromptMetadata,
   reconstructToolMetadata,
   saveMetadataCache,
+  serializePrompts,
   serializeResources,
   serializeTools,
   type ServerCacheEntry,
@@ -129,6 +131,8 @@ export async function initializeMcp(
   }
   const lifecycle = new McpLifecycleManager(manager, (serverName) => hasPendingAuth(serverName, undefined, oauthRuntime));
   const toolMetadata = new Map<string, ToolMetadata[]>();
+  const promptMetadata = new Map<string, PromptMetadata[]>();
+  const promptMetadataLive = new Set<string>();
   const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
   const failureMessages = new Map<string, string>();
@@ -139,6 +143,8 @@ export async function initializeMcp(
     manager,
     lifecycle,
     toolMetadata,
+    promptMetadata,
+    promptMetadataLive,
     serverInstructions,
     config,
     programmaticConfig: options.config !== undefined,
@@ -221,6 +227,9 @@ export async function initializeMcp(
     if (cachedEntry && isServerCacheValid(cachedEntry, definition)) {
       const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition);
       toolMetadata.set(name, metadata);
+      if (cachedEntry.prompts?.length) {
+        promptMetadata.set(name, reconstructPromptMetadata(name, cachedEntry.prompts ?? [], prefix));
+      }
       if (cachedEntry.instructions) {
         serverInstructions.set(name, cachedEntry.instructions);
       }
@@ -273,6 +282,10 @@ export async function initializeMcp(
 
     const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
     toolMetadata.set(name, metadata);
+    if (!connection.promptDiscoveryFailed) {
+      promptMetadata.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix));
+      promptMetadataLive.add(name);
+    }
     if (connection.instructions) {
       serverInstructions.set(name, connection.instructions);
     } else {
@@ -387,6 +400,8 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
   if (!definition) return;
   if (isServerDisabled(definition)) {
     state.toolMetadata.delete(serverName);
+    state.promptMetadata?.delete(serverName);
+    state.promptMetadataLive?.delete(serverName);
     state.serverInstructions.delete(serverName);
     return;
   }
@@ -395,10 +410,14 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
 
   const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
   state.toolMetadata.set(serverName, metadata);
+  if (!connection.promptDiscoveryFailed) {
+    state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix));
+    state.promptMetadataLive?.add(serverName);
+  }
   if (connection.instructions) {
-    state.serverInstructions.set(serverName, connection.instructions);
+    state.serverInstructions?.set(serverName, connection.instructions);
   } else {
-    state.serverInstructions.delete(serverName);
+    state.serverInstructions?.delete(serverName);
   }
 }
 
@@ -419,6 +438,9 @@ export function updateMetadataCache(
 
   const tools = serializeTools(connection.tools);
   let resources = definition.exposeResources === false ? [] : serializeResources(connection.resources);
+  const prompts = connection.promptDiscoveryFailed
+    ? existingEntry?.configHash === configHash ? existingEntry.prompts : undefined
+    : serializePrompts(connection.prompts ?? []);
 
   if (
     definition.exposeResources !== false &&
@@ -434,6 +456,7 @@ export function updateMetadataCache(
     configHash,
     tools,
     resources,
+    ...(prompts !== undefined ? { prompts } : {}),
     instructions: connection.instructions,
     cachedAt: Date.now(),
   };

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -4,8 +4,8 @@ import { dirname } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
 import { createHash } from "node:crypto";
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { McpTool, McpResource, ServerEntry, ToolMetadata } from "./types.ts";
-import { formatToolName, isToolExcluded, type ToolPrefix } from "./types.ts";
+import type { McpTool, McpResource, McpPrompt, McpPromptArgument, ServerEntry, ToolMetadata, PromptMetadata } from "./types.ts";
+import { formatPromptCommandName, formatToolName, isToolExcluded, type ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -32,10 +32,18 @@ export interface CachedResource {
   description?: string;
 }
 
+export interface CachedPrompt {
+  name: string;
+  title?: string;
+  description?: string;
+  arguments?: { name: string; description?: string; required?: boolean }[];
+}
+
 export interface ServerCacheEntry {
   configHash: string;
   tools: CachedTool[];
   resources: CachedResource[];
+  prompts?: CachedPrompt[];
   instructions?: string;
   cachedAt: number;
 }
@@ -203,6 +211,47 @@ export function serializeResources(resources: McpResource[]): CachedResource[] {
       name: r.name,
       description: r.description,
     }));
+}
+
+export function serializePrompts(prompts: McpPrompt[]): CachedPrompt[] {
+  return (prompts ?? [])
+    .filter(prompt => prompt?.name)
+    .map(prompt => ({
+      name: prompt.name,
+      title: prompt.title,
+      description: prompt.description,
+      arguments: Array.isArray(prompt.arguments)
+        ? prompt.arguments.filter(argument => argument?.name).map(argument => ({
+            name: argument.name,
+            description: argument.description,
+            required: argument.required,
+          }))
+        : undefined,
+    }));
+}
+
+export function reconstructPromptMetadata(
+  serverName: string,
+  prompts: ReadonlyArray<McpPrompt | CachedPrompt>,
+  prefix: ToolPrefix,
+): PromptMetadata[] {
+  return (prompts ?? []).filter(prompt => prompt?.name).map(prompt => {
+    const args: McpPromptArgument[] = Array.isArray(prompt.arguments)
+      ? prompt.arguments.filter(argument => argument?.name).map(argument => ({
+          name: argument.name,
+          description: argument.description,
+          required: argument.required,
+        }))
+      : [];
+    return {
+      serverName,
+      originalName: prompt.name,
+      commandName: formatPromptCommandName(prompt.name, serverName, prefix),
+      title: prompt.title,
+      description: prompt.description ?? "",
+      arguments: args,
+    };
+  });
 }
 
 function stableStringify(value: unknown): string {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "proxy-modes.ts",
     "direct-tools.ts",
     "commands.ts",
+    "prompts.ts",
     "onboarding-state.ts",
     "mcp-setup-panel.ts",
     "types.ts",

--- a/prompts.ts
+++ b/prompts.ts
@@ -1,0 +1,353 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type {
+  GetPromptResult,
+  PromptMessage,
+} from "@modelcontextprotocol/client";
+import type { McpExtensionState } from "./state.ts";
+import { isServerDisabled, type McpConfig, type PromptMetadata } from "./types.ts";
+import { formatPromptCommandName } from "./types.ts";
+import { lazyConnect } from "./init.ts";
+import { isServerCacheValid, loadMetadataCache, reconstructPromptMetadata } from "./metadata-cache.ts";
+import { logger } from "./logger.ts";
+import { truncateAtWord } from "./utils.ts";
+
+/**
+ * Resolve prompt metadata for slash-command registration at extension load
+ * time. Mirrors `resolveDirectTools`: reads the persistent metadata cache so
+ * commands are available before any server connects.
+ */
+export function resolveCachedPrompts(config: McpConfig): PromptMetadata[] {
+  const cache = loadMetadataCache();
+  if (!cache?.servers) return [];
+
+  const prefix = config.settings?.toolPrefix ?? "server";
+  const specs: PromptMetadata[] = [];
+
+  for (const [serverName, entry] of Object.entries(cache.servers)) {
+    const definition = config.mcpServers[serverName];
+    if (!definition || isServerDisabled(definition)) continue;
+    if (!entry?.prompts?.length || !isServerCacheValid(entry, definition)) continue;
+    specs.push(...reconstructPromptMetadata(serverName, entry.prompts, prefix));
+  }
+
+  return specs;
+}
+
+/**
+ * Parse a slash-command argument string into positional and named MCP prompt
+ * arguments. Supports bash-style quoting so callers can pass values with
+ * spaces:
+ *
+ *   /mcp__demo__brief today "important tasks"
+ *   /mcp__demo__brief day=today topic="important tasks"
+ */
+export function parsePromptArgs(input: string): { positional: string[]; named: Record<string, string> } {
+  const positional: string[] = [];
+  const named: Record<string, string> = {};
+
+  const tokens = tokenizeArgs(input);
+  for (const token of tokens) {
+    const eq = findUnquotedEquals(token);
+    if (eq > 0) {
+      const key = token.slice(0, eq).trim();
+      const value = stripQuotes(token.slice(eq + 1).trim());
+      if (key) {
+        named[key] = value;
+        continue;
+      }
+    }
+    positional.push(stripQuotes(token));
+  }
+
+  return { positional, named };
+}
+
+function tokenizeArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function findUnquotedEquals(token: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < token.length; i++) {
+    const ch = token[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") quote = ch;
+    else if (ch === "=") return i;
+  }
+  return -1;
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2 && (value.startsWith('"') || value.startsWith("'")) && value.endsWith(value[0])) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export interface ResolvedPromptArgs {
+  ok: boolean;
+  /** Present when `ok === true`. */
+  args?: Record<string, string>;
+  /** Present when `ok === false`. */
+  error?: string;
+}
+
+/**
+ * Map positional and named arguments onto the prompt's declared argument
+ * list. Named arguments win over positional when both target the same slot.
+ * Missing required arguments produce a helpful usage message that the
+ * command handler surfaces via `ctx.ui.notify`.
+ */
+export function resolvePromptArgs(
+  metadata: PromptMetadata,
+  parsed: { positional: string[]; named: Record<string, string> },
+): ResolvedPromptArgs {
+  const args: Record<string, string> = {};
+
+  const declared = metadata.arguments;
+  let positionalIndex = 0;
+  for (const argDef of declared) {
+    const value = parsed.named[argDef.name] ?? parsed.positional[positionalIndex++];
+    if (value !== undefined && value !== "") {
+      args[argDef.name] = value;
+    }
+  }
+
+  // Preserve named arguments the prompt did not declare so servers with
+  // permissive schemas still receive them. The MCP spec allows arbitrary
+  // string key/values in `prompts/get` params.arguments.
+  for (const [key, value] of Object.entries(parsed.named)) {
+    if (!(key in args)) args[key] = value;
+  }
+
+  const missing = declared.filter(a => a.required && (args[a.name] === undefined || args[a.name] === ""));
+  if (missing.length > 0) {
+    return { ok: false, error: buildUsageMessage(metadata, missing) };
+  }
+
+  return { ok: true, args };
+}
+
+function buildUsageMessage(metadata: PromptMetadata, missing: PromptMetadata["arguments"]): string {
+  const usage = metadata.arguments
+    .map(a => (a.required ? `<${a.name}>` : `[${a.name}]`))
+    .join(" ");
+  const missingList = missing.map(a => a.name).join(", ");
+  return `Missing required argument${missing.length > 1 ? "s" : ""}: ${missingList}.\nUsage: /${metadata.commandName} ${usage}`.trim();
+}
+
+/**
+ * Flatten a `GetPromptResult` into a single string suitable for
+ * `pi.sendUserMessage`. MCP prompts can contain multiple messages with
+ * mixed roles; we preserve role attribution as inline markers so the model
+ * still sees the intended conversational shape without needing a
+ * multi-message replay API on the pi side.
+ */
+export function formatPromptResult(result: GetPromptResult): string {
+  const lines: string[] = [];
+  for (const message of result.messages) {
+    const text = extractMessageText(message);
+    if (!text) continue;
+    if (message.role === "user" && result.messages.length === 1) {
+      lines.push(text);
+    } else {
+      lines.push(`[${message.role}] ${text}`);
+    }
+  }
+  return lines.join("\n\n").trim();
+}
+
+function extractMessageText(message: PromptMessage): string {
+  const content = message.content;
+  if (!content || typeof content !== "object") return "";
+  switch (content.type) {
+    case "text":
+      return content.text ?? "";
+    case "resource": {
+      const resource = content.resource;
+      if (!resource) return "";
+      if ("text" in resource && typeof resource.text === "string") {
+        return `[resource ${resource.uri}]\n${resource.text}`;
+      }
+      return `[resource ${resource.uri}]`;
+    }
+    case "resource_link":
+      return `[resource_link ${content.uri ?? ""}${content.name ? ` — ${content.name}` : ""}]`;
+    case "image":
+      return `[image ${content.mimeType ?? "unknown"}${content.data ? " (embedded)" : ""}]`;
+    case "audio":
+      return `[audio ${content.mimeType ?? "unknown"}]`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Build the pi command definition for a single MCP prompt. Registered once
+ * per prompt at extension load time from the metadata cache; the same
+ * factory is reused by tests to invoke the handler without a running pi.
+ */
+export function createPromptCommand(
+  pi: ExtensionAPI,
+  getState: () => McpExtensionState | null,
+  metadata: PromptMetadata,
+) {
+  const description = buildCommandDescription(metadata);
+
+  return {
+    description,
+    handler: async (args: string, ctx: ExtensionCommandContext) => {
+      const state = getState();
+      if (!state) {
+        if (ctx.hasUI) ctx.ui.notify("MCP not initialized", "error");
+        return;
+      }
+
+      const liveMetadata = findLivePromptMetadata(state, metadata.serverName, metadata.originalName);
+      if (state.promptMetadataLive?.has(metadata.serverName) && !liveMetadata) {
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            `MCP prompt "${metadata.originalName}" is no longer advertised by server "${metadata.serverName}". Run /mcp reconnect to refresh.`,
+            "error",
+          );
+        }
+        return;
+      }
+      const live = liveMetadata ?? metadata;
+      const parsed = parsePromptArgs(args ?? "");
+      const resolved = resolvePromptArgs(live, parsed);
+      if (!resolved.ok) {
+        if (ctx.hasUI) ctx.ui.notify(resolved.error ?? "Invalid prompt arguments", "error");
+        return;
+      }
+      const promptArgs = resolved.args ?? {};
+
+      if (!state.config.mcpServers[metadata.serverName]) {
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            `MCP prompt "${live.originalName}" is no longer configured. Run /mcp reconnect to refresh.`,
+            "error",
+          );
+        }
+        return;
+      }
+
+      const connected = await lazyConnect(state, metadata.serverName, ctx.signal);
+      if (!connected) {
+        if (ctx.hasUI) {
+          const conn = state.manager.getConnection(metadata.serverName);
+          const message = conn?.status === "needs-auth"
+            ? `MCP server "${metadata.serverName}" needs authentication. Run /mcp-auth ${metadata.serverName}.`
+            : `MCP server "${metadata.serverName}" is not available. Run /mcp reconnect ${metadata.serverName}.`;
+          ctx.ui.notify(message, "error");
+        }
+        return;
+      }
+
+      const refreshed = findLivePromptMetadata(state, metadata.serverName, metadata.originalName);
+      if (state.promptMetadataLive?.has(metadata.serverName) && !refreshed) {
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            `MCP prompt "${metadata.originalName}" is no longer advertised by server "${metadata.serverName}". Run /mcp reconnect to refresh.`,
+            "error",
+          );
+        }
+        return;
+      }
+      const dispatchMetadata = refreshed ?? live;
+      let result: GetPromptResult;
+      try {
+        result = await state.manager.getPrompt(
+          metadata.serverName,
+          dispatchMetadata.originalName,
+          Object.keys(promptArgs).length > 0 ? promptArgs : undefined,
+          ctx.signal,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.debug(`MCP prompt "${live.originalName}" on ${metadata.serverName} failed: ${message}`);
+        if (ctx.hasUI) {
+          ctx.ui.notify(`MCP prompt "${live.originalName}" failed: ${message}`, "error");
+        }
+        return;
+      }
+
+      const text = formatPromptResult(result);
+      if (!text) {
+        if (ctx.hasUI) {
+          ctx.ui.notify(`MCP prompt "${live.originalName}" returned no text content.`, "warning");
+        }
+        return;
+      }
+
+      pi.sendUserMessage(text);
+    },
+  };
+}
+
+function findLivePromptMetadata(
+  state: McpExtensionState,
+  serverName: string,
+  originalName: string,
+): PromptMetadata | undefined {
+  return state.promptMetadata?.get(serverName)?.find(p => p.originalName === originalName);
+}
+
+function buildCommandDescription(metadata: PromptMetadata): string {
+  const base = metadata.description || metadata.title || `MCP prompt from ${metadata.serverName}`;
+  return truncateAtWord(`MCP: ${base}`, 120) || `MCP prompt from ${metadata.serverName}`;
+}
+
+/**
+ * Public helper used by `/mcp prompts` to render the list of prompts known
+ * to the adapter, whether from a live connection or the metadata cache.
+ */
+export function listAllPromptMetadata(state: McpExtensionState): PromptMetadata[] {
+  const flat: PromptMetadata[] = [];
+  for (const list of state.promptMetadata?.values() ?? []) flat.push(...list);
+  flat.sort((a, b) => a.commandName.localeCompare(b.commandName));
+  return flat;
+}
+
+// Re-exported so index.ts can format cache-only prompt-command names without
+// duplicating the namespace logic.
+export { formatPromptCommandName };

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -8,6 +8,7 @@ import { lazyConnect, markKeepAliveAfterConnect, notifyToolMetadataUpdated, upda
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
+import { reconstructPromptMetadata } from "./metadata-cache.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
@@ -693,6 +694,10 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     const prefix = state.config.settings?.toolPrefix ?? "server";
     const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
     state.toolMetadata.set(serverName, metadata);
+    if (!connection.promptDiscoveryFailed) {
+      state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix));
+      state.promptMetadataLive?.add(serverName);
+    }
     if (connection.instructions) {
       state.serverInstructions.set(serverName, connection.instructions);
     } else {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -12,6 +12,7 @@ import {
   isServerDisabled,
   type McpTool,
   type McpResource,
+  type McpPrompt,
   type ServerDefinition,
   type ServerStreamResultPatchNotification,
   type Transport,
@@ -73,6 +74,9 @@ export interface ServerConnection {
   definition: ServerDefinition;
   tools: McpTool[];
   resources: McpResource[];
+  prompts: McpPrompt[];
+  /** True when prompts were advertised but prompts/list failed. */
+  promptDiscoveryFailed?: boolean;
   instructions?: string;
   lastUsedAt: number;
   inFlight: number;
@@ -319,6 +323,7 @@ export class McpServerManager {
         definition,
         tools: [],
         resources: [],
+        prompts: [],
         instructions: client.getInstructions?.(),
         lastUsedAt: Date.now(),
         inFlight: 0,
@@ -341,13 +346,17 @@ export class McpServerManager {
         }
       };
 
-      // Discover tools and resources
-      const [tools, resources] = await Promise.all([
+      // Discover tools, resources, and prompts. Prompt listing is optional:
+      // only servers advertising the capability are queried.
+      const [tools, resources, promptResult] = await Promise.all([
         this.fetchAllTools(client, requestOptions),
         this.fetchAllResources(client, requestOptions),
+        this.fetchAllPrompts(client, requestOptions),
       ]);
       connection.tools = tools;
       connection.resources = resources;
+      connection.prompts = promptResult.prompts;
+      connection.promptDiscoveryFailed = promptResult.failed;
 
       return connection;
     } catch (error) {
@@ -376,6 +385,7 @@ export class McpServerManager {
           definition,
           tools: [],
           resources: [],
+          prompts: [],
           lastUsedAt: Date.now(),
           inFlight: 0,
           status: "needs-auth",
@@ -458,6 +468,11 @@ export class McpServerManager {
               this.handleResourcesListChanged(serverName, client, error, resources);
             },
           },
+          prompts: {
+            onChanged: (error: Error | null, prompts: McpPrompt[] | null) => {
+              this.handlePromptsListChanged(serverName, client, error, prompts);
+            },
+          },
         },
       },
     );
@@ -500,6 +515,24 @@ export class McpServerManager {
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.tools = tools;
     this.metadataListChangedListener?.(serverName, "tools-list-changed");
+  }
+
+  private handlePromptsListChanged(
+    serverName: string,
+    client: Client,
+    error: Error | null,
+    prompts: McpPrompt[] | null,
+  ): void {
+    if (error) {
+      logger.debug(`MCP: prompts/list_changed refresh failed for ${serverName}: ${error.message}`);
+      return;
+    }
+    if (!prompts) return;
+    const connection = this.connections.get(serverName);
+    if (!connection || connection.client !== client || connection.status !== "connected") return;
+    connection.prompts = prompts;
+    connection.promptDiscoveryFailed = false;
+    this.metadataListChangedListener?.(serverName, "prompts-list-changed");
   }
 
   private handleResourcesListChanged(
@@ -663,6 +696,30 @@ export class McpServerManager {
     return allTools;
   }
 
+  private async fetchAllPrompts(
+    client: Client,
+    requestOptions?: RequestOptions,
+  ): Promise<{ prompts: McpPrompt[]; failed: boolean }> {
+    const capabilities = client.getServerCapabilities?.();
+    if (!capabilities?.prompts) return { prompts: [], failed: false };
+
+    try {
+      const prompts: McpPrompt[] = [];
+      let cursor: string | undefined;
+      do {
+        const result = await client.listPrompts(cursor ? { cursor } : undefined, requestOptions);
+        prompts.push(...(result.prompts ?? []));
+        cursor = result.nextCursor;
+      } while (cursor);
+      return { prompts, failed: false };
+    } catch (error) {
+      if (requestOptions?.signal?.aborted) throwIfAborted(requestOptions.signal);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: prompts/list failed: ${message}`);
+      return { prompts: [], failed: true };
+    }
+  }
+
   private async fetchAllResources(client: Client, requestOptions?: RequestOptions): Promise<McpResource[]> {
     try {
       const allResources: McpResource[] = [];
@@ -702,6 +759,29 @@ export class McpServerManager {
 
   removeUiStreamListener(streamToken: string): void {
     this.uiStreamListeners.delete(streamToken);
+  }
+
+  async getPrompt(
+    name: string,
+    promptName: string,
+    args?: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<import("@modelcontextprotocol/client").GetPromptResult> {
+    const connection = this.connections.get(name);
+    if (!connection || connection.status !== "connected") {
+      throw new Error(`Server "${name}" is not connected`);
+    }
+    try {
+      this.touch(name);
+      this.incrementInFlight(name);
+      return await connection.client.getPrompt(
+        { name: promptName, ...(args ? { arguments: args } : {}) },
+        this.getRequestOptions(name, signal),
+      );
+    } finally {
+      this.decrementInFlight(name);
+      this.touch(name);
+    }
   }
 
   async readResource(name: string, uri: string, signal?: AbortSignal): Promise<ReadResourceResult> {

--- a/state.ts
+++ b/state.ts
@@ -3,7 +3,7 @@ import type { ConsentManager } from "./consent-manager.ts";
 import type { McpLifecycleManager } from "./lifecycle.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import type { AuthStorageOptions } from "./mcp-auth.ts";
-import type { ToolMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from "./types.ts";
+import type { ToolMetadata, PromptMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from "./types.ts";
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
 import type { UiServerHandle } from "./ui-server.ts";
 import type { McpRuntimeOwner } from "./runtime-owner.ts";
@@ -33,6 +33,9 @@ export interface McpExtensionState {
   manager: McpServerManager;
   lifecycle: McpLifecycleManager;
   toolMetadata: Map<string, ToolMetadata[]>;
+  promptMetadata: Map<string, PromptMetadata[]>;
+  /** Servers whose prompt inventory came from successful live discovery. */
+  promptMetadataLive: Set<string>;
   serverInstructions: Map<string, string>;
   config: McpConfig;
   programmaticConfig?: boolean;

--- a/types.ts
+++ b/types.ts
@@ -38,6 +38,20 @@ export interface McpResource {
   _meta?: Record<string, unknown>;
 }
 
+export interface McpPromptArgument {
+  name: string;
+  description?: string;
+  required?: boolean;
+}
+
+export interface McpPrompt {
+  name: string;
+  title?: string;
+  description?: string;
+  arguments?: McpPromptArgument[];
+  _meta?: Record<string, unknown>;
+}
+
 export interface UiResourceMeta {
   csp?: UiResourceCsp;
   permissions?: UiResourcePermissions;
@@ -392,6 +406,15 @@ export interface ToolMetadata {
   uiStreamMode?: UiStreamMode;
 }
 
+export interface PromptMetadata {
+  serverName: string;
+  originalName: string;
+  commandName: string;
+  title?: string;
+  description: string;
+  arguments: McpPromptArgument[];
+}
+
 export interface DirectToolSpec {
   serverName: string;
   originalName: string;
@@ -456,6 +479,21 @@ export function formatToolName(
   const p = getServerPrefix(serverName, prefix);
   const sanitized = toolName.replace(/\./g, "_");
   return p ? `${p}_${sanitized}` : sanitized;
+}
+
+export function sanitizePromptName(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "");
+  if (!cleaned) return "prompt";
+  return /^[0-9]/.test(cleaned) ? `_${cleaned}` : cleaned;
+}
+
+export function formatPromptCommandName(
+  promptName: string,
+  serverName: string,
+  prefix: ToolPrefix,
+): string {
+  const serverPart = getServerPrefix(serverName, prefix) || serverName.replace(/-/g, "_") || "server";
+  return `mcp__${serverPart}__${sanitizePromptName(promptName)}`;
 }
 
 function normalizeToolName(value: string): string {


### PR DESCRIPTION
## Summary

Adds MCP prompts support. Servers that advertise the [`prompts` capability](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts) — agent-board, atlas, etc. — get their prompt templates surfaced as pi slash commands. Prompts join tools and resources as first-class MCP surfaces bridged into pi.

## Changes

- Discover prompts during connect only when the server advertises the capability — no wire calls otherwise. Paginated `prompts/list` cursors are followed to completion.
- Cache alongside tools/resources in `mcp-cache.json`. `ServerCacheEntry.prompts` is optional so existing caches keep working.
- Register each prompt as `pi.registerCommand("mcp__<server>__<prompt>", ...)`, matching Claude Code's convention. Names with dots/spaces/leading digits are sanitised; the server portion honours the existing `toolPrefix` setting. Collisions drop the second registration with a debug log.
- Handler lazy-connects, parses positional / `key=value` / bash-quoted args, validates required arguments with a usage hint, calls `prompts/get`, and delivers the result via `pi.sendUserMessage()`. Multi-turn prompts are flattened with role attribution.
- `/mcp prompts` lists everything the adapter knows about, cached or live.

## UX

```
$ /mcp__agent_board__status
… server-provided prompt content is sent as the next user message …

$ /mcp prompts
agent-board:
  /mcp__agent_board__status [pipeline_id]
      Show status of active pipelines
  /mcp__agent_board__paused
      Report all pipelines waiting for human input
```

No new config surface — a server that doesn't advertise `capabilities.prompts` gets nothing wired.

## Validation

- `npx tsc --noEmit` clean
- `npm test` — 465 passing, 2 pre-existing failures on `examples/interactive-visualizer/dist/*` unrelated to this branch
- New coverage: `prompts.test.ts` (23), `prompts-sdk-integration.test.ts` (6, real stdio fixture), `index-lifecycle.test.ts` (+19 including collision-drop guard)
