### PR TITLE
Document the describe error field as an object

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -611,7 +611,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     (pi.registerTool as (tool: unknown) => unknown)({
       name: "mcp_script",
       label: "MCP Script",
-      description: "Run a trusted JavaScript MCP script to orchestrate MCP tools. Discover with await tools.search({ query }) — resolves to { items: [{ path, name, server, description? }], total, hasMore, nextOffset }, not an { ok, data } envelope. Inspect with await tools.describe({ path }) — resolves to the tool descriptor with inputTypeScript, or { path, error }. Then call tools.call(path, args) — resolves to { ok: true, data } or { ok: false, error: { code, message } } — or use direct flat calls when the name is already known; use emit(value) for user-visible output. Load the mcp-scripting skill for the full workflow guide.",
+      description: "Run a trusted JavaScript MCP script to orchestrate MCP tools. Discover with await tools.search({ query }) — resolves to { items: [{ path, name, server, description? }], total, hasMore, nextOffset }, not an { ok, data } envelope. Inspect with await tools.describe({ path }) — resolves to the tool descriptor with inputTypeScript, or { path, error: { code, message, suggestions } }. Then call tools.call(path, args) — resolves to { ok: true, data } or { ok: false, error: { code, message } } — or use direct flat calls when the name is already known; use emit(value) for user-visible output. Load the mcp-scripting skill for the full workflow guide.",
       promptSnippet: "Run a JavaScript MCP script to chain and filter tool calls in one request",
       parameters: Type.Object({
         code: Type.String({ description: "Trusted JavaScript MCP script. Use tools.<prefixedToolName>(args) and emit(value)." }),


### PR DESCRIPTION
Follow-up to #260 from Greptile's P2: `tools.describe` errors are `{ code, message, suggestions }` objects (see `describeTool` in `mcp-code.ts`), so the tool description now spells that out the same way the `call` error case does.