### PR TITLE
feat: freeze direct-tool refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
+
 ## [2.17.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `oauthDir` | Legacy OAuth `tokens.json` import directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. Persistent OAuth credentials are stored in the OS credential store, not this directory. |
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
+| `freezeDirectTools` | Keep direct-tool registration stable after the initial sync so automatic reconnects and list-change notifications do not rebuild the system prompt. Use `mcp({ connect: "server" })` or `/mcp reconnect <server>` to refresh deliberately. Default: false. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
@@ -414,6 +415,8 @@ To hide specific tools while still using `directTools: true`, add `excludeTools`
 Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`. If 75+ direct tools resolve, the adapter prints a warning but still registers the tools you configured.
 
 Direct tools register from the metadata cache in the Pi agent dir (`~/.pi/agent/mcp-cache.json` by default, or `$PI_CODING_AGENT_DIR/mcp-cache.json` when set), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only while the cache populates, then the extension hot-loads the refreshed direct tools into the current session. Servers that advertise MCP list-change notifications refresh the current session when their tool or resource list changes. On Pi versions that expose `pi.unregisterTool()`, stale direct tools are removed from the registry during refresh; older Pi versions still deactivate them from the active tool set. To force a refresh: `/mcp reconnect <server>`.
+
+If prompt-cache stability matters more than automatic direct-tool hot-loading, set `settings.freezeDirectTools` to `true`. The initial direct-tool sync still runs, but later automatic reconnects, lazy-connects, and list-change notifications keep the registered tool surface unchanged. Deliberate refreshes through `mcp({ connect: "server" })` or `/mcp reconnect <server>` still update direct tools.
 
 When you change direct-tool toggles in `/mcp`, the extension updates direct tool registration in the current session. Broader setup writes from `/mcp setup` still use Pi's normal reload flow because they can add or restructure MCP config files.
 

--- a/index.ts
+++ b/index.ts
@@ -471,6 +471,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         case "reconnect":
           commandOwner?.throwIfInactive();
           await reconnectServers(state, commandCtx, targetServer);
+          if (directToolsFrozen) syncToolSurface(commandCtx);
           break;
         case "tools":
           await showTools(state, commandCtx);

--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const fallbackDeactivatedTools = new Set<string>();
   let proxyToolRegistered = false;
   let proxyToolDescription: string | null = null;
+  let directToolsFrozen = false;
 
   // OMP remaps `typebox` to a host shim that historically lacked Type.Unsafe.
   // Prefer Unsafe when present (real TypeBox / fixed OMP shim); otherwise pass
@@ -278,12 +279,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       nextState.onToolMetadataUpdated = (_serverName, _reason) => {
         if (state !== nextState || !owner.isActive()) return;
         syncPromptCommands();
+        if (directToolsFrozen) {
+          logger.debug(`MCP: metadata update for ${_serverName} (${_reason}) skipped — directTools frozen`);
+          return;
+        }
         syncToolSurface(ctx);
       };
       syncPromptCommands();
       syncToolSurface(ctx);
       updateStatusBar(nextState);
       initPromise = null;
+      if (earlyConfig.settings?.freezeDirectTools === true) {
+        directToolsFrozen = true;
+        logger.info("MCP: direct tools frozen after initial sync — reconnects won't rebuild the system prompt; use mcp({ connect: \"server\" }) to rediscover");
+      }
     }).catch(async err => {
       if (!owner.isActive() || generation !== lifecycleGeneration) {
         return;

--- a/types.ts
+++ b/types.ts
@@ -407,6 +407,11 @@ export interface McpSettings {
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
   disableProxyTool?: boolean;
+  /** Freeze direct-tool registration after the initial sync. Automatic metadata updates
+   * (reconnects, lazy-connect, tool-list-changed) won't rebuild the system prompt,
+   * preserving the prompt-cache prefix. The agent rediscovers explicitly via
+   * mcp({ connect: "server" }). Default: false. */
+  freezeDirectTools?: boolean;
   autoAuth?: boolean;
   sampling?: boolean;
   samplingAutoApprove?: boolean;


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #254 that preserves @ddfourtwo's `settings.freezeDirectTools` contribution and adds the missing explicit reconnect refresh path.

It keeps direct-tool registration stable after initial sync when `settings.freezeDirectTools` is true, so automatic reconnects, lazy-connects, and metadata notifications do not rebuild the system prompt. Explicit refreshes through `mcp({ connect: "server" })` and `/mcp reconnect <server>` still update direct tools deliberately.

## Validation

- `npx tsc --noEmit`
- `git diff --check`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory npm run test:oauth`
- `npm pack --dry-run`
- `npm install --prefix examples/interactive-visualizer --no-package-lock --no-audit --no-fund`
- `npm run --prefix examples/interactive-visualizer build`
- `npx vitest run __tests__/server-manager-streamable-http.test.ts` fails on both this branch and pristine `origin/main` with the same pre-existing GET-count assertion.

## Credit

Thanks @ddfourtwo for PR #254 and the prompt-cache analysis behind this setting.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `settings.freezeDirectTools`, a flag that stabilises the direct-tool surface after the initial sync so automatic reconnects, lazy-connects, and list-change notifications do not rebuild the system prompt — while preserving deliberate refresh through `/mcp reconnect` and `mcp({ connect: "server" })`.

- Adds a `directToolsFrozen` boolean in the adapter closure, armed after `syncToolSurface` completes in `startInitialization`; the `onToolMetadataUpdated` callback returns early when the flag is set, skipping `syncToolSurface` but still running `syncPromptCommands`.
- Explicit refresh paths bypass the freeze: `/mcp reconnect` calls `syncToolSurface` unconditionally after reconnect when frozen, and `mcp({ connect })` always calls it regardless of the flag.
- `types.ts`, `README.md`, and `CHANGELOG.md` are updated consistently with the new setting.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the freeze logic is correctly scoped to `onToolMetadataUpdated` and both explicit refresh paths work as documented.

The `directToolsFrozen` flag is set once after initial sync but never cleared between `session_start` events in the same adapter installation. In the current lifecycle this is harmless — `earlyConfig` is static, so the flag would be re-armed to the same value on the next session anyway — but the gap makes the state machine harder to reason about and could silently misfire if the closure is ever reused across config reloads.

**Files Needing Attention:** The `directToolsFrozen` lifecycle in `index.ts` (specifically the `session_start` handler and `startInitialization`) is worth a second look.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| index.ts | Core feature implementation: adds `directToolsFrozen` flag (never reset to `false` between sessions), gates `onToolMetadataUpdated`'s `syncToolSurface` call on the flag, and adds explicit unfrozen sync after `/mcp reconnect` and `mcp({ connect })`. Logic is correct for the static-config lifecycle; minor state-reset gap on `session_start`. |
| types.ts | Adds optional `freezeDirectTools?: boolean` field to `McpSettings` with a clear JSDoc comment; placement and typing are correct. |
| README.md | Documents new `freezeDirectTools` setting in the settings table and adds a prose section under Direct Tools explaining freeze semantics and deliberate-refresh paths. |
| CHANGELOG.md | Adds changelog entry for `freezeDirectTools` under `[Unreleased]` with credit to the original contributor. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host as Extension Host
    participant Adapter as MCP Adapter
    participant State as MCP State
    participant Tools as Tool Registry

    Host->>Adapter: session_start
    Adapter->>State: startInitialization()
    State-->>Adapter: nextState resolved
    Adapter->>Tools: syncToolSurface() [initial sync, always runs]
    Adapter->>Adapter: "directToolsFrozen = true (if freezeDirectTools)"

    Note over Adapter,State: Automatic events blocked when frozen

    State->>Adapter: onToolMetadataUpdated
    alt "directToolsFrozen = true"
        Adapter->>Adapter: return early, syncToolSurface skipped
    else "directToolsFrozen = false"
        Adapter->>Tools: syncToolSurface()
    end

    Note over Adapter,Tools: Explicit refresh paths always sync

    Host->>Adapter: /mcp reconnect server
    Adapter->>State: reconnectServers()
    alt "directToolsFrozen = true"
        Adapter->>Tools: syncToolSurface() explicit
    end

    Host->>Adapter: mcp connect server
    Adapter->>State: executeConnect()
    Adapter->>Tools: syncToolSurface() always bypasses freeze
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `index.ts`, line 268-279 ([link](https://github.com/nicobailon/pi-mcp-adapter/blob/2e80958115035b8a73ce53bd91fc993377270178/index.ts#L268-L279)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `directToolsFrozen` is never reset when a new session starts, so it leaks across `session_start` events within the same adapter lifetime. The initial `syncToolSurface` on line 289 runs unconditionally (correct), but if `earlyConfig` is ever re-read with `freezeDirectTools: false` during a subsequent session — or if a future refactor re-uses the closure across config reloads — the stale `true` value will silently suppress all `onToolMetadataUpdated` refreshes for the new session. Resetting it at the top of each initialization pass makes the state machine self-contained.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 268-279

   Comment:
   `directToolsFrozen` is never reset when a new session starts, so it leaks across `session_start` events within the same adapter lifetime. The initial `syncToolSurface` on line 289 runs unconditionally (correct), but if `earlyConfig` is ever re-read with `freezeDirectTools: false` during a subsequent session — or if a future refactor re-uses the closure across config reloads — the stale `true` value will silently suppress all `onToolMetadataUpdated` refreshes for the new session. Resetting it at the top of each initialization pass makes the state machine self-contained.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
index.ts:268-279
`directToolsFrozen` is never reset when a new session starts, so it leaks across `session_start` events within the same adapter lifetime. The initial `syncToolSurface` on line 289 runs unconditionally (correct), but if `earlyConfig` is ever re-read with `freezeDirectTools: false` during a subsequent session — or if a future refactor re-uses the closure across config reloads — the stale `true` value will silently suppress all `onToolMetadataUpdated` refreshes for the new session. Resetting it at the top of each initialization pass makes the state machine self-contained.

```suggestion
    return promise.then(async (nextState) => {
      if (!owner.isActive() || generation !== lifecycleGeneration || initPromise !== promise) {
        try {
          await shutdownState(nextState, staleReason);
        } catch (error) {
          console.error(`MCP: failed to clean stale initialization state: ${formatTerminalError(error)}`);
        }
        return;
      }

      directToolsFrozen = false;
      state = nextState;
      nextState.onToolMetadataUpdated = (_serverName, _reason) => {
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve explicit direct-tool recon..."](https://github.com/nicobailon/pi-mcp-adapter/commit/2e80958115035b8a73ce53bd91fc993377270178) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49373922)</sub>

<!-- /greptile_comment -->