### PR TITLE
fix: double connections `.close()` race

### DIFF
--- a/__tests__/server-manager-close-ownership.test.ts
+++ b/__tests__/server-manager-close-ownership.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { McpServerManager } from "../server-manager.ts";
+import { fileURLToPath } from "node:url";
+
+const fixture = fileURLToPath(new URL("./fixtures/delayed-mcp-server.mjs", import.meta.url));
+const definition = { command: process.execPath, args: [fixture] };
 
 describe("McpServerManager connection close ownership", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
+  const __dirname = fileURLToPath(new URL("./fixtures/delayed-mcp-server.mjs", import.meta.url));
   it("closes a connected stdio transport exactly once via client.close", async () => {
     const manager = new McpServerManager(join(__dirname, ".."));
 
-    const connection = await manager.connect("demo", {
-      command: "node",
-      args: [join(__dirname, "fixtures", "delayed-mcp-server.mjs")],
-    });
+    const connection = await manager.connect("demo", definition);
     const clientCloseSpy = vi.spyOn(connection.client, "close");
     const transportCloseSpy = vi.spyOn(connection.transport, "close");
 

--- a/__tests__/server-manager-close-ownership.test.ts
+++ b/__tests__/server-manager-close-ownership.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { McpServerManager } from "../server-manager.ts";
+
+describe("McpServerManager connection close ownership", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes a connected stdio transport exactly once via client.close", async () => {
+    const manager = new McpServerManager(join(__dirname, ".."));
+
+    const connection = await manager.connect("demo", {
+      command: "node",
+      args: [join(__dirname, "fixtures", "delayed-mcp-server.mjs")],
+    });
+    const clientCloseSpy = vi.spyOn(connection.client, "close");
+    const transportCloseSpy = vi.spyOn(connection.transport, "close");
+
+    await manager.close("demo");
+
+    expect(clientCloseSpy).toHaveBeenCalledTimes(1);
+    expect(transportCloseSpy).toHaveBeenCalledTimes(1);
+    expect(clientCloseSpy.mock.invocationCallOrder[0]).toBeLessThan(transportCloseSpy.mock.invocationCallOrder[0]);
+  });
+});

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -925,9 +925,10 @@ export class McpServerManager {
   }
 
   private async disposeConnection(connection: ServerConnection): Promise<void> {
+    
     const results = await Promise.allSettled([
+      // Only client.close() is needed; the client owns the transport and will close it internally.
       Promise.resolve().then(() => connection.client.close()),
-      Promise.resolve().then(() => connection.transport.close()),
       this.traceWriter?.flush() ?? Promise.resolve(),
     ]);
     const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : []);

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -925,7 +925,6 @@ export class McpServerManager {
   }
 
   private async disposeConnection(connection: ServerConnection): Promise<void> {
-    
     const results = await Promise.allSettled([
       // Only client.close() is needed; the client owns the transport and will close it internally.
       Promise.resolve().then(() => connection.client.close()),


### PR DESCRIPTION
`client.close()` should already close transport underneath

This double-close race when running `pi` with `--mode json` to sometimes not shut down gracefully, leading to a hanging pi, awaiting a close which will never happen(cause one `.close()` will never resolve)

I wish i could provide reproduction steps, unfortunately we found it happens randomly(only in json mode, as stdout is a lot more crowded then, so some promises are still in-flight) ; sometimes that double-close was totally fine, sometimes it leads to process hang