### PR TITLE
fix: gate resource discovery on the resources capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved persistent OAuth credentials from plaintext `tokens.json` files into the operating system credential store, with one-way legacy import and fail-closed behavior when secure storage is unavailable. Thanks Sam Atkins (@atkinsam) for issue #180.
 
 ### Fixed
+- Skipped `resources/list` for MCP servers that do not advertise the `resources` capability, matching the existing prompt discovery gate and silencing the SDK v2 debug line that tools-only servers printed on every connect. Thanks Aleksandr Davydenko (@kotuke) for PR #213.
 - Made the MCP footer show enabled configured servers as the primary count, with active connections as secondary state, so lazy servers no longer look broken before first use or after idle shutdown. Thanks blumlaut (@Blumlaut) for issue #93.
 - Show the actual proxied MCP server/tool name in `mcp` tool results. Thanks Finn (@finnvyrn) and @dillontkh for issue #68.
 - Removed the remaining TypeScript import cycles reported by `madge`. Thanks @av1155 for issue #101.

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -145,6 +145,9 @@ describe("AbortSignal propagation", () => {
   it("server-manager resource discovery does not swallow host aborts", async () => {
     const controller = new AbortController();
     const client = {
+      // Resource discovery is capability-gated, so the abort path is only
+      // reachable for a server that advertises `resources`.
+      getServerCapabilities: () => ({ resources: {} }),
       listResources: vi.fn(async (_params, options?: { signal?: AbortSignal }) => {
         options?.signal?.throwIfAborted();
         return { resources: [] };

--- a/__tests__/fixtures/tools-only-server.mjs
+++ b/__tests__/fixtures/tools-only-server.mjs
@@ -1,0 +1,21 @@
+import { Server } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+
+// A minimal MCP server that advertises tools only — no `resources`, no
+// `prompts`. Used by resources-capability.test.ts to check that the adapter
+// skips resources/list instead of asking a server that cannot answer.
+const server = new Server(
+  { name: "tools-only-server", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler("tools/list", async () => ({
+  tools: [{ name: "noop", inputSchema: { type: "object", properties: {} } }],
+}));
+
+server.setRequestHandler("tools/call", async () => ({
+  content: [{ type: "text", text: "ok" }],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -47,6 +47,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     this.connect = vi.fn((transport: unknown, requestOptions: unknown) =>
       mocks.connectImpl(transport, requestOptions)
     );
+    this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
     this.listTools = vi.fn((params: unknown, requestOptions: unknown) =>
       mocks.listToolsImpl(params, requestOptions)
     );

--- a/__tests__/resources-capability.test.ts
+++ b/__tests__/resources-capability.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { McpServerManager } from "../server-manager.ts";
+
+const managers: McpServerManager[] = [];
+
+describe("resources capability negotiation", () => {
+  afterEach(async () => {
+    await Promise.all(managers.splice(0).map(m => m.closeAll()));
+  });
+
+  it("skips resources/list for servers that omit the capability", async () => {
+    const listResources = vi.fn(async () => ({ resources: [{ name: "unreachable", uri: "test://unreachable" }] }));
+    const client = { getServerCapabilities: () => ({ tools: {} }), listResources };
+    const manager = new McpServerManager({} as any);
+
+    await expect((manager as any).fetchAllResources(client)).resolves.toEqual([]);
+    expect(listResources).not.toHaveBeenCalled();
+  });
+
+  it("lists resources for servers that advertise the capability", async () => {
+    const resource = { name: "readme", uri: "test://readme" };
+    const listResources = vi.fn(async () => ({ resources: [resource] }));
+    const client = { getServerCapabilities: () => ({ tools: {}, resources: {} }), listResources };
+    const manager = new McpServerManager({} as any);
+
+    await expect((manager as any).fetchAllResources(client)).resolves.toEqual([resource]);
+    expect(listResources).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty resource list for a tools-only server", async () => {
+    // The fixture advertises tools only, so fetchAllResources short-circuits
+    // without hitting the wire.
+    const fixture = fileURLToPath(new URL("./fixtures/tools-only-server.mjs", import.meta.url));
+    const manager = new McpServerManager();
+    managers.push(manager);
+    await manager.connect("tools-only", { command: process.execPath, args: [fixture] });
+
+    const connection = manager.getConnection("tools-only")!;
+    expect(connection.tools.map(t => t.name)).toEqual(["noop"]);
+    expect(connection.resources).toEqual([]);
+  });
+});

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -18,6 +18,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     this.setRequestHandler = vi.fn();
     this.setNotificationHandler = vi.fn();
     this.connect = vi.fn(async () => undefined);
+    this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
     this.close = vi.fn(async () => undefined);

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -374,8 +374,8 @@ export class McpServerManager {
         }
       };
 
-      // Discover tools, resources, and prompts. Prompt listing is optional:
-      // only servers advertising the capability are queried.
+      // Discover tools, resources, and prompts. Resource and prompt listing is
+      // optional: only servers advertising the capability are queried.
       const [tools, resources, promptResult] = await Promise.all([
         this.fetchAllTools(client, requestOptions),
         this.fetchAllResources(client, requestOptions),
@@ -753,6 +753,9 @@ export class McpServerManager {
   }
 
   private async fetchAllResources(client: Client, requestOptions?: RequestOptions): Promise<McpResource[]> {
+    const capabilities = client.getServerCapabilities?.();
+    if (!capabilities?.resources) return [];
+
     try {
       const allResources: McpResource[] = [];
       let cursor: string | undefined;
@@ -768,7 +771,7 @@ export class McpServerManager {
       if (requestOptions?.signal?.aborted) {
         throwIfAborted(requestOptions.signal);
       }
-      // Server may not support resources
+      // The server advertises resources but the listing failed
       return [];
     }
   }


### PR DESCRIPTION
## Problem

Since `2.12.0` moved the client to `@modelcontextprotocol/client@2.0.0-beta.5`, connecting a server that only advertises `tools` prints a debug line into the TUI on every Pi start:

```
Client.listResources() called but server does not advertise resources capability - returning empty list
```

The SDK v1 client stayed silent in the same situation, so this only became visible with the v2 beta.5 migration (#210).

## Cause

`server-manager.ts` discovers prompts behind a capability gate but asks for resources unconditionally:

```ts
// fetchAllPrompts
const capabilities = client.getServerCapabilities?.();
if (!capabilities?.prompts) return { prompts: [], failed: false };

// fetchAllResources
const result = await client.listResources(cursor ? { cursor } : undefined, requestOptions);
```

The asymmetry dates from the prompts work in `2.12.0` (#203), which added the gate for prompts and left resource discovery as it was.

## Fix

Apply the same gate in `fetchAllResources`. Nothing is functionally broken today — the SDK returns an empty list either way — but a tools-only server no longer causes a wire request or a debug line at startup.

A server that serves resources without advertising the capability is not spec-compliant, and the SDK v2 client already refuses to list them, so the gate does not change what such a server yields.

## Tests

- `__tests__/resources-capability.test.ts` (new): `resources/list` is not called when the capability is absent, is called when it is present, and a tools-only server connects with an empty resource list. Mirrors the existing "prompts capability negotiation" case in `__tests__/prompts-sdk-integration.test.ts`.
- `__tests__/fixtures/tools-only-server.mjs` (new): minimal server advertising `tools` only — the existing fixtures all advertise `resources`.
- Three mocked clients that assert on `resources/list` (`abort-signal`, `proxy-modes-auto-auth`, `server-manager-sampling`) now expose `getServerCapabilities`, like the real SDK client. Without it the mocks describe a server that advertises nothing, and their assertions would no longer test what they were written for.

Locally on Node 24: `npx tsc --noEmit`, `npm test` (738 passed), `npm run test:oauth` (107 passed) and `npm run test:conformance` (all scenarios pass or match the baseline) are green.
