### PR TITLE
fix(auth): recover revoked Linux keyring sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
+- Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
 
 ## [2.17.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ The adapter owns only its client socket and closes that connection when the Pi r
 
 ### Remote/headless OAuth
 
-If Pi is running on a remote server and cannot open a local browser, start OAuth through the proxy tool. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable:
+If Pi is running on a remote server and cannot open a local browser, start OAuth through the proxy tool. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable.
+
+On Linux, if credential access fails because Pi inherited a revoked session keyring, the adapter uses a best-effort recovery path through `keyctl session - node <packaged helper>` so explicit re-authentication can write fresh credentials without killing a long-lived tmux server. This path requires `keyctl` and `node` on `PATH`; missing, locked, or otherwise unavailable credential stores still fail closed.
 
 ```js
 mcp({ action: "auth-start", server: "linear-server" })

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -34,7 +34,15 @@ describe("OAuth credential-store diagnostics", () => {
 });
 
 describe("mcp-auth storage paths", () => {
-  const originalOAuthDir = process.env.MCP_OAUTH_DIR;
+  const originalEnv = {
+    MCP_OAUTH_DIR: process.env.MCP_OAUTH_DIR,
+    PI_MCP_ADAPTER_TEST_AUTH_STORE: process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE,
+    PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY: process.env.PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY,
+    PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL: process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL,
+    PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE: process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE,
+    PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER: process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER,
+    PI_MCP_ADAPTER_FAKE_KEYRING_STORE: process.env.PI_MCP_ADAPTER_FAKE_KEYRING_STORE,
+  };
   let authDir: string;
 
   beforeEach(() => {
@@ -44,10 +52,12 @@ describe("mcp-auth storage paths", () => {
   });
 
   afterEach(() => {
-    if (originalOAuthDir === undefined) {
-      delete process.env.MCP_OAUTH_DIR;
-    } else {
-      process.env.MCP_OAUTH_DIR = originalOAuthDir;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
     rmSync(authDir, { recursive: true, force: true });
   });
@@ -179,5 +189,73 @@ describe("mcp-auth storage paths", () => {
     const entries = getTestAuthSecretStoreEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0][0]).not.toContain(".chunk.");
+  });
+
+  it("routes revoked Linux keyring operations through the recovery helper", () => {
+    const harnessDir = mkdtempSync(join(tmpdir(), "pi-mcp-keyring-recovery-"));
+    const keyctlPath = join(harnessDir, "keyctl");
+    const helperPath = join(harnessDir, "helper.cjs");
+    const storePath = join(harnessDir, "store.json");
+
+    writeFileSync(keyctlPath, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" != "session" ] || [ "$2" != "-" ]; then exit 64; fi
+shift 2
+exec "$@"
+`, { mode: 0o755 });
+    writeFileSync(helperPath, `const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const path = process.env.PI_MCP_ADAPTER_FAKE_KEYRING_STORE;
+const store = existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : {};
+if (input.operation === 'read') {
+  const value = store[input.account];
+  process.stdout.write(JSON.stringify(value === undefined ? { ok: true, found: false } : { ok: true, found: true, value }) + '\\n');
+} else if (input.operation === 'write') {
+  store[input.account] = input.payload;
+  writeFileSync(path, JSON.stringify(store));
+  process.stdout.write(JSON.stringify({ ok: true }) + '\\n');
+} else if (input.operation === 'remove') {
+  delete store[input.account];
+  writeFileSync(path, JSON.stringify(store));
+  process.stdout.write(JSON.stringify({ ok: true }) + '\\n');
+} else {
+  process.stdout.write(JSON.stringify({ ok: false, error: 'bad op' }) + '\\n');
+  process.exitCode = 1;
+}
+`);
+
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "keyrevoked";
+    process.env.PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY = "1";
+    process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL = keyctlPath;
+    process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE = process.execPath;
+    process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER = helperPath;
+    process.env.PI_MCP_ADAPTER_FAKE_KEYRING_STORE = storePath;
+
+    const accessToken = "x".repeat(5000);
+    saveAuthEntry("recovered", { tokens: { accessToken } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("recovered")?.tokens?.accessToken).toBe(accessToken);
+
+    clearAllCredentials("recovered");
+
+    expect(getAuthEntry("recovered")).toBeUndefined();
+    expect(JSON.parse(readFileSync(storePath, "utf8"))).toEqual({});
+    rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it("does not use the recovery helper for generic secure-store failures", () => {
+    const harnessDir = mkdtempSync(join(tmpdir(), "pi-mcp-keyring-no-recovery-"));
+    const keyctlPath = join(harnessDir, "keyctl");
+    const storePath = join(harnessDir, "store.json");
+    writeFileSync(keyctlPath, "#!/usr/bin/env bash\nexit 99\n", { mode: 0o755 });
+
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+    process.env.PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY = "1";
+    process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL = keyctlPath;
+    process.env.PI_MCP_ADAPTER_FAKE_KEYRING_STORE = storePath;
+
+    expect(() => getAuthEntry("generic-unavailable")).toThrow(/OS secure credential store/);
+    expect(existsSync(storePath)).toBe(false);
+    rmSync(harnessDir, { recursive: true, force: true });
   });
 });

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -10,10 +10,12 @@
  * then the plaintext file is removed.
  */
 
+import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { createRequire } from 'module';
 import { readFileSync, existsSync, rmSync } from 'fs';
 import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { getAgentPath } from './agent-dir.ts';
 import { resolveConfiguredOAuthDir } from './config.ts';
 
@@ -21,6 +23,12 @@ const require = createRequire(import.meta.url);
 const AUTH_SECRET_SERVICE = 'pi-mcp-adapter.oauth';
 const TEST_AUTH_STORE_ENV = 'PI_MCP_ADAPTER_TEST_AUTH_STORE';
 const AUTH_SECRET_CHUNK_SIZE = 1800;
+const KEYRING_RECOVERY_DISABLED_ENV = 'PI_MCP_ADAPTER_DISABLE_KEYRING_RECOVERY';
+const KEYRING_RECOVERY_KEYCTL_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL';
+const KEYRING_RECOVERY_NODE_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE';
+const KEYRING_RECOVERY_HELPER_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER';
+const TEST_LINUX_KEYRING_RECOVERY_ENV = 'PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY';
+const KEYRING_RECOVERY_TIMEOUT_MS = 10_000;
 const AUTH_CHUNK_MANIFEST_KEY = '__piMcpAdapterOAuthChunked';
 
 /** OAuth token storage format */
@@ -167,6 +175,22 @@ const unavailableAuthSecretStore: AuthSecretStore = {
   },
 };
 
+function createKeyRevokedTestError(): Error {
+  return new Error("Couldn't access platform storage: KeyRevoked", { cause: new Error('KeyRevoked') });
+}
+
+const keyRevokedAuthSecretStore: AuthSecretStore = {
+  read() {
+    throw createKeyRevokedTestError();
+  },
+  write() {
+    throw createKeyRevokedTestError();
+  },
+  remove() {
+    throw createKeyRevokedTestError();
+  },
+};
+
 export function resetTestAuthSecretStore(): void {
   memoryAuthEntries.clear();
 }
@@ -182,6 +206,7 @@ export function removeTestAuthSecretStoreEntry(account: string): void {
 function getAuthSecretStore(): AuthSecretStore {
   if (process.env[TEST_AUTH_STORE_ENV] === 'memory') return memoryAuthSecretStore;
   if (process.env[TEST_AUTH_STORE_ENV] === 'unavailable') return unavailableAuthSecretStore;
+  if (process.env[TEST_AUTH_STORE_ENV] === 'keyrevoked') return keyRevokedAuthSecretStore;
   return keyringAuthSecretStore;
 }
 
@@ -257,6 +282,75 @@ function getKeyringNativeBindingSuffixes(platform: NodeJS.Platform, arch: NodeJS
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+type KeyringRecoveryOperation = 'read' | 'write' | 'remove';
+
+type KeyringRecoveryResponse =
+  | { ok: true; found?: boolean; value?: string }
+  | { ok: false; error?: string };
+
+function isLinuxKeyringRecoveryEnabled(): boolean {
+  if (process.env[KEYRING_RECOVERY_DISABLED_ENV] === '1') return false;
+  return process.platform === 'linux' || process.env[TEST_LINUX_KEYRING_RECOVERY_ENV] === '1';
+}
+
+function shouldAttemptLinuxKeyringRecovery(error: unknown): boolean {
+  return isLinuxKeyringRecoveryEnabled()
+    && causeChainContains(error, /key\s*(?:has been\s*)?revoked|keyrevoked/i);
+}
+
+function runLinuxKeyringRecoveryOperation(operation: KeyringRecoveryOperation, account: string, payload?: string): KeyringRecoveryResponse {
+  const keyctl = process.env[KEYRING_RECOVERY_KEYCTL_ENV]?.trim() || 'keyctl';
+  const node = process.env[KEYRING_RECOVERY_NODE_ENV]?.trim() || 'node';
+  const helper = process.env[KEYRING_RECOVERY_HELPER_ENV]?.trim()
+    || fileURLToPath(new URL('./mcp-keyring-helper.cjs', import.meta.url));
+  const request = JSON.stringify({ operation, service: AUTH_SECRET_SERVICE, account, payload });
+  const result = spawnSync(keyctl, ['session', '-', node, helper], {
+    input: `${request}\n`,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+    timeout: KEYRING_RECOVERY_TIMEOUT_MS,
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    throw new Error(`Linux keyring recovery helper could not start: ${result.error.message}`, { cause: result.error });
+  }
+  if (result.status !== 0) {
+    throw new Error(`Linux keyring recovery helper failed with exit code ${result.status ?? 'unknown'}`);
+  }
+
+  let response: unknown;
+  try {
+    response = JSON.parse(result.stdout.trim()) as unknown;
+  } catch (error) {
+    throw new Error('Linux keyring recovery helper returned invalid JSON', { cause: error });
+  }
+  if (typeof response !== 'object' || response === null || typeof (response as { ok?: unknown }).ok !== 'boolean') {
+    throw new Error('Linux keyring recovery helper returned an invalid response');
+  }
+  const typedResponse = response as KeyringRecoveryResponse;
+  if (typedResponse.ok === false) {
+    throw new Error(typedResponse.error || 'Linux keyring recovery helper failed');
+  }
+  if (operation === 'read' && typedResponse.found === true && typeof typedResponse.value !== 'string') {
+    throw new Error('Linux keyring recovery helper returned an invalid read response');
+  }
+  return typedResponse;
+}
+
+const linuxKeyringRecoveryAuthSecretStore: AuthSecretStore = {
+  read(account) {
+    const response = runLinuxKeyringRecoveryOperation('read', account);
+    return response.ok && response.found === true ? response.value : undefined;
+  },
+  write(account, payload) {
+    runLinuxKeyringRecoveryOperation('write', account, payload);
+  },
+  remove(account) {
+    runLinuxKeyringRecoveryOperation('remove', account);
+  },
+};
 
 export function loadTestKeyringEntryClass(keyringRequire: KeyringRequire, platform: NodeJS.Platform, arch: NodeJS.Architecture): KeyringEntryConstructor {
   return loadKeyringEntryClass(keyringRequire, platform, arch);
@@ -366,8 +460,7 @@ function createChunkManifest(payload: string): AuthEntryChunkManifest {
   };
 }
 
-function readChunkedAuthEntry(serverName: string, account: string, manifest: AuthEntryChunkManifest): AuthEntry {
-  const store = getAuthSecretStore();
+function readChunkedAuthEntry(store: AuthSecretStore, serverName: string, account: string, manifest: AuthEntryChunkManifest): AuthEntry {
   const chunks = getAuthEntryChunkAccounts(account, manifest).map((chunkAccount) => {
     try {
       const chunk = store.read(chunkAccount);
@@ -410,9 +503,8 @@ function removeLegacyAuthEntry(serverName: string, options?: AuthStorageOptions)
   }
 }
 
-function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
+function writeSecureAuthEntryToStore(store: AuthSecretStore, serverName: string, entry: AuthEntry): void {
   const account = getAuthEntryAccount(serverName);
-  const store = getAuthSecretStore();
   const payload = JSON.stringify(entry);
   const previousManifest = readExistingChunkManifest(store, serverName, account);
   const manifest = payload.length > AUTH_SECRET_CHUNK_SIZE ? createChunkManifest(payload) : undefined;
@@ -441,11 +533,21 @@ function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
   }
 }
 
+function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
+  try {
+    writeSecureAuthEntryToStore(getAuthSecretStore(), serverName, entry);
+  } catch (error) {
+    if (!shouldAttemptLinuxKeyringRecovery(error)) throw error;
+    writeSecureAuthEntryToStore(linuxKeyringRecoveryAuthSecretStore, serverName, entry);
+  }
+}
+
 /**
  * Read the auth entry for a server from the OS secure store, importing and
  * deleting a legacy plaintext entry when present.
  */
-function readAuthEntry(
+function readAuthEntryFromStore(
+  store: AuthSecretStore,
   serverName: string,
   options?: AuthStorageOptions,
   behavior: { migrateLegacy?: boolean } = {},
@@ -453,7 +555,7 @@ function readAuthEntry(
   const account = getAuthEntryAccount(serverName);
   let payload: string | undefined;
   try {
-    payload = getAuthSecretStore().read(account);
+    payload = store.read(account);
   } catch (error) {
     throw new OAuthCredentialStoreError(
       `Failed to read OAuth credentials for ${serverName} from the OS secure credential store`,
@@ -465,7 +567,7 @@ function readAuthEntry(
   if (payload !== undefined) {
     const manifest = readChunkManifestFromPayload(serverName, payload, 'OS secure credential store');
     const entry = manifest
-      ? readChunkedAuthEntry(serverName, account, manifest)
+      ? readChunkedAuthEntry(store, serverName, account, manifest)
       : parseAuthEntryPayload(serverName, payload, 'OS secure credential store');
     removeLegacyAuthEntry(serverName, options);
     return entry;
@@ -474,9 +576,22 @@ function readAuthEntry(
   const legacyEntry = readLegacyAuthEntry(serverName, options);
   if (!legacyEntry) return undefined;
   if (behavior.migrateLegacy === false) return legacyEntry;
-  writeSecureAuthEntry(serverName, legacyEntry);
+  writeSecureAuthEntryToStore(store, serverName, legacyEntry);
   removeLegacyAuthEntry(serverName, options);
   return legacyEntry;
+}
+
+function readAuthEntry(
+  serverName: string,
+  options?: AuthStorageOptions,
+  behavior: { migrateLegacy?: boolean } = {},
+): AuthEntry | undefined {
+  try {
+    return readAuthEntryFromStore(getAuthSecretStore(), serverName, options, behavior);
+  } catch (error) {
+    if (!shouldAttemptLinuxKeyringRecovery(error)) throw error;
+    return readAuthEntryFromStore(linuxKeyringRecoveryAuthSecretStore, serverName, options, behavior);
+  }
 }
 
 /**
@@ -538,9 +653,8 @@ export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: 
 /**
  * Remove auth entry for a server.
  */
-export function removeAuthEntry(serverName: string, options?: AuthStorageOptions): void {
+function removeAuthEntryFromStore(store: AuthSecretStore, serverName: string): void {
   const account = getAuthEntryAccount(serverName);
-  const store = getAuthSecretStore();
   try {
     const payload = store.read(account);
     const manifest = payload === undefined ? undefined : readChunkManifestFromPayload(serverName, payload, 'OS secure credential store');
@@ -552,6 +666,15 @@ export function removeAuthEntry(serverName: string, options?: AuthStorageOptions
       'remove',
       error,
     );
+  }
+}
+
+export function removeAuthEntry(serverName: string, options?: AuthStorageOptions): void {
+  try {
+    removeAuthEntryFromStore(getAuthSecretStore(), serverName);
+  } catch (error) {
+    if (!shouldAttemptLinuxKeyringRecovery(error)) throw error;
+    removeAuthEntryFromStore(linuxKeyringRecoveryAuthSecretStore, serverName);
   }
   removeLegacyAuthEntry(serverName, options);
 }

--- a/mcp-keyring-helper.cjs
+++ b/mcp-keyring-helper.cjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+const { createRequire } = require('node:module');
+const { dirname, join } = require('node:path');
+
+const requireFromHere = createRequire(__filename);
+
+function loadKeyringEntryClass() {
+  try {
+    return requireFromHere('@napi-rs/keyring').Entry;
+  } catch (loaderError) {
+    const suffixes = getNativeBindingSuffixes(process.platform, process.arch);
+    let lastError;
+    for (const suffix of suffixes) {
+      try {
+        const packageJsonPath = requireFromHere.resolve(`@napi-rs/keyring-${suffix}/package.json`);
+        return requireFromHere(join(dirname(packageJsonPath), `keyring.${suffix}.node`)).Entry;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    const error = new Error(`Failed to load @napi-rs/keyring in recovery helper: ${lastError?.message ?? loaderError.message}`);
+    error.cause = loaderError;
+    throw error;
+  }
+}
+
+function getNativeBindingSuffixes(platform, arch) {
+  if (platform === 'linux') {
+    if (arch === 'arm64') return ['linux-arm64-gnu', 'linux-arm64-musl'];
+    if (arch === 'arm') return ['linux-arm-gnueabihf'];
+    if (arch === 'riscv64') return ['linux-riscv64-gnu'];
+    if (arch === 'x64') return ['linux-x64-gnu', 'linux-x64-musl'];
+  }
+  return [];
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      input += chunk;
+      if (input.length > 1024 * 1024) {
+        reject(new Error('request too large'));
+        process.stdin.destroy();
+      }
+    });
+    process.stdin.on('error', reject);
+    process.stdin.on('end', () => resolve(input));
+  });
+}
+
+function writeResponse(response) {
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+(async () => {
+  try {
+    const request = JSON.parse(await readStdin());
+    if (!request || typeof request !== 'object') throw new Error('invalid request');
+    const { operation, service, account, payload } = request;
+    if (!['read', 'write', 'remove'].includes(operation)) throw new Error('invalid operation');
+    if (typeof service !== 'string' || !service) throw new Error('invalid service');
+    if (typeof account !== 'string' || !account) throw new Error('invalid account');
+
+    const Entry = loadKeyringEntryClass();
+    const entry = new Entry(service, account);
+
+    if (operation === 'read') {
+      const value = entry.getPassword();
+      writeResponse(value === null ? { ok: true, found: false } : { ok: true, found: true, value });
+      return;
+    }
+    if (operation === 'write') {
+      if (typeof payload !== 'string') throw new Error('invalid payload');
+      entry.setPassword(payload);
+      writeResponse({ ok: true });
+      return;
+    }
+
+    entry.deleteCredential();
+    writeResponse({ ok: true });
+  } catch (error) {
+    writeResponse({ ok: false, error: error instanceof Error ? error.message : String(error) });
+    process.exitCode = 1;
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "npx-resolver.ts",
     "oauth-handler.ts",
     "mcp-auth.ts",
+    "mcp-keyring-helper.cjs",
     "mcp-oauth-provider.ts",
     "mcp-callback-server.ts",
     "mcp-auth-flow.ts",


### PR DESCRIPTION
## Summary

Closes #248 by adding a bounded Linux recovery path for OAuth credential storage when Pi inherits a revoked session keyring from a long-lived tmux session.

When a credential-store operation fails with a classified Linux `KeyRevoked` error, the adapter retries that read/write/remove through a packaged helper launched with `keyctl session - node <helper>`. That gives explicit re-authentication a fresh session keyring without changing how Pi itself was launched. Other credential-store failures still fail closed.

## Validation

- `npx tsc --noEmit`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory npx vitest run __tests__/mcp-auth-storage.test.ts __tests__/commands-panel-auth-storage.test.ts`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory npm run test:oauth`
- `npm run test:conformance`
- `npm pack --dry-run`
- `git diff --check`

Local `npm test` still reproduces the pre-existing unrelated StreamableHTTP GET-count assertion seen on `origin/main`; focused auth gates pass and CI will be the cross-platform gate.

## Credit

Thanks @anthod0 for issue #248 and the Linux keyring recovery validation prototype.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a bounded Linux recovery path that intercepts `KeyRevoked` errors from the OS keyring (common when Pi runs inside a long-lived tmux session that inherited a stale session keyring) and retries the credential operation through `keyctl session - node mcp-keyring-helper.cjs`, giving the subprocess a fresh kernel session without restarting Pi.

- `mcp-auth.ts` is cleanly refactored into `*FromStore` helpers that accept an explicit `AuthSecretStore`; the public `readAuthEntry`, `writeSecureAuthEntry`, and `removeAuthEntry` each gain a try/catch that checks the cause chain for \"KeyRevoked\" and retries with a new `linuxKeyringRecoveryAuthSecretStore` backed by `spawnSync`.
- `mcp-keyring-helper.cjs` is a new packaged CJS module that receives a JSON operation request on stdin, performs the keyring operation via `@napi-rs/keyring`, and writes a JSON response to stdout; it is wired into the package `files` list.
- Two new tests cover the full round-trip (including chunked 5 000-char tokens) and confirm that generic store failures do not trigger the recovery path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a well-scoped fallback that only activates on a specifically classified error and fails closed for all other failures; the core auth contract is unchanged.

The refactoring into *FromStore helpers is clean and correct. The main things worth a second look: spawnSync with a 10 s timeout blocks the event loop during recovery, and the timeout-expiry case is indistinguishable from a missing binary in the error message. Neither breaks the happy path or causes data loss, but both could cause operational surprises in production.

**Files Needing Attention:** mcp-auth.ts around runLinuxKeyringRecoveryOperation (spawnSync timeout handling and event-loop blocking) and README.md (missing documentation for opt-out and override env vars).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| mcp-auth.ts | Core change: adds a Linux keyring recovery path via `spawnSync`/`keyctl session` for `read`, `write`, and `remove`. The refactoring is clean — cause-chain error classification is correct and chunk propagation through the recovery store is handled. Main concern is `spawnSync` with a 10 s timeout blocking the event loop. |
| mcp-keyring-helper.cjs | New packaged CJS helper that runs inside a `keyctl session -` subprocess and performs read/write/remove against `@napi-rs/keyring` via JSON on stdin/stdout. Input validation, size limits, and error routing are all present. |
| __tests__/mcp-auth-storage.test.ts | Adds two targeted tests: one exercising the full recovery round-trip with chunked 5 000-char tokens, and one confirming generic store failures do not trigger recovery. Env cleanup correctly generalized. |
| README.md | Documents the new recovery path. Missing: opt-out env var `PI_MCP_ADAPTER_DISABLE_KEYRING_RECOVERY` and override env vars for binary paths. |
| package.json | Adds `mcp-keyring-helper.cjs` to the package `files` list so it ships with the published artifact. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Auth operation: read / write / remove] --> B[Call primary store via getAuthSecretStore]
    B --> C{Succeeds?}
    C -- Yes --> D[Return result]
    C -- No --> E{shouldAttemptLinuxKeyringRecovery?}
    E -- No --> F[Re-throw OAuthCredentialStoreError]
    E -- Yes --> G[runLinuxKeyringRecoveryOperation]
    G --> H[spawnSync: keyctl session - node mcp-keyring-helper.cjs]
    H --> I{Helper exit code}
    I -- non-zero --> J[Throw: helper failed / timed out]
    I -- 0 --> K[Parse JSON response]
    K --> L{response.ok?}
    L -- false --> M[Throw helper error]
    L -- true --> N[Return result to caller]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
mcp-auth.ts:308-314
**`spawnSync` blocks the event loop for up to 10 s**

`spawnSync` with `timeout: 10_000` is a fully synchronous call that pins the Node.js event loop. Because auth operations (`readAuthEntry`, `writeSecureAuthEntry`, `removeAuthEntry`) can be triggered from any concurrent MCP request, a slow or hung `keyctl` on the first recovery attempt would freeze all in-flight requests for the full 10-second timeout. Consider `execFileSync` with a shorter timeout or, if the wider adapter architecture permits it, promoting this to an async path with `spawnAsync`/`execFile`.

### Issue 2
README.md:224-228
**Opt-out and override env vars not documented**

The implementation adds several env vars that let operators control the recovery path — `PI_MCP_ADAPTER_DISABLE_KEYRING_RECOVERY` (to turn it off entirely), `PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL`, `PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE`, and `PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER` (to supply explicit binary/helper paths). None are mentioned in this README section, so users who need to disable the feature (e.g., a locked-down environment where spawning `keyctl` is forbidden) or who need to point to a non-`PATH` `node` binary (common with `nvm`/`fnm` installs) have no documented path.

### Issue 3
mcp-auth.ts:319-321
When `spawnSync` times out, `result.status` is `null` and `result.signal` is `'SIGTERM'`. The current fallback `?? 'unknown'` loses the timeout context. Distinguishing the timeout case produces a clearer diagnostic.

```suggestion
  if (result.status !== 0) {
    if (result.status === null && result.signal != null) {
      throw new Error(`Linux keyring recovery helper timed out (killed by ${result.signal})`);
    }
    throw new Error(`Linux keyring recovery helper failed with exit code ${result.status ?? 'unknown'}`);
  }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): recover revoked Linux keyring..."](https://github.com/nicobailon/pi-mcp-adapter/commit/3cee69a3aed014ef3799679a58d99932401a3b45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49377524)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->