### PR TITLE
fix: handle unavailable OAuth credential store in MCP panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevented `/mcp` and `/mcp-auth` from crashing when the OS OAuth credential store is unavailable.
+
 ## [2.15.0] - 2026-07-25
 
 ### Added

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -84,6 +84,44 @@ describe("authenticateServer", () => {
     }
   });
 
+  it("reports credential removal failures without escaping the logout command boundary", async () => {
+    mocks.removeAuth.mockRejectedValueOnce(new Error("simulated secure credential store unavailable"));
+    const ui = { notify: vi.fn() };
+    const { logoutServer } = await import("../commands.ts");
+
+    const close = vi.fn();
+    const result = await logoutServer("sentry", {
+      config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+      authStorageOptions: {},
+      manager: { close },
+    } as any, { hasUI: true, ui } as any);
+
+    expect(result).toEqual({ ok: false, message: "simulated secure credential store unavailable" });
+    expect(close).not.toHaveBeenCalled();
+    expect(ui.notify).toHaveBeenCalledWith(
+      'Failed to clear OAuth credentials for "sentry": simulated secure credential store unavailable',
+      "error",
+    );
+  });
+
+  it("reports a close failure accurately after credentials were removed", async () => {
+    mocks.removeAuth.mockResolvedValueOnce(undefined);
+    const ui = { notify: vi.fn() };
+    const { logoutServer } = await import("../commands.ts");
+
+    const result = await logoutServer("sentry", {
+      config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+      authStorageOptions: {},
+      manager: { close: vi.fn(async () => { throw new Error("close failed"); }) },
+    } as any, { hasUI: true, ui } as any);
+
+    expect(result).toEqual({ ok: false, message: "close failed" });
+    expect(ui.notify).toHaveBeenCalledWith(
+      'OAuth credentials were cleared for "sentry", but its connection could not be closed: close failed',
+      "error",
+    );
+  });
+
   it("surfaces the exact OAuth URL through UI notification", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {

--- a/__tests__/commands-panel-auth-storage.test.ts
+++ b/__tests__/commands-panel-auth-storage.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openMcpAuthPanel, openMcpPanel } from "../commands.ts";
+
+const previousAuthStore = process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+
+afterEach(() => {
+  if (previousAuthStore === undefined) delete process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+  else process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = previousAuthStore;
+});
+
+function stripAnsi(input: string): string {
+  return input.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function createPanelHarness() {
+  let rendered = "";
+  const ui = {
+    notify: vi.fn(),
+    custom: vi.fn((factory: any) => {
+      const panel = factory({ requestRender() {} }, undefined, undefined, () => {});
+      rendered = stripAnsi(panel.render(100).join("\n"));
+      panel.handleInput("\x03");
+    }),
+  };
+  return { ui, getRendered: () => rendered };
+}
+
+function createState() {
+  return {
+    programmaticConfig: false,
+    config: {
+      mcpServers: {
+        oauth: { url: "https://example.test/mcp", auth: "oauth" },
+      },
+    },
+    authStorageOptions: {},
+    manager: { getConnection: () => undefined },
+    failureTracker: new Map(),
+    failureMessages: new Map(),
+  } as any;
+}
+
+describe("MCP panels with unavailable OAuth credential storage", () => {
+  it.each([
+    ["/mcp", openMcpPanel],
+    ["/mcp-auth", openMcpAuthPanel],
+  ])("opens %s without throwing and presents the failure reason", async (_command, openPanel) => {
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+    const { ui, getRendered } = createPanelHarness();
+
+    await expect(openPanel(
+      createState(),
+      { getFlag: () => undefined } as any,
+      { hasUI: true, cwd: "/tmp", ui } as any,
+    )).resolves.toEqual({ configChanged: false });
+
+    expect(getRendered()).toContain("failed");
+    expect(getRendered()).not.toContain("needs auth");
+    expect(getRendered()).toContain("OAuth credential store unavailable");
+  });
+});

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -2,7 +2,32 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { tmpdir } from "node:os";
-import { getAuthEntry, getAuthEntryFilePath, getAuthStorageOptions, saveAuthEntry } from "../mcp-auth.ts";
+import {
+  formatOAuthCredentialStoreUnavailable,
+  getAuthEntry,
+  getAuthEntryFilePath,
+  getAuthStorageOptions,
+  inspectAuthForUrl,
+  OAuthCredentialStoreError,
+  saveAuthEntry,
+} from "../mcp-auth.ts";
+
+describe("OAuth credential-store diagnostics", () => {
+  it("recognizes a revoked Linux keyring through the error cause chain", () => {
+    const nativeError = new Error("Couldn't access platform storage: KeyRevoked", {
+      cause: new Error("KeyRevoked"),
+    });
+    const error = new OAuthCredentialStoreError("read failed", "read", nativeError);
+
+    const message = formatOAuthCredentialStoreUnavailable(error);
+    if (process.platform === "linux") {
+      expect(message).toContain("Linux session keyring may be revoked");
+      expect(message).toContain("fresh login/keyring session");
+    } else {
+      expect(message).toContain("OAuth credential store unavailable");
+    }
+  });
+});
 
 describe("mcp-auth storage paths", () => {
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
@@ -58,6 +83,21 @@ describe("mcp-auth storage paths", () => {
     expect(existsSync(filePath)).toBe(false);
     expect(getAuthEntry("configured", options)?.tokens?.accessToken).toBe("legacy-token");
     rmSync(project, { recursive: true, force: true });
+  });
+
+  it("does not migrate legacy credentials during status-only inspection", () => {
+    const filePath = getAuthEntryFilePath("status-only");
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify({
+      tokens: { accessToken: "legacy-token" },
+      serverUrl: "https://example.com/mcp",
+    }), "utf-8");
+
+    expect(inspectAuthForUrl("status-only", "https://example.com/mcp").status).toBe("present");
+    expect(existsSync(filePath)).toBe(true);
+
+    expect(getAuthEntry("status-only")?.tokens?.accessToken).toBe("legacy-token");
+    expect(existsSync(filePath)).toBe(false);
   });
 
   it("does not use configured oauthDir values as secure-store namespaces", () => {

--- a/commands.ts
+++ b/commands.ts
@@ -17,7 +17,7 @@ import { markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateMetadataCac
 import { loadMetadataCache, reconstructPromptMetadata } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
-import { getAuthForUrl, getAuthStorageOptions } from "./mcp-auth.ts";
+import { getAuthStorageOptions, inspectAuthForUrl } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
 import { isAbortError } from "./runtime-owner.ts";
@@ -312,9 +312,33 @@ export async function logoutServer(
     return { ok: false, message };
   }
 
-  await removeAuth(serverName, { authStorageOptions: state.authStorageOptions, signal: state.owner?.signal, runtime: state.oauthRuntime });
+  const signal = state.owner?.signal;
+  try {
+    await removeAuth(serverName, { authStorageOptions: state.authStorageOptions, signal, runtime: state.oauthRuntime });
+  } catch (error) {
+    if (isAbortError(error, signal)) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (ui) {
+      ui.notify(`Failed to clear OAuth credentials for "${serverName}": ${sanitizeTerminalText(message)}`, "error");
+    }
+    return { ok: false, message };
+  }
+
   state.owner?.throwIfInactive();
-  await state.manager.close(serverName);
+  try {
+    await state.manager.close(serverName);
+  } catch (error) {
+    if (isAbortError(error, signal)) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (ui) {
+      ui.notify(
+        `OAuth credentials were cleared for "${serverName}", but its connection could not be closed: ${sanitizeTerminalText(message)}`,
+        "error",
+      );
+    }
+    return { ok: false, message };
+  }
+
   state.owner?.throwIfInactive();
   updateStatusBar(state);
 
@@ -416,6 +440,11 @@ function buildMcpPanelCallbacks(
   config: McpConfig,
   ctx: ExtensionContext,
 ): McpPanelCallbacks {
+  // Panel-only diagnostics keep status inspection from mutating connection
+  // failure state while allowing the existing panel failure UI to show why the
+  // credential store could not be inspected.
+  const authStatusFailures = new Map<string, string>();
+
   return {
     reconnect: (serverName: string) => reconnectServer(state, ctx, serverName),
     canAuthenticate: (serverName: string) => {
@@ -424,12 +453,10 @@ function buildMcpPanelCallbacks(
     },
     authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
     getConnectionStatus: (serverName: string) => {
+      authStatusFailures.delete(serverName);
       const definition = config.mcpServers[serverName];
       if (isServerDisabled(definition)) return "disabled";
       const connection = state.manager.getConnection(serverName);
-      if (connection?.status === "needs-auth") {
-        return "needs-auth";
-      }
       let serverUrl: string | undefined;
       try {
         serverUrl = definition ? resolveServerUrl(definition) : undefined;
@@ -441,15 +468,22 @@ function buildMcpPanelCallbacks(
         && serverUrl
         && definition.oauth !== false
         && definition.oauth?.grantType !== "client_credentials"
-        && !getAuthForUrl(serverName, serverUrl, state.authStorageOptions)?.tokens
       ) {
-        return "needs-auth";
+        const authStatus = inspectAuthForUrl(serverName, serverUrl, state.authStorageOptions);
+        if (authStatus.status === "unavailable") {
+          authStatusFailures.set(serverName, authStatus.message);
+          return "failed";
+        }
+        if (authStatus.status === "absent" || !authStatus.entry.tokens) {
+          return "needs-auth";
+        }
       }
+      if (connection?.status === "needs-auth") return "needs-auth";
       if (connection?.status === "connected") return "connected";
       if (getFailureAgeSeconds(state, serverName) !== null) return "failed";
       return "idle";
     },
-    getFailureMessage: (serverName: string) => getFailureMessage(state, serverName),
+    getFailureMessage: (serverName: string) => authStatusFailures.get(serverName) ?? getFailureMessage(state, serverName),
     refreshCacheAfterReconnect: (serverName: string) => {
       const freshCache = loadMetadataCache();
       return freshCache?.servers?.[serverName] ?? null;

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -64,6 +64,46 @@ export interface AuthStorageOptions {
   baseDir?: string;
 }
 
+export class OAuthCredentialStoreError extends Error {
+  readonly code = 'OAUTH_CREDENTIAL_STORE_UNAVAILABLE';
+
+  constructor(
+    message: string,
+    readonly operation: 'read' | 'write' | 'remove',
+    cause: unknown,
+  ) {
+    super(message, { cause });
+    this.name = 'OAuthCredentialStoreError';
+  }
+}
+
+export type OAuthCredentialStatus =
+  | { status: 'present'; entry: AuthEntry }
+  | { status: 'absent' }
+  | { status: 'unavailable'; message: string };
+
+function causeChainContains(error: unknown, pattern: RegExp): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while ((typeof current === 'object' && current !== null) || typeof current === 'function') {
+    if (seen.has(current)) break;
+    seen.add(current);
+    const candidate = current as { name?: unknown; message?: unknown; code?: unknown; cause?: unknown };
+    if ([candidate.name, candidate.message, candidate.code].some(value => typeof value === 'string' && pattern.test(value))) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+export function formatOAuthCredentialStoreUnavailable(error: OAuthCredentialStoreError): string {
+  if (process.platform === 'linux' && causeChainContains(error, /key\s*(?:has been\s*)?revoked|keyrevoked/i)) {
+    return 'OAuth credential store unavailable: the Linux session keyring may be revoked. Start Pi from a fresh login/keyring session and retry.';
+  }
+  return 'OAuth credential store unavailable. Configure or unlock the OS credential store and retry.';
+}
+
 interface KeyringEntry {
   getPassword(): string | null;
   setPassword(password: string): void;
@@ -209,7 +249,11 @@ function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
   try {
     getAuthSecretStore().write(account, JSON.stringify(entry, null, 2));
   } catch (error) {
-    throw new Error(`Failed to write OAuth credentials for ${serverName} to the OS secure credential store`, { cause: error });
+    throw new OAuthCredentialStoreError(
+      `Failed to write OAuth credentials for ${serverName} to the OS secure credential store`,
+      'write',
+      error,
+    );
   }
 }
 
@@ -217,13 +261,21 @@ function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
  * Read the auth entry for a server from the OS secure store, importing and
  * deleting a legacy plaintext entry when present.
  */
-function readAuthEntry(serverName: string, options?: AuthStorageOptions): AuthEntry | undefined {
+function readAuthEntry(
+  serverName: string,
+  options?: AuthStorageOptions,
+  behavior: { migrateLegacy?: boolean } = {},
+): AuthEntry | undefined {
   const account = getAuthEntryAccount(serverName);
   let payload: string | undefined;
   try {
     payload = getAuthSecretStore().read(account);
   } catch (error) {
-    throw new Error(`Failed to read OAuth credentials for ${serverName} from the OS secure credential store`, { cause: error });
+    throw new OAuthCredentialStoreError(
+      `Failed to read OAuth credentials for ${serverName} from the OS secure credential store`,
+      'read',
+      error,
+    );
   }
 
   if (payload !== undefined) {
@@ -234,6 +286,7 @@ function readAuthEntry(serverName: string, options?: AuthStorageOptions): AuthEn
 
   const legacyEntry = readLegacyAuthEntry(serverName, options);
   if (!legacyEntry) return undefined;
+  if (behavior.migrateLegacy === false) return legacyEntry;
   writeSecureAuthEntry(serverName, legacyEntry);
   removeLegacyAuthEntry(serverName, options);
   return legacyEntry;
@@ -264,6 +317,26 @@ export function getAuthForUrl(serverName: string, serverUrl: string, options?: A
 }
 
 /**
+ * Inspect credentials for status-only UI paths without treating an unavailable
+ * secure store as missing credentials. Authentication operations continue to
+ * use getAuthForUrl() directly and therefore remain fail-closed.
+ */
+export function inspectAuthForUrl(
+  serverName: string,
+  serverUrl: string,
+  options?: AuthStorageOptions,
+): OAuthCredentialStatus {
+  try {
+    const entry = readAuthEntry(serverName, options, { migrateLegacy: false });
+    if (!entry?.serverUrl || entry.serverUrl !== serverUrl) return { status: 'absent' };
+    return { status: 'present', entry };
+  } catch (error) {
+    if (!(error instanceof OAuthCredentialStoreError)) throw error;
+    return { status: 'unavailable', message: formatOAuthCredentialStoreUnavailable(error) };
+  }
+}
+
+/**
  * Save auth entry for a server.
  */
 export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: string, options?: AuthStorageOptions): void {
@@ -283,7 +356,11 @@ export function removeAuthEntry(serverName: string, options?: AuthStorageOptions
   try {
     getAuthSecretStore().remove(account);
   } catch (error) {
-    throw new Error(`Failed to remove OAuth credentials for ${serverName} from the OS secure credential store`, { cause: error });
+    throw new OAuthCredentialStoreError(
+      `Failed to remove OAuth credentials for ${serverName} from the OS secure credential store`,
+      'remove',
+      error,
+    );
   }
   removeLegacyAuthEntry(serverName, options);
 }


### PR DESCRIPTION
## Problem

A long-running tmux server may inherit a Linux session keyring from its original SSH session. After that session ends, the keyring can be revoked while tmux remains alive.
Opening `/mcp` or `/mcp-auth` then reads OAuth credentials from the revoked keyring. The resulting `KeyRevoked` error escapes panel construction and terminates Pi.

## Fix

Handle credential-store failures in status-only panel paths and show the affected server as failed with an actionable diagnostic. OAuth operations remain fail-closed with no plaintext fallback.
Logout storage failures are also caught and reported instead of terminating Pi.

## Tests

Added regression coverage for:
- Opening `/mcp` and `/mcp-auth` with unavailable credential storage.
- Revoked Linux keyring diagnostics.
- Side-effect-free credential inspection.
- Logout storage and connection-close failures.