### PR TITLE
State exact return shapes in the mcp_script tool description

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -611,7 +611,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     (pi.registerTool as (tool: unknown) => unknown)({
       name: "mcp_script",
       label: "MCP Script",
-      description: "Run a trusted JavaScript MCP script to orchestrate MCP tools. Discover with await tools.search({ query }), inspect with await tools.describe({ path }), then call tools.call(path, args), or use direct flat calls when the name is already known; use emit(value) for user-visible output. Calls return { ok, data } or { ok, error }; load the mcp-scripting skill for the full workflow guide.",
+      description: "Run a trusted JavaScript MCP script to orchestrate MCP tools. Discover with await tools.search({ query }) — resolves to { items: [{ path, name, server, description? }], total, hasMore, nextOffset }, not an { ok, data } envelope. Inspect with await tools.describe({ path }) — resolves to the tool descriptor with inputTypeScript, or { path, error }. Then call tools.call(path, args) — resolves to { ok: true, data } or { ok: false, error: { code, message } } — or use direct flat calls when the name is already known; use emit(value) for user-visible output. Load the mcp-scripting skill for the full workflow guide.",
       promptSnippet: "Run a JavaScript MCP script to chain and filter tool calls in one request",
       parameters: Type.Object({
         code: Type.String({ description: "Trusted JavaScript MCP script. Use tools.<prefixedToolName>(args) and emit(value)." }),


### PR DESCRIPTION
One-line docs fix from a live test drive of `mcp_script` against real servers.

With `tools.call` returning `{ ok, data }`, `tools.search` returning `{ items, total, hasMore, nextOffset }`, and `tools.describe` returning the descriptor or `{ path, error }`, a model that has not loaded the `mcp-scripting` skill has to guess — and in the test drive it guessed `search.data`, got `undefined`, and failed its script. The tool description is the only surface models reliably read, so the shapes now live there.

Verified in the same test-drive session: the corrected destructuring (`{ items }`) works end-to-end against a live server (search → describe → 3 calls, all ok).