### PR TITLE
perf: avoid full ICU wrap for collapsed MCP tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Collapsed MCP tool results no longer ICU-wrap the full payload on every TUI invalidate. Collapsed rows wrap only a small prefix, which stops composer keystroke lag after large MCP dumps.
+
 ## [2.15.0] - 2026-07-25
 
 ### Added

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -159,6 +159,27 @@ describe("MCP tool result renderer", () => {
     expect(output).not.toContain("segment-8");
   });
 
+  it("keeps collapsed rendering cheap for multi-10KB MCP dumps", () => {
+    const huge = `${"word ".repeat(20_000)}\n${"line\n".repeat(2_000)}tail-marker`;
+    const toolResult = result([{ type: "text", text: huge }]);
+
+    // Match the product path: each TUI invalidate rebuilds via renderResult().
+    const started = performance.now();
+    let component = renderMcpToolResult(toolResult, collapsedOptions, plainTheme, { isError: false });
+    for (let i = 0; i < 50; i++) {
+      component = renderMcpToolResult(toolResult, collapsedOptions, plainTheme, { isError: false });
+      component.render(80);
+    }
+    const elapsedMs = performance.now() - started;
+
+    const output = component.render(80).join("\n");
+    expect(output).toContain("word");
+    expect(output).toContain("Ctrl+O to expand");
+    expect(output).not.toContain("tail-marker");
+    // Full-text ICU wrap of this payload is hundreds of ms; prefix wrap stays small.
+    expect(elapsedMs).toBeLessThan(100);
+  });
+
   it("shows proxy call result identity without hiding the third content line", () => {
     const output = renderMcpToolResult(
       result([{ type: "text", text: "one\ntwo\nthree\nfour" }], { mode: "call", server: "figma", tool: "get_nodes" }),

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -34,6 +34,12 @@ export interface McpToolResultDisplay {
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
 const DEFAULT_MAX_COLLAPSED_LINES = 3;
+/**
+ * Collapsed TUI rows only need enough source text to fill a few visual lines.
+ * Capping here keeps ICU/grapheme wrapping off multi-10KB MCP dumps on every
+ * keystroke invalidate (Pi rebuilds tool rows on each composer render).
+ */
+const COLLAPSED_RENDER_CHAR_SLACK = 8;
 
 class CollapsibleText implements Component {
   constructor(
@@ -45,8 +51,22 @@ class CollapsibleText implements Component {
   ) {}
 
   render(width: number): string[] {
-    const lines = new Text(this.text, 0, 0).render(width);
-    if (this.expanded || lines.length <= this.maxCollapsedLines) return lines;
+    if (this.expanded) {
+      return new Text(this.text, 0, 0).render(width);
+    }
+
+    // Only wrap a prefix large enough to fill the collapsed viewport. Full-text
+    // wrap of large MCP results dominates the main-thread sample (Intl.Segmenter).
+    // Multi-line dumps are already truncated by formatMcpToolResultLines.
+    const safeWidth = Math.max(1, Math.floor(width));
+    const charBudget = safeWidth * (this.maxCollapsedLines + 1) * COLLAPSED_RENDER_CHAR_SLACK;
+    const prefix = this.text.length > charBudget
+      ? this.text.slice(0, charBudget)
+      : this.text;
+    const fullyIncluded = prefix === this.text;
+
+    const lines = new Text(prefix, 0, 0).render(width);
+    if (fullyIncluded && lines.length <= this.maxCollapsedLines) return lines;
 
     return [
       ...lines.slice(0, this.maxCollapsedLines),
@@ -191,7 +211,9 @@ export function renderMcpToolResult(
 
   const hasErrorDetails = Boolean(result.details.error);
   const expanded = options.expanded || context?.isError === true || hasErrorDetails;
-  const display = formatMcpToolResultLines(result, true);
+  // Keep logical collapse for multi-line dumps; CollapsibleText still handles
+  // single-line visual wrap without scanning the full body when collapsed.
+  const display = formatMcpToolResultLines(result, expanded);
   const identity = formatMcpToolResultIdentity(result.details);
   const output = [
     ...(identity ? [activeTheme.fg("muted", identity)] : []),


### PR DESCRIPTION
Issue: #232

### What

Collapsed MCP tool-result rows were ICU-wrapping the **entire** payload on every TUI invalidate. Pi rebuilds custom tool rows on each composer keystroke (`invalidate` → `updateDisplay` → `renderResult`), so large MCP dumps made typing lag in long sessions.

This changes `CollapsibleText` so collapsed mode only wraps a small character-budget prefix large enough to fill a few visual lines, then slices and shows the existing `…` / Ctrl+O chrome. Expanded and error paths still wrap the full body.

Also passes the real `expanded` flag into `formatMcpToolResultLines` so multi-line dumps are logically truncated before join (previously the render path always passed `true`).

### Why

- Collapse previously limited **display**, not **work**: `new Text(fullBody).render(width)` still ran `Intl.Segmenter` over multi-10KB dumps.
- Live `sample` on a lagging `pi -c` session showed main-thread time in `SegmentIterator` while typing.
- A/B on the same long session: stock adapter laggy; local fix snappy; no mcp-adapter (other extensions still loaded) also snappy.

Measured on a ~100 KiB first-line dump, 50 product-path rebuild+render cycles on this host:

| Path | Time |
|------|------|
| Prefix-wrap (this PR) | ~10–25 ms |
| Full ICU wrap | ~215–250 ms |

### Behavior notes

- Collapsed preview is approximate: same start of the dump, still capped to `maxCollapsedLines` visual rows. Tail remains hidden until Ctrl+O / error expand.
- Expanded, `isError`, and `details.error` paths are unchanged and still full-fidelity.
- Residual O(n) split/theme/join of a huge single line before the prefix slice remains; ICU wrap was the dominant cost.
- Model context / proxy token cost is unchanged (TUI-only).

### Tests

- Added a regression test that rebuilds via `renderMcpToolResult(...)` each iteration (matches Pi's product path), renders a multi-10KB payload collapsed, asserts the tail stays hidden, and keeps a time budget that full ICU wrap exceeds on this class of payload.
- Existing collapse / identity / error / expanded cases remain green.
- Locally: `npx tsc --noEmit`, `npx vitest run __tests__/tool-result-renderer.test.ts` (24 passed). No public API change.
