### PR TITLE
perf: avoid pretty-printing the raw MCP result on the tool-call hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accepted JSONC-style comments and trailing commas in MCP JSON config files. Thanks @GoCoder7 for issue #124.
 
 ### Changed
+- Measured and spilled oversized raw MCP result details as compact JSON instead of pretty-printed JSON, reducing hot-path allocation and event-loop work. Thanks José Maia (@glitch-ux) for issue #214 and PR #215.
 - Renamed generated MCP resource tools from `get_<resource>` to `read_<resource>` to match the MCP `resources/read` operation. Thanks @vdom-1 for issue #185.
 
 ### Security

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -85,6 +85,21 @@ describe("guardMcpOutput", () => {
     expect((summarized.mcpResult as McpResultSummary).fullResultPath).toBeTruthy();
   });
 
+  it("spills the oversized raw result as compact JSON and reports its compact byte size", async () => {
+    const rawMcpResult = { content: [{ type: "text", text: "ok" }], isError: false, structuredContent: { rows: "z".repeat(500) } };
+    const guarded = await guardMcpOutput([{ type: "text", text: "ok" }], { detailsMaxBytes: 50, rawMcpResult });
+
+    const summary = guarded.mcpResult as McpResultSummary;
+    expect(summary.omitted).toBe(true);
+    expect(summary.fullResultPath).toBeTruthy();
+
+    const compact = JSON.stringify(rawMcpResult);
+    const saved = await readFile(summary.fullResultPath!, "utf8");
+    expect(saved).toBe(compact);
+    expect(saved).not.toContain("\n");
+    expect(summary.rawResultBytes).toBe(Buffer.byteLength(compact, "utf8"));
+  });
+
   it("passes image blocks through untouched, even large ones", async () => {
     const image = { type: "image" as const, data: "A".repeat(100_000), mimeType: "image/png" };
     const guarded = await guardMcpOutput(

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -262,6 +262,12 @@ function formatTruncationNotice(
  * raw JSON to a temp file.
  */
 async function boundMcpResult(result: unknown, detailsMaxBytes: number): Promise<unknown> {
+  // Serialize once, compact. This runs on every proxied tool call purely to size
+  // the raw result against detailsMaxBytes: when it fits we return the object
+  // untouched (the string was only a measurement), and when it doesn't we reuse
+  // the same string as the spilled artifact. Pretty-printing here would allocate
+  // a larger throwaway copy on the hot path that never reaches the model, and
+  // compact JSON tracks the raw result's actual context cost more closely.
   const raw = safeStringify(result);
   const rawBytes = byteLength(raw);
   if (rawBytes <= detailsMaxBytes) return result;
@@ -368,7 +374,11 @@ function asRecord(value: unknown): Recordish | undefined {
 
 function safeStringify(value: unknown): string {
   try {
-    return JSON.stringify(value, null, 2);
+    // Compact on purpose: the only caller (boundMcpResult) uses this to measure
+    // and, when oversized, to spill the raw result — never to render it for the
+    // model. Indentation would just inflate a hot-path string that is discarded
+    // whenever the result fits within detailsMaxBytes.
+    return JSON.stringify(value);
   } catch {
     return String(value);
   }

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -262,12 +262,6 @@ function formatTruncationNotice(
  * raw JSON to a temp file.
  */
 async function boundMcpResult(result: unknown, detailsMaxBytes: number): Promise<unknown> {
-  // Serialize once, compact. This runs on every proxied tool call purely to size
-  // the raw result against detailsMaxBytes: when it fits we return the object
-  // untouched (the string was only a measurement), and when it doesn't we reuse
-  // the same string as the spilled artifact. Pretty-printing here would allocate
-  // a larger throwaway copy on the hot path that never reaches the model, and
-  // compact JSON tracks the raw result's actual context cost more closely.
   const raw = safeStringify(result);
   const rawBytes = byteLength(raw);
   if (rawBytes <= detailsMaxBytes) return result;
@@ -374,10 +368,7 @@ function asRecord(value: unknown): Recordish | undefined {
 
 function safeStringify(value: unknown): string {
   try {
-    // Compact on purpose: the only caller (boundMcpResult) uses this to measure
-    // and, when oversized, to spill the raw result — never to render it for the
-    // model. Indentation would just inflate a hot-path string that is discarded
-    // whenever the result fits within detailsMaxBytes.
+    // The output guard measures and spills raw MCP results; it does not render this JSON for the model.
     return JSON.stringify(value);
   } catch {
     return String(value);


### PR DESCRIPTION

Issue: #214

### What

`boundMcpResult` (`mcp-output-guard.ts`) serializes every proxied tool result with `JSON.stringify(result, null, 2)` purely to size it against `detailsMaxBytes`. On the common path the raw object is returned unchanged and that pretty-printed string is discarded, so the indentation is pure allocation on the per-tool-call hot path; on the oversized path the same string is spilled to a temp file. The indented form is never rendered for the model, so the whitespace buys nothing.

This changes the serialization to compact (`JSON.stringify(value)`).

### Why

- The pretty string is thrown away whenever the result fits `detailsMaxBytes` (default 16 KiB) — the overwhelmingly common case — so its extra size is wasted allocation/GC pressure on the hot path.
- On large results the synchronous serialization stalls the event loop longer than necessary in a process that is concurrently driving child processes and HTTP connections.
- Compact JSON reflects the raw result's actual model-context cost more closely than the indented form (an inlined raw result enters context serialized compactly).

Measured on a ~1.5 MB structured result (8k rows): serialization ~31% faster (4.6 ms → 3.2 ms) and the throwaway string ~22% smaller.

### Behavior notes

- The `detailsMaxBytes` gate is now measured against compact JSON, so a result whose compact JSON is within the limit but whose pretty JSON exceeded it is now inlined into `details.mcpResult` rather than summarized.
- The spilled `mcp-result` artifact and the reported `rawResultBytes` are now compact.

Both seem like the right default, but if you'd prefer to preserve the exact previous summarize boundary I can measure compact while keeping a pretty-printed spill — just say the word.

### Tests

- Added a regression test asserting the oversized raw result spills as compact JSON and that `rawResultBytes` reports the compact size.
- `npx tsc --noEmit`, `npm test` (vitest), `npm run test:oauth`, and `npm run test:conformance` all pass locally. No public API change.

The change is 2 lines of behavior plus comments explaining why the compact form is intentional.
