### PR TITLE
fix: tolerate -32601 from tools/list so resources-only servers can connect

### DIFF
--- a/__tests__/fixtures/resources-only-server.mjs
+++ b/__tests__/fixtures/resources-only-server.mjs
@@ -1,0 +1,27 @@
+import { Server } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+
+// A minimal MCP server that advertises resources only — no `tools`, no
+// `prompts`. Used by resources-capability.test.ts to check that the adapter
+// connects without aborting when tools/list is not supported, the spec-
+// canonical shape for read-only data sources.
+const server = new Server(
+  { name: "resources-only-server", version: "1.0.0" },
+  { capabilities: { resources: {} } },
+);
+
+const resource = {
+  name: "resource_name",
+  uri: "test://uri",
+  description: "Test resource",
+  mimeType: "application/json",
+};
+
+server.setRequestHandler("resources/list", async () => ({ resources: [resource] }));
+
+server.setRequestHandler("resources/read", async () => ({
+  contents: [{ uri: resource.uri, mimeType: resource.mimeType, text: '{"status":"ok"}' }],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/__tests__/resources-capability.test.ts
+++ b/__tests__/resources-capability.test.ts
@@ -41,3 +41,43 @@ describe("resources capability negotiation", () => {
     expect(connection.resources).toEqual([]);
   });
 });
+
+describe("tools capability negotiation", () => {
+  afterEach(async () => {
+    await Promise.all(managers.splice(0).map(m => m.closeAll()));
+  });
+
+  it("returns tools for servers that advertise the capability", async () => {
+    const tool = { name: "noop", inputSchema: { type: "object" as const } };
+    const listTools = vi.fn(async () => ({ tools: [tool] }));
+    const client = { getServerCapabilities: () => ({ tools: {} }), listTools };
+    const manager = new McpServerManager({} as any);
+
+    await expect((manager as any).fetchAllTools(client)).resolves.toEqual([tool]);
+    expect(listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty tool list when tools/list fails with MethodNotFound", async () => {
+    // Spec-correct resources-only servers respond to tools/list with -32601.
+    const listTools = vi.fn(async () => {
+      throw new Error("MCP error -32601: tools not supported");
+    });
+    const client = { getServerCapabilities: () => ({ resources: {} }), listTools };
+    const manager = new McpServerManager({} as any);
+
+    await expect((manager as any).fetchAllTools(client)).resolves.toEqual([]);
+    expect(listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("connects to a resources-only server and surfaces an empty tool list", async () => {
+    // The fixture advertises resources only — tools/list is not implemented.
+    const fixture = fileURLToPath(new URL("./fixtures/resources-only-server.mjs", import.meta.url));
+    const manager = new McpServerManager();
+    managers.push(manager);
+    await manager.connect("resources-only", { command: process.execPath, args: [fixture] });
+
+    const connection = manager.getConnection("resources-only")!;
+    expect(connection.tools).toEqual([]);
+    expect(connection.resources.map(r => r.name)).toEqual(["current_price"]);
+  });
+});

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -734,16 +734,24 @@ export class McpServerManager {
   }
 
   private async fetchAllTools(client: Client, requestOptions?: RequestOptions): Promise<McpTool[]> {
-    const allTools: McpTool[] = [];
-    let cursor: string | undefined;
+    try {
+      const allTools: McpTool[] = [];
+      let cursor: string | undefined;
 
-    do {
-      const result = await client.listTools(cursor ? { cursor } : undefined, requestOptions);
-      allTools.push(...(result.tools ?? []));
-      cursor = result.nextCursor;
-    } while (cursor);
+      do {
+        const result = await client.listTools(cursor ? { cursor } : undefined, requestOptions);
+        allTools.push(...(result.tools ?? []));
+        cursor = result.nextCursor;
+      } while (cursor);
 
-    return allTools;
+      return allTools;
+    } catch {
+      if (requestOptions?.signal?.aborted) {
+        throwIfAborted(requestOptions.signal);
+      }
+      // Server may not support tools
+      return [];
+    }
   }
 
   private async fetchAllPrompts(


### PR DESCRIPTION
Spec-correct MCP servers may omit any capability; a server that does not declare `tools` (or that declares it but does not implement `tools/list`) responds to a `tools/list` call with `-32601 Method not found`. 

The connect path in `McpServerManager` calls `fetchAllTools` in parallel with `fetchAllResources` / `fetchAllPrompts`; only the latter two catch that error, so any spec-correct resources-only server failed to connect with "MCP error -32601: tools not supported", and no resource-derived tool was ever registered.

**Fix:**
Wrap the body of `fetchAllTools` in the same try/catch used by `fetchAllResources`: re-throw on abort, otherwise return `[]`. 