### PR TITLE
fix(auth): fallback load keyring native binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added per-server OAuth `authorizationParams` for provider-specific authorization URL parameters such as Google's `access_type=offline`, while rejecting OAuth flow-owned parameter overrides. Thanks @hank-warren for issue #238.
 
 ### Fixed
+- Added a best-effort absolute-path fallback for loading the `@napi-rs/keyring` native binding when compiled Pi/Bun cannot resolve the package loader. Thanks @sgiath for issue #230.
 - Bound collapsed MCP tool result rendering by character count as well as line count, preventing huge single-line results from slowing long TUI sessions. Thanks @Whisperfall for issue #249.
 - Let configured `oauth.scope` override OAuth discovery scopes during authorization flows. Thanks @viggy28 for issue #225 and @adity982 for PR #226.
 

--- a/mcp-auth.test.ts
+++ b/mcp-auth.test.ts
@@ -32,6 +32,7 @@ import {
   clearClientInfo,
   clearTokens,
   resetTestAuthSecretStore,
+  loadTestKeyringEntryClass,
   type AuthEntry,
 } from "./mcp-auth.ts"
 
@@ -57,6 +58,85 @@ describe("mcp-auth", () => {
     } catch {
       // Ignore cleanup errors
     }
+  })
+
+
+  describe("keyring native binding fallback", () => {
+    class FakeEntry {
+      constructor(readonly service: string, readonly account: string) {}
+      getPassword(): string | null { return null }
+      setPassword(): void {}
+      deleteCredential(): boolean { return true }
+    }
+
+    it("loads the native binding by absolute path when the package loader fails", () => {
+      const loaderError = new Error("package loader failed")
+      const nativePath = "/tmp/keyring-darwin-arm64/keyring.darwin-arm64.node"
+      const required: string[] = []
+      const requireStub = Object.assign((id: string) => {
+        required.push(id)
+        if (id === "@napi-rs/keyring") throw loaderError
+        if (id === nativePath) return { Entry: FakeEntry }
+        throw new Error(`unexpected require: ${id}`)
+      }, {
+        resolve(id: string) {
+          assert.strictEqual(id, "@napi-rs/keyring-darwin-arm64/package.json")
+          return "/tmp/keyring-darwin-arm64/package.json"
+        },
+      })
+
+      const Entry = loadTestKeyringEntryClass(requireStub, "darwin", "arm64")
+
+      assert.strictEqual(Entry, FakeEntry)
+      assert.deepStrictEqual(required, ["@napi-rs/keyring", nativePath])
+    })
+
+    it("tries the Linux musl package when the gnu package is unavailable", () => {
+      const loaderError = new Error("package loader failed")
+      const nativePath = "/tmp/keyring-linux-x64-musl/keyring.linux-x64-musl.node"
+      const resolved: string[] = []
+      const requireStub = Object.assign((id: string) => {
+        if (id === "@napi-rs/keyring") throw loaderError
+        if (id === nativePath) return { Entry: FakeEntry }
+        throw new Error(`unexpected require: ${id}`)
+      }, {
+        resolve(id: string) {
+          resolved.push(id)
+          if (id === "@napi-rs/keyring-linux-x64-musl/package.json") return "/tmp/keyring-linux-x64-musl/package.json"
+          throw new Error(`missing package: ${id}`)
+        },
+      })
+
+      const Entry = loadTestKeyringEntryClass(requireStub, "linux", "x64")
+
+      assert.strictEqual(Entry, FakeEntry)
+      assert.deepStrictEqual(resolved, [
+        "@napi-rs/keyring-linux-x64-gnu/package.json",
+        "@napi-rs/keyring-linux-x64-musl/package.json",
+      ])
+    })
+
+    it("keeps the original loader error in the cause chain when fallback fails", () => {
+      const loaderError = new Error("package loader failed")
+      const fallbackError = new Error("native binding failed")
+      const requireStub = Object.assign((id: string) => {
+        if (id === "@napi-rs/keyring") throw loaderError
+        throw fallbackError
+      }, {
+        resolve() { return "/tmp/keyring-darwin-arm64/package.json" },
+      })
+
+      assert.throws(() => loadTestKeyringEntryClass(requireStub, "darwin", "arm64"), (error) => {
+        assert(error instanceof Error)
+        assert.match(error.message, /absolute-path native binding fallback also failed: native binding failed/)
+        let current: unknown = error
+        while (current && typeof current === "object") {
+          if (current === loaderError) return true
+          current = (current as { cause?: unknown }).cause
+        }
+        assert.fail("original loader error was not preserved in the cause chain")
+      })
+    })
   })
 
   describe("getAuthEntry", () => {

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -13,7 +13,7 @@
 import { createHash } from 'crypto';
 import { createRequire } from 'module';
 import { readFileSync, existsSync, rmSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { getAgentPath } from './agent-dir.ts';
 import { resolveConfiguredOAuthDir } from './config.ts';
 
@@ -113,6 +113,8 @@ interface KeyringEntry {
 }
 
 type KeyringEntryConstructor = new (service: string, account: string) => KeyringEntry;
+type KeyringModule = { Entry: KeyringEntryConstructor };
+type KeyringRequire = ((id: string) => unknown) & { resolve(id: string): string };
 
 interface AuthSecretStore {
   read(account: string): string | undefined;
@@ -185,11 +187,79 @@ function getAuthSecretStore(): AuthSecretStore {
 
 function getKeyringEntry(account: string): KeyringEntry {
   try {
-    KeyringEntryClass ??= (require('@napi-rs/keyring') as { Entry: KeyringEntryConstructor }).Entry;
+    KeyringEntryClass ??= loadKeyringEntryClass();
     return new KeyringEntryClass(AUTH_SECRET_SERVICE, account);
   } catch (error) {
     throw new Error('OAuth secure credential storage is unavailable. Configure the OS credential store and retry authentication.', { cause: error });
   }
+}
+
+function loadKeyringEntryClass(keyringRequire: KeyringRequire = require, platform: NodeJS.Platform = process.platform, arch: NodeJS.Architecture = process.arch): KeyringEntryConstructor {
+  try {
+    return (keyringRequire('@napi-rs/keyring') as KeyringModule).Entry;
+  } catch (loaderError) {
+    try {
+      return loadKeyringNativeBindingFallback(keyringRequire, platform, arch).Entry;
+    } catch (fallbackError) {
+      throw new Error(`Failed to load @napi-rs/keyring; absolute-path native binding fallback also failed: ${formatErrorMessage(fallbackError)}`, {
+        cause: loaderError,
+      });
+    }
+  }
+}
+
+function loadKeyringNativeBindingFallback(keyringRequire: KeyringRequire, platform: NodeJS.Platform, arch: NodeJS.Architecture): KeyringModule {
+  const targets = getKeyringNativeBindingTargets(platform, arch);
+  if (targets.length === 0) {
+    throw new Error(`Unsupported @napi-rs/keyring native binding target: ${platform}-${arch}`);
+  }
+
+  let lastError: unknown;
+  for (const target of targets) {
+    try {
+      const packageJsonPath = keyringRequire.resolve(`${target.packageName}/package.json`);
+      return keyringRequire(join(dirname(packageJsonPath), target.bindingFile)) as KeyringModule;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function getKeyringNativeBindingTargets(platform: NodeJS.Platform, arch: NodeJS.Architecture): { packageName: string; bindingFile: string }[] {
+  return getKeyringNativeBindingSuffixes(platform, arch).map(suffix => ({
+    packageName: `@napi-rs/keyring-${suffix}`,
+    bindingFile: `keyring.${suffix}.node`,
+  }));
+}
+
+function getKeyringNativeBindingSuffixes(platform: NodeJS.Platform, arch: NodeJS.Architecture): string[] {
+  if (platform === 'darwin') {
+    if (arch === 'arm64') return ['darwin-arm64'];
+    if (arch === 'x64') return ['darwin-x64'];
+  }
+  if (platform === 'win32') {
+    if (arch === 'arm64') return ['win32-arm64-msvc'];
+    if (arch === 'x64') return ['win32-x64-msvc'];
+    if (arch === 'ia32') return ['win32-ia32-msvc'];
+  }
+  if (platform === 'linux') {
+    if (arch === 'arm64') return ['linux-arm64-gnu', 'linux-arm64-musl'];
+    if (arch === 'arm') return ['linux-arm-gnueabihf'];
+    if (arch === 'riscv64') return ['linux-riscv64-gnu'];
+    if (arch === 'x64') return ['linux-x64-gnu', 'linux-x64-musl'];
+  }
+  if (platform === 'freebsd' && arch === 'x64') return ['freebsd-x64'];
+  return [];
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function loadTestKeyringEntryClass(keyringRequire: KeyringRequire, platform: NodeJS.Platform, arch: NodeJS.Architecture): KeyringEntryConstructor {
+  return loadKeyringEntryClass(keyringRequire, platform, arch);
 }
 
 export function getAuthStorageOptions(oauthDir: unknown, cwd = process.cwd()): AuthStorageOptions {


### PR DESCRIPTION
## Summary
Adds a best-effort absolute-path fallback for loading the `@napi-rs/keyring` native binding when the normal package loader fails inside compiled Pi/Bun. The fallback resolves the installed platform package `package.json`, requires the native `.node` file by absolute path, tries Linux GNU then musl where both packages exist, and preserves the original package-loader error in the cause chain if all fallback attempts fail.

Closes #230. Thanks @sgiath for the report and the absolute-path control evidence that pinpointed the loader as the failure.

## Validation
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test --test-concurrency=1 mcp-auth.test.ts`
- `npx tsc --noEmit`
- Exact-head CI passed (run 30653540556)
- Equivalent compiled Bun runtime validation on darwin-arm64: a `bun build --compile` standalone binary (Bun 1.3.5) reproduces the exact #230 failure mode — the `@napi-rs/keyring` package loader fails with "Cannot find native binding" — and the same compiled binary calling this branch's `loadKeyringEntryClass` successfully loads the binding via the absolute-path fallback and completes a real OS keychain set/get/delete round-trip.
- Linux GNU→musl fallback ordering is covered by unit tests; the resolution mechanism (disk-anchored `require.resolve` of the platform package) is platform-independent.