### PR TITLE
feat: freezeDirectTools setting for cache-stable direct tools

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const fallbackDeactivatedTools = new Set<string>();
   let proxyToolRegistered = false;
   let proxyToolDescription: string | null = null;
+  let directToolsFrozen = false;
 
   // OMP remaps `typebox` to a host shim that historically lacked Type.Unsafe.
   // Prefer Unsafe when present (real TypeBox / fixed OMP shim); otherwise pass
@@ -278,12 +279,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       nextState.onToolMetadataUpdated = (_serverName, _reason) => {
         if (state !== nextState || !owner.isActive()) return;
         syncPromptCommands();
+        if (directToolsFrozen) {
+          logger.debug(`MCP: metadata update for ${_serverName} (${_reason}) skipped — directTools frozen`);
+          return;
+        }
         syncToolSurface(ctx);
       };
       syncPromptCommands();
       syncToolSurface(ctx);
       updateStatusBar(nextState);
       initPromise = null;
+      if (earlyConfig.settings?.freezeDirectTools === true) {
+        directToolsFrozen = true;
+        logger.info("MCP: direct tools frozen after initial sync — reconnects won't rebuild the system prompt; use mcp({ connect: \"server\" }) to rediscover");
+      }
     }).catch(async err => {
       if (!owner.isActive() || generation !== lifecycleGeneration) {
         return;

--- a/types.ts
+++ b/types.ts
@@ -407,6 +407,11 @@ export interface McpSettings {
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
   disableProxyTool?: boolean;
+  /** Freeze direct-tool registration after the initial sync. Automatic metadata updates
+   * (reconnects, lazy-connect, tool-list-changed) won't rebuild the system prompt,
+   * preserving the prompt-cache prefix. The agent rediscovers explicitly via
+   * mcp({ connect: "server" }). Default: false. */
+  freezeDirectTools?: boolean;
   autoAuth?: boolean;
   sampling?: boolean;
   samplingAutoApprove?: boolean;


### PR DESCRIPTION
## Problem

When `directTools` is enabled, every MCP reconnect / lazy-connect / tool-list-change fires `onToolMetadataUpdated` → `syncToolSurface` → `registerTool` per diff. Pi's extension loader fires `refreshTools()` → `_rebuildSystemPrompt()` on each `registerTool` call (`dist/core/extensions/loader.js:190`, `dist/core/agent-session.js:584`), and the system prompt + tool definitions are the **prompt-cache prefix**. So any metadata update invalidates the entire cached prefix, producing a full cache miss (`cacheRead=0`) on the next turn.

With ~70 direct tools and lazy-connect servers, this breaks the cache on every MCP lifecycle event.

**Verified:** a 65k-prefix turn missed with `cacheRead=0` only 63s after a 99.9%-hit turn, because MCP tools finished registering asynchronously between the two turns (the server's lazy-connect fired `notifyToolMetadataUpdated("lazy-connect")` mid-session.

## Fix

 (default: , opt-in):

1. The initial  runs once after MCP init (eager: all direct tools registered from the metadata cache before the first prompt).
2. A  flag is set.
3. Subsequent  callbacks skip  — reconnects and metadata refreshes no longer rebuild the system prompt.
4. The agent can still rediscover explicitly via , which calls  directly (not through the notification callback), accepting the cache miss as a deliberate action.

## Verification

With  enabled, a lazy-connect mid-session (model calls a direct MCP tool → server spawns → ) **no longer breaks the cache** — next turn retains 99.7% cache hit (vs 0.0% without the freeze):

| | without freeze | with freeze |
|---|---|---|
| Turn 1 (calls MCP tool, triggers lazy-connect) | CH=99.3% → 0.0% on next turn | CH=84.1% |
| Turn 2 (after lazy-connect) | **CH=0.0%** (cacheRead=0, full prefix miss) | **CH=99.7%** (cacheRead=57088, stable) |

## Configuration

## Changes

- : add  to 
- : add  flag, gate  in the  callback, set the flag after the initial sync

14 insertions, 0 deletions. Zero behavior change for existing users (default ).
PRBODY
)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in `freezeDirectTools` setting that prevents `onToolMetadataUpdated` callbacks from calling `syncToolSurface` after the initial sync, preserving the prompt-cache prefix across MCP reconnects and lazy-connect events.

- **`types.ts`**: Adds `freezeDirectTools?: boolean` to `McpSettings` with accurate JSDoc; default `false` means zero behavior change for existing users.
- **`index.ts`**: Introduces a `directToolsFrozen` closure-level flag, set once after the initial `syncToolSurface` call completes. Subsequent metadata-update callbacks skip `syncToolSurface` when frozen; `syncPromptCommands` still runs. The flag is never reset, which is intentional — the initial sync on every new lifecycle generation is a direct call that bypasses the guard, so new-session tool discovery still works correctly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is purely additive and off by default.

The freeze flag is set only after a successful initial sync, the default is false so no existing behaviour changes, and the direct-call path in each new lifecycle generation bypasses the flag so session restarts always perform a fresh initial sync. The single-threaded JS execution model eliminates any race between the sync and the flag being set.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| index.ts | Adds `directToolsFrozen` flag; gates `syncToolSurface` in the `onToolMetadataUpdated` callback and sets the flag after the initial sync when `freezeDirectTools` is enabled. Logic is sound and default is false. |
| types.ts | Adds `freezeDirectTools?: boolean` to `McpSettings` with a clear JSDoc comment. Straightforward type addition, default-false, no breaking changes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[session_start / startInitialization] --> B[startInitialization resolves]
    B --> C[Register onToolMetadataUpdated callback]
    C --> D[syncPromptCommands]
    D --> E[syncToolSurface - initial direct call]
    E --> F{freezeDirectTools === true?}
    F -- Yes --> G[directToolsFrozen = true]
    F -- No --> H[directToolsFrozen stays false]
    G --> I[initPromise = null]
    H --> I

    J[MCP event: reconnect / lazy-connect] --> K[onToolMetadataUpdated fires]
    K --> L{state valid & owner active?}
    L -- No --> M[return early]
    L -- Yes --> N[syncPromptCommands]
    N --> O{directToolsFrozen?}
    O -- Yes --> P[log debug, skip syncToolSurface - cache prefix preserved]
    O -- No --> Q[syncToolSurface - cache prefix invalidated]

    R[explicit mcp connect call] --> S[syncToolSurface direct call - bypasses freeze flag]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: freezeDirectTools setting for cach..."](https://github.com/nicobailon/pi-mcp-adapter/commit/7fc8dfd34ff4b0802a0206777d5d1235190846b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49333562)</sub>

<!-- /greptile_comment -->