### PR TITLE
feat: support environment variables in HTTP MCP server URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added environment-variable interpolation for HTTP MCP server URLs, with missing URL variables failing closed before requests are sent. Thanks @ozeias for PR #206.
 - Added `settings.oauthDir` to store MCP OAuth credentials in a project-specific directory, with `MCP_OAUTH_DIR` still taking precedence. Thanks @Termina1 for PR #105.
 - Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `args` | Command arguments |
 | `env` | Environment variables; supports `${VAR}` and `$env:VAR` interpolation |
 | `cwd` | Working directory; supports `${VAR}`, `$env:VAR`, and `~` expansion |
-| `url` | HTTP endpoint (StreamableHTTP with SSE fallback) |
+| `url` | HTTP endpoint (StreamableHTTP with SSE fallback); supports `${VAR}` and `$env:VAR` interpolation |
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `args` | Command arguments |
 | `env` | Environment variables; supports `${VAR}` and `$env:VAR` interpolation |
 | `cwd` | Working directory; supports `${VAR}`, `$env:VAR`, and `~` expansion |
-| `url` | HTTP endpoint (StreamableHTTP with SSE fallback); supports `${VAR}` and `$env:VAR` interpolation |
+| `url` | HTTP endpoint (StreamableHTTP with SSE fallback); supports raw `${VAR}` and `$env:VAR` interpolation, and missing URL variables fail before any request is sent |
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -46,6 +46,31 @@ describe("authenticateServer", () => {
     }
   });
 
