### PR TITLE
feat: add per-server tool prefix override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added an optional per-server `toolPrefix` override for direct MCP tools, prompts, and proxy summaries, falling back to the global prefix when unset. Thanks @FurryWolfX for issue #229.
+- Added an advisory warning when resolved direct tools pass the documented 75-tool threshold, with no cap or enforcement. Thanks @JasonLandbridge for issue #240.
+
 ### Changed
 - Restored the MCP SDK v1 client for compatibility with deployed MCP servers and OAuth providers. This rollback temporarily removes SDK v2-only protocol negotiation while retaining OAuth issuer binding and callback issuer validation. Thanks @hyknerf for PR #237 and issue #236, @leonfox28 for issue #227, and @JorelLatraille for issue #241.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `requestTimeoutMs` | Request timeout in milliseconds for live MCP calls (overrides global; if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
+| `toolPrefix` | Override global `settings.toolPrefix` for this server (`"server"`, `"short"`, `"none"`, or `"mcp"`) |
 | `includeTools` | `string[]` of tool names or glob patterns to expose (matches original names like `get_screenshot`, generated resource names like `read_figjam`, and prefixed names like `figma_get_screenshot`) |
 | `excludeTools` | `string[]` of tool names or glob patterns to hide (applied after `includeTools`) |
 | `debug` | Show server stderr (default: false) |
@@ -272,7 +273,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 
 | Setting | Description |
 |---------|-------------|
-| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__`, using server-mode normalization) |
+| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), `"none"`, or `"mcp"` (prefixes with `mcp__`, using server-mode normalization). Per-server `toolPrefix` overrides this for that server. |
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
@@ -407,7 +408,7 @@ To hide specific tools while still using `directTools: true`, add `excludeTools`
 
 `includeTools` and `excludeTools` filter direct tools, proxy search/list/describe, and the `/mcp` panel view.
 
-Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`.
+Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`. If 75+ direct tools resolve, the adapter prints a warning but still registers the tools you configured.
 
 Direct tools register from the metadata cache in the Pi agent dir (`~/.pi/agent/mcp-cache.json` by default, or `$PI_CODING_AGENT_DIR/mcp-cache.json` when set), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only while the cache populates, then the extension hot-loads the refreshed direct tools into the current session. Servers that advertise MCP list-change notifications refresh the current session when their tool or resource list changes. On Pi versions that expose `pi.unregisterTool()`, stale direct tools are removed from the registry during refresh; older Pi versions still deactivate them from the active tool set. To force a refresh: `/mcp reconnect <server>`.
 

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { buildProxyDescription, resolveDirectTools } from "../direct-tools.ts";
+import { DIRECT_TOOLS_ADVISORY_THRESHOLD, buildProxyDescription, resolveDirectTools } from "../direct-tools.ts";
 import {
   computeServerHash,
   getMissingConfiguredDirectToolServers,
@@ -22,6 +22,7 @@ const originalHashEnv = {
 };
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const [key, value] of Object.entries(originalHashEnv)) {
     if (value === undefined) {
       delete process.env[key];
@@ -418,6 +419,18 @@ describe("excludeTools filtering", () => {
     expect(reconstructed.map((tool) => tool.name)).toEqual(["figma_get_nodes", "figma_read_figjam"]);
   });
 
+  it("honors per-server toolPrefix while building live metadata", () => {
+    const { metadata } = buildToolMetadata(
+      [{ name: "search", description: "Search" }] as any,
+      [],
+      { command: "npx", args: ["-y", "github"], toolPrefix: "none" },
+      "github",
+      "server",
+    );
+
+    expect(metadata.map((tool) => tool.name)).toEqual(["search"]);
+  });
+
   it("sanitizes registered names while preserving raw MCP names", () => {
     const { metadata } = buildToolMetadata(
       [{ name: "namespace.tool", description: "Namespaced tool" }] as any,
@@ -510,6 +523,69 @@ describe("excludeTools filtering", () => {
     const specs = resolveDirectTools(config, cache, "server");
 
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes"]);
+  });
+
+  it("honors per-server toolPrefix during direct tool registration from cache", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "none" },
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "github"],
+          directTools: true,
+          toolPrefix: "server",
+        },
+      },
+    };
+
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        github: {
+          configHash: computeServerHash(config.mcpServers.github),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Search" }],
+          resources: [],
+        },
+      },
+    };
+
+    const specs = resolveDirectTools(config, cache, "none");
+
+    expect(specs.map((spec) => spec.prefixedName)).toEqual(["github_search"]);
+  });
+
+  it("warns without capping when resolved direct tools exceed the README threshold", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const tools = Array.from({ length: DIRECT_TOOLS_ADVISORY_THRESHOLD }, (_, index) => ({
+      name: `tool_${index}`,
+      description: `Tool ${index}`,
+    }));
+    const config: McpConfig = {
+      mcpServers: {
+        huge: {
+          command: "npx",
+          args: ["-y", "huge"],
+          directTools: true,
+        },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        huge: {
+          configHash: computeServerHash(config.mcpServers.huge),
+          cachedAt: Date.now(),
+          tools,
+          resources: [],
+        },
+      },
+    };
+
+    const specs = resolveDirectTools(config, cache, "server");
+
+    expect(specs).toHaveLength(DIRECT_TOOLS_ADVISORY_THRESHOLD);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("75+ direct tools"));
   });
 
   it("filters included tools during direct tool registration from cache", () => {

--- a/commands.ts
+++ b/commands.ts
@@ -166,7 +166,7 @@ export async function reconnectServer(
     const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
     state.toolMetadata.set(name, metadata);
     if (!connection.promptDiscoveryFailed) {
-      state.promptMetadata?.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix));
+      state.promptMetadata?.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix, definition));
       state.promptMetadataLive?.add(name);
     }
     if (connection.instructions) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -11,7 +11,7 @@ import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatToolName, isServerDisabled, isToolAllowed } from "./types.ts";
+import { formatToolName, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
@@ -20,6 +20,7 @@ import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
+export const DIRECT_TOOLS_ADVISORY_THRESHOLD = 75;
 
 type DirectAutoAuthResult =
   | { status: "skipped" }
@@ -140,10 +141,12 @@ export function resolveDirectTools(
 
     if (!toolFilter) continue;
 
+    const effectivePrefix = resolveToolPrefix(definition, prefix);
+
     for (const tool of serverCache.tools ?? []) {
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
-      if (!isToolAllowed(tool.name, serverName, prefix, definition.includeTools, definition.excludeTools)) continue;
-      const prefixedName = formatToolName(tool.name, serverName, prefix);
+      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) continue;
+      const prefixedName = formatToolName(tool.name, serverName, effectivePrefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);
         continue;
@@ -168,8 +171,8 @@ export function resolveDirectTools(
       for (const resource of serverCache.resources ?? []) {
         const baseName = `read_${resourceNameToToolName(resource.name)}`;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
-        if (!isToolAllowed(baseName, serverName, prefix, definition.includeTools, definition.excludeTools)) continue;
-        const prefixedName = formatToolName(baseName, serverName, prefix);
+        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) continue;
+        const prefixedName = formatToolName(baseName, serverName, effectivePrefix);
         if (BUILTIN_NAMES.has(prefixedName)) {
           console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`);
           continue;
@@ -188,6 +191,10 @@ export function resolveDirectTools(
         });
       }
     }
+  }
+
+  if (specs.length >= DIRECT_TOOLS_ADVISORY_THRESHOLD) {
+    console.warn(`MCP: ${specs.length} direct tools resolved. Each direct tool adds prompt context; README guidance recommends targeted sets of 5-20 tools and using the proxy or an explicit string[] when 75+ direct tools would be registered.`);
   }
 
   return specs;
@@ -217,13 +224,14 @@ export function buildProxyDescription(
     const definition = config.mcpServers[serverName];
     if (isServerDisabled(definition)) continue;
     const entry = cache?.servers?.[serverName];
+    const effectivePrefix = resolveToolPrefix(definition, prefix);
     const toolCount = (entry?.tools ?? []).filter(
-      (tool) => isToolAllowed(tool.name, serverName, prefix, definition.includeTools, definition.excludeTools),
+      (tool) => isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools),
     ).length;
     const resourceCount = definition?.exposeResources !== false
       ? (entry?.resources ?? []).filter((resource) => {
           const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          return isToolAllowed(baseName, serverName, prefix, definition.includeTools, definition.excludeTools);
+          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools);
         }).length
       : 0;
     const totalItems = toolCount + resourceCount;

--- a/init.ts
+++ b/init.ts
@@ -245,7 +245,7 @@ export async function initializeMcp(
         resourceCounts.set(name, cachedEntry.resources.length);
       }
       if (cachedEntry.prompts?.length) {
-        promptMetadata.set(name, reconstructPromptMetadata(name, cachedEntry.prompts ?? [], prefix));
+        promptMetadata.set(name, reconstructPromptMetadata(name, cachedEntry.prompts ?? [], prefix, definition));
       }
       if (cachedEntry.instructions) {
         serverInstructions.set(name, cachedEntry.instructions);
@@ -301,7 +301,7 @@ export async function initializeMcp(
     toolMetadata.set(name, metadata);
     resourceCounts.set(name, connection.resources.length);
     if (!connection.promptDiscoveryFailed) {
-      promptMetadata.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix));
+      promptMetadata.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix, definition));
       promptMetadataLive.add(name);
     }
     if (connection.instructions) {
@@ -433,7 +433,7 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
   state.toolMetadata.set(serverName, metadata);
   state.resourceCounts?.set(serverName, connection.resources.length);
   if (!connection.promptDiscoveryFailed) {
-    state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix));
+    state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix, definition));
     state.promptMetadataLive?.add(serverName);
   }
   if (connection.instructions) {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -19,7 +19,7 @@ import type {
   ToolMetadata,
   PromptMetadata,
 } from "./types.ts";
-import { formatPromptCommandName, formatToolName, isServerDisabled, isToolAllowed, type ToolPrefix } from "./types.ts";
+import { formatPromptCommandName, formatToolName, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -175,18 +175,19 @@ export function reconstructToolMetadata(
   serverName: string,
   entry: ServerCacheEntry,
   prefix: ToolPrefix,
-  definition: Pick<ServerEntry, "exposeResources" | "includeTools" | "excludeTools">
+  definition: Pick<ServerEntry, "exposeResources" | "includeTools" | "excludeTools" | "toolPrefix">
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
   const seenNames = new Set<string>();
+  const effectivePrefix = resolveToolPrefix(definition, prefix);
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
-    if (!isToolAllowed(tool.name, serverName, prefix, definition.includeTools, definition.excludeTools)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
       continue;
     }
 
-    const name = formatToolName(tool.name, serverName, prefix);
+    const name = formatToolName(tool.name, serverName, effectivePrefix);
     if (seenNames.has(name)) {
       continue;
     }
@@ -206,11 +207,11 @@ export function reconstructToolMetadata(
     for (const resource of entry.resources ?? []) {
       if (!resource?.name || !resource?.uri) continue;
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, prefix, definition.includeTools, definition.excludeTools)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
         continue;
       }
 
-      const name = formatToolName(baseName, serverName, prefix);
+      const name = formatToolName(baseName, serverName, effectivePrefix);
       if (seenNames.has(name)) {
         continue;
       }
@@ -271,7 +272,9 @@ export function reconstructPromptMetadata(
   serverName: string,
   prompts: ReadonlyArray<McpPrompt | CachedPrompt>,
   prefix: ToolPrefix,
+  definition?: Pick<ServerEntry, "toolPrefix">,
 ): PromptMetadata[] {
+  const effectivePrefix = resolveToolPrefix(definition, prefix);
   return (prompts ?? []).filter(prompt => prompt?.name).map(prompt => {
     const args: McpPromptArgument[] = Array.isArray(prompt.arguments)
       ? prompt.arguments.filter(argument => argument?.name).map(argument => ({
@@ -283,7 +286,7 @@ export function reconstructPromptMetadata(
     return {
       serverName,
       originalName: prompt.name,
-      commandName: formatPromptCommandName(prompt.name, serverName, prefix),
+      commandName: formatPromptCommandName(prompt.name, serverName, effectivePrefix),
       title: prompt.title,
       description: prompt.description ?? "",
       arguments: args,

--- a/prompts.ts
+++ b/prompts.ts
@@ -27,7 +27,7 @@ export function resolveCachedPrompts(config: McpConfig): PromptMetadata[] {
     const definition = config.mcpServers[serverName];
     if (!definition || isServerDisabled(definition)) continue;
     if (!entry?.prompts?.length || !isServerCacheValid(entry, definition)) continue;
-    specs.push(...reconstructPromptMetadata(serverName, entry.prompts, prefix));
+    specs.push(...reconstructPromptMetadata(serverName, entry.prompts, prefix, definition));
   }
 
   return specs;

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -696,7 +696,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
     state.toolMetadata.set(serverName, metadata);
     if (!connection.promptDiscoveryFailed) {
-      state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix));
+      state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix, definition));
       state.promptMetadataLive?.add(serverName);
     }
     if (connection.instructions) {

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,7 +1,7 @@
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from "./types.ts";
-import { formatToolName, isToolAllowed } from "./types.ts";
+import { formatToolName, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
 
@@ -15,17 +15,18 @@ export function buildToolMetadata(
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
   const seenNames = new Set<string>();
+  const effectivePrefix = resolveToolPrefix(definition, prefix);
 
   for (const tool of tools) {
     if (!tool?.name) {
       failedTools.push("(unnamed)");
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, prefix, definition.includeTools, definition.excludeTools)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
       continue;
     }
 
-    const name = formatToolName(tool.name, serverName, prefix);
+    const name = formatToolName(tool.name, serverName, effectivePrefix);
     if (seenNames.has(name)) {
       continue;
     }
@@ -50,11 +51,11 @@ export function buildToolMetadata(
   if (definition.exposeResources !== false) {
     for (const resource of resources) {
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, prefix, definition.includeTools, definition.excludeTools)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
         continue;
       }
 
-      const name = formatToolName(baseName, serverName, prefix);
+      const name = formatToolName(baseName, serverName, effectivePrefix);
       if (seenNames.has(name)) {
         continue;
       }

--- a/types.ts
+++ b/types.ts
@@ -349,6 +349,8 @@ export interface ServerEntry {
   exposeResources?: boolean;
   // Direct tool registration
   directTools?: boolean | string[];
+  // Override settings.toolPrefix for this server.
+  toolPrefix?: ToolPrefix;
   // Include/exclude specific MCP tools/resources by original or prefixed name
   includeTools?: string[];
   excludeTools?: string[];
@@ -568,6 +570,13 @@ export function formatToolName(
   const p = getServerPrefix(serverName, prefix);
   const sanitized = toolName.replace(/\./g, "_");
   return p ? `${p}_${sanitized}` : sanitized;
+}
+
+export function resolveToolPrefix(
+  definition?: Pick<ServerEntry, "toolPrefix">,
+  globalPrefix?: ToolPrefix,
+): ToolPrefix {
+  return definition?.toolPrefix ?? globalPrefix ?? "server";
 }
 
 export function sanitizePromptName(name: string): string {


### PR DESCRIPTION
Implements two related direct-tool requests.

Per-server `toolPrefix` (#229): each server entry can now override the global direct-tool prefix, and falls back to the global value when unset. The override applies to live and cached tool metadata, direct tool registration, proxy summaries, and prompt command metadata. Collision behavior is unchanged: builtin-name and duplicate-name skips still run against the final resolved name.

Direct-tool count warning (#240): once resolved direct tools pass the 75-tool threshold already documented in the README, there is an advisory warning. No cap, no enforcement, nothing is dropped.

Credit:
- Thanks @FurryWolfX for issue #229.
- Thanks @JasonLandbridge for issue #240.

Validation:
- `npx vitest run __tests__/direct-tools.test.ts` (29 tests)
- `npx tsc --noEmit`
