### PR TITLE
perf: avoid repeated collapsed result wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Prevented `/mcp` and `/mcp-auth` from crashing when the OS OAuth credential store is unavailable.
+- Kept collapsed MCP tool results from re-wrapping full multi-10KB payloads on repeated TUI renders, avoiding composer keystroke lag after large MCP dumps. Thanks @hyknerf for PR #233 and @chapmanb for the held-Text follow-up fix.
 
 ## [2.15.0] - 2026-07-25
 

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -159,6 +159,29 @@ describe("MCP tool result renderer", () => {
     expect(output).not.toContain("segment-8");
   });
 
+  it("keeps repeated collapsed renders cheap for multi-10KB MCP dumps", () => {
+    const huge = `${"word ".repeat(20_000)}\n${"line\n".repeat(2_000)}tail-marker`;
+    const component = renderMcpToolResult(
+      result([{ type: "text", text: huge }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false },
+    );
+
+    component.render(80);
+    const started = performance.now();
+    for (let i = 0; i < 50; i++) {
+      component.render(80);
+    }
+    const elapsedMs = performance.now() - started;
+
+    const output = component.render(80).join("\n");
+    expect(output).toContain("word");
+    expect(output).toContain("Ctrl+O to expand");
+    expect(output).not.toContain("tail-marker");
+    expect(elapsedMs).toBeLessThan(100);
+  });
+
   it("shows proxy call result identity without hiding the third content line", () => {
     const output = renderMcpToolResult(
       result([{ type: "text", text: "one\ntwo\nthree\nfour" }], { mode: "call", server: "figma", tool: "get_nodes" }),

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -34,23 +34,48 @@ export interface McpToolResultDisplay {
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
 const DEFAULT_MAX_COLLAPSED_LINES = 3;
+const COLLAPSED_RENDER_CHAR_SLACK = 8;
 
 class CollapsibleText implements Component {
+  private readonly fullText: Text;
+  private readonly footerText: Text;
+  private collapsedText: { charBudget: number; fullyIncluded: boolean; text: Text } | null = null;
+
   constructor(
     private readonly text: string,
     private readonly expanded: boolean,
     private readonly maxCollapsedLines: number,
     private readonly ellipsis: string,
     private readonly expandHint: string,
-  ) {}
+  ) {
+    this.fullText = new Text(text, 0, 0);
+    this.footerText = new Text(`${ellipsis}\n${expandHint}`, 0, 0);
+  }
 
   render(width: number): string[] {
-    const lines = new Text(this.text, 0, 0).render(width);
-    if (this.expanded || lines.length <= this.maxCollapsedLines) return lines;
+    if (this.expanded) {
+      return this.fullText.render(width);
+    }
+
+    const safeWidth = Math.max(1, Math.floor(width));
+    const charBudget = safeWidth * (this.maxCollapsedLines + 1) * COLLAPSED_RENDER_CHAR_SLACK;
+    if (!this.collapsedText || this.collapsedText.charBudget !== charBudget) {
+      const prefix = this.text.length > charBudget
+        ? this.text.slice(0, charBudget)
+        : this.text;
+      this.collapsedText = {
+        charBudget,
+        fullyIncluded: prefix === this.text,
+        text: new Text(prefix, 0, 0),
+      };
+    }
+
+    const lines = this.collapsedText.text.render(width);
+    if (this.collapsedText.fullyIncluded && lines.length <= this.maxCollapsedLines) return lines;
 
     return [
       ...lines.slice(0, this.maxCollapsedLines),
-      ...new Text(`${this.ellipsis}\n${this.expandHint}`, 0, 0).render(width),
+      ...this.footerText.render(width),
     ];
   }
 
@@ -191,7 +216,7 @@ export function renderMcpToolResult(
 
   const hasErrorDetails = Boolean(result.details.error);
   const expanded = options.expanded || context?.isError === true || hasErrorDetails;
-  const display = formatMcpToolResultLines(result, true);
+  const display = formatMcpToolResultLines(result, expanded);
   const identity = formatMcpToolResultIdentity(result.details);
   const output = [
     ...(identity ? [activeTheme.fg("muted", identity)] : []),


### PR DESCRIPTION
Maintainer replacement for #233, rebased onto current `main`.

Collapsed MCP tool results were re-wrapping the entire payload through the ICU wrapper on every TUI render, so a large result made composer keystrokes lag. This caches the collapsed rendering work across repeated renders and bounds the payload before wrapping, since collapsed mode only ever shows a short prefix.

Credit:
- Thanks @hyknerf for #233 and issue #232. The approach here is yours.
- Thanks @chapmanb for the held-`Text` follow-up, which is what keeps the repeated-render path from redoing the work.

Validation:
- `npx vitest run __tests__/tool-result-renderer.test.ts` (24 tests)
- `npx tsc --noEmit`
