### PR TITLE
Executor-inspired upgrades: ranked search, approval gate, mcp_code, and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
+- Added opt-in `mcp_code` plain-JavaScript codemode for chaining MCP calls from tool-restricted subagents.
 - Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.
 - Added optional global and per-server `approveTools` patterns that require interactive approval before matching proxy, direct, resource, or iframe-originated MCP tool calls.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
 - Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.
+- Added optional global and per-server `approveTools` patterns that require interactive approval before matching proxy, direct, resource, or iframe-originated MCP tool calls.
 
 ## [2.17.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
-- Added compact TypeScript-shaped parameter rendering to MCP tool describe and schema-inclusive search results, with existing schema formatting retained as a fallback.
-- Added probe-classified HTTP connection failure messages to identify endpoint protocol mismatches without affecting healthy connections.
-- Added opt-in `mcp_code` plain-JavaScript codemode for chaining MCP calls from tool-restricted subagents.
-- Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.
-- Added optional global and per-server `approveTools` patterns that require interactive approval before matching proxy, direct, resource, or iframe-originated MCP tool calls.
+- Ranked, paginated MCP tool search: best matches come first in a short page of 12 instead of an unranked dump of every match with full schemas, so the model stops guessing and each search costs a fraction of the tokens. Misses on describe/call now return top-5 "Did you mean" suggestions, letting the model self-correct a typo or missing prefix in the same turn instead of burning a round trip.
+- Optional `approveTools` patterns (global and per-server) add the missing middle tier between "tool runs instantly" and "tool hidden entirely": flag risky tools and Pi asks before running them — Allow once / Allow for session / Deny — across proxy, direct, resource, and iframe-originated calls. Safe tools keep full speed; a deny is a normal result the model adapts to, not a crash.
+- Opt-in `mcp_code` plain-JavaScript codemode turns N-step MCP jobs into one call: loop, filter, and chain tools inside a single sandboxed script and get one result back — built for tool-restricted subagents where every round trip costs child context. Every scripted call still goes through auth, output guarding, and the approval gate.
+- HTTP connection failures are now probe-classified into a plain-language diagnosis (for example "endpoint returned HTML (200) — this URL does not appear to speak MCP") instead of an opaque "fetch failed", so setup mistakes are fixed in seconds. Healthy connections are never probed.
+- Tool parameters render as compact TypeScript shapes (`{ query: string; limit?: number }`) in describe and search, replacing multi-line schema dumps — the model reads less and acts sooner, with the previous formatting kept as a fallback for exotic schemas.
+- `/mcp setup` gained curated one-click presets (DeepWiki, Context7, Notion, GitHub, Chrome DevTools): pick, preview the exact config write, confirm — new servers in under a minute with no hand-typed setup.
+
+The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint shape probe, TypeScript-shaped schemas, and codemode design in this release are adapted from [Executor](https://github.com/UsefulSoftwareCo/executor) by Rhys Sullivan (@RhysSullivan). Thanks Rhys.
 
 ## [2.17.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
+- Added probe-classified HTTP connection failure messages to identify endpoint protocol mismatches without affecting healthy connections.
 - Added opt-in `mcp_code` plain-JavaScript codemode for chaining MCP calls from tool-restricted subagents.
 - Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.
 - Added optional global and per-server `approveTools` patterns that require interactive approval before matching proxy, direct, resource, or iframe-originated MCP tool calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
+- Added compact TypeScript-shaped parameter rendering to MCP tool describe and schema-inclusive search results, with existing schema formatting retained as a fallback.
 - Added probe-classified HTTP connection failure messages to identify endpoint protocol mismatches without affecting healthy connections.
 - Added opt-in `mcp_code` plain-JavaScript codemode for chaining MCP calls from tool-restricted subagents.
 - Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
+- Added ranked, paginated MCP tool search and did-you-mean suggestions for unresolved tool names.
 
 ## [2.17.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
     "showStatusIcon": true,
     "mcpFooterStatus": "full",
     "hostConfigDiscovery": "off",
+    "codeMode": true,
     "oauthDir": ".pi/mcp-oauth",
     "trace": {
       "enabled": true,
@@ -286,6 +287,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `freezeDirectTools` | Keep direct-tool registration stable after the initial sync so automatic reconnects and list-change notifications do not rebuild the system prompt. Use `mcp({ connect: "server" })` or `/mcp reconnect <server>` to refresh deliberately. Default: false. |
+| `codeMode` | Register the MCP-only `mcp_code` plain-JavaScript tool (default: false). |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
@@ -315,6 +317,22 @@ Tune the limits with the object form:
 ```
 
 Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — to disable the guard and restore raw output behavior. Saved temp files are created with mode `0600` under the system temp directory and are not cleaned up automatically; note that spilled MCP output may contain sensitive data.
+
+### MCP Code Mode
+
+Set `settings.codeMode` to `true` to register `mcp_code({ code, timeoutMs? })`. It runs plain JavaScript with three capabilities: a flat `tools.<prefixedToolName>(args)` proxy, `emit(value)`, and a captured `console`. MCP calls return `{ ok: true, data }` or `{ ok: false, error: { code, message } }`, so a failed call does not stop the rest of the script. Emitted values and console output appear before the script's final return value, and the combined result uses the normal MCP output guard. The default timeout is 30 seconds.
+
+```js
+const first = await tools.github_search_issues({ query: "is:open label:bug" });
+if (!first.ok) return first;
+const selected = first.data.content.filter((item) => item.type === "text");
+emit({ searched: true });
+return selected;
+```
+
+For a tool-restricted subagent, enable code mode in the adapter configuration, then launch the child Pi with its tool allowlist set to `["mcp_code"]`. Have the parent discover MCP tool names with `mcp({ search: "..." })` and include the relevant prefixed names in the child's task; the child can then loop, filter, and chain those MCP calls without filesystem, shell, or edit tools. The adapter's ordinary lazy connection, authentication, output guard, abort handling, and approval gates still apply to every call.
+
+`node:vm` is **NOT a security boundary**. This feature is capability shaping only; do not run untrusted code as though it were sandboxed. `mcp_code` is also distinct from Pi's code-mode skill: Pi's skill batches general Pi tools, while `mcp_code` exposes MCP calls only and can be the child's sole tool.
 
 ### MCP Prompts
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The adapter reads standard MCP files automatically. No extra setup needed if you
 |---------------------|--------------|
 | `.mcp.json` or `~/.config/mcp/mcp.json` | Pi uses it immediately. The first time you open `/mcp`, you'll see a short heads-up explaining which file Pi detected and that Pi only writes adapter-specific overrides to its own files. |
 | Host-specific configs (Cursor, Claude Code, Codex, etc.) but no standard MCP files | Run `/mcp setup` to adopt those host configs into Pi. The setup flow shows exactly what it found, lets you pick which ones to import, and previews the exact file changes before writing. |
-| Nothing configured yet | Run `/mcp setup` to scaffold a minimal `.mcp.json`, quick-add RepoPrompt, or inspect what the adapter discovered on your machine. |
+| Nothing configured yet | Run `/mcp setup` to scaffold a minimal `.mcp.json`, add a curated known server, quick-add RepoPrompt, or inspect what the adapter discovered on your machine. |
 
 If you prefer the terminal, you can also run `pi-mcp-adapter init` after install to scan for host-specific configs and add missing compatibility imports to the Pi agent dir (`~/.pi/agent/mcp.json` by default, or `$PI_CODING_AGENT_DIR/mcp.json` when set).
 
@@ -262,6 +262,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
     "showStatusIcon": true,
     "mcpFooterStatus": "full",
     "hostConfigDiscovery": "off",
+    "approveTools": ["github_delete_*", "notion_update_*"],
     "codeMode": true,
     "oauthDir": ".pi/mcp-oauth",
     "trace": {
@@ -283,6 +284,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
 | `mcpFooterStatus` | MCP footer verbosity: `"full"` (default), `"compact"` for `MCP connected/enabled`, or `"off"` to clear the persistent footer status. `/mcp status` remains available. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
+| `approveTools` | `true` to require approval before every MCP tool call, or an array of glob patterns such as `["github_delete_*", "notion_update_*"]`. Per-server `approveTools` overrides this. |
 | `oauthDir` | Legacy OAuth `tokens.json` import directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. Persistent OAuth credentials are stored in the OS credential store, not this directory. |
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
@@ -296,7 +298,25 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `outputGuard` | Guard oversized MCP output: `true` (default), `false`, or `{ maxBytes, maxLines, detailsMaxBytes }`. See [Output Guard](#output-guard). |
 | `trace` | Opt-in metadata-only protocol tracing. Set `{ enabled: true }` globally or `trace: true` on a server. The per-session JSONL file defaults to `.pi/mcp-traces/`; `file`, `maxBytes` (default 262144), and `maxEvents` (default 10000) can be set. Raw MCP payloads, prompts, tool arguments/results, auth data, and URLs are never persisted. |
 
-Per-server `idleTimeout` and `requestTimeoutMs` override the global settings. `debug` remains stderr display and is unrelated to protocol tracing.
+Per-server `idleTimeout`, `requestTimeoutMs`, and `approveTools` override the global settings. `debug` remains stderr display and is unrelated to protocol tracing.
+
+### Tool Approval
+
+Use `approveTools` when a tool should stay visible but not run without confirmation. This is useful for destructive or high-cost actions where hiding the tool would make planning harder, but running it silently is too risky.
+
+```json
+{
+  "settings": {
+    "approveTools": ["github_delete_*", "notion_update_*"]
+  },
+  "mcpServers": {
+    "github": { "approveTools": ["delete_*", "merge_pull_request"] },
+    "docs": { "approveTools": false }
+  }
+}
+```
+
+When a matching tool is called from the proxy tool, a direct MCP tool, a resource call, or an MCP UI iframe, Pi asks: **Allow once**, **Allow for session**, or **Deny**. Session approvals are kept in memory only. In headless sessions, matching calls fail closed with an `approval_required` result instead of running. `excludeTools` still removes tools entirely; `approveTools` only gates visible tools at call time.
 
 ### Output Guard
 
@@ -442,7 +462,7 @@ When you change direct-tool toggles in `/mcp`, the extension updates direct tool
 
 **Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers and toggle tools between direct and proxy from the same overlay. For OAuth, press Enter on a server that needs auth or `ctrl+a` on any OAuth server.
 
-**Guided first-run setup:** Run `/mcp setup` to inspect detected shared MCP files, adopt compatibility imports from other hosts, open discovered config paths, preview exact before/after file diffs for writes, scaffold a minimal project `.mcp.json`, or quick-add RepoPrompt into a standard/shared MCP file.
+**Guided first-run setup:** Run `/mcp setup` to inspect detected shared MCP files, adopt compatibility imports from other hosts, open discovered config paths, preview exact before/after file diffs for writes, scaffold a minimal project `.mcp.json`, add a curated known server (DeepWiki, Context7, Notion, GitHub, or Chrome DevTools), or quick-add RepoPrompt into a standard/shared MCP file.
 
 **Subagent integration:** If you use the subagent extension, agents can request direct MCP tools in their frontmatter with `mcp:server-name` syntax. See the subagent README for details.
 
@@ -531,7 +551,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 |------|---------|
 | Status | `mcp({ })` |
 | List server | `mcp({ server: "name" })` |
-| Search | `mcp({ search: "screenshot navigate" })` |
+| Search | `mcp({ search: "screenshot navigate", limit: 12, offset: 0 })` |
 | Describe | `mcp({ describe: "tool_name" })` |
 | Instructions | `mcp({ instructions: "name" })` |
 | Call | `mcp({ tool: "...", args: { key: "value" } })` |
@@ -544,9 +564,13 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 
 MCP proxy and direct-tool results render compactly by default: long text shows the first three terminal-wrapped lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
 
-Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are OR'd.
+Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are ranked by weighted matches across name, server, and description, then returned one page at a time (`limit` defaults to 12). Use `details.nextOffset` for the next page. Regex search is still available with `regex: true`, but regex results are paginated without ranking.
 
-Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`.
+Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`. When `describe` or `tool` cannot resolve a name, the result includes top suggestions so the agent can correct a typo or missing prefix in the same turn.
+
+When `includeSchemas` is enabled, search and describe render common JSON Schema parameters as compact TypeScript shapes like `{ query: string; limit?: number; }`, with the older schema formatter retained as a fallback for unsupported schemas.
+
+For HTTP servers, failed connects run a one-request shape probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
 
 Servers that provide usage guidance via the MCP `instructions` field surface it at three levels: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 
@@ -555,7 +579,7 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 | Command | What it does |
 |---------|--------------|
 | `/mcp` | Interactive panel and first-run onboarding surface |
-| `/mcp setup` | Guided setup for imports, a minimal `.mcp.json`, RepoPrompt quick-add, and config-path inspection |
+| `/mcp setup` | Guided setup for imports, a minimal `.mcp.json`, curated known servers, RepoPrompt quick-add, and config-path inspection |
 | `/mcp tools` | List all tools |
 | `/mcp prompts` | List all MCP prompts registered as slash commands |
 | `/mcp reconnect` | Reconnect all servers |

--- a/__tests__/fixtures/mcp-code-server.mjs
+++ b/__tests__/fixtures/mcp-code-server.mjs
@@ -1,0 +1,38 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "mcp-code-server", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Echo a value",
+      inputSchema: {
+        type: "object",
+        properties: { value: {} },
+      },
+    },
+    {
+      name: "fail",
+      description: "Return an MCP tool error",
+      inputSchema: { type: "object", properties: {} },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === "fail") {
+    return { isError: true, content: [{ type: "text", text: "fixture failure" }] };
+  }
+  return {
+    content: [{ type: "text", text: String(request.params.arguments?.value ?? "") }],
+    structuredContent: { echoed: request.params.arguments?.value },
+  };
+});
+
+await server.connect(new StdioServerTransport());

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { createMcpAdapter } from "../index.ts";
+import { runMcpCode } from "../mcp-code.ts";
+import { McpServerManager } from "../server-manager.ts";
+import type { McpExtensionState } from "../state.ts";
+
+const fixture = fileURLToPath(new URL("./fixtures/mcp-code-server.mjs", import.meta.url));
+const definition = { command: process.execPath, args: [fixture] };
+let manager: McpServerManager;
+let state: McpExtensionState;
+
+function textBlocks(result: Awaited<ReturnType<typeof runMcpCode>>): string[] {
+  return result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text);
+}
+
+describe("runMcpCode", () => {
+  it("registers mcp_code only when code mode is enabled", () => {
+    const registerTool = vi.fn();
+    createMcpAdapter({ config: { settings: { codeMode: true }, mcpServers: {} } })({
+      registerTool,
+      registerFlag: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+      getAllTools: vi.fn(() => []),
+    } as any);
+
+    expect(registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp_code" }));
+  });
+
+  beforeAll(async () => {
+    manager = new McpServerManager();
+    await manager.connect("fixture", definition);
+    state = {
+      config: { settings: {}, mcpServers: { fixture: definition } },
+      toolMetadata: new Map([
+        ["fixture", [
+          { name: "fixture_echo", originalName: "echo", description: "Echo a value" },
+          { name: "fixture_fail", originalName: "fail", description: "Return an MCP tool error" },
+        ]],
+      ]),
+      manager,
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as unknown as McpExtensionState;
+  });
+
+  afterAll(async () => {
+    await manager.closeAll();
+  });
+
+  it("calls a prefixed MCP tool through the flat tools proxy", async () => {
+    const result = await runMcpCode(
+      state,
+      'return await tools.fixture_echo({ value: "round trip" });',
+    );
+
+    expect(JSON.parse(textBlocks(result).at(-1)!)).toMatchObject({
+      ok: true,
+      data: {
+        content: [{ type: "text", text: "round trip" }],
+        structuredContent: { echoed: "round trip" },
+      },
+    });
+  });
+
+  it("returns a failure envelope and lets the script continue", async () => {
+    const result = await runMcpCode(
+      state,
+      "const failure = await tools.fixture_fail({}); return { failure, continued: true };",
+    );
+
+    expect(JSON.parse(textBlocks(result).at(-1)!)).toMatchObject({
+      continued: true,
+      failure: {
+        ok: false,
+        error: { code: "tool_error", message: expect.stringContaining("fixture failure") },
+      },
+    });
+    expect(result.details).not.toHaveProperty("error");
+  });
+
+  it("bounds synchronous runaway code and preserves partial emits", async () => {
+    const result = await runMcpCode(state, 'emit("before timeout"); while (true) {}', 20);
+
+    expect(textBlocks(result)[0]).toBe("before timeout");
+    expect(result.details).toMatchObject({ error: "timeout", timeoutMs: 20 });
+    expect(textBlocks(result).at(-1)).toBe("mcp_code timed out after 20ms");
+  });
+
+  it("orders emitted and captured console blocks before the return value", async () => {
+    const result = await runMcpCode(
+      state,
+      'emit("first"); console.log("second"); return "last";',
+    );
+
+    expect(textBlocks(result)).toEqual(["first", "[console.log] second", "last"]);
+  });
+
+  it("rejects tools enumeration with discovery guidance without exposing host globals", async () => {
+    const result = await runMcpCode(
+      state,
+      `let message;
+      try { Object.keys(tools); } catch (error) { message = error.message; }
+      return { message, globals: [typeof require, typeof fetch, typeof process] };`,
+    );
+
+    expect(JSON.parse(textBlocks(result)[0])).toEqual({
+      message: "tools is not enumerable — use mcp({ search })",
+      globals: ["undefined", "undefined", "undefined"],
+    });
+  });
+});

--- a/__tests__/mcp-panel-keybindings.test.ts
+++ b/__tests__/mcp-panel-keybindings.test.ts
@@ -1,4 +1,4 @@
-import { KeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
+import { KeybindingsManager, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { createMcpPanel } from "../mcp-panel.ts";
 import { createMcpSetupPanel, type SetupPanelCallbacks } from "../mcp-setup-panel.ts";
@@ -61,9 +61,11 @@ function createSetupCallbacks(): SetupPanelCallbacks {
     previewImports: () => preview,
     previewStarterProject: () => preview,
     previewRepoPrompt: () => null,
+    previewKnownServer: () => preview,
     adoptImports: async () => ({ added: [], path: "/tmp/x" }),
     scaffoldProjectConfig: vi.fn(async () => ({ path: "/tmp/x" })),
     addRepoPrompt: async () => ({ path: "/tmp/x", serverName: "repoprompt" }),
+    addKnownServer: async (preset) => ({ path: "/tmp/x", serverName: preset.name }),
     openPath: async () => {},
     markSetupCompleted: () => {},
   };
@@ -184,6 +186,32 @@ describe("mcp-setup-panel custom keybindings", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(callbacks.scaffoldProjectConfig).toHaveBeenCalledTimes(1);
+    panel.dispose();
+  });
+
+  it("keeps setup previews usable at mobile width", () => {
+    const panel = createMcpSetupPanel(
+      createEmptyDiscovery(),
+      createSetupCallbacks(),
+      {
+        mode: "setup",
+        onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    // Actions for this discovery: view-example, scaffold-project, show-precedence, known presets, close.
+    panel.handleInput(DOWN);
+    panel.handleInput(DOWN);
+    panel.handleInput(DOWN);
+    const lines = panel.render(37);
+    const output = lines.join("\n");
+
+    expect(Math.max(...lines.map((line) => visibleWidth(line)))).toBeLessThanOrEqual(37);
+    expect(output).toContain("DeepWiki");
+    expect(output).toContain("write preview");
+    expect(output).toContain("Enter select");
     panel.dispose();
   });
 

--- a/__tests__/mcp-probe.test.ts
+++ b/__tests__/mcp-probe.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeMcpEndpoint } from "../mcp-probe.ts";
+
+const fetchMock = vi.fn();
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+function mockFetch(...responses: Response[]): void {
+  fetchMock.mockResolvedValueOnce(responses[0]);
+  for (const response of responses.slice(1)) fetchMock.mockResolvedValueOnce(response);
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+describe("MCP endpoint shape probe", () => {
+  it("classifies an HTML 200 response as not MCP", async () => {
+    mockFetch(new Response("<html>Welcome</html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    }));
+
+    await expect(probeMcpEndpoint("https://example.test/mcp")).resolves.toMatchObject({
+      isMcp: false,
+      classification: expect.stringContaining("HTML (200)"),
+    });
+  });
+
+  it("classifies a GraphQL-style JSON error as not MCP", async () => {
+    mockFetch(new Response(JSON.stringify({ errors: [{ message: "Cannot query field" }] }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }));
+
+    await expect(probeMcpEndpoint("https://example.test/graphql")).resolves.toMatchObject({
+      isMcp: false,
+      classification: expect.stringContaining("application/json (400)"),
+    });
+  });
+
+  it("recognizes a Bearer JSON-RPC authentication error", async () => {
+    mockFetch(new Response(JSON.stringify({
+      jsonrpc: "2.0", id: 1, error: { code: -32001, message: "Unauthorized" },
+    }), {
+      status: 401,
+      headers: { "www-authenticate": "Bearer" },
+    }));
+
+    await expect(probeMcpEndpoint("https://example.test/mcp")).resolves.toMatchObject({ isMcp: true });
+  });
+
+  it("recognizes an SSE response", async () => {
+    mockFetch(new Response("event: message\ndata: {}\n\n", {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    }));
+
+    await expect(probeMcpEndpoint("https://example.test/mcp")).resolves.toMatchObject({ isMcp: true });
+  });
+
+  it("retries GET after a POST 405", async () => {
+    mockFetch(
+      new Response("Method Not Allowed", { status: 405 }),
+      new Response("event: message\ndata: {}\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    await expect(probeMcpEndpoint("https://example.test/mcp")).resolves.toMatchObject({ isMcp: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ headers: { Accept: "text/event-stream" } });
+    expect(fetchMock.mock.calls[1]?.[1]?.signal).not.toBe(fetchMock.mock.calls[0]?.[1]?.signal);
+  });
+});

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { executeCall, executeSearch } from "../proxy-modes.ts";
+import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
 
 function createState(): McpExtensionState {
@@ -18,6 +18,11 @@ function createState(): McpExtensionState {
             originalName: "search",
             description: "Search demo records",
             inputSchema: { type: "object", properties: {} },
+          },
+          {
+            name: "demo_find",
+            originalName: "find",
+            description: "Find demo records",
           },
         ],
       ],
@@ -58,13 +63,42 @@ describe("proxy discovery", () => {
   it("accepts safe regex queries", () => {
     const result = executeSearch(createState(), "^demo_[a-z]+$", true);
 
-    expect(result.details).toMatchObject({ count: 1, query: "^demo_[a-z]+$" });
+    expect(result.details).toMatchObject({ count: 2, query: "^demo_[a-z]+$" });
   });
 
   it("keeps non-regex searches unaffected by the regex length cap", () => {
     const result = executeSearch(createState(), "search terms ".repeat(40), false);
 
     expect(result.details).not.toMatchObject({ error: "query_too_long" });
+  });
+
+  it("returns ranked paged search details", () => {
+    const result = executeSearch(createState(), "demo", false, undefined, false, 1, 0);
+
+    expect(result.details).toMatchObject({
+      count: 2,
+      hasMore: true,
+      nextOffset: 1,
+      matches: [{ server: "demo", tool: "demo_find", score: expect.any(Number) }],
+    });
+  });
+
+  it("paginates regex search results without changing their order", () => {
+    const result = executeSearch(createState(), "^demo_", true, undefined, false, 1, 1);
+
+    expect(result.details).toMatchObject({
+      count: 2,
+      hasMore: false,
+      nextOffset: null,
+      matches: [{ server: "demo", tool: "demo_find", score: 0 }],
+    });
+  });
+
+  it("suggests the matching tool for a prefix-mangled describe name", () => {
+    const result = executeDescribe(createState(), "demo_sear");
+
+    expect(result.details).toMatchObject({ suggestions: ["demo_search"] });
+    expect(result.content[0].text).toContain("Did you mean: demo_search");
   });
 
   it("tells callers to invoke native Pi tools directly", async () => {

--- a/__tests__/search-ranking.test.ts
+++ b/__tests__/search-ranking.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { paginate, scoreToolMatch } from "../search-ranking.ts";
+
+const tool = (name: string, description: string) => ({
+  name,
+  originalName: name,
+  description,
+});
+
+describe("search ranking", () => {
+  it("ranks an exact name above a description match", () => {
+    const exact = scoreToolMatch(tool("search_records", "Find records"), "demo", "search")!;
+    const description = scoreToolMatch(tool("find_records", "Search records"), "demo", "search")!;
+
+    expect(exact).toBeGreaterThan(description);
+  });
+
+  it("drops partial two-token matches", () => {
+    expect(scoreToolMatch(tool("search_records", "Find records"), "demo", "search missing")).toBeNull();
+  });
+
+  it("ignores single-letter possessive tokens instead of stem-matching them", () => {
+    // "project's" tokenizes to ["project", "s"]; a bare "s" must not match "simulator".
+    expect(scoreToolMatch(tool("sync_icon", "Add an icon to your project's icons file."), "better-icons", "simulator")).toBeNull();
+    // Real stems still match: "sync" (4+ chars) may prefix-match "synchronize".
+    expect(scoreToolMatch(tool("sync_icon", "Sync an icon."), "better-icons", "synchronize")).not.toBeNull();
+  });
+
+  it("paginates including offsets beyond the result set", () => {
+    expect(paginate(["a", "b", "c"], 1, 1)).toEqual({
+      items: ["b"], total: 3, hasMore: true, nextOffset: 2,
+    });
+    expect(paginate(["a", "b", "c"], 5, 1)).toEqual({
+      items: [], total: 3, hasMore: false, nextOffset: null,
+    });
+  });
+});

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -49,6 +49,7 @@ describe("McpServerManager stderr capture", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("pipes stderr for normal stdio servers and preserves inherit for debug", async () => {
@@ -96,7 +97,11 @@ describe("McpServerManager stderr capture", () => {
     expect(Buffer.byteLength(capturedError?.message ?? "", "utf8")).toBeLessThanOrEqual(8_192 + 100);
   });
 
-  it("keeps empty stderr and non-stdio errors unchanged", async () => {
+  it("keeps empty stdio stderr unchanged and enriches HTTP errors with a probe", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("<html>Not found</html>", {
+      status: 404,
+      headers: { "content-type": "text/html" },
+    })));
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();
     mocks.connectImpl = async () => {
@@ -104,7 +109,9 @@ describe("McpServerManager stderr capture", () => {
     };
 
     await expect(manager.connect("stdio", { command: "node" })).rejects.toThrow(/^MCP error -32000: Connection closed$/);
-    await expect(manager.connect("http", { url: "https://example.com/mcp" })).rejects.toThrow(/^MCP error -32000: Connection closed$/);
+    await expect(manager.connect("http", { url: "https://example.com/mcp" })).rejects.toThrow(
+      /MCP error -32000: Connection closed — probe: endpoint returned HTML \(404\)/,
+    );
   });
 
   it("bounds captured stderr and keeps only its final three lines", async () => {

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
+import type { McpExtensionState } from "../state.ts";
+import { ensureToolCallApproved, isToolCallApprovalRequired } from "../tool-approval.ts";
+import type { McpConfig, ToolMetadata } from "../types.ts";
+
+const tool: ToolMetadata = {
+  name: "demo_search-records",
+  originalName: "search-records",
+  description: "Search records",
+};
+
+function createState(options: {
+  approveTools?: boolean | string[];
+  decision?: "Allow once" | "Allow for session" | "Deny";
+  interactive?: boolean;
+} = {}) {
+  const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
+  const select = vi.fn().mockResolvedValue(options.decision ?? "Allow once");
+  const connection = {
+    status: "connected",
+    client: { callTool },
+    tools: [{ name: "search-records", description: "Search records" }],
+    resources: [],
+    prompts: [],
+  };
+  const state = {
+    config: {
+      mcpServers: {
+        demo: {
+          command: "demo",
+          ...(options.approveTools === undefined ? {} : { approveTools: options.approveTools }),
+        },
+      },
+    },
+    toolMetadata: new Map([["demo", [tool]]]),
+    resourceCounts: new Map(),
+    promptMetadata: new Map(),
+    promptMetadataLive: new Set(),
+    serverInstructions: new Map(),
+    approvedToolCalls: new Map<string, true>(),
+    manager: {
+      getConnection: () => connection,
+      getRequestOptions: () => undefined,
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+    },
+    failureTracker: new Map(),
+    failureMessages: new Map(),
+    ...(options.interactive === false ? {} : { ui: { select } }),
+  } as unknown as McpExtensionState;
+  return { state, callTool, select };
+}
+
+describe("tool approval", () => {
+  it("matches original, prefixed, normalized, and read_* resource tool names", () => {
+    const cases: Array<{ config: McpConfig; meta: ToolMetadata }> = [
+      {
+        config: { mcpServers: { demo: { approveTools: ["search_records"] } } },
+        meta: tool,
+      },
+      {
+        config: { mcpServers: { demo: { approveTools: ["demo_search_records"] } } },
+        meta: tool,
+      },
+      {
+        config: { mcpServers: { "docs-mcp": {} }, settings: { approveTools: ["docs_read_*"] } },
+        meta: { name: "docs_read_handbook", originalName: "read_handbook", description: "Read handbook", resourceUri: "docs://handbook" },
+      },
+    ];
+
+    for (const { config, meta } of cases) {
+      expect(isToolCallApprovalRequired(config, Object.keys(config.mcpServers)[0], meta)).toBe(true);
+    }
+  });
+
+  it("fails closed headlessly with a structured approval_required result", async () => {
+    const { state, callTool } = createState({ approveTools: true, interactive: false });
+
+    const result = await executeCall(state, tool.name, { query: "private" });
+
+    expect(result.details).toEqual({
+      mode: "call",
+      error: "approval_required",
+      server: "demo",
+      tool: "search-records",
+    });
+    expect(result.content[0].text).toContain("approval-gated");
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("returns approval_denied without throwing or invoking proxy or direct tools", async () => {
+    const proxy = createState({ approveTools: true, decision: "Deny" });
+    await expect(executeCall(proxy.state, tool.name, {})).resolves.toMatchObject({
+      details: { error: "approval_denied", server: "demo", tool: "search-records" },
+    });
+    expect(proxy.callTool).not.toHaveBeenCalled();
+
+    const direct = createState({ approveTools: true, decision: "Deny" });
+    const execute = createDirectToolExecutor(() => direct.state, () => null, {
+      serverName: "demo",
+      originalName: "search-records",
+      prefixedName: "demo_search-records",
+      description: "Search records",
+    });
+    await expect(execute("call-1", {}, undefined, undefined, {} as never)).resolves.toMatchObject({
+      details: { error: "approval_denied", server: "demo", tool: "search-records" },
+    });
+    expect(direct.callTool).not.toHaveBeenCalled();
+  });
+
+  it("caches only Allow for session decisions", async () => {
+    const session = createState({ approveTools: true, decision: "Allow for session" });
+    await ensureToolCallApproved(session.state, "demo", tool, {}, undefined);
+    await ensureToolCallApproved(session.state, "demo", tool, {}, undefined);
+    expect(session.select).toHaveBeenCalledTimes(1);
+    expect(session.state.approvedToolCalls.has("demo\u0000search-records")).toBe(true);
+
+    const once = createState({ approveTools: true, decision: "Allow once" });
+    await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
+    await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
+    expect(once.select).toHaveBeenCalledTimes(2);
+    expect(once.state.approvedToolCalls.size).toBe(0);
+  });
+
+  it("propagates aborts while the approval dialog is open", async () => {
+    const { state, select } = createState({ approveTools: true });
+    select.mockImplementation(() => new Promise(() => {}));
+    const controller = new AbortController();
+    const reason = new Error("stopped");
+    reason.name = "AbortError";
+
+    const pending = ensureToolCallApproved(state, "demo", tool, {}, controller.signal);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  it("marks gated tools in describe and search output without hiding them", () => {
+    const { state } = createState({ approveTools: true });
+
+    expect(executeDescribe(state, tool.name).content[0].text).toContain("search-records (requires approval)");
+    expect(executeSearch(state, "search", false, undefined, false).content[0].text).toContain("(requires approval)");
+  });
+});

--- a/__tests__/ts-shape.test.ts
+++ b/__tests__/ts-shape.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { renderTsShape } from "../ts-shape.ts";
+
+describe("renderTsShape", () => {
+  it("renders required and optional object properties", () => {
+    expect(renderTsShape({
+      type: "object",
+      properties: { query: { type: "string" }, limit: { type: "integer" } },
+      required: ["query"],
+    })).toBe("{ query: string; limit?: number; }");
+  });
+
+  it("renders enum unions", () => {
+    expect(renderTsShape({ enum: ["fast", "safe", null] })).toBe('"fast" | "safe" | null');
+  });
+
+  it("renders nested objects and arrays", () => {
+    expect(renderTsShape({
+      type: "object",
+      properties: {
+        config: {
+          type: "object",
+          properties: { tags: { type: "array", items: { type: "string" } } },
+          required: ["tags"],
+        },
+      },
+      required: ["config"],
+    })).toBe("{ config: { tags: string[]; }; }");
+  });
+
+  it("hoists local references as named definitions", () => {
+    expect(renderTsShape({
+      type: "object",
+      properties: { address: { $ref: "#/$defs/Address" } },
+      required: ["address"],
+      $defs: {
+        Address: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+      },
+    })).toBe("type Address = { city: string; };\n\n{ address: Address; }");
+  });
+
+  it("ignores unsupported unreferenced definitions", () => {
+    expect(renderTsShape({
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      $defs: {
+        Unused: { if: { type: "string" }, then: { type: "number" } },
+      },
+    })).toBe("{ query: string; }");
+  });
+
+  it("returns null for exotic schemas", () => {
+    expect(renderTsShape({ if: { type: "string" }, then: { type: "number" } })).toBeNull();
+    expect(renderTsShape({ $ref: "https://example.com/schema" })).toBeNull();
+  });
+});

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -3,7 +3,8 @@ import http from "node:http";
 import { startUiServer, type UiServerOptions, type UiServerHandle } from "../ui-server.ts";
 import type { McpServerManager } from "../server-manager.ts";
 import type { ConsentManager } from "../consent-manager.ts";
-import type { UiResourceContent } from "../types.ts";
+import type { McpConfig, UiResourceContent } from "../types.ts";
+import type { McpExtensionState } from "../state.ts";
 
 // Helper to make HTTP requests to the server
 async function request(
@@ -557,6 +558,39 @@ describe("UiServer", () => {
         undefined,
         requestOptions,
       );
+    });
+
+    it("returns a gated iframe call as an approval_denied tool result", async () => {
+      const mockClient = { callTool: vi.fn() };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
+      });
+      const config: McpConfig = {
+        mcpServers: { "test-server": { command: "demo", approveTools: true } },
+      };
+      const state = {
+        config,
+        approvedToolCalls: new Map(),
+        ui: { select: vi.fn().mockResolvedValue("Deny") },
+      } as unknown as McpExtensionState;
+      handle = await startUiServer(createServerOptions({ manager, config, state }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "some_tool", arguments: { dangerous: true } },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ok: true,
+        result: {
+          details: { error: "approval_denied", server: "test-server", tool: "some_tool" },
+        },
+      });
+      expect(mockClient.callTool).not.toHaveBeenCalled();
     });
 
     it("checks consent before calling tool", async () => {

--- a/commands.ts
+++ b/commands.ts
@@ -4,6 +4,8 @@ import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCall
 import {
   ensureCompatibilityImports,
   getMcpDiscoverySummary,
+  getProjectConfigPath,
+  type KnownServerPreset,
   getServerProvenance,
   previewCompatibilityImports,
   previewSharedServerEntry,
@@ -395,6 +397,7 @@ export async function openMcpSetup(
       if (!repoPrompt.entry || !repoPrompt.targetPath || !repoPrompt.serverName) return null;
       return previewSharedServerEntry(repoPrompt.targetPath, repoPrompt.serverName, repoPrompt.entry);
     },
+    previewKnownServer: (preset: KnownServerPreset) => previewSharedServerEntry(getProjectConfigPath(ctx.cwd), preset.id, preset.entry),
     adoptImports: async (imports: ImportKind[]) => {
       const result = ensureCompatibilityImports(imports, configOverridePath);
       if (result.added.length > 0) configChanged = true;
@@ -413,6 +416,11 @@ export async function openMcpSetup(
       const path = writeSharedServerEntry(repoPrompt.targetPath, repoPrompt.serverName, repoPrompt.entry);
       configChanged = true;
       return { path, serverName: repoPrompt.serverName };
+    },
+    addKnownServer: async (preset: KnownServerPreset) => {
+      const path = writeSharedServerEntry(getProjectConfigPath(ctx.cwd), preset.id, preset.entry);
+      configChanged = true;
+      return { path, serverName: preset.name };
     },
     openPath: async (targetPath: string) => {
       await openPath(pi, targetPath);

--- a/config.ts
+++ b/config.ts
@@ -20,6 +20,46 @@ const REPOPROMPT_BINARY_CANDIDATES = [
   "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp",
 ];
 
+export interface KnownServerPreset {
+  id: string;
+  name: string;
+  summary: string;
+  entry: ServerEntry;
+}
+
+export const KNOWN_SERVER_PRESETS: readonly KnownServerPreset[] = [
+  {
+    id: "deepwiki",
+    name: "DeepWiki",
+    summary: "Ask questions about public GitHub repositories.",
+    entry: { url: "https://mcp.deepwiki.com/mcp" },
+  },
+  {
+    id: "context7",
+    name: "Context7",
+    summary: "Look up current library documentation and examples.",
+    entry: { url: "https://mcp.context7.com/mcp" },
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    summary: "Search and work with your Notion workspace.",
+    entry: { url: "https://mcp.notion.com/mcp", auth: "oauth" },
+  },
+  {
+    id: "github",
+    name: "GitHub",
+    summary: "Work with GitHub through your Copilot account.",
+    entry: { url: "https://api.githubcopilot.com/mcp", auth: "oauth" },
+  },
+  {
+    id: "chrome-devtools",
+    name: "Chrome DevTools",
+    summary: "Inspect and automate a local Chrome browser.",
+    entry: { command: "npx", args: ["-y", "chrome-devtools-mcp@latest"] },
+  },
+];
+
 const IMPORT_PATHS: Record<ImportKind, string[]> = {
   cursor: [join(homedir(), ".cursor", "mcp.json")],
   "claude-code": [

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -17,6 +17,7 @@ import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
+import { ensureToolCallApproved } from "./tool-approval.ts";
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
@@ -369,6 +370,30 @@ export function createDirectToolExecutor(
       return {
         content: [{ type: "text" as const, text: `MCP server "${spec.serverName}" not connected` }],
         details: { error: "not_connected", server: spec.serverName },
+      };
+    }
+
+    const approval = await ensureToolCallApproved(state, spec.serverName, {
+      name: spec.prefixedName,
+      originalName: spec.originalName,
+      description: spec.description,
+      inputSchema: spec.inputSchema,
+      resourceUri: spec.resourceUri,
+      uiResourceUri: spec.uiResourceUri,
+      uiStreamMode: spec.uiStreamMode,
+    }, params, ownedSignal);
+    if (approval.ok === false) {
+      const denied = approval.reason === "denied";
+      const message = denied
+        ? `The user declined approval to run MCP tool "${spec.originalName}" on server "${spec.serverName}".`
+        : `MCP tool "${spec.originalName}" on server "${spec.serverName}" is approval-gated and requires an interactive session.`;
+      return {
+        content: [{ type: "text" as const, text: message }],
+        details: {
+          error: denied ? "approval_denied" : "approval_required",
+          server: spec.serverName,
+          tool: spec.originalName,
+        },
       };
     }
 

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolR
 import { toolErrorOverride } from "./error-signal.ts";
 import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
+import { runMcpCode } from "./mcp-code.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export {
@@ -605,6 +606,52 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
     },
   });
+
+  if (earlyConfig.settings?.codeMode === true) {
+    (pi.registerTool as (tool: unknown) => unknown)({
+      name: "mcp_code",
+      label: "MCP Code",
+      description: "Run plain JavaScript that can call MCP tools through the flat tools.<prefixedToolName>(args) proxy. For tool names with hyphens or other non-identifier characters, use bracket syntax: tools[\"server_tool-name\"](args).",
+      promptSnippet: "Run plain JavaScript to chain and filter MCP tool calls in one request",
+      parameters: Type.Object({
+        code: Type.String({ description: "Plain JavaScript to execute. Use tools.<prefixedToolName>(args) and emit(value)." }),
+        // Raw JSON schema: host TypeBox shims may omit Type.Number (see index-lifecycle shim test).
+        timeoutMs: Type.Optional({ type: "number", minimum: 1, description: "Execution timeout in milliseconds (default: 30000)" } as any),
+      }),
+      renderResult: renderMcpToolResult,
+      async execute(_toolCallId, params: { code: string; timeoutMs?: number }, signal) {
+        const executeOwner = currentOwner;
+        if (!state && initPromise) {
+          try {
+            const initialized = await awaitWithTimeout(initPromise, INIT_WAIT_TIMEOUT_MS);
+            if (initialized === INIT_WAIT_TIMED_OUT) {
+              return {
+                content: [{ type: "text" as const, text: "MCP initialization is still in progress. Try again shortly." }],
+                details: { mode: "code", error: "init_timeout", timeoutMs: INIT_WAIT_TIMEOUT_MS },
+              };
+            }
+            executeOwner?.throwIfInactive();
+            state = initialized;
+          } catch (error) {
+            if (executeOwner && isAbortError(error, executeOwner.signal)) throw error;
+            const message = error instanceof Error ? error.message : String(error);
+            return {
+              content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
+              details: { mode: "code", error: "init_failed", message },
+            };
+          }
+        }
+        if (!state) {
+          return {
+            content: [{ type: "text" as const, text: "MCP not initialized" }],
+            details: { mode: "code", error: "not_initialized" },
+          };
+        }
+        executeOwner?.throwIfInactive();
+        return runMcpCode(state, params.code, params.timeoutMs, getPiTools, signal);
+      },
+    });
+  }
 
   function registerProxyTool(description: string): void {
     (pi.registerTool as (tool: unknown) => unknown)({

--- a/index.ts
+++ b/index.ts
@@ -628,6 +628,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
         regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
+        // Raw JSON schema: host TypeBox shims may omit Type.Number (see index-lifecycle shim test).
+        limit: Type.Optional({ type: "number", minimum: 1, description: "Maximum search results to return (default: 12)" } as any),
+        offset: Type.Optional({ type: "number", minimum: 0, description: "Search result offset (default: 0)" } as any),
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
       }),
@@ -641,6 +644,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         search?: string;
         regex?: boolean;
         includeSchemas?: boolean;
+        limit?: number;
+        offset?: number;
         server?: string;
         action?: string;
       }, signal, _onUpdate, _ctx) {
@@ -742,8 +747,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         if (params.instructions) {
           return executeInstructions(state, params.instructions);
         }
-        if (params.search) {
-          return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas);
+        if (params.search !== undefined) {
+          return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, params.limit, params.offset);
         }
         if (params.server) {
           return executeList(state, params.server);

--- a/init.ts
+++ b/init.ts
@@ -147,6 +147,7 @@ export async function initializeMcp(
   const serverInstructions = new Map<string, string>();
   const failureTracker = new Map<string, number>();
   const failureMessages = new Map<string, string>();
+  const approvedToolCalls = new Map<string, true>();
   const uiResourceHandler = new UiResourceHandler(manager, config);
   const consentManager = new ConsentManager("once-per-server");
   const state: McpExtensionState = {
@@ -164,6 +165,7 @@ export async function initializeMcp(
     authStorageOptions,
     failureTracker,
     failureMessages,
+    approvedToolCalls,
     uiResourceHandler,
     consentManager,
     uiServer: null,

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -1,0 +1,183 @@
+import type { ToolInfo } from "@earendil-works/pi-coding-agent";
+import { formatWithOptions } from "node:util";
+import vm from "node:vm";
+import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
+import { executeCall } from "./proxy-modes.ts";
+import { combineAbortSignals } from "./runtime-owner.ts";
+import type { McpExtensionState } from "./state.ts";
+import type { ContentBlock } from "./types.ts";
+
+export const DEFAULT_MCP_CODE_TIMEOUT_MS = 30_000;
+const TOOLS_ENUMERATION_ERROR = "tools is not enumerable — use mcp({ search })";
+
+class McpCodeTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`mcp_code timed out after ${timeoutMs}ms`);
+    this.name = "McpCodeTimeoutError";
+  }
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "undefined";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function toContentBlock(value: unknown): ContentBlock {
+  if (typeof value === "object" && value !== null) {
+    const block = value as Record<string, unknown>;
+    if (block.type === "text" && typeof block.text === "string") {
+      return { type: "text", text: block.text };
+    }
+    if (block.type === "image" && typeof block.data === "string" && typeof block.mimeType === "string") {
+      return { type: "image", data: block.data, mimeType: block.mimeType };
+    }
+  }
+  return { type: "text", text: formatValue(value) };
+}
+
+function textFromContent(content: ContentBlock[]): string {
+  return content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function isVmTimeout(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const value = error as { code?: unknown; message?: unknown };
+  return value.code === "ERR_SCRIPT_EXECUTION_TIMEOUT"
+    || (typeof value.message === "string" && value.message.includes("Script execution timed out"));
+}
+
+export async function runMcpCode(
+  state: McpExtensionState,
+  code: string,
+  timeoutMs = DEFAULT_MCP_CODE_TIMEOUT_MS,
+  getPiTools?: () => ToolInfo[],
+  signal?: AbortSignal,
+) {
+  const resolvedTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.floor(timeoutMs)
+    : DEFAULT_MCP_CODE_TIMEOUT_MS;
+  const output: ContentBlock[] = [];
+  const externalSignal = combineAbortSignals(state.owner?.signal, signal);
+  const timeoutController = new AbortController();
+  const callSignal = combineAbortSignals(externalSignal, timeoutController.signal);
+
+  const emit = (value: unknown): void => {
+    output.push(toContentBlock(value));
+  };
+
+  const capturedConsole = Object.freeze({
+    log: (...args: unknown[]) => emit(`[console.log] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
+    info: (...args: unknown[]) => emit(`[console.info] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
+    warn: (...args: unknown[]) => emit(`[console.warn] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
+    error: (...args: unknown[]) => emit(`[console.error] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
+    debug: (...args: unknown[]) => emit(`[console.debug] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
+  });
+
+  const tools = new Proxy(Object.create(null) as Record<string, unknown>, {
+    get(_target, property) {
+      if (typeof property !== "string") return undefined;
+      return async (args?: Record<string, unknown>) => {
+        const result = await executeCall(state, property, args, undefined, getPiTools, callSignal);
+        const details = result.details;
+        if (details.error !== undefined) {
+          const message = typeof details.message === "string"
+            ? details.message
+            : textFromContent(result.content);
+          return {
+            ok: false as const,
+            error: { code: String(details.error), message },
+          };
+        }
+        return {
+          ok: true as const,
+          data: details.mcpResult !== undefined ? details.mcpResult : textFromContent(result.content),
+        };
+      };
+    },
+    ownKeys() {
+      throw new Error(TOOLS_ENUMERATION_ERROR);
+    },
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener = () => {};
+  let errorCode: "timeout" | "aborted" | "script_error" | undefined;
+  let errorMessage: string | undefined;
+
+  try {
+    if (externalSignal?.aborted) {
+      throw externalSignal.reason instanceof Error
+        ? externalSignal.reason
+        : new Error(String(externalSignal.reason ?? "MCP request aborted"));
+    }
+
+    const context = vm.createContext(Object.assign(Object.create(null), {
+      tools,
+      emit,
+      console: capturedConsole,
+    }), {
+      codeGeneration: { strings: false, wasm: false },
+      name: "mcp_code",
+    });
+    const script = new vm.Script(`(async () => {\n${code}\n})()`, { filename: "mcp_code.js" });
+    const execution = Promise.resolve(script.runInContext(context, { timeout: resolvedTimeoutMs }));
+    const timeoutError = new McpCodeTimeoutError(resolvedTimeoutMs);
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        timeoutController.abort(timeoutError);
+        reject(timeoutError);
+      }, resolvedTimeoutMs);
+    });
+    const aborted = externalSignal
+      ? new Promise<never>((_resolve, reject) => {
+          const onAbort = () => reject(externalSignal.reason instanceof Error
+            ? externalSignal.reason
+            : new Error(String(externalSignal.reason ?? "MCP request aborted")));
+          externalSignal.addEventListener("abort", onAbort, { once: true });
+          removeAbortListener = () => externalSignal.removeEventListener("abort", onAbort);
+        })
+      : new Promise<never>(() => {});
+
+    const returnValue = await Promise.race([execution, timeout, aborted]);
+    if (returnValue !== undefined) output.push(toContentBlock(returnValue));
+  } catch (error) {
+    if (error instanceof McpCodeTimeoutError || isVmTimeout(error)) {
+      errorCode = "timeout";
+      errorMessage = `mcp_code timed out after ${resolvedTimeoutMs}ms`;
+      timeoutController.abort(error);
+    } else if (externalSignal?.aborted) {
+      errorCode = "aborted";
+      errorMessage = error instanceof Error ? error.message : String(error);
+    } else {
+      errorCode = "script_error";
+      errorMessage = error instanceof Error ? error.message : String(error);
+    }
+    output.push({ type: "text", text: errorMessage });
+  } finally {
+    clearTimeout(timer);
+    removeAbortListener();
+  }
+
+  // Snapshot: a timed-out script may still be running and emitting into `output`.
+  const guarded = await guardMcpOutput(
+    output.length > 0 ? [...output] : [{ type: "text", text: "(no output)" }],
+    resolveMcpOutputGuardOptions(state.config.settings),
+  );
+  return {
+    content: guarded.content,
+    details: {
+      mode: "code",
+      ...(errorCode ? { error: errorCode, message: errorMessage } : {}),
+      timeoutMs: resolvedTimeoutMs,
+      ...guardedMcpDetails(guarded),
+    },
+  };
+}

--- a/mcp-probe.ts
+++ b/mcp-probe.ts
@@ -1,0 +1,90 @@
+const PROBE_TIMEOUT_MS = 5_000;
+
+export interface McpProbeResult {
+  isMcp: boolean;
+  classification: string;
+}
+
+const INITIALIZE_REQUEST = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "pi-mcp-probe", version: "2.1.2" },
+  },
+};
+
+function isJsonRpcEnvelope(value: unknown): boolean {
+  return typeof value === "object" && value !== null &&
+    (value as { jsonrpc?: unknown }).jsonrpc === "2.0" &&
+    ("result" in value || "error" in value);
+}
+
+function isBearerChallenge(response: Response): boolean {
+  return /(?:^|,)\s*Bearer\b/i.test(response.headers.get("www-authenticate") ?? "");
+}
+
+function responseKind(response: Response): string {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType === "text/html") return "HTML";
+  if (contentType) return contentType;
+  return "an untyped response";
+}
+
+async function hasJsonRpcEnvelope(response: Response): Promise<boolean> {
+  try {
+    return isJsonRpcEnvelope(JSON.parse(await response.text()));
+  } catch {
+    return false;
+  }
+}
+
+async function classifyResponse(response: Response, allowJson: boolean): Promise<McpProbeResult | null> {
+  const isSse = response.headers.get("content-type")?.toLowerCase().startsWith("text/event-stream");
+  if (response.ok && isSse) {
+    return { isMcp: true, classification: "endpoint responded with an MCP event stream" };
+  }
+
+  const isJsonRpc = (allowJson || response.status === 401) && await hasJsonRpcEnvelope(response);
+  if (response.ok && allowJson && isJsonRpc) {
+    return { isMcp: true, classification: "endpoint responded with a JSON-RPC 2.0 envelope" };
+  }
+  if (response.status === 401 && isBearerChallenge(response) && isJsonRpc) {
+    return { isMcp: true, classification: "endpoint requires Bearer authentication and responded with a JSON-RPC 2.0 error" };
+  }
+
+  return null;
+}
+
+function notMcp(response: Response): McpProbeResult {
+  return {
+    isMcp: false,
+    classification: `endpoint returned ${responseKind(response)} (${response.status}) — this URL does not appear to speak MCP`,
+  };
+}
+
+/** Makes one unauthenticated metadata-only request to identify an HTTP endpoint's protocol shape. */
+export async function probeMcpEndpoint(url: string | URL): Promise<McpProbeResult> {
+  const postResponse = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(INITIALIZE_REQUEST),
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+  const postClassification = await classifyResponse(postResponse, true);
+  if (postClassification) return postClassification;
+
+  if (![404, 405, 406, 415].includes(postResponse.status)) return notMcp(postResponse);
+
+  const getResponse = await fetch(url, {
+    headers: { Accept: "text/event-stream" },
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+  const getClassification = await classifyResponse(getResponse, false);
+  return getClassification ?? notMcp(getResponse);
+}

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -1,7 +1,7 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import type { ImportKind } from "./types.ts";
-import type { ConfigWritePreview, McpDiscoverySummary } from "./config.ts";
+import { KNOWN_SERVER_PRESETS, type ConfigWritePreview, type KnownServerPreset, type McpDiscoverySummary } from "./config.ts";
 import type { McpOnboardingState } from "./onboarding-state.ts";
 
 interface SetupTheme {
@@ -23,6 +23,11 @@ const DEFAULT_THEME: SetupTheme = {
   warning: "33",
   muted: "2;3",
 };
+
+const MIN_PANEL_WIDTH = 24;
+const COMPACT_WIDTH = 60;
+const COMPACT_ACTION_ROWS = 7;
+const DESKTOP_PREVIEW_WIDTH = 74;
 
 function fg(code: string, text: string): string {
   return code ? `\x1b[${code}m${text}\x1b[0m` : text;
@@ -50,9 +55,11 @@ export interface SetupPanelCallbacks {
   previewImports: (imports: ImportKind[]) => ConfigWritePreview;
   previewStarterProject: () => ConfigWritePreview;
   previewRepoPrompt: () => ConfigWritePreview | null;
+  previewKnownServer: (preset: KnownServerPreset) => ConfigWritePreview;
   adoptImports: (imports: ImportKind[]) => Promise<{ added: ImportKind[]; path: string }>;
   scaffoldProjectConfig: () => Promise<{ path: string }>;
   addRepoPrompt: () => Promise<{ path: string; serverName: string }>;
+  addKnownServer: (preset: KnownServerPreset) => Promise<{ path: string; serverName: string }>;
   openPath: (path: string) => Promise<void>;
   markSetupCompleted: () => void;
 }
@@ -72,6 +79,7 @@ type ActionId =
   | "show-precedence"
   | "open-paths"
   | "add-repoprompt"
+  | "add-known-server"
   | "scaffold-project"
   | "close";
 
@@ -79,6 +87,7 @@ interface Action {
   id: ActionId;
   label: string;
   description: string;
+  preset?: KnownServerPreset;
 }
 
 export class McpSetupPanel {
@@ -141,6 +150,9 @@ export class McpSetupPanel {
     actions.push({ id: "show-precedence", label: "Explain config precedence", description: "Show the read order and where Pi writes compatibility settings." });
     if (this.getDetectedPaths().length > 0) {
       actions.push({ id: "open-paths", label: "Open detected config paths", description: "Browse the actual config files that Pi discovered on this machine." });
+    }
+    for (const preset of KNOWN_SERVER_PRESETS) {
+      actions.push({ id: "add-known-server", label: preset.name, description: preset.summary, preset });
     }
     if (!this.discovery.repoPrompt.configured && this.discovery.repoPrompt.executablePath && this.discovery.repoPrompt.targetPath && this.discovery.repoPrompt.entry && this.discovery.repoPrompt.serverName) {
       actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to shared MCP config", description: "Write a standard MCP entry for RepoPrompt to the recommended shared target, then reload MCP in-session." });
@@ -207,7 +219,7 @@ export class McpSetupPanel {
     }
     if (this.keys.selectConfirm(data)) {
       const selected = this.getSelectedAction();
-      if (selected) void this.runAction(selected.id);
+      if (selected) void this.runAction(selected);
     }
   }
 
@@ -261,26 +273,26 @@ export class McpSetupPanel {
     }
   }
 
-  private async runAction(action: ActionId): Promise<void> {
-    if (action === "run-setup") {
+  private async runAction(action: Action): Promise<void> {
+    if (action.id === "run-setup") {
       this.screen = "setup";
       this.actionCursor = 0;
       this.tui.requestRender();
       return;
     }
-    if (action === "adopt-imports") {
+    if (action.id === "adopt-imports") {
       this.screen = "imports";
       this.importCursor = 0;
       this.tui.requestRender();
       return;
     }
-    if (action === "open-paths") {
+    if (action.id === "open-paths") {
       this.screen = "paths";
       this.pathCursor = 0;
       this.tui.requestRender();
       return;
     }
-    if (action === "scaffold-project") {
+    if (action.id === "scaffold-project") {
       await this.runBusy(async () => {
         const result = await this.callbacks.scaffoldProjectConfig();
         this.callbacks.markSetupCompleted();
@@ -288,7 +300,7 @@ export class McpSetupPanel {
       });
       return;
     }
-    if (action === "add-repoprompt") {
+    if (action.id === "add-repoprompt") {
       await this.runBusy(async () => {
         const result = await this.callbacks.addRepoPrompt();
         this.callbacks.markSetupCompleted();
@@ -296,7 +308,16 @@ export class McpSetupPanel {
       });
       return;
     }
-    if (action === "close") {
+    if (action.id === "add-known-server" && action.preset) {
+      const preset = action.preset;
+      await this.runBusy(async () => {
+        const result = await this.callbacks.addKnownServer(preset);
+        this.callbacks.markSetupCompleted();
+        this.notice = { text: `Added ${result.serverName} to ${result.path}. Pi will reload after this panel closes.`, tone: "success" };
+      });
+      return;
+    }
+    if (action.id === "close") {
       this.cleanup();
       this.done();
       return;
@@ -343,18 +364,24 @@ export class McpSetupPanel {
   }
 
   render(width: number): string[] {
-    const innerW = Math.max(40, width - 2);
+    const panelW = Math.max(MIN_PANEL_WIDTH, width);
+    const innerW = panelW - 2;
+    const contentW = this.contentWidth(innerW);
     const lines: string[] = [];
     const border = fg(this.t.border, "─".repeat(innerW));
     lines.push(`┌${border}┐`);
     lines.push(this.padLine(fg(this.t.title, "MCP setup"), innerW));
-    lines.push(this.padLine(this.discoverySummaryLine(), innerW));
-    lines.push(this.padLine(fg(this.t.muted, this.secondarySummaryLine()), innerW));
+    for (const line of wrapText(this.discoverySummaryLine(), contentW)) {
+      lines.push(this.padLine(line, innerW));
+    }
+    for (const line of wrapText(this.secondarySummaryLine(), contentW)) {
+      lines.push(this.padLine(fg(this.t.muted, line), innerW));
+    }
     lines.push(this.padLine("", innerW));
 
     if (this.notice) {
       const tone = this.notice.tone === "success" ? this.t.success : this.notice.tone === "warning" ? this.t.warning : this.t.hint;
-      for (const line of wrapText(this.notice.text, innerW - 6)) {
+      for (const line of wrapText(this.notice.text, contentW)) {
         lines.push(this.padLine(fg(tone, line), innerW));
       }
       lines.push(this.padLine("", innerW));
@@ -377,20 +404,35 @@ export class McpSetupPanel {
   private renderActions(innerW: number): string[] {
     const lines: string[] = [];
     const actions = this.getActions();
-    for (let index = 0; index < actions.length; index++) {
+    const compact = innerW < COMPACT_WIDTH;
+    const { start, end } = compact
+      ? this.visibleActionRange(actions.length)
+      : { start: 0, end: actions.length };
+
+    if (start > 0) {
+      lines.push(this.padLine(fg(this.t.muted, `… ${start} more above`), innerW));
+    }
+    for (let index = start; index < end; index++) {
       const action = actions[index];
+      if (action.id === "add-known-server" && (index === start || actions[index - 1]?.id !== "add-known-server")) {
+        lines.push(this.padLine(fg(this.t.title, "Add a known server"), innerW));
+      }
       const selected = index === this.actionCursor;
       const cursor = selected ? fg(this.t.selected, "›") : " ";
-      lines.push(this.padLine(`${cursor} ${truncateToWidth(action.label, innerW - 4)}`, innerW));
+      lines.push(this.padLine(`${cursor} ${truncateToWidth(action.label, this.contentWidth(innerW) - 2)}`, innerW));
+    }
+    if (end < actions.length) {
+      lines.push(this.padLine(fg(this.t.muted, `… ${actions.length - end} more below`), innerW));
     }
     lines.push(this.padLine("", innerW));
 
-    const preview = this.getActionPreview(this.getSelectedAction()?.id ?? "view-example");
+    const preview = this.getActionPreview(this.getSelectedAction(), this.previewWidth(innerW));
     for (const line of preview) {
       lines.push(this.padLine(line, innerW));
     }
     lines.push(this.padLine("", innerW));
-    lines.push(this.padLine(fg(this.t.muted, "Enter selects, Esc goes back, Ctrl+C closes."), innerW));
+    const hint = compact ? "Enter select · Esc back" : "Enter selects, Esc goes back, Ctrl+C closes.";
+    lines.push(this.padLine(fg(this.t.muted, hint), innerW));
     return lines;
   }
 
@@ -407,7 +449,7 @@ export class McpSetupPanel {
     lines.push(this.padLine("", innerW));
     const selected = this.discovery.imports.filter((entry) => this.selectedImports.has(entry.kind)).map((entry) => entry.kind);
     const preview = this.callbacks.previewImports(selected);
-    for (const line of this.formatWritePreview("Compatibility import write preview", preview)) {
+    for (const line of this.formatWritePreview("Compatibility import write preview", preview, [], this.previewWidth(innerW))) {
       lines.push(this.padLine(line, innerW));
     }
     return lines;
@@ -457,12 +499,27 @@ export class McpSetupPanel {
     return `Shared MCP files are preferred. Pi-owned files are only for compatibility imports and adapter-specific overrides.${hostNote}${conflictNote}`;
   }
 
-  private getActionPreview(action: ActionId): string[] {
-    switch (action) {
+  private visibleActionRange(total: number): { start: number; end: number } {
+    if (total <= COMPACT_ACTION_ROWS) return { start: 0, end: total };
+    const half = Math.floor(COMPACT_ACTION_ROWS / 2);
+    const start = Math.min(Math.max(0, this.actionCursor - half), Math.max(0, total - COMPACT_ACTION_ROWS));
+    return { start, end: Math.min(total, start + COMPACT_ACTION_ROWS) };
+  }
+
+  private contentWidth(innerW: number): number {
+    return Math.max(8, innerW - 4);
+  }
+
+  private previewWidth(innerW: number): number {
+    return Math.max(12, Math.min(DESKTOP_PREVIEW_WIDTH, this.contentWidth(innerW)));
+  }
+
+  private getActionPreview(action?: Action, previewW = DESKTOP_PREVIEW_WIDTH): string[] {
+    switch (action?.id) {
       case "run-setup":
         return this.formatPreview([
           "Run setup to adopt host-specific imports, inspect detected paths, and scaffold a minimal `.mcp.json` if needed.",
-        ]);
+        ], previewW);
       case "adopt-imports":
         return this.formatWritePreview(
           "Compatibility import write preview",
@@ -471,6 +528,7 @@ export class McpSetupPanel {
             `Detected imports: ${this.discovery.imports.map((entry) => `${entry.kind} (${entry.serverCount} servers)`).join(", ")}`,
             "Selected imports are written into the Pi agent dir config as Pi-owned compatibility state.",
           ],
+          previewW,
         );
       case "view-example":
         return this.formatPreview([
@@ -485,7 +543,7 @@ export class McpSetupPanel {
           "}",
           "",
           "Use Scaffold project `.mcp.json` when you want a safe empty shell instead of a live example server.",
-        ]);
+        ], previewW);
       case "show-precedence":
         return this.formatPreview([
           "Read order (later entries win):",
@@ -501,16 +559,16 @@ export class McpSetupPanel {
             `${conflict.serverName}: ${conflict.sources.map((source) => source.path).join(" -> ")} (winner: ${conflict.winner.path})`,
           ),
           "Pi writes compatibility imports and adapter-only overrides to Pi-owned files."
-        ]);
+        ], previewW);
       case "open-paths":
         return this.formatPreview(this.getDetectedPaths().length > 0
           ? ["Detected paths:", ...this.getDetectedPaths()]
-          : ["No config paths were detected."]);
+          : ["No config paths were detected."], previewW);
       case "add-repoprompt": {
         const repoPrompt = this.discovery.repoPrompt;
         const preview = this.callbacks.previewRepoPrompt();
         if (!preview) {
-          return this.formatPreview(["RepoPrompt is not available to add from this setup screen."]);
+          return this.formatPreview(["RepoPrompt is not available to add from this setup screen."], previewW);
         }
         return this.formatWritePreview(
           "RepoPrompt write preview",
@@ -520,6 +578,17 @@ export class McpSetupPanel {
             `Target: ${repoPrompt.targetPath ?? "n/a"}`,
             `Server name: ${repoPrompt.serverName ?? "repoprompt"}`,
           ],
+          previewW,
+        );
+      }
+      case "add-known-server": {
+        const preset = action.preset;
+        if (!preset) return this.formatPreview(["Known server preset is unavailable."], previewW);
+        return this.formatWritePreview(
+          `${preset.name} write preview`,
+          this.callbacks.previewKnownServer(preset),
+          [preset.summary],
+          previewW,
         );
       }
       case "scaffold-project":
@@ -530,38 +599,39 @@ export class McpSetupPanel {
             "This writes a minimal `.mcp.json` in the current project using the shared MCP layout.",
             "It intentionally avoids adding a fake placeholder server that would fail on first reload.",
           ],
+          previewW,
         );
       case "close":
       default:
-        return this.formatPreview(["Close the setup flow."]);
+        return this.formatPreview(["Close the setup flow."], previewW);
     }
   }
 
-  private formatPreview(lines: string[]): string[] {
+  private formatPreview(lines: string[], width = DESKTOP_PREVIEW_WIDTH): string[] {
     const preview: string[] = [];
     for (const line of lines) {
-      preview.push(...wrapText(line, 74));
+      preview.push(...wrapText(line, width));
     }
     return preview;
   }
 
-  private formatWritePreview(title: string, preview: ConfigWritePreview, intro: string[] = []): string[] {
+  private formatWritePreview(title: string, preview: ConfigWritePreview, intro: string[] = [], width = DESKTOP_PREVIEW_WIDTH): string[] {
     const lines: string[] = [];
     for (const line of intro) {
-      lines.push(...wrapText(line, 74));
+      lines.push(...wrapText(line, width));
     }
     if (intro.length > 0) lines.push("");
-    lines.push(...wrapText(`${title}: ${preview.path}`, 74));
-    lines.push(...wrapText(preview.existed ? "Existing file detected. Showing exact before/after diff." : "New file will be created. Showing exact content diff.", 74));
+    lines.push(...wrapText(`${title}: ${preview.path}`, width));
+    lines.push(...wrapText(preview.existed ? "Existing file detected. Showing exact before/after diff." : "New file will be created. Showing exact content diff.", width));
     lines.push("");
     const diffLines = preview.diffText.split("\n");
     const maxLines = 18;
     const shown = diffLines.slice(0, maxLines);
     for (const line of shown) {
-      lines.push(...wrapText(line, 74));
+      lines.push(...wrapText(line, width));
     }
     if (diffLines.length > maxLines) {
-      lines.push(...wrapText(`… ${diffLines.length - maxLines} more diff line${diffLines.length - maxLines === 1 ? "" : "s"}`, 74));
+      lines.push(...wrapText(`… ${diffLines.length - maxLines} more diff line${diffLines.length - maxLines === 1 ? "" : "s"}`, width));
     }
     return lines;
   }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "abort.ts",
     "runtime-owner.ts",
     "tool-metadata.ts",
+    "search-ranking.ts",
     "init.ts",
     "ui-session.ts",
     "proxy-modes.ts",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "tool-registrar.ts",
     "tool-result-renderer.ts",
     "mcp-output-guard.ts",
+    "mcp-code.ts",
     "resource-tools.ts",
     "lifecycle.ts",
     "mcp-status.ts",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "abort.ts",
     "runtime-owner.ts",
     "tool-metadata.ts",
+    "ts-shape.ts",
     "search-ranking.ts",
     "tool-approval.ts",
     "init.ts",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "runtime-owner.ts",
     "tool-metadata.ts",
     "search-ranking.ts",
+    "tool-approval.ts",
     "init.ts",
     "ui-session.ts",
     "proxy-modes.ts",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "tool-result-renderer.ts",
     "mcp-output-guard.ts",
     "mcp-code.ts",
+    "mcp-probe.ts",
     "resource-tools.ts",
     "lifecycle.ts",
     "mcp-status.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -8,6 +8,7 @@ import { lazyConnect, markKeepAliveAfterConnect, notifyToolMetadataUpdated, upda
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
+import { renderTsShape } from "./ts-shape.ts";
 import { reconstructPromptMetadata } from "./metadata-cache.ts";
 import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
@@ -428,7 +429,8 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
   text += `\n${toolMeta.description || "(no description)"}\n`;
 
   if (toolMeta.inputSchema && !toolMeta.resourceUri) {
-    text += `\nParameters:\n${formatSchema(toolMeta.inputSchema)}`;
+    const shape = renderTsShape(toolMeta.inputSchema);
+    text += shape === null ? `\nParameters:\n${formatSchema(toolMeta.inputSchema)}` : `\nShape:\n${shape}`;
   } else if (toolMeta.resourceUri) {
     text += `\nNo parameters required (resource tool).`;
   } else {
@@ -528,7 +530,10 @@ export function executeSearch(
       text += `${match.tool.name}${approvalMarker}\n`;
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
-        text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`;
+        const shape = renderTsShape(match.tool.inputSchema);
+        text += shape === null
+          ? `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
+          : `\n  Shape:\n${shape.split("\n").map(line => `    ${line}`).join("\n")}\n`;
       } else if (match.tool.resourceUri) {
         text += "  No parameters (resource tool).\n";
       }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -16,6 +16,7 @@ import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateA
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts";
+import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -416,7 +417,10 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
     };
   }
 
-  let text = `${toolMeta.name}\n`;
+  const approvalMarker = isToolCallApprovalRequired(state.config, serverName, toolMeta)
+    ? " (requires approval)"
+    : "";
+  let text = `${toolMeta.name}${approvalMarker}\n`;
   text += `Server: ${serverName}\n`;
   if (toolMeta.resourceUri) {
     text += `Type: Resource (reads from ${toolMeta.resourceUri})\n`;
@@ -517,8 +521,11 @@ export function executeSearch(
 
   let text = `Found ${page.total} tool${page.total === 1 ? "" : "s"} matching "${query}":\n\n`;
   for (const match of page.items) {
+    const approvalMarker = isToolCallApprovalRequired(state.config, match.server, match.tool)
+      ? " (requires approval)"
+      : "";
     if (showSchemas) {
-      text += `${match.tool.name}\n`;
+      text += `${match.tool.name}${approvalMarker}\n`;
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
         text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`;
@@ -527,7 +534,7 @@ export function executeSearch(
       }
       text += "\n";
     } else {
-      text += `- ${match.tool.name}`;
+      text += `- ${match.tool.name}${approvalMarker}`;
       if (match.tool.description) text += ` - ${truncateAtWord(match.tool.description, 50)}`;
       text += "\n";
     }
@@ -998,7 +1005,6 @@ export async function executeCall(
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
       if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
       updateStatusBar(state);
       return {
@@ -1010,6 +1016,23 @@ export async function executeCall(
 
   if (isServerDisabled(state.config.mcpServers[serverName])) {
     return disabledCallResult(serverName, toolMeta);
+  }
+
+  const approval = await ensureToolCallApproved(state, serverName, toolMeta, args, ownedSignal);
+  if (approval.ok === false) {
+    const denied = approval.reason === "denied";
+    const message = denied
+      ? `The user declined approval to run MCP tool "${toolMeta.originalName}" on server "${serverName}".`
+      : `MCP tool "${toolMeta.originalName}" on server "${serverName}" is approval-gated and requires an interactive session.`;
+    return {
+      content: [{ type: "text" as const, text: message }],
+      details: {
+        mode: "call",
+        error: denied ? "approval_denied" : "approval_required",
+        server: serverName,
+        tool: toolMeta.originalName,
+      },
+    };
   }
 
   let uiSession: UiSessionRuntime | null = null;

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -15,6 +15,7 @@ import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } 
 import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
+import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 
@@ -407,9 +408,11 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
 
   if (!serverName || !toolMeta) {
     if (disabledMatch) return disabledResult("describe", disabledMatch);
+    const suggestions = rankSuggestions(state, toolName, 5);
+    const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
     return {
-      content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.` }],
-      details: { mode: "describe", error: "tool_not_found", requestedTool: toolName },
+      content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.${suggestionText}` }],
+      details: { mode: "describe", error: "tool_not_found", requestedTool: toolName, suggestions },
     };
   }
 
@@ -440,32 +443,32 @@ export function executeSearch(
   regex?: boolean,
   server?: string,
   includeSchemas?: boolean,
+  limit = 12,
+  offset = 0,
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
   if (server && isServerDisabled(state.config.mcpServers[server])) return disabledResult("search", server);
 
-  const matches: Array<{ server: string; tool: ToolMetadata }> = [];
-
-  let pattern: RegExp;
-  try {
-    if (regex) {
+  let matches: Array<{ server: string; tool: ToolMetadata; score: number }>;
+  if (regex) {
+    let pattern: RegExp;
+    try {
       if (query.length > MAX_REGEX_SEARCH_QUERY_LENGTH) {
         return {
           content: [{ type: "text" as const, text: `Regex query is too long; maximum length is ${MAX_REGEX_SEARCH_QUERY_LENGTH} characters.` }],
           details: { mode: "search", error: "query_too_long", query, maxLength: MAX_REGEX_SEARCH_QUERY_LENGTH },
         };
       }
-
       pattern = new RegExp(query, "i");
       let safety;
       try {
         const { checkSync } = require("recheck") as typeof import("recheck");
         safety = checkSync(query, "i", REGEX_SAFETY_CHECK_PARAMS);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const reason = error instanceof Error ? error.message : String(error);
         return {
           content: [{ type: "text" as const, text: "Regex query rejected because safety analysis failed." }],
-          details: { mode: "search", error: "unsafe_pattern", query, reason: message },
+          details: { mode: "search", error: "unsafe_pattern", query, reason },
         };
       }
       if (safety.status !== "safe") {
@@ -474,76 +477,71 @@ export function executeSearch(
           details: { mode: "search", error: "unsafe_pattern", query, safetyStatus: safety.status },
         };
       }
-    } else {
-      const terms = query.trim().split(/\s+/).filter(t => t.length > 0);
-      if (terms.length === 0) {
-        return {
-          content: [{ type: "text" as const, text: "Search query cannot be empty" }],
-          details: { mode: "search", error: "empty_query" },
-        };
-      }
-      const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-      pattern = new RegExp(escaped.join("|"), "i");
+    } catch {
+      return {
+        content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
+        details: { mode: "search", error: "invalid_pattern", query },
+      };
     }
-  } catch {
-    return {
-      content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
-      details: { mode: "search", error: "invalid_pattern", query },
-    };
-  }
 
-  for (const [serverName, metadata] of state.toolMetadata.entries()) {
-    if (isServerDisabled(state.config.mcpServers[serverName])) continue;
-    if (server && serverName !== server) continue;
-    for (const tool of metadata) {
-      if (pattern.test(tool.name) || pattern.test(tool.description)) {
-        matches.push({
-          server: serverName,
-          tool,
-        });
+    matches = [];
+    for (const [serverName, metadata] of state.toolMetadata.entries()) {
+      if (isServerDisabled(state.config.mcpServers[serverName])) continue;
+      if (server && serverName !== server) continue;
+      for (const tool of metadata) {
+        if (pattern.test(tool.name) || pattern.test(tool.description)) matches.push({ server: serverName, tool, score: 0 });
       }
     }
+  } else if (query.trim().length === 0) {
+    if (!server) {
+      return {
+        content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+        details: { mode: "search", error: "empty_query" },
+      };
+    }
+    matches = (state.toolMetadata.get(server) ?? [])
+      .map(tool => ({ server, tool, score: 0 }))
+      .sort((a, b) => a.tool.name.localeCompare(b.tool.name));
+  } else {
+    matches = rankToolMatches(state, query, server);
   }
 
-  const totalCount = matches.length;
-
-  if (totalCount === 0) {
-    const msg = server
-      ? `No tools matching "${query}" in "${server}"`
-      : `No tools matching "${query}"`;
+  const page = paginate(matches, offset, limit);
+  if (page.total === 0) {
+    const msg = server ? `No tools matching "${query}" in "${server}"` : `No tools matching "${query}"`;
     return {
       content: [{ type: "text" as const, text: msg }],
-      details: { mode: "search", matches: [], count: 0, query },
+      details: { mode: "search", matches: [], count: 0, hasMore: false, nextOffset: null, query },
     };
   }
 
-  let text = `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}":\n\n`;
-
-  for (const match of matches) {
+  let text = `Found ${page.total} tool${page.total === 1 ? "" : "s"} matching "${query}":\n\n`;
+  for (const match of page.items) {
     if (showSchemas) {
       text += `${match.tool.name}\n`;
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
         text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`;
       } else if (match.tool.resourceUri) {
-        text += `  No parameters (resource tool).\n`;
+        text += "  No parameters (resource tool).\n";
       }
       text += "\n";
     } else {
       text += `- ${match.tool.name}`;
-      if (match.tool.description) {
-        text += ` - ${truncateAtWord(match.tool.description, 50)}`;
-      }
+      if (match.tool.description) text += ` - ${truncateAtWord(match.tool.description, 50)}`;
       text += "\n";
     }
   }
+  if (page.hasMore) text += `\n${page.items.length} of ${page.total} — offset: ${page.nextOffset} for more\n`;
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
     details: {
       mode: "search",
-      matches: matches.map(m => ({ server: m.server, tool: m.tool.name })),
-      count: totalCount,
+      matches: page.items.map(match => ({ server: match.server, tool: match.tool.name, score: match.score })),
+      count: page.total,
+      hasMore: page.hasMore,
+      nextOffset: page.nextOffset,
       query,
     },
   };
@@ -803,9 +801,11 @@ export async function executeCall(
             if (connectedAfterAuth) {
               toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
               if (!toolMeta) {
+                const suggestions = rankSuggestions(state, toolName, 5);
+                const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
                 return {
-                  content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.` }],
-                  details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName },
+                  content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.${suggestionText}` }],
+                  details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
                 };
               }
             }
@@ -893,9 +893,11 @@ export async function executeCall(
     } else {
       msg += ` Use mcp({ search: "..." }) to search.`;
     }
+    const suggestions = rankSuggestions(state, toolName, 5);
+    if (suggestions.length > 0) msg += ` Did you mean: ${suggestions.join(", ")}`;
     return {
       content: [{ type: "text" as const, text: msg }],
-      details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer },
+      details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer, suggestions },
     };
   }
 
@@ -987,9 +989,11 @@ export async function executeCall(
         const hint = available.length > 0
           ? `Available tools on "${serverName}": ${available.join(", ")}`
           : `Server "${serverName}" has no tools.`;
+        const suggestions = rankSuggestions(state, toolName, 5);
+        const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
         return {
-          content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}` }],
-          details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName },
+          content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}${suggestionText}` }],
+          details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
         };
       }
     } catch (error) {

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -1,0 +1,126 @@
+import type { McpExtensionState } from "./state.ts";
+import type { ToolMetadata } from "./types.ts";
+import { getServerPrefix, isServerDisabled } from "./types.ts";
+
+/**
+ * Shortest field token allowed to stem-match a longer query token.
+ * Real descriptions tokenize possessives into single letters ("project's" -> ["project", "s"]),
+ * which would otherwise make every query starting with that letter a match.
+ */
+const MIN_STEM_LENGTH = 4;
+
+const FIELD_WEIGHTS = {
+  name: 12,
+  originalName: 10,
+  server: 8,
+  description: 5,
+} as const;
+
+export interface RankedToolMatch {
+  server: string;
+  tool: ToolMetadata;
+  score: number;
+}
+
+export function normalizeSearchText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_./:-]+/g, " ")
+    .toLowerCase();
+}
+
+export function tokenize(value: string): string[] {
+  return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+export function scoreToolMatch(tool: ToolMetadata, server: string, query: string): number | null {
+  const normalizedQuery = normalizeSearchText(query).trim();
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return null;
+
+  const fields = {
+    name: normalizeSearchText(tool.name),
+    originalName: normalizeSearchText(tool.originalName),
+    server: normalizeSearchText(server),
+    description: normalizeSearchText(tool.description),
+  };
+  let score = 0;
+  let phraseMatched = false;
+  let wholeFieldExact = false;
+  const matchedTokens = new Set<string>();
+
+  for (const [field, value] of Object.entries(fields) as Array<[keyof typeof FIELD_WEIGHTS, string]>) {
+    const weight = FIELD_WEIGHTS[field];
+    const fieldTokens = tokenize(value);
+    if (value === normalizedQuery) {
+      score += weight * 14;
+      phraseMatched = true;
+      wholeFieldExact = true;
+    } else if (value.startsWith(normalizedQuery)) {
+      score += weight * 9;
+      phraseMatched = true;
+    } else if (value.includes(normalizedQuery)) {
+      score += weight * 6;
+      phraseMatched = true;
+    }
+
+    for (const token of queryTokens) {
+      if (fieldTokens.includes(token)) {
+        score += weight * 4;
+        matchedTokens.add(token);
+      } else if (fieldTokens.some(fieldToken => fieldToken.startsWith(token) || (fieldToken.length >= MIN_STEM_LENGTH && token.startsWith(fieldToken)))) {
+        score += weight * 2;
+        matchedTokens.add(token);
+      } else if (value.includes(token)) {
+        score += weight;
+        matchedTokens.add(token);
+      }
+    }
+  }
+
+  const coverage = matchedTokens.size / queryTokens.length;
+  if (!phraseMatched && (queryTokens.length <= 2 ? coverage !== 1 : coverage < 0.6)) return null;
+
+  score += coverage === 1 ? 25 : Math.round(coverage * 10);
+  if (tokenize(fields.name).includes(queryTokens[0])) score += 8;
+  if (wholeFieldExact) score += 20;
+  return score;
+}
+
+export function rankToolMatches(state: McpExtensionState, query: string, server?: string): RankedToolMatch[] {
+  const matches: RankedToolMatch[] = [];
+  for (const [serverName, metadata] of state.toolMetadata.entries()) {
+    if (server && serverName !== server) continue;
+    if (isServerDisabled(state.config.mcpServers[serverName])) continue;
+    for (const tool of metadata) {
+      const score = scoreToolMatch(tool, serverName, query);
+      if (score !== null) matches.push({ server: serverName, tool, score });
+    }
+  }
+  return matches.sort((a, b) => b.score - a.score || a.tool.name.localeCompare(b.tool.name));
+}
+
+export function paginate<T>(items: T[], offset: number, limit: number): { items: T[]; total: number; hasMore: boolean; nextOffset: number | null } {
+  const safeOffset = Number.isFinite(offset) ? Math.max(0, Math.trunc(offset)) : 0;
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.trunc(limit)) : 1;
+  const total = items.length;
+  const page = items.slice(safeOffset, safeOffset + safeLimit);
+  const nextOffset = safeOffset + page.length;
+  return {
+    items: page,
+    total,
+    hasMore: nextOffset < total,
+    nextOffset: nextOffset < total ? nextOffset : null,
+  };
+}
+
+export function rankSuggestions(state: McpExtensionState, name: string, limit: number): string[] {
+  const stripped = Object.keys(state.config.mcpServers)
+    .flatMap(server => (["server", "short", "mcp"] as const)
+      .map(prefix => getServerPrefix(server, prefix)))
+    .filter((candidate): candidate is string => Boolean(candidate) && name.startsWith(`${candidate}_`))
+    .sort((a, b) => b.length - a.length)
+    .map(candidate => name.slice(candidate.length + 1));
+  const query = stripped[0] ?? name;
+  return rankToolMatches(state, query).slice(0, limit).map(match => match.tool.name);
+}

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -14,6 +14,7 @@ import {
   type UrlElicitationRequiredError,
 } from "@modelcontextprotocol/sdk/types.js";
 import { UnixSocketClientTransport } from "./unix-socket-transport.ts";
+import { probeMcpEndpoint } from "./mcp-probe.ts";
 import {
   isServerDisabled,
   type McpTool,
@@ -221,7 +222,10 @@ export class McpServerManager {
     const generation = this.closeGenerations.get(name) ?? 0;
     const attemptController = new AbortController();
     const attemptSignal = combineAbortSignals(ownedSignal, attemptController.signal);
-    const promise = this.createConnection(name, definition, attemptSignal, ownedSignal);
+    const connectionAttempt = this.createConnection(name, definition, attemptSignal, ownedSignal);
+    const promise = definition.url
+      ? connectionAttempt.catch(async error => { throw await this.enrichHttpConnectionError(definition, error); })
+      : connectionAttempt;
     this.connectPromises.set(name, promise);
     this.connectAttempts.set(name, attemptController);
 
@@ -454,6 +458,16 @@ export class McpServerManager {
         }
       }
       throw reportedError;
+    }
+  }
+
+  private async enrichHttpConnectionError(definition: ServerDefinition, error: unknown): Promise<Error> {
+    const originalMessage = error instanceof Error ? error.message : String(error);
+    try {
+      const probe = await probeMcpEndpoint(resolveServerUrl(definition)!);
+      return new Error(`${originalMessage} — probe: ${probe.classification}`, { cause: error });
+    } catch {
+      return error instanceof Error ? error : new Error(originalMessage);
     }
   }
 

--- a/state.ts
+++ b/state.ts
@@ -46,6 +46,8 @@ export interface McpExtensionState {
   authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;
   failureMessages: Map<string, string>;
+  /** Session-only approvals keyed by server and original tool name. */
+  approvedToolCalls: Map<string, true>;
   uiResourceHandler: UiResourceHandler;
   consentManager: ConsentManager;
   uiServer: UiServerHandle | null;

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -1,0 +1,78 @@
+import { abortable } from "./abort.ts";
+import { combineAbortSignals } from "./runtime-owner.ts";
+import type { McpExtensionState } from "./state.ts";
+import {
+  getToolNameCandidates,
+  matchesToolPattern,
+  resolveToolPrefix,
+  type McpConfig,
+  type ToolMetadata,
+} from "./types.ts";
+import { sanitizeTerminalText } from "./utils.ts";
+
+export type ToolCallApprovalResult =
+  | { ok: true }
+  | { ok: false; reason: "denied" | "approval_required_headless" };
+
+export function isToolCallApprovalRequired(
+  config: McpConfig,
+  serverName: string,
+  toolMeta: Pick<ToolMetadata, "originalName">,
+): boolean {
+  const definition = config.mcpServers[serverName];
+  const approval = definition?.approveTools !== undefined
+    ? definition.approveTools
+    : config.settings?.approveTools;
+
+  if (approval === true) return true;
+  if (!Array.isArray(approval) || approval.length === 0) return false;
+
+  const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+  return matchesToolPattern(
+    getToolNameCandidates(toolMeta.originalName, serverName, prefix),
+    approval,
+  );
+}
+
+export async function ensureToolCallApproved(
+  state: McpExtensionState,
+  serverName: string,
+  toolMeta: ToolMetadata,
+  args: Record<string, unknown> | undefined,
+  signal?: AbortSignal,
+): Promise<ToolCallApprovalResult> {
+  if (!isToolCallApprovalRequired(state.config, serverName, toolMeta)) {
+    return { ok: true };
+  }
+
+  const cacheKey = `${serverName}\u0000${toolMeta.originalName}`;
+  if (state.approvedToolCalls.has(cacheKey)) {
+    return { ok: true };
+  }
+
+  if (!state.ui) {
+    return { ok: false, reason: "approval_required_headless" };
+  }
+
+  const json = JSON.stringify(args ?? {}, null, 2);
+  const sanitized = sanitizeTerminalText(json);
+  const preview = sanitized.length > 500 ? `${sanitized.slice(0, 500)}...` : sanitized;
+  const title = `MCP: ${sanitizeTerminalText(serverName)} wants to run ${sanitizeTerminalText(toolMeta.originalName)}`;
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  const decision = await abortable(
+    state.ui.select(
+      `${title}\n\nArguments:\n${preview}`,
+      ["Allow once", "Allow for session", "Deny"],
+    ),
+    ownedSignal,
+  );
+
+  if (decision === "Allow once") {
+    return { ok: true };
+  }
+  if (decision === "Allow for session") {
+    state.approvedToolCalls.set(cacheKey, true);
+    return { ok: true };
+  }
+  return { ok: false, reason: "denied" };
+}

--- a/ts-shape.ts
+++ b/ts-shape.ts
@@ -1,0 +1,142 @@
+type Schema = Record<string, unknown>;
+
+const UNSUPPORTED_KEYWORDS = ["if", "then", "else", "allOf", "not", "patternProperties", "additionalProperties"];
+
+/** Renders the useful JSON Schema subset as TypeScript, or null for unsupported schemas. */
+export function renderTsShape(inputSchema: unknown): string | null {
+  try {
+    if (!isSchema(inputSchema)) return null;
+
+    const definitions = new Map<string, Schema>();
+    for (const key of ["$defs", "definitions"]) {
+      const rawDefinitions = inputSchema[key];
+      if (rawDefinitions === undefined) continue;
+      if (!isSchema(rawDefinitions)) return null;
+      for (const [name, definition] of Object.entries(rawDefinitions)) {
+        if (!isSchema(definition)) return null;
+        definitions.set(`${key}/${decodePointerToken(name)}`, definition);
+      }
+    }
+
+    const aliases = new Map<string, string>();
+    const usedAliases = new Set<string>();
+    let aliasIndex = 0;
+    const aliasFor = (definitionKey: string) => {
+      let alias = aliases.get(definitionKey);
+      if (alias) return alias;
+      const name = definitionKey.slice(definitionKey.indexOf("/") + 1);
+      alias = /^[A-Za-z_$][\w$]*$/.test(name) && !usedAliases.has(name) ? name : `Definition${++aliasIndex}`;
+      while (usedAliases.has(alias)) alias = `Definition${++aliasIndex}`;
+      aliases.set(definitionKey, alias);
+      usedAliases.add(alias);
+      return alias;
+    };
+
+    const render = (schema: unknown): string | null => {
+      if (!isSchema(schema) || hasUnsupportedKeyword(schema)) return null;
+
+      if ("$ref" in schema) {
+        if (typeof schema.$ref !== "string") return null;
+        const match = schema.$ref.match(/^#\/(\$defs|definitions)\/([^/]+)$/);
+        if (!match) return null;
+        const definitionKey = `${match[1]}/${decodePointerToken(match[2])}`;
+        if (!definitions.has(definitionKey)) return null;
+        return aliasFor(definitionKey);
+      }
+
+      if (Array.isArray(schema.enum)) {
+        const values = schema.enum.map(renderLiteral);
+        return values.every((value): value is string => value !== null) ? values.join(" | ") : null;
+      }
+      if (Object.hasOwn(schema, "const")) return renderLiteral(schema.const);
+
+      if (Array.isArray(schema.anyOf) || Array.isArray(schema.oneOf)) {
+        const variants = (schema.anyOf ?? schema.oneOf) as unknown[];
+        if (variants.length === 0) return null;
+        const rendered = variants.map(render);
+        return rendered.every((value): value is string => value !== null) ? rendered.join(" | ") : null;
+      }
+
+      if (schema.type === "object" || schema.properties !== undefined) {
+        if (schema.properties === undefined) return "{}";
+        if (!isSchema(schema.properties)) return null;
+        const required = new Set(Array.isArray(schema.required)
+          ? schema.required.filter((name): name is string => typeof name === "string")
+          : []);
+        const properties: string[] = [];
+        for (const [name, property] of Object.entries(schema.properties)) {
+          const rendered = render(property);
+          if (rendered === null) return null;
+          properties.push(`${formatPropertyName(name)}${required.has(name) ? "" : "?"}: ${rendered};`);
+        }
+        return properties.length === 0 ? "{}" : `{ ${properties.join(" ")} }`;
+      }
+
+      if (schema.type === "array") {
+        if (schema.items === undefined) return "unknown[]";
+        const item = render(schema.items);
+        return item === null ? null : `${needsParentheses(item) ? `(${item})` : item}[]`;
+      }
+
+      if (Array.isArray(schema.type)) {
+        const types = schema.type.map(renderType);
+        return types.every((type): type is string => type !== null) ? types.join(" | ") : null;
+      }
+      if (typeof schema.type === "string") return renderType(schema.type);
+      return "unknown";
+    };
+
+    const root = render(inputSchema);
+    if (root === null) return null;
+
+    const definitionsText: string[] = [];
+    for (const [key, alias] of aliases) {
+      const definition = definitions.get(key);
+      if (!definition) return null;
+      const rendered = render(definition);
+      if (rendered === null) return null;
+      definitionsText.push(`type ${alias} = ${rendered};`);
+    }
+    return definitionsText.length > 0 ? `${definitionsText.join("\n")}\n\n${root}` : root;
+  } catch {
+    return null;
+  }
+}
+
+function isSchema(value: unknown): value is Schema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasUnsupportedKeyword(schema: Schema): boolean {
+  return UNSUPPORTED_KEYWORDS.some(keyword => Object.hasOwn(schema, keyword));
+}
+
+function decodePointerToken(token: string): string {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function renderType(type: unknown): string | null {
+  switch (type) {
+    case "string": return "string";
+    case "number":
+    case "integer": return "number";
+    case "boolean": return "boolean";
+    case "null": return "null";
+    case "object": return "{}";
+    case "array": return "unknown[]";
+    default: return null;
+  }
+}
+
+function renderLiteral(value: unknown): string | null {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : null;
+}
+
+function formatPropertyName(name: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+function needsParentheses(type: string): boolean {
+  return type.includes(" | ");
+}

--- a/types.ts
+++ b/types.ts
@@ -408,6 +408,8 @@ export interface McpSettings {
   idleTimeout?: number; // minutes, default 10, 0 to disable
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
+  /** Register the MCP-only plain-JavaScript codemode tool. Defaults to false. */
+  codeMode?: boolean;
   /** Default approval gate for matching tools/resources; per-server settings override it. */
   approveTools?: boolean | string[];
   disableProxyTool?: boolean;

--- a/types.ts
+++ b/types.ts
@@ -356,6 +356,8 @@ export interface ServerEntry {
   // Include/exclude specific MCP tools/resources by original or prefixed name
   includeTools?: string[];
   excludeTools?: string[];
+  // Require interactive approval before calling matching MCP tools/resources.
+  approveTools?: boolean | string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
   /** Enable metadata-only JSONL protocol tracing for this server. */
@@ -406,6 +408,8 @@ export interface McpSettings {
   idleTimeout?: number; // minutes, default 10, 0 to disable
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;
+  /** Default approval gate for matching tools/resources; per-server settings override it. */
+  approveTools?: boolean | string[];
   disableProxyTool?: boolean;
   /** Freeze direct-tool registration after the initial sync. Automatic metadata updates
    * (reconnects, lazy-connect, tool-list-changed) won't rebuild the system prompt,
@@ -608,7 +612,7 @@ function normalizeToolName(value: string): string {
   return value.replace(/-/g, "_");
 }
 
-function getToolNameCandidates(toolName: string, serverName: string, prefix: ToolPrefix): Set<string> {
+export function getToolNameCandidates(toolName: string, serverName: string, prefix: ToolPrefix): Set<string> {
   return new Set<string>([
     normalizeToolName(toolName),
     normalizeToolName(formatToolName(toolName, serverName, prefix)),
@@ -623,7 +627,7 @@ function globToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
-function matchesToolPattern(candidates: Set<string>, patterns?: unknown): boolean {
+export function matchesToolPattern(candidates: Set<string>, patterns?: unknown): boolean {
   if (!Array.isArray(patterns) || patterns.length === 0) return false;
 
   for (const pattern of patterns) {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -13,7 +13,9 @@ import { formatAuthRequiredMessage } from "./utils.ts";
 import { buildHostHtmlTemplate, buildCspMetaContent } from "./host-html-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
+import type { McpExtensionState } from "./state.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
+import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 import {
   extractUiPromptText,
   getVisualizationStreamEnvelope,
@@ -52,6 +54,8 @@ export interface UiServerOptions {
    * tool calls run without recovery (unchanged pre-existing behavior).
    */
   config?: McpConfig;
+  /** Live state enables TUI approval prompts for iframe-originated tool calls. */
+  state?: McpExtensionState;
   onNeedsAuth?: SessionRecoveryDeps["onNeedsAuth"];
   consentManager: ConsentManager;
   hostContext?: UiHostContext;
@@ -355,16 +359,51 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           return;
         }
 
+        const callArgs = {
+          name: callParams.name,
+          arguments:
+            callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
+              ? callParams.arguments
+              : {},
+        };
+        const toolMeta = {
+          name: callParams.name,
+          originalName: callParams.name,
+          description: "",
+        };
+        const approval = options.state
+          ? await ensureToolCallApproved(
+              options.state,
+              options.serverName,
+              toolMeta,
+              callArgs.arguments,
+              options.state.owner?.signal,
+            )
+          : options.config && isToolCallApprovalRequired(options.config, options.serverName, toolMeta)
+            ? { ok: false as const, reason: "approval_required_headless" as const }
+            : { ok: true as const };
+        if (approval.ok === false) {
+          const denied = approval.reason === "denied";
+          const message = denied
+            ? `The user declined approval to run MCP tool "${callParams.name}" on server "${options.serverName}".`
+            : `MCP tool "${callParams.name}" on server "${options.serverName}" is approval-gated and requires an interactive session.`;
+          sendJson(res, 200, {
+            ok: true,
+            result: {
+              content: [{ type: "text" as const, text: message }],
+              details: {
+                error: denied ? "approval_denied" : "approval_required",
+                server: options.serverName,
+                tool: callParams.name,
+              },
+            },
+          });
+          return;
+        }
+
         try {
           options.manager.touch(options.serverName);
           options.manager.incrementInFlight(options.serverName);
-          const callArgs = {
-            name: callParams.name,
-            arguments:
-              callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
-                ? callParams.arguments
-                : {},
-          };
           const result = options.config
             ? await withSessionRecovery(
                 { manager: options.manager, config: options.config, onNeedsAuth: options.onNeedsAuth },

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -269,6 +269,7 @@ export async function maybeStartUiSession(
       resource,
       manager: state.manager,
       config: state.config,
+      state,
       onNeedsAuth: request.onNeedsAuth,
       consentManager: state.consentManager,
       hostContext,


### PR DESCRIPTION
Six feature groups adapted from [Executor](https://github.com/UsefulSoftwareCo/executor) by Rhys Sullivan (@RhysSullivan) — thanks Rhys for the design groundwork.

One commit per feature:

- **Ranked + paginated search** — weighted field scoring with a token-coverage gate, page of 12, `{count, hasMore, nextOffset}` in details. Did-you-mean suggestions (top 5) on unresolved describe/call names.
- **`approveTools` approval gate** — global and per-server boolean/glob patterns gate tool calls at invocation time on all three call paths (proxy, direct tools, MCP Apps iframe). Allow once / Allow for session / Deny via TUI prompt; headless fails closed; decisions are session-only, never persisted. Visibility is untouched and `excludeTools` still wins by construction.
- **Opt-in `mcp_code`** — plain-JS codemode in `node:vm` for tool-restricted subagents: flat `tools.*` proxy routing through `executeCall` (so auth, lazy connect, output guard, and the approval gate all compose), `emit()`, captured console, 30s default timeout. Explicitly documented as capability shaping, not a security boundary.
- **Connect-failure shape probe** — one unauthenticated JSON-RPC initialize classifies failed HTTP endpoints ("returned HTML — not MCP") to enrich failure messages. Zero requests on healthy paths.
- **TS-shaped schemas** — small best-effort JSON-Schema→TypeScript renderer in describe/search, falling back to the existing formatter. No vendored compiler.
- **Setup presets** — five curated known servers in `/mcp setup` with preview-before-write, generalizing the RepoPrompt quick-add.

Everything is opt-in or invisible by default: no `approveTools`/`codeMode` config means zero behavior change.

Review follow-ups addressed after Greptile's pass:

- TS-shaped schema output now renders only definitions actually referenced from the root schema, so unsupported unused `$defs` no longer force a fallback.
- The HTTP probe gives POST and fallback GET separate timeout budgets.
- Removed a shadowed `ownedSignal` declaration in the reconnect error path.

Validation:

- CI: passing on this branch.
- Local: `npx tsc --noEmit` passes; targeted new tests pass. Building `examples/interactive-visualizer` makes its dist tests pass locally. The remaining local-only failure under the linked worktree dependencies is the pre-existing StreamableHTTP GET-count assertion; CI passes it on a clean install.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds six opt-in feature groups: ranked/paginated search with did-you-mean suggestions, an `approveTools` interactive approval gate across all three call paths, an opt-in `mcp_code` plain-JS codemode, a connect-failure HTTP probe, a TS-shaped schema renderer, and five curated setup presets. All features are off by default and compose cleanly with the existing auth, output-guard, and lazy-connect machinery.

- **`mcp_code` (`mcp-code.ts`)**: Runs a user-supplied async IIFE in a `node:vm` context with `tools.*` routing through `executeCall`. One confirmed bug: when the `timeout` Promise wins `Promise.race`, `timeoutController.abort` causes any in-flight `executeCall` to throw, which rejects the still-pending `execution` Promise with no handler — an unhandled rejection that crashes Node.js 15+ by default.
- **`approveTools` gate (`tool-approval.ts`, `proxy-modes.ts`, `direct-tools.ts`, `ui-server.ts`)**: Headless fails closed; TUI offers allow-once/allow-for-session/deny; session approvals keyed by server+originalName. Logic is consistent across proxy, direct-tool, and iframe paths.
- **Ranked search, TS shapes, HTTP probe, setup presets**: Previously-flagged issues (unreferenced `$defs` fallback, shared probe timeout budget, shadow `ownedSignal`) are all addressed in this revision.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for all paths that don't use `codeMode: true`; the `mcp_code` feature has a process-crash risk under timeout+abort.

The approval gate, ranked search, TS shapes, probe, and setup presets are well-constructed and previously-flagged issues are addressed. The one real defect is in `mcp-code.ts`: after the timeout Promise wins the race, `timeoutController.abort` causes the still-running async IIFE's in-flight `executeCall` to throw, rejecting the `execution` Promise with no handler — an unhandled rejection that terminates the Node.js process in default mode. Since `codeMode` is opt-in and disabled by default, users who don't set `settings.codeMode: true` are completely unaffected.

**Files Needing Attention:** mcp-code.ts — the unhandled-rejection and output-array-race issues in `runMcpCode` need attention before `codeMode` is used in production.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| mcp-code.ts | New `mcp_code` codemode: dangling `execution` Promise causes unhandled rejection on timeout+abort; `output` array race during `guardMcpOutput` |
| tool-approval.ts | New approval gate: headless fail-close, TUI prompt with allow-once/allow-for-session/deny, session-keyed cache — logic looks correct |
| ts-shape.ts | TS-shape renderer: iterates only actually-referenced `$defs` (via `aliases` Map), handles circular $refs safely; wrapped in try-catch fallback |
| mcp-probe.ts | HTTP probe: each leg (POST and GET) gets its own independent `AbortSignal.timeout(5000)` budget — PR-described fix confirmed |
| search-ranking.ts | Ranked + paginated search with weighted field scoring, token coverage gate, pagination helper, and did-you-mean suggestions — logic correct |
| proxy-modes.ts | Approval gate integrated into call path; previously-flagged `ownedSignal` shadow removed; reconnect suggestion text added |
| direct-tools.ts | Approval gate correctly wired before `incrementInFlight`/`callTool`; existing auth and session-recovery paths unchanged |
| ui-server.ts | Approval gate added to iframe proxy path; exceptions fall through to the outer request-handler try-catch; `callArgs` refactored before the approval check |
| config.ts | Adds five `KNOWN_SERVER_PRESETS` for setup panel; no logic changes to existing import/discovery paths |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tool call arrives proxy / direct / iframe] --> B{approveTools configured?}
    B -- No --> E[Execute tool call]
    B -- Yes --> C{Session approval cached?}
    C -- Yes --> E
    C -- No --> D{UI available?}
    D -- No --> F[Fail closed approval_required_headless]
    D -- Yes --> G[TUI prompt Allow once / Allow for session / Deny]
    G -- Allow once --> E
    G -- Allow for session --> H[Cache in approvedToolCalls] --> E
    G -- Deny --> I[Return approval_denied]
    E --> J[guardMcpOutput return result]

    subgraph mcp_code
        K[runMcpCode] --> L[vm.Script async IIFE tools.* executeCall callSignal]
        L --> M{Promise.race}
        M -- execution wins --> N[Normal return]
        M -- timeout wins --> O[timeoutController.abort rejects execution]
        M -- abort wins --> P[aborted error]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
mcp-code.ts:131-149
**Unhandled rejection from `execution` after timeout wins the race**

When the vm async IIFE is mid-`await executeCall(...)` at the moment the `timeout` Promise wins the race, `timeoutController.abort(timeoutError)` is called. That abort causes the in-flight `executeCall` to throw (`throwIfAborted(ownedSignal)` fires immediately). That throw propagates through the Proxy's `async (args) => { ... }` as a rejection and ultimately rejects `execution`. Because `Promise.race` already settled with the timeout error, nobody is listening to `execution`, making it an unhandled rejection. In Node.js 15+ the default `--unhandled-rejections` mode is `throw`, which crashes the process. Adding `execution.catch(() => {})` immediately after creating it suppresses the dangling rejection safely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat: curated known-server presets in /m..."](https://github.com/nicobailon/pi-mcp-adapter/commit/4e963a9a6b2713ae2cebf9af8c77b2e41980eda5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49387662)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->