### PR TITLE
fix: chunk oversized OAuth credential records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Prevented `/mcp` and `/mcp-auth` from crashing when the OS OAuth credential store is unavailable.
+- Stored oversized OAuth credential payloads as secure-store manifests plus chunks, so Windows Credential Manager value limits no longer block OAuth completion for large token records. Thanks @LysanderdeJong for issue #223.
 - Stored OAuth credential payloads as compact JSON, so multiline secrets no longer corrupt gnome-keyring plaintext keyrings. Thanks @hank-warren for issue #239.
 - Kept collapsed MCP tool results from re-wrapping full multi-10KB payloads on repeated TUI renders, avoiding composer keystroke lag after large MCP dumps. Thanks @hyknerf for PR #233 and @chapmanb for the held-Text follow-up fix.
 

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -3,12 +3,16 @@ import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  clearAllCredentials,
   formatOAuthCredentialStoreUnavailable,
   getAuthEntry,
   getAuthEntryFilePath,
   getAuthStorageOptions,
+  getTestAuthSecretStoreEntries,
   inspectAuthForUrl,
   OAuthCredentialStoreError,
+  removeTestAuthSecretStoreEntry,
+  resetTestAuthSecretStore,
   saveAuthEntry,
 } from "../mcp-auth.ts";
 
@@ -36,6 +40,7 @@ describe("mcp-auth storage paths", () => {
   beforeEach(() => {
     authDir = mkdtempSync(join(tmpdir(), "pi-mcp-auth-storage-"));
     process.env.MCP_OAUTH_DIR = authDir;
+    resetTestAuthSecretStore();
   });
 
   afterEach(() => {
@@ -126,5 +131,53 @@ describe("mcp-auth storage paths", () => {
     expect(filePath.startsWith(authDir)).toBe(true);
     expect(filePath.startsWith(join(project, ".pi", "oauth"))).toBe(false);
     rmSync(project, { recursive: true, force: true });
+  });
+
+  it("chunks large secure-store entries and reads them back", () => {
+    const accessToken = "x".repeat(5000);
+    saveAuthEntry("large-entry", { tokens: { accessToken } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("large-entry")?.tokens?.accessToken).toBe(accessToken);
+    const entries = getTestAuthSecretStoreEntries();
+    const manifestEntry = entries.find(([account]) => !account.includes(".chunk."));
+    const chunkEntries = entries.filter(([account]) => account.includes(".chunk."));
+
+    expect(manifestEntry).toBeDefined();
+    const manifest = JSON.parse(manifestEntry![1]) as { __piMcpAdapterOAuthChunked?: number; chunkCount?: number };
+    expect(manifest.__piMcpAdapterOAuthChunked).toBe(1);
+    expect(chunkEntries).toHaveLength(manifest.chunkCount);
+    expect(chunkEntries.every(([, payload]) => payload.length <= 1800)).toBe(true);
+  });
+
+  it("returns unavailable status when a stored chunk cannot be read", () => {
+    saveAuthEntry("large-status", { tokens: { accessToken: "x".repeat(5000) } }, "https://example.com/mcp");
+    const chunkAccount = getTestAuthSecretStoreEntries().find(([account]) => account.includes(".chunk."))?.[0];
+    expect(chunkAccount).toBeDefined();
+    removeTestAuthSecretStoreEntry(chunkAccount!);
+
+    expect(inspectAuthForUrl("large-status", "https://example.com/mcp").status).toBe("unavailable");
+  });
+
+  it("removes chunk payloads when credentials are cleared", () => {
+    saveAuthEntry("large-remove", { tokens: { accessToken: "x".repeat(5000) } }, "https://example.com/mcp");
+    const storedAccounts = getTestAuthSecretStoreEntries().map(([account]) => account);
+    expect(storedAccounts.some(account => account.includes(".chunk."))).toBe(true);
+
+    clearAllCredentials("large-remove");
+
+    const remainingAccounts = new Set(getTestAuthSecretStoreEntries().map(([account]) => account));
+    expect(storedAccounts.every(account => !remainingAccounts.has(account))).toBe(true);
+  });
+
+  it("cleans stale chunks when a large entry is replaced by a small one", () => {
+    saveAuthEntry("large-to-small", { tokens: { accessToken: "x".repeat(5000) } }, "https://example.com/mcp");
+    expect(getTestAuthSecretStoreEntries().some(([account]) => account.includes(".chunk."))).toBe(true);
+
+    saveAuthEntry("large-to-small", { tokens: { accessToken: "small" } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("large-to-small")?.tokens?.accessToken).toBe("small");
+    const entries = getTestAuthSecretStoreEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0][0]).not.toContain(".chunk.");
   });
 });

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -20,6 +20,8 @@ import { resolveConfiguredOAuthDir } from './config.ts';
 const require = createRequire(import.meta.url);
 const AUTH_SECRET_SERVICE = 'pi-mcp-adapter.oauth';
 const TEST_AUTH_STORE_ENV = 'PI_MCP_ADAPTER_TEST_AUTH_STORE';
+const AUTH_SECRET_CHUNK_SIZE = 1800;
+const AUTH_CHUNK_MANIFEST_KEY = '__piMcpAdapterOAuthChunked';
 
 /** OAuth token storage format */
 export interface StoredTokens {
@@ -118,6 +120,12 @@ interface AuthSecretStore {
   remove(account: string): void;
 }
 
+interface AuthEntryChunkManifest {
+  [AUTH_CHUNK_MANIFEST_KEY]: 1;
+  chunkCount: number;
+  chunkDigest: string;
+}
+
 let KeyringEntryClass: KeyringEntryConstructor | undefined;
 const memoryAuthEntries = new Map<string, string>();
 
@@ -159,6 +167,14 @@ const unavailableAuthSecretStore: AuthSecretStore = {
 
 export function resetTestAuthSecretStore(): void {
   memoryAuthEntries.clear();
+}
+
+export function getTestAuthSecretStoreEntries(): [string, string][] {
+  return [...memoryAuthEntries.entries()];
+}
+
+export function removeTestAuthSecretStoreEntry(account: string): void {
+  memoryAuthEntries.delete(account);
 }
 
 function getAuthSecretStore(): AuthSecretStore {
@@ -212,12 +228,92 @@ export function getAuthEntryFilePath(serverName: string, options?: AuthStorageOp
   return join(getServerDir(serverName, options), 'tokens.json');
 }
 
-function parseAuthEntryPayload(serverName: string, payload: string, source: string): AuthEntry {
+function parseJsonPayload(serverName: string, payload: string, source: string): unknown {
   try {
-    return JSON.parse(payload) as AuthEntry;
+    return JSON.parse(payload) as unknown;
   } catch (error) {
     throw new Error(`Failed to parse OAuth credentials for ${serverName} from ${source}`, { cause: error });
   }
+}
+
+function parseAuthEntryPayload(serverName: string, payload: string, source: string): AuthEntry {
+  return parseJsonPayload(serverName, payload, source) as AuthEntry;
+}
+
+function isAuthEntryChunkManifest(value: unknown): value is AuthEntryChunkManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const manifest = value as Partial<AuthEntryChunkManifest>;
+  return manifest[AUTH_CHUNK_MANIFEST_KEY] === 1
+    && Number.isInteger(manifest.chunkCount)
+    && manifest.chunkCount !== undefined
+    && manifest.chunkCount > 0
+    && typeof manifest.chunkDigest === 'string'
+    && /^[a-f0-9]{16}$/.test(manifest.chunkDigest);
+}
+
+function getAuthEntryChunkAccount(account: string, manifest: AuthEntryChunkManifest, index: number): string {
+  return `${account}.chunk.${manifest.chunkDigest}.${index}`;
+}
+
+function getAuthEntryChunkAccounts(account: string, manifest: AuthEntryChunkManifest): string[] {
+  return Array.from({ length: manifest.chunkCount }, (_, index) => getAuthEntryChunkAccount(account, manifest, index));
+}
+
+function readChunkManifestFromPayload(serverName: string, payload: string, source: string): AuthEntryChunkManifest | undefined {
+  const parsed = parseJsonPayload(serverName, payload, source);
+  return isAuthEntryChunkManifest(parsed) ? parsed : undefined;
+}
+
+function readExistingChunkManifest(store: AuthSecretStore, serverName: string, account: string): AuthEntryChunkManifest | undefined {
+  try {
+    const payload = store.read(account);
+    return payload === undefined ? undefined : readChunkManifestFromPayload(serverName, payload, 'OS secure credential store');
+  } catch {
+    return undefined;
+  }
+}
+
+function removeChunkPayloads(store: AuthSecretStore, account: string, manifest: AuthEntryChunkManifest): void {
+  for (const chunkAccount of getAuthEntryChunkAccounts(account, manifest)) {
+    store.remove(chunkAccount);
+  }
+}
+
+function tryRemoveChunkPayloads(store: AuthSecretStore, account: string, manifest: AuthEntryChunkManifest | undefined): void {
+  if (!manifest) return;
+  try {
+    removeChunkPayloads(store, account, manifest);
+  } catch {
+    // Stale chunk cleanup must not hide a successful credential write.
+  }
+}
+
+function createChunkManifest(payload: string): AuthEntryChunkManifest {
+  return {
+    [AUTH_CHUNK_MANIFEST_KEY]: 1,
+    chunkCount: Math.ceil(payload.length / AUTH_SECRET_CHUNK_SIZE),
+    chunkDigest: createHash('sha256').update(payload, 'utf8').digest('hex').slice(0, 16),
+  };
+}
+
+function readChunkedAuthEntry(serverName: string, account: string, manifest: AuthEntryChunkManifest): AuthEntry {
+  const store = getAuthSecretStore();
+  const chunks = getAuthEntryChunkAccounts(account, manifest).map((chunkAccount) => {
+    try {
+      const chunk = store.read(chunkAccount);
+      if (chunk === undefined) {
+        throw new Error(`Missing OAuth credential chunk ${chunkAccount} for ${serverName}`);
+      }
+      return chunk;
+    } catch (error) {
+      throw new OAuthCredentialStoreError(
+        `Failed to read OAuth credentials for ${serverName} from the OS secure credential store`,
+        'read',
+        error,
+      );
+    }
+  });
+  return parseAuthEntryPayload(serverName, chunks.join(''), 'OS secure credential store chunks');
 }
 
 function readLegacyAuthEntry(serverName: string, options?: AuthStorageOptions): AuthEntry | undefined {
@@ -246,10 +342,26 @@ function removeLegacyAuthEntry(serverName: string, options?: AuthStorageOptions)
 
 function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
   const account = getAuthEntryAccount(serverName);
+  const store = getAuthSecretStore();
+  const payload = JSON.stringify(entry);
+  const previousManifest = readExistingChunkManifest(store, serverName, account);
+  const manifest = payload.length > AUTH_SECRET_CHUNK_SIZE ? createChunkManifest(payload) : undefined;
+
   try {
-    // Compact: multiline secrets corrupt gnome-keyring plaintext (GKeyFile) collections.
-    getAuthSecretStore().write(account, JSON.stringify(entry));
+    if (manifest) {
+      for (const [index, chunk] of payload.match(new RegExp(`.{1,${AUTH_SECRET_CHUNK_SIZE}}`, 'gs'))?.entries() ?? []) {
+        store.write(getAuthEntryChunkAccount(account, manifest, index), chunk);
+      }
+      store.write(account, JSON.stringify(manifest));
+    } else {
+      // Compact: multiline secrets corrupt gnome-keyring plaintext (GKeyFile) collections.
+      store.write(account, payload);
+    }
+    if (previousManifest?.chunkDigest !== manifest?.chunkDigest) {
+      tryRemoveChunkPayloads(store, account, previousManifest);
+    }
   } catch (error) {
+    tryRemoveChunkPayloads(store, account, manifest);
     throw new OAuthCredentialStoreError(
       `Failed to write OAuth credentials for ${serverName} to the OS secure credential store`,
       'write',
@@ -280,7 +392,10 @@ function readAuthEntry(
   }
 
   if (payload !== undefined) {
-    const entry = parseAuthEntryPayload(serverName, payload, 'OS secure credential store');
+    const manifest = readChunkManifestFromPayload(serverName, payload, 'OS secure credential store');
+    const entry = manifest
+      ? readChunkedAuthEntry(serverName, account, manifest)
+      : parseAuthEntryPayload(serverName, payload, 'OS secure credential store');
     removeLegacyAuthEntry(serverName, options);
     return entry;
   }
@@ -354,8 +469,12 @@ export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: 
  */
 export function removeAuthEntry(serverName: string, options?: AuthStorageOptions): void {
   const account = getAuthEntryAccount(serverName);
+  const store = getAuthSecretStore();
   try {
-    getAuthSecretStore().remove(account);
+    const payload = store.read(account);
+    const manifest = payload === undefined ? undefined : readChunkManifestFromPayload(serverName, payload, 'OS secure credential store');
+    if (manifest) removeChunkPayloads(store, account, manifest);
+    store.remove(account);
   } catch (error) {
     throw new OAuthCredentialStoreError(
       `Failed to remove OAuth credentials for ${serverName} from the OS secure credential store`,


### PR DESCRIPTION
Fixes #223.

Windows Credential Manager rejects large per-value passwords, so OAuth could complete the token exchange and then fail while persisting a large token/client record. This keeps storage in the OS secure store but writes oversized records as a small manifest at the existing account plus numbered chunk entries. Existing single-entry credentials remain readable, and removal cleans up manifest/chunk records.

Credit:
- Thanks @LysanderdeJong for the report, repro, and suggested manifest/chunk direction in #223.

Validation:
- `npx vitest run __tests__/mcp-auth-storage.test.ts` (11 tests)
- `npx tsc --noEmit`
- `npm run test:oauth` (109 tests)
- fresh read-only review found one blocker around chunk-read failure wrapping; fixed with a regression that missing chunks report unavailable status instead of escaping raw storage errors.
