### PR TITLE
feat: add MCP footer status modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `settings.mcpFooterStatus` to compact or hide the persistent MCP footer status. Thanks @jwintz for issue #5.
 - Added per-server OAuth `authorizationParams` for provider-specific authorization URL parameters such as Google's `access_type=offline`, while rejecting OAuth flow-owned parameter overrides. Thanks @hank-warren for issue #238.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
     "idleTimeout": 10,
     "requestTimeoutMs": 30000,
     "showStatusIcon": true,
+    "mcpFooterStatus": "full",
     "hostConfigDiscovery": "off",
     "oauthDir": ".pi/mcp-oauth",
     "trace": {
@@ -277,6 +278,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
+| `mcpFooterStatus` | MCP footer verbosity: `"full"` (default), `"compact"` for `MCP connected/enabled`, or `"off"` to clear the persistent footer status. `/mcp status` remains available. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
 | `oauthDir` | Legacy OAuth `tokens.json` import directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. Persistent OAuth credentials are stored in the OS credential store, not this directory. |
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |

--- a/__tests__/init-status.test.ts
+++ b/__tests__/init-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { updateStatusBar } from "../init.ts";
+import { formatMcpStatus } from "../utils.ts";
 import type { McpSettings } from "../types.ts";
 
 function createState(ui: unknown, settings: Partial<McpSettings> = {}) {
@@ -9,6 +10,12 @@ function createState(ui: unknown, settings: Partial<McpSettings> = {}) {
     manager: { getAllConnections: vi.fn(() => new Map()) },
   } as any;
 }
+
+describe("formatMcpStatus", () => {
+  it("returns undefined when the MCP footer is off", () => {
+    expect(formatMcpStatus({ settings: { mcpFooterStatus: "off" } }, "connecting...")).toBeUndefined();
+  });
+});
 
 describe("updateStatusBar", () => {
   it("shows enabled servers instead of active connections as the primary count", () => {
@@ -73,5 +80,22 @@ describe("updateStatusBar", () => {
     updateStatusBar(state);
 
     expect(setStatus).toHaveBeenCalledWith("mcp", "styled:MCP: 1 server enabled (1 connected) (1 disabled)");
+  });
+
+  it("can show a compact connected/enabled footer", () => {
+    const setStatus = vi.fn();
+    const state = createState({ setStatus }, { mcpFooterStatus: "compact" });
+    state.manager.getAllConnections.mockReturnValue(new Map([["demo", { status: "connected" }]]));
+
+    updateStatusBar(state);
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", "MCP 1/1");
+  });
+
+  it("can clear the MCP footer status", () => {
+    const setStatus = vi.fn();
+    updateStatusBar(createState({ setStatus }, { mcpFooterStatus: "off" }));
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", undefined);
   });
 });

--- a/init.ts
+++ b/init.ts
@@ -261,7 +261,8 @@ export async function initializeMcp(
       });
 
   if (ui && startupServers.length > 0) {
-    ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${startupServers.length} servers...`));
+    const status = formatMcpStatus(state.config, `connecting to ${startupServers.length} servers...`);
+    ui.setStatus("mcp", status);
   }
 
   const results = await parallelLimit(startupServers, 10, async ([name, definition]) => {
@@ -399,6 +400,9 @@ export async function initializeMcp(
 
   owner.throwIfInactive();
   lifecycle.startHealthChecks(runtimeSignal);
+  if (config.settings?.mcpFooterStatus === "off") {
+    ui?.setStatus("mcp", undefined);
+  }
   publishMcpStatusSnapshot(state);
 
   return state;
@@ -524,10 +528,24 @@ export function updateStatusBar(state: McpExtensionState): void {
     const definition = state.config.mcpServers[name];
     return connection.status === "connected" && definition !== undefined && !isServerDisabled(definition);
   }).length;
-  let status = `${enabledCount} ${enabledCount === 1 ? "server" : "servers"} enabled`;
-  if (connectedCount > 0) status += ` (${connectedCount} connected)`;
-  if (disabledCount > 0) status += ` (${disabledCount} disabled)`;
-  const formattedStatus = formatMcpStatus(state.config, status);
+  const footerStatus = state.config.settings?.mcpFooterStatus ?? "full";
+  if (footerStatus === "off") {
+    ui.setStatus("mcp", undefined);
+    return;
+  }
+
+  let status = footerStatus === "compact"
+    ? `MCP ${connectedCount}/${enabledCount}`
+    : `${enabledCount} ${enabledCount === 1 ? "server" : "servers"} enabled`;
+  if (footerStatus === "full") {
+    if (connectedCount > 0) status += ` (${connectedCount} connected)`;
+    if (disabledCount > 0) status += ` (${disabledCount} disabled)`;
+  }
+  const formattedStatus = footerStatus === "compact" ? status : formatMcpStatus(state.config, status);
+  if (formattedStatus === undefined) {
+    ui.setStatus("mcp", undefined);
+    return;
+  }
   ui.setStatus("mcp", ui.theme ? ui.theme.fg("accent", formattedStatus) : formattedStatus);
 }
 
@@ -565,7 +583,8 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
 
   try {
     if (state.ui) {
-      state.ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${serverName}...`));
+      const status = formatMcpStatus(state.config, `connecting to ${serverName}...`);
+      state.ui.setStatus("mcp", status);
     }
     const newConnection = await state.manager.connect(serverName, definition, ownedSignal);
     if (newConnection.status === "needs-auth") {

--- a/types.ts
+++ b/types.ts
@@ -382,6 +382,7 @@ export interface McpOutputGuardSettings {
 // Settings
 export type ToolPrefix = "server" | "none" | "short" | "mcp";
 export type HostConfigDiscovery = "off" | "prompt" | "on";
+export type McpFooterStatus = "full" | "compact" | "off";
 
 export interface McpTraceSettings {
   /** Enable tracing for all servers unless a server sets trace to false. */
@@ -398,6 +399,8 @@ export interface McpSettings {
   toolPrefix?: ToolPrefix;
   /** Show the plug prefix in MCP status and connection text (default: true). Set to false to disable it. */
   showStatusIcon?: boolean;
+  /** Footer status verbosity: full details, compact connected/enabled count, or no footer status. Defaults to full. */
+  mcpFooterStatus?: McpFooterStatus;
   /** Discover detected host-specific MCP configs only when explicitly enabled. */
   hostConfigDiscovery?: HostConfigDiscovery;
   idleTimeout?: number; // minutes, default 10, 0 to disable

--- a/utils.ts
+++ b/utils.ts
@@ -277,7 +277,8 @@ export function formatAuthRequiredMessage(
   return template ? template.replaceAll("${server}", serverName) : defaultMessage;
 }
 
-export function formatMcpStatus(config: Pick<McpConfig, "settings">, message: string): string {
+export function formatMcpStatus(config: Pick<McpConfig, "settings">, message: string): string | undefined {
+  if (config.settings?.mcpFooterStatus === "off") return undefined;
   return `${config.settings?.showStatusIcon === false ? "MCP: " : "🔌 MCP: "}${message}`;
 }
 


### PR DESCRIPTION
## Summary

Adds `settings.mcpFooterStatus` so users can keep the current MCP footer, compact it, or hide it entirely.

- `full` preserves the existing default footer behavior
- `compact` shows a short connected/enabled count such as `MCP 1/1`
- `off` clears the adapter-owned `mcp` footer status slot, including connecting states

`/mcp status` and connection notifications remain unchanged.

Closes #5.

## Validation

- `npx vitest run __tests__/init-stale-ctx-race.test.ts __tests__/init-status.test.ts __tests__/lifecycle-lazy-keep-alive-init.test.ts __tests__/lifecycle-lazy-keep-alive.test.ts __tests__/disabled-server.test.ts`
- `npx tsc --noEmit`
- `git diff --check`
- Fresh read-only review: no issues found (`.pi-subagents/artifacts/60543c27_delegate_0_output.md`)

Head: f4b5040375c87042b7dfbfe1458c23de19bbf55b
