### PR TITLE
fix(oauth): prefer configured scope over discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Let configured `oauth.scope` override OAuth discovery scopes during authorization flows. Thanks @viggy28 for issue #225 and @adity982 for PR #226.
+
 ## [2.16.0] - 2026-07-30
 
 ### Added

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -874,6 +874,34 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("direct-complete")).toBeUndefined();
   });
 
+  it("prefers a configured scope over discovery for start and completion", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(null, {
+      headers: { "www-authenticate": 'Bearer scope="session:role:all"' },
+    }));
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+      return "REDIRECT";
+    });
+    const { completeAuth, startAuth } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("configured-scope", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+      oauth: { scope: "session:role:MCP_ROLE" },
+    });
+    await expect(completeAuth("configured-scope", "auth-code")).resolves.toBe("authenticated");
+
+    expect(mocks.sdkAuth).toHaveBeenNthCalledWith(1, expect.anything(), {
+      serverUrl: "https://api.example.com/mcp",
+      scope: "session:role:MCP_ROLE",
+    });
+    expect(mocks.sdkAuth).toHaveBeenNthCalledWith(2, expect.anything(), {
+      serverUrl: "https://api.example.com/mcp",
+      authorizationCode: "auth-code",
+      scope: "session:role:MCP_ROLE",
+    });
+  });
+
   it("uses an explicit OAuth redirect URI for callback binding and metadata", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       expect(provider.redirectUrl).toBe("http://127.0.0.1:3118/callback");

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -57,6 +57,10 @@ type AuthDiscovery = {
   scope?: string
 }
 
+function applyConfiguredScope(discovery: AuthDiscovery, config: McpOAuthConfig): AuthDiscovery {
+  return config.scope !== undefined ? { ...discovery, scope: config.scope } : discovery
+}
+
 type PendingAuth = {
   serverName: string
   authProvider: McpOAuthProvider
@@ -304,7 +308,7 @@ export async function startAuth(
       },
     }, authStorageOptions, runtime.signal)
     try {
-      const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
+      const discovery = applyConfiguredScope(await probeAuthDiscovery(serverUrl, definition, signal), config)
       throwIfAborted(signal)
       const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
       throwIfAborted(signal)
@@ -370,7 +374,7 @@ export async function startAuth(
 
     throwIfAborted(signal)
 
-    const discovery = await probeAuthDiscovery(serverUrl, definition, signal)
+    const discovery = applyConfiguredScope(await probeAuthDiscovery(serverUrl, definition, signal), config)
     throwIfAborted(signal)
     const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
     throwIfAborted(signal)


### PR DESCRIPTION
## Summary

- preserve OAuth discovery metadata while letting an explicit `oauth.scope` override the scope advertised by `WWW-Authenticate`
- carry the resolved scope through both authorization start and code completion
- add regression coverage for the configured-vs-discovered scope conflict

## Validation

- `npm test -- __tests__/mcp-auth-flow-client-credentials.test.ts` (30 tests passed)

Closes #225