### PR TITLE
refactor: simplify chunk splitting and ajv formats wiring

### DIFF
--- a/json-schema-validator.ts
+++ b/json-schema-validator.ts
@@ -8,6 +8,9 @@ import type {
   jsonSchemaValidator as JsonSchemaValidatorProvider,
 } from "@modelcontextprotocol/sdk/validation/types.js";
 
+// ajv-formats types target its bundled ajv; the runtime accepts both instances.
+const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;
+
 type SchemaDialect =
   | { status: "unstamped" }
   | { status: "stamped"; uri: string };
@@ -41,7 +44,6 @@ export function createJsonSchemaValidator(): JsonSchemaValidatorProvider {
         draft2020Validator ??= (() => {
           const Ajv2020 = Ajv2020Import as unknown as typeof Ajv;
           const ajv = new Ajv2020({ strict: false, allErrors: true });
-          const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;
           addFormats(ajv);
           return new AjvJsonSchemaValidator(ajv);
         })();
@@ -58,7 +60,6 @@ export function createJsonSchemaValidator(): JsonSchemaValidatorProvider {
           validateSchema: false,
           allErrors: true,
         });
-        const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;
         addFormats(ajv);
         return new AjvJsonSchemaValidator(ajv);
       })();

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -244,8 +244,8 @@ function isAuthEntryChunkManifest(value: unknown): value is AuthEntryChunkManife
   if (typeof value !== 'object' || value === null) return false;
   const manifest = value as Partial<AuthEntryChunkManifest>;
   return manifest[AUTH_CHUNK_MANIFEST_KEY] === 1
+    && typeof manifest.chunkCount === 'number'
     && Number.isInteger(manifest.chunkCount)
-    && manifest.chunkCount !== undefined
     && manifest.chunkCount > 0
     && typeof manifest.chunkDigest === 'string'
     && /^[a-f0-9]{16}$/.test(manifest.chunkDigest);
@@ -349,7 +349,8 @@ function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
 
   try {
     if (manifest) {
-      for (const [index, chunk] of payload.match(new RegExp(`.{1,${AUTH_SECRET_CHUNK_SIZE}}`, 'gs'))?.entries() ?? []) {
+      for (let index = 0; index < manifest.chunkCount; index++) {
+        const chunk = payload.slice(index * AUTH_SECRET_CHUNK_SIZE, (index + 1) * AUTH_SECRET_CHUNK_SIZE);
         store.write(getAuthEntryChunkAccount(account, manifest, index), chunk);
       }
       store.write(account, JSON.stringify(manifest));


### PR DESCRIPTION
Post-merge polish pass over the unreleased changes. No behavior change.

- `mcp-auth.ts`: split oversized OAuth payloads with a slice loop driven by the manifest `chunkCount` instead of a dynamically built regex, so the written chunks are aligned with the manifest by construction; tidy the manifest type guard narrowing.
- `json-schema-validator.ts`: hoist the duplicated `ajv-formats` cast to module scope.

Validation:
- `npx vitest run __tests__/mcp-auth-storage.test.ts __tests__/json-schema-validator.test.ts` (18 tests)
- `npx tsc --noEmit`
- `npm run test:oauth` (109 tests)