+  it("fails OAuth authentication before requests when URL variables are missing", async () => {
+    const originalUrl = process.env.MCP_AUTH_URL;
+    delete process.env.MCP_AUTH_URL;
+    mocks.authenticate.mockClear();
+    const ui = { notify: vi.fn(), setStatus: vi.fn() };
+    const { authenticateServer } = await import("../commands.ts");
+
+    try {
+      const result = await authenticateServer("sentry", {
+        mcpServers: { sentry: { url: "https://${MCP_AUTH_URL}/mcp", auth: "oauth" } },
+      }, { hasUI: true, ui } as any);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Missing environment variable in MCP server URL: MCP_AUTH_URL");
+      expect(mocks.authenticate).not.toHaveBeenCalled();
+      expect(ui.notify).toHaveBeenCalledWith(
+        'Failed to authenticate "sentry": Missing environment variable in MCP server URL: MCP_AUTH_URL',
+        "error",
+      );
+    } finally {
+      if (originalUrl === undefined) delete process.env.MCP_AUTH_URL;
+      else process.env.MCP_AUTH_URL = originalUrl;
+    }
+  });
+
   it("surfaces the exact OAuth URL through UI notification", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -20,6 +20,32 @@ vi.mock("../init.ts", () => ({
 }));
 
 describe("authenticateServer", () => {
+  it("interpolates the server URL before OAuth authentication", async () => {
+    const originalUrl = process.env.MCP_AUTH_URL;
+    process.env.MCP_AUTH_URL = "https://mcp.sentry.dev/mcp";
+    mocks.authenticate.mockResolvedValueOnce("authenticated");
+    const ui = { notify: vi.fn(), setStatus: vi.fn() };
+    const { authenticateServer } = await import("../commands.ts");
+
+    try {
+      const definition = { url: "${MCP_AUTH_URL}", auth: "oauth" as const };
+      const result = await authenticateServer("sentry", {
+        mcpServers: { sentry: definition },
+      }, { hasUI: true, ui } as any);
+
+      expect(result.ok).toBe(true);
+      expect(mocks.authenticate).toHaveBeenCalledWith(
+        "sentry",
+        "https://mcp.sentry.dev/mcp",
+        definition,
+        { onAuthorizationUrl: expect.any(Function) },
+      );
+    } finally {
+      if (originalUrl === undefined) delete process.env.MCP_AUTH_URL;
+      else process.env.MCP_AUTH_URL = originalUrl;
+    }
+  });
+
   it("surfaces the exact OAuth URL through UI notification", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -152,6 +152,19 @@ describe("buildProxyDescription", () => {
 });
 
 describe("metadata cache hashing", () => {
+  it("hashes interpolated URLs", () => {
+    process.env.MCP_HASH_URL = "https://one.example.test/mcp";
+    const first = computeServerHash({ url: "${MCP_HASH_URL}" });
+
+    process.env.MCP_HASH_URL = "https://two.example.test/mcp";
+    const second = computeServerHash({ url: "${MCP_HASH_URL}" });
+
+    expect(first).not.toBe(second);
+    expect(computeServerHash({ url: "${MCP_HASH_URL}" })).toBe(
+      computeServerHash({ url: "https://two.example.test/mcp" }),
+    );
+  });
+
   it("hashes interpolated cwd", () => {
     process.env.MCP_HASH_CWD = "/tmp/mcp-one";
     const first = computeServerHash({ command: "node", cwd: "${MCP_HASH_CWD}/server" });

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -12,6 +12,7 @@ const originalHashEnv = {
   MCP_HASH_ENV: process.env.MCP_HASH_ENV,
   MCP_HASH_HEADER: process.env.MCP_HASH_HEADER,
   MCP_HASH_TOKEN: process.env.MCP_HASH_TOKEN,
+  MCP_HASH_URL: process.env.MCP_HASH_URL,
 };
 
 afterEach(() => {
@@ -163,6 +164,49 @@ describe("metadata cache hashing", () => {
     expect(computeServerHash({ url: "${MCP_HASH_URL}" })).toBe(
       computeServerHash({ url: "https://two.example.test/mcp" }),
     );
+  });
+
+  it("does not hash URL placeholders with missing environment variables", () => {
+    delete process.env.MCP_HASH_URL;
+
+    expect(() => computeServerHash({ url: "https://${MCP_HASH_URL}/mcp" })).toThrow(
+      "Missing environment variable in MCP server URL: MCP_HASH_URL",
+    );
+  });
+
+  it("treats cached URL placeholders with missing environment variables as cache misses", () => {
+    delete process.env.MCP_HASH_URL;
+
+    expect(isServerCacheValid({
+      configHash: "cached",
+      cachedAt: Date.now(),
+      tools: [],
+      resources: [],
+    }, { url: "https://${MCP_HASH_URL}/mcp" })).toBe(false);
+  });
+
+  it("skips cached direct tools when URL placeholders are missing", () => {
+    delete process.env.MCP_HASH_URL;
+
+    const config: McpConfig = {
+      settings: { directTools: true },
+      mcpServers: {
+        remote: { url: "https://${MCP_HASH_URL}/mcp" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        remote: {
+          configHash: "cached",
+          cachedAt: Date.now(),
+          tools: [{ name: "search", inputSchema: { type: "object" } }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
   });
 
   it("hashes interpolated cwd", () => {

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -75,6 +75,7 @@ describe("McpServerManager HTTP bearer auth", () => {
   const originalEnv = {
     MCP_TEST_BEARER_TOKEN: process.env.MCP_TEST_BEARER_TOKEN,
     MCP_TEST_BEARER_TOKEN_ENV: process.env.MCP_TEST_BEARER_TOKEN_ENV,
+    MCP_TEST_URL: process.env.MCP_TEST_URL,
   };
 
   beforeEach(() => {
@@ -90,6 +91,30 @@ describe("McpServerManager HTTP bearer auth", () => {
         process.env[key] = value;
       }
     }
+  });
+
+  it("interpolates ${VAR} URL placeholders", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    process.env.MCP_TEST_URL = "https://example.test/mcp";
+
+    const manager = new McpServerManager();
+    await manager.connect("remote", {
+      url: "${MCP_TEST_URL}",
+    });
+
+    expect(mocks.httpTransports.at(-1)!.url.href).toBe("https://example.test/mcp");
+  });
+
+  it("interpolates $env:VAR URL placeholders", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    process.env.MCP_TEST_URL = "https://example.test/mcp";
+
+    const manager = new McpServerManager();
+    await manager.connect("remote", {
+      url: "$env:MCP_TEST_URL",
+    });
+
+    expect(mocks.httpTransports.at(-1)!.url.href).toBe("https://example.test/mcp");
   });
 
   it("interpolates ${VAR} bearerToken placeholders", async () => {

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -117,6 +117,18 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(mocks.httpTransports.at(-1)!.url.href).toBe("https://example.test/mcp");
   });
 
+  it("fails closed when URL placeholders are missing", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    delete process.env.MCP_TEST_URL;
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("remote", {
+      url: "https://${MCP_TEST_URL}/mcp",
+    })).rejects.toThrow("Missing environment variable in MCP server URL: MCP_TEST_URL");
+
+    expect(mocks.httpTransports).toHaveLength(0);
+  });
+
   it("interpolates ${VAR} bearerToken placeholders", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     process.env.MCP_TEST_BEARER_TOKEN = "placeholder-token";

--- a/commands.ts
+++ b/commands.ts
@@ -18,7 +18,7 @@ import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth } from "./mcp-auth-flow.ts";
 import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
-import { openPath } from "./utils.ts";
+import { openPath, resolveServerUrl } from "./utils.ts";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -166,7 +166,8 @@ export async function authenticateServer(
     return { ok: false, message };
   }
 
-  if (!definition.url) {
+  const serverUrl = resolveServerUrl(definition);
+  if (!serverUrl) {
     const message = `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`;
     ctx.ui.notify(message, "error");
     return { ok: false, message };
@@ -175,7 +176,7 @@ export async function authenticateServer(
   try {
     ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
     const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
-    const status = await authenticate(serverName, definition.url, definition, {
+    const status = await authenticate(serverName, serverUrl, definition, {
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
       onAuthorizationUrl: (authorizationUrl) => {
         ctx.ui.notify(
@@ -331,12 +332,13 @@ function buildMcpPanelCallbacks(
       if (connection?.status === "needs-auth") {
         return "needs-auth";
       }
+      const serverUrl = definition ? resolveServerUrl(definition) : undefined;
       if (
         definition?.auth === "oauth"
-        && definition.url
+        && serverUrl
         && definition.oauth !== false
         && definition.oauth?.grantType !== "client_credentials"
-        && !getAuthForUrl(serverName, definition.url, state.authStorageOptions)?.tokens
+        && !getAuthForUrl(serverName, serverUrl, state.authStorageOptions)?.tokens
       ) {
         return "needs-auth";
       }

--- a/commands.ts
+++ b/commands.ts
@@ -166,14 +166,14 @@ export async function authenticateServer(
     return { ok: false, message };
   }
 
-  const serverUrl = resolveServerUrl(definition);
-  if (!serverUrl) {
-    const message = `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`;
-    ctx.ui.notify(message, "error");
-    return { ok: false, message };
-  }
-
   try {
+    const serverUrl = resolveServerUrl(definition);
+    if (!serverUrl) {
+      const message = `Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`;
+      ctx.ui.notify(message, "error");
+      return { ok: false, message };
+    }
+
     ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`);
     const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, ctx.cwd);
     const status = await authenticate(serverName, serverUrl, definition, {
@@ -332,7 +332,12 @@ function buildMcpPanelCallbacks(
       if (connection?.status === "needs-auth") {
         return "needs-auth";
       }
-      const serverUrl = definition ? resolveServerUrl(definition) : undefined;
+      let serverUrl: string | undefined;
+      try {
+        serverUrl = definition ? resolveServerUrl(definition) : undefined;
+      } catch {
+        return "failed";
+      }
       if (
         definition?.auth === "oauth"
         && serverUrl

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -13,7 +13,7 @@ import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } 
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
@@ -49,7 +49,8 @@ async function attemptDirectAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition || !supportsOAuth(definition) || !definition.url) {
+  const serverUrl = definition ? resolveServerUrl(definition) : undefined;
+  if (!definition || !supportsOAuth(definition) || !serverUrl) {
     return { status: "skipped" };
   }
 
@@ -67,9 +68,9 @@ async function attemptDirectAutoAuth(
 
   try {
     if (state.authStorageOptions) {
-      await authenticate(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions });
+      await authenticate(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions });
     } else {
-      await authenticate(serverName, definition.url, definition);
+      await authenticate(serverName, serverUrl, definition);
     }
     return { status: "success" };
   } catch (error) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -49,8 +49,18 @@ async function attemptDirectAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  const serverUrl = definition ? resolveServerUrl(definition) : undefined;
-  if (!definition || !supportsOAuth(definition) || !serverUrl) {
+  if (!definition || !supportsOAuth(definition)) {
+    return { status: "skipped" };
+  }
+
+  let serverUrl: string | undefined;
+  try {
+    serverUrl = resolveServerUrl(definition);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "failed", message: getDirectAuthFailedMessage(state, serverName, message) };
+  }
+  if (!serverUrl) {
     return { status: "skipped" };
   }
 

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -114,7 +114,13 @@ export function isServerCacheValid(
   definition: ServerEntry,
   maxAgeMs: number = CACHE_MAX_AGE_MS
 ): boolean {
-  if (!entry || entry.configHash !== computeServerHash(definition)) return false;
+  let configHash: string;
+  try {
+    configHash = computeServerHash(definition);
+  } catch {
+    return false;
+  }
+  if (!entry || entry.configHash !== configHash) return false;
   if (!entry.cachedAt || typeof entry.cachedAt !== "number") return false;
   if (maxAgeMs > 0 && Date.now() - entry.cachedAt > maxAgeMs) return false;
   return true;

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -7,7 +7,13 @@ import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { McpTool, McpResource, ServerEntry, ToolMetadata } from "./types.ts";
 import { formatToolName, isToolExcluded } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
-import { extractToolUiStreamMode, interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
+import {
+  extractToolUiStreamMode,
+  interpolateEnvRecord,
+  resolveBearerToken,
+  resolveConfigPath,
+  resolveServerUrl,
+} from "./utils.ts";
 
 const CACHE_VERSION = 1;
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -91,7 +97,7 @@ export function computeServerHash(definition: ServerEntry): string {
     args: definition.args,
     env: interpolateEnvRecord(definition.env),
     cwd: resolveConfigPath(definition.cwd),
-    url: definition.url,
+    url: resolveServerUrl(definition),
     headers: interpolateEnvRecord(definition.headers),
     auth: definition.auth,
     bearerToken: resolveBearerToken(definition),

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -10,7 +10,7 @@ import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from ".
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatAuthRequiredMessage, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 
@@ -87,7 +87,8 @@ async function attemptAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition || !supportsOAuth(definition) || !definition.url) {
+  const serverUrl = definition ? resolveServerUrl(definition) : undefined;
+  if (!definition || !supportsOAuth(definition) || !serverUrl) {
     return { status: "skipped" };
   }
 
@@ -105,9 +106,9 @@ async function attemptAutoAuth(
 
   try {
     if (state.authStorageOptions) {
-      await authenticate(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions });
+      await authenticate(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions });
     } else {
-      await authenticate(serverName, definition.url, definition);
+      await authenticate(serverName, serverUrl, definition);
     }
     return { status: "success" };
   } catch (error) {
@@ -262,7 +263,8 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
     };
   }
 
-  if (!definition.url || !supportsOAuth(definition)) {
+  const serverUrl = resolveServerUrl(definition);
+  if (!serverUrl || !supportsOAuth(definition)) {
     return {
       content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
       details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
@@ -271,8 +273,8 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
 
   try {
     const { authorizationUrl } = state.authStorageOptions
-      ? await startAuth(serverName, definition.url, definition, { authStorageOptions: state.authStorageOptions })
-      : await startAuth(serverName, definition.url, definition);
+      ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions })
+      : await startAuth(serverName, serverUrl, definition);
     if (!authorizationUrl) {
       return {
         content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -87,8 +87,18 @@ async function attemptAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  const serverUrl = definition ? resolveServerUrl(definition) : undefined;
-  if (!definition || !supportsOAuth(definition) || !serverUrl) {
+  if (!definition || !supportsOAuth(definition)) {
+    return { status: "skipped" };
+  }
+
+  let serverUrl: string | undefined;
+  try {
+    serverUrl = resolveServerUrl(definition);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "failed", message: getAuthFailedMessage(state, serverName, message) };
+  }
+  if (!serverUrl) {
     return { status: "skipped" };
   }
 
@@ -263,15 +273,15 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
     };
   }
 
-  const serverUrl = resolveServerUrl(definition);
-  if (!serverUrl || !supportsOAuth(definition)) {
-    return {
-      content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
-      details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
-    };
-  }
-
   try {
+    const serverUrl = resolveServerUrl(definition);
+    if (!serverUrl || !supportsOAuth(definition)) {
+      return {
+        content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
+        details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
+      };
+    }
+
     const { authorizationUrl } = state.authStorageOptions
       ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions })
       : await startAuth(serverName, serverUrl, definition);

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -28,7 +28,7 @@ import {
   registerElicitationHandler,
   type ServerElicitationConfig,
 } from "./elicitation-handler.ts";
-import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath } from "./utils.ts";
+import { interpolateEnvRecord, resolveBearerToken, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 
 export interface ServerConnection {
@@ -360,7 +360,8 @@ export class McpServerManager {
     signal?: AbortSignal,
   ): Promise<Transport> {
     throwIfAborted(signal);
-    const url = new URL(definition.url!);
+    const serverUrl = resolveServerUrl(definition)!;
+    const url = new URL(serverUrl);
 
     // Build headers first (including any bearer token)
     const headers = resolveHeaders(definition.headers) ?? {};
@@ -382,7 +383,7 @@ export class McpServerManager {
       const oauthConfig = extractOAuthConfig(definition);
       authProvider = new McpOAuthProvider(
         serverName,
-        definition.url!,
+        serverUrl,
         oauthConfig,
         {
           onRedirect: async (_authUrl) => {

--- a/utils.ts
+++ b/utils.ts
@@ -65,6 +65,17 @@ export function interpolateEnvVars(value: string): string {
     .replace(/\$env:(\w+)/g, (_, name) => process.env[name] ?? "");
 }
 
+function getMissingEnvVars(value: string): string[] {
+  const missing = new Set<string>();
+  for (const match of value.matchAll(/\$\{(\w+)\}|\$env:(\w+)/g)) {
+    const name = match[1] ?? match[2];
+    if (name && process.env[name] === undefined) {
+      missing.add(name);
+    }
+  }
+  return [...missing];
+}
+
 export function interpolateEnvRecord(values: Record<string, string> | undefined): Record<string, string> | undefined {
   if (!values) return undefined;
 
@@ -76,7 +87,20 @@ export function interpolateEnvRecord(values: Record<string, string> | undefined)
 }
 
 export function resolveServerUrl(definition: Pick<ServerEntry, "url">): string | undefined {
-  return definition.url === undefined ? undefined : interpolateEnvVars(definition.url);
+  if (definition.url === undefined) return undefined;
+
+  const missing = getMissingEnvVars(definition.url);
+  if (missing.length > 0) {
+    throw new Error(`Missing environment variable${missing.length === 1 ? "" : "s"} in MCP server URL: ${missing.join(", ")}`);
+  }
+
+  const resolved = interpolateEnvVars(definition.url);
+  try {
+    new URL(resolved);
+  } catch (error) {
+    throw new Error(`Invalid MCP server URL after environment interpolation: ${resolved}`, { cause: error });
+  }
+  return resolved;
 }
 
 export function resolveConfigPath(value: string | undefined): string | undefined {

--- a/utils.ts
+++ b/utils.ts
@@ -75,6 +75,10 @@ export function interpolateEnvRecord(values: Record<string, string> | undefined)
   return resolved;
 }
 
+export function resolveServerUrl(definition: Pick<ServerEntry, "url">): string | undefined {
+  return definition.url === undefined ? undefined : interpolateEnvVars(definition.url);
+}
+
 export function resolveConfigPath(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
 


### PR DESCRIPTION
## Summary

- Support `${VAR}` and `$env:VAR` in HTTP MCP server URLs.
- Use resolved URLs for transports, OAuth, and metadata cache identity.
- Document the supported URL placeholders.

This allows one MCP configuration to use environment-specific URLs across projects, worktrees and setups where configuration comes from secrets managers or environment-injected development tools.