### PR TITLE
fix: store OAuth credentials as compact JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Prevented `/mcp` and `/mcp-auth` from crashing when the OS OAuth credential store is unavailable.
+- Stored OAuth credential payloads as compact JSON, so multiline secrets no longer corrupt gnome-keyring plaintext keyrings. Thanks @hank-warren for issue #239.
 - Kept collapsed MCP tool results from re-wrapping full multi-10KB payloads on repeated TUI renders, avoiding composer keystroke lag after large MCP dumps. Thanks @hyknerf for PR #233 and @chapmanb for the held-Text follow-up fix.
 
 ## [2.15.0] - 2026-07-25

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -247,7 +247,8 @@ function removeLegacyAuthEntry(serverName: string, options?: AuthStorageOptions)
 function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
   const account = getAuthEntryAccount(serverName);
   try {
-    getAuthSecretStore().write(account, JSON.stringify(entry, null, 2));
+    // Compact: multiline secrets corrupt gnome-keyring plaintext (GKeyFile) collections.
+    getAuthSecretStore().write(account, JSON.stringify(entry));
   } catch (error) {
     throw new OAuthCredentialStoreError(
       `Failed to write OAuth credentials for ${serverName} to the OS secure credential store`,


### PR DESCRIPTION
Fixes #239.

OAuth entries were written to the OS credential store as pretty-printed JSON, so the stored secret contained newlines. On Linux plaintext gnome-keyring collections that value is written raw into a GKeyFile, and the collection fails to round-trip on daemon restart, which can take out every secret in the keyring, not just ours.

Serializing compactly is the whole fix. Reads are unchanged and already `JSON.parse`, so entries written by older versions keep working.

Thanks @hank-warren for the report and the diagnosis.

Validation:
- `npx vitest run __tests__/mcp-auth-storage.test.ts`
- `npx tsc --noEmit`
