### PR TITLE
feat(oauth): support authorization parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added per-server OAuth `authorizationParams` for provider-specific authorization URL parameters such as Google's `access_type=offline`, while rejecting OAuth flow-owned parameter overrides. Thanks @hank-warren for issue #238.
+
 ### Fixed
 - Let configured `oauth.scope` override OAuth discovery scopes during authorization flows. Thanks @viggy28 for issue #225 and @adity982 for PR #226.
 

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -58,6 +58,7 @@ You can optionally provide a pre-registered client:
         "clientId": "your-client-id",
         "clientSecret": "your-client-secret",
         "scope": "read write",
+        "authorizationParams": { "access_type": "offline", "prompt": "consent" },
         "redirectUri": "http://localhost:3118/callback"
       }
     }
@@ -75,6 +76,7 @@ You can optionally provide a pre-registered client:
 - `oauth.clientId` - Pre-registered client ID (optional, SDK tries dynamic registration if not provided)
 - `oauth.clientSecret` - Client secret for confidential clients (optional)
 - `oauth.scope` - Requested OAuth scopes (optional)
+- `oauth.authorizationParams` - Extra authorization URL parameters for provider-specific extensions, such as Google's `{ "access_type": "offline", "prompt": "consent" }`. Flow-owned parameters like `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden.
 - `oauth.redirectUri` - Exact browser callback URI to advertise and bind, such as `http://localhost:3118/callback` (optional)
 - `oauth.clientName` - Client display name used for dynamic registration (optional, defaults to `Pi Coding Agent`)
 - `oauth.clientUri` - Client homepage URI used for dynamic registration (optional)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
 | `oauthDir` | Legacy OAuth `tokens.json` import directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. Persistent OAuth credentials are stored in the OS credential store, not this directory. |
+| `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -707,6 +707,41 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getAuthForUrl("cancel-token", "https://api.example.com/mcp")?.tokens).toBeUndefined();
   });
 
+  it("adds configured authorization URL parameters", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize?client_id=abc"));
+      return "REDIRECT";
+    });
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    const result = await startAuth("google", "https://gmailmcp.googleapis.com/mcp/v1", {
+      url: "https://gmailmcp.googleapis.com/mcp/v1",
+      auth: "oauth",
+      oauth: {
+        authorizationParams: { access_type: "offline", prompt: "consent" },
+      },
+    });
+
+    const url = new URL(result.authorizationUrl);
+    expect(url.searchParams.get("client_id")).toBe("abc");
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+  });
+
+  it("rejects authorization URL parameters that override the OAuth flow", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize?state=flow-state"));
+      return "REDIRECT";
+    });
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    await expect(startAuth("bad-param", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+      oauth: { authorizationParams: { state: "config-state" } },
+    })).rejects.toThrow("OAuth authorizationParams.state cannot override an authorization flow parameter");
+  });
+
   it("uses a custom authorization URL handler instead of raw console output", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -297,6 +297,25 @@ describe("mcp-auth-flow", () => {
       )
     })
 
+    it("should reject malformed OAuth authorizationParams", () => {
+      assert.throws(
+        () => extractOAuthConfig({
+          url: "https://api.example.com/mcp",
+          auth: "oauth",
+          oauth: { authorizationParams: [] as unknown as Record<string, string> },
+        }),
+        /authorizationParams must be an object/
+      )
+      assert.throws(
+        () => extractOAuthConfig({
+          url: "https://api.example.com/mcp",
+          auth: "oauth",
+          oauth: { authorizationParams: { prompt: 123 as unknown as string } },
+        }),
+        /authorizationParams\.prompt must be a string/
+      )
+    })
+
     it("should trim OAuth redirectUri and client metadata values", () => {
       const config = extractOAuthConfig({
         url: "https://api.example.com/mcp",

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -166,6 +166,18 @@ export function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     if (typeof definition.oauth.scope !== "string") throw new Error("OAuth scope must be a string")
     config.scope = interpolateEnvVars(definition.oauth.scope)
   }
+  if (definition.oauth?.authorizationParams !== undefined) {
+    const params = definition.oauth.authorizationParams
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new Error("OAuth authorizationParams must be an object")
+    }
+    config.authorizationParams = {}
+    for (const [key, value] of Object.entries(params)) {
+      if (!key) throw new Error("OAuth authorizationParams keys must not be empty")
+      if (typeof value !== "string") throw new Error(`OAuth authorizationParams.${key} must be a string`)
+      config.authorizationParams[key] = interpolateEnvVars(value)
+    }
+  }
   if (definition.oauth?.redirectUri !== undefined) {
     if (typeof definition.oauth.redirectUri !== "string") {
       throw new Error("OAuth redirectUri must be a string")

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -82,9 +82,33 @@ export interface McpOAuthConfig {
   clientId?: string
   clientSecret?: string
   scope?: string
+  authorizationParams?: Record<string, string>
   redirectUri?: string
   clientName?: string
   clientUri?: string
+}
+
+const reservedAuthorizationParams = new Set([
+  "client_id",
+  "code_challenge",
+  "code_challenge_method",
+  "redirect_uri",
+  "resource",
+  "response_type",
+  "scope",
+  "state",
+])
+
+function addAuthorizationParams(authorizationUrl: URL, params: Record<string, string> | undefined): URL {
+  if (!params) return authorizationUrl
+  const nextUrl = new URL(authorizationUrl.toString())
+  for (const [key, value] of Object.entries(params)) {
+    if (reservedAuthorizationParams.has(key) || nextUrl.searchParams.has(key)) {
+      throw new Error(`OAuth authorizationParams.${key} cannot override an authorization flow parameter`)
+    }
+    nextUrl.searchParams.set(key, value)
+  }
+  return nextUrl
 }
 
 /** Callbacks for OAuth flow interactions */
@@ -386,7 +410,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       )
     }
     // URL is passed to callback, not logged (may contain sensitive params)
-    await this.callbacks.onRedirect(authorizationUrl)
+    await this.callbacks.onRedirect(addAuthorizationParams(authorizationUrl, this.config.authorizationParams))
   }
 
   /**

--- a/types.ts
+++ b/types.ts
@@ -307,6 +307,8 @@ export interface OAuthConfig {
   clientSecret?: string;
   /** Requested OAuth scopes */
   scope?: string;
+  /** Extra authorization URL parameters for provider-specific extensions. Flow-owned parameters cannot be overridden. */
+  authorizationParams?: Record<string, string>;
   /** Exact authorization-code redirect URI for pre-registered clients */
   redirectUri?: string;
   /** Client display name for dynamic registration */


### PR DESCRIPTION
## Summary
Adds per-server `oauth.authorizationParams` so providers such as Google can receive authorization URL extensions like `access_type=offline` and `prompt=consent`. The implementation rejects OAuth flow-owned or duplicate parameters so config cannot override SDK-generated values.

Closes #238. Thanks @hank-warren for the report and Google refresh-token reproduction.

## Validation
- `git diff --check`
- `npx vitest run __tests__/mcp-auth-flow-client-credentials.test.ts -t "authorization URL parameters|authorization URL handler"`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test --test-concurrency=1 mcp-auth-flow.test.ts`
- `npm run test:oauth`
- `npx tsc --noEmit`
- Fresh read-only review artifact: `/tmp/pi-mcp-backlog-inventory-1LKLVi/review-238-def28f0.md` reported no blockers