### PR TITLE
fix: double connection close race

### DIFF
--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -87,6 +87,18 @@ describe("MCP manager owner races", () => {
     expect(manager.getConnection("demo")).toBeUndefined();
   });
 
+  it("closes established connections through the owning client only", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager("/tmp/session");
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+    mocks.transports[0].close = vi.fn(() => new Promise<void>(() => {}));
+
+    await expect(manager.close("demo")).resolves.toBeUndefined();
+
+    expect(mocks.clients[0].close).toHaveBeenCalledTimes(1);
+    expect(mocks.transports[0].close).not.toHaveBeenCalled();
+  });
+
   it("closeAll aborts pending connects and settles without late insertion", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const connectGate = gate();

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -925,9 +925,14 @@ export class McpServerManager {
   }
 
   private async disposeConnection(connection: ServerConnection): Promise<void> {
+    // The SDK client owns the transport after client.connect(transport). Calling
+    // both client.close() and transport.close() races two shutdown paths against
+    // the same underlying handles; some transports tolerate that, but others can
+    // leave one close awaiting state already consumed by the other. Close through
+    // the client only, and keep direct transport.close() for pre-connect abort
+    // cleanup where the client has not taken ownership yet.
     const results = await Promise.allSettled([
       Promise.resolve().then(() => connection.client.close()),
-      Promise.resolve().then(() => connection.transport.close()),
       this.traceWriter?.flush() ?? Promise.resolve(),
     ]);
     const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : []);


### PR DESCRIPTION
`client.close()` should already close `transport` underneath

This double-close race when running `pi` with `--mode json` to sometimes not shut down gracefully, leading to a hanging `pi`, awaiting a close which will never happen(cause one `.close()` will never resolve)