### PR TITLE
fix: render MCP tools without a theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred loading the regex safety checker until regex search is used, improving startup time. Thanks @kaushikgopal for PR #175.
 
 ### Fixed
+- Avoided MCP renderer crashes without a TUI theme and preserved status-bar updates with plain fallback text. Thanks @fankangsong for PR #183.
 - Sanitized dotted MCP tool names before registering them with Pi. Thanks @benjaminrickels for PR #190.
 - Reconnected OAuth MCP servers automatically after successful panel or `/mcp-auth` authorization, and made panel reconnect force a fresh connection like `/mcp reconnect`. Thanks @mightymatth for issue #171.
 - Recovered stale Streamable HTTP MCP sessions that report `-32000 Server not initialized` after a server restart. Thanks @vicary for issue #184.

--- a/__tests__/init-status.test.ts
+++ b/__tests__/init-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { updateStatusBar } from "../init.ts";
+
+function createState(ui: unknown) {
+  return {
+    ui,
+    config: { mcpServers: { demo: { command: "demo" } } },
+    manager: { getAllConnections: vi.fn(() => new Map()) },
+  } as any;
+}
+
+describe("updateStatusBar", () => {
+  it("updates a usable UI even when its theme is unavailable", () => {
+    const setStatus = vi.fn();
+    const state = createState({ setStatus, theme: undefined });
+
+    updateStatusBar(state);
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", "MCP: 0/1 servers");
+  });
+
+  it("keeps themed status text when a theme is available", () => {
+    const setStatus = vi.fn();
+    const state = createState({
+      setStatus,
+      theme: { fg: vi.fn((_name: string, text: string) => `styled:${text}`) },
+    });
+
+    updateStatusBar(state);
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", "styled:MCP: 0/1 servers");
+  });
+});

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -1,9 +1,11 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import {
+  createMcpDirectToolCallRenderer,
   formatMcpDirectToolCallLines,
   formatMcpProxyToolCallLines,
   formatMcpToolResultLines,
+  renderMcpProxyToolCall,
   renderMcpToolResult,
 } from "../tool-result-renderer.ts";
 
@@ -202,5 +204,35 @@ describe("MCP tool result renderer", () => {
     expect(output).toContain("line 4");
     expect(output).not.toContain("Ctrl+O to expand");
     expect(output).not.toContain("…");
+  });
+
+  it("renders results without a theme", () => {
+    const output = renderMcpToolResult(
+      result([{ type: "text", text: "hello world" }]),
+      collapsedOptions,
+    ).render(80).join("\n");
+
+    expect(output).toContain("hello world");
+  });
+
+  it("renders partial results without a theme", () => {
+    const output = renderMcpToolResult(
+      result([]),
+      { expanded: false, isPartial: true },
+    ).render(80).join("\n");
+
+    expect(output).toContain("Running MCP tool...");
+  });
+});
+
+describe("MCP tool call renderers without a theme", () => {
+  it("renders proxy calls without a theme", () => {
+    const output = renderMcpProxyToolCall({ tool: "test_tool", server: "demo" }).render(80).join("\n");
+    expect(output).toContain("mcp call test_tool @ demo");
+  });
+
+  it("renders direct calls without a theme", () => {
+    const output = createMcpDirectToolCallRenderer("test_tool")({ key: "value" }).render(80).join("\n");
+    expect(output).toContain("test_tool");
   });
 });

--- a/init.ts
+++ b/init.ts
@@ -318,7 +318,8 @@ export function updateStatusBar(state: McpExtensionState): void {
     return;
   }
   const connectedCount = state.manager.getAllConnections().size;
-  ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`));
+  const status = `MCP: ${connectedCount}/${total} servers`;
+  ui.setStatus("mcp", ui.theme ? ui.theme.fg("accent", status) : status);
 }
 
 export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -9,6 +9,8 @@ interface RenderTheme {
   bold?: (text: string) => string;
 }
 
+const plainTheme: RenderTheme = { fg: (_name, text) => text };
+
 export interface McpProxyToolCallInput {
   tool?: string;
   args?: string | Record<string, unknown>;
@@ -119,19 +121,20 @@ export function formatMcpDirectToolCallLines(
   return [displayName, formatJsonish(args, maxInputChars)];
 }
 
-function renderToolCallLines(lines: string[], theme: RenderTheme) {
+function renderToolCallLines(lines: string[], theme?: RenderTheme) {
+  const activeTheme = theme ?? plainTheme;
   const [title = "mcp", ...rest] = lines;
-  const styledTitle = theme.fg("toolTitle", theme.bold ? theme.bold(title) : title);
-  const styledRest = rest.map(line => theme.fg("muted", line));
+  const styledTitle = activeTheme.fg("toolTitle", activeTheme.bold ? activeTheme.bold(title) : title);
+  const styledRest = rest.map(line => activeTheme.fg("muted", line));
   return new Text([styledTitle, ...styledRest].join("\n"), 0, 0);
 }
 
-export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme: RenderTheme) {
+export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme?: RenderTheme) {
   return renderToolCallLines(formatMcpProxyToolCallLines(args), theme);
 }
 
 export function createMcpDirectToolCallRenderer(displayName: string) {
-  return (args: Record<string, unknown>, theme: RenderTheme) => {
+  return (args: Record<string, unknown>, theme?: RenderTheme) => {
     return renderToolCallLines(formatMcpDirectToolCallLines(displayName, args), theme);
   };
 }
@@ -164,23 +167,24 @@ export function formatMcpToolResultLines(
 export function renderMcpToolResult(
   result: AgentToolResult<McpToolResultDetails>,
   options: ToolRenderResultOptions,
-  theme: RenderTheme,
+  theme?: RenderTheme,
   context?: McpToolRenderContext,
 ) {
+  const activeTheme = theme ?? plainTheme;
   if (options.isPartial) {
-    return new Text(theme.fg("warning", "Running MCP tool..."), 0, 0);
+    return new Text(activeTheme.fg("warning", "Running MCP tool..."), 0, 0);
   }
 
   const hasErrorDetails = Boolean(result.details.error);
   const expanded = options.expanded || context?.isError === true || hasErrorDetails;
   const display = formatMcpToolResultLines(result, true);
-  const output = display.lines.map((line) => theme.fg("toolOutput", line)).join("\n");
+  const output = display.lines.map((line) => activeTheme.fg("toolOutput", line)).join("\n");
 
   return new CollapsibleText(
     output,
     expanded,
     DEFAULT_MAX_COLLAPSED_LINES,
-    theme.fg("muted", "…"),
-    theme.fg("muted", "(Ctrl+O to expand)"),
+    activeTheme.fg("muted", "…"),
+    activeTheme.fg("muted", "(Ctrl+O to expand)"),
   );
 }


### PR DESCRIPTION
This is a clean current-main replacement for #183. The original branch is stale/conflicting and `maintainerCanModify` is disabled, so I could not update it in place.

It keeps the valid part of @fankangsong's contribution: MCP tool call/result rendering no longer crashes when the runtime does not provide a TUI theme. It also keeps status-bar updates working with plain fallback text instead of suppressing them when `ui.theme` is missing, and preserves the current visual-row collapse behavior.

Validation passed locally:

- `npm test -- __tests__/tool-result-renderer.test.ts __tests__/init-status.test.ts __tests__/mcp-output-guard.test.ts __tests__/index-lifecycle.test.ts __tests__/lifecycle-lazy-keep-alive.test.ts`
- `npx tsc --noEmit`
- `git diff --check`
- full `npm test`
- fresh read-only review with no blockers

Thanks @fankangsong for the original report and implementation in #183.
