### PR TITLE
fix: harden MCP Apps UI hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint shape probe, TypeScript-shaped schemas, and codemode design in this release are adapted from [Executor](https://github.com/UsefulSoftwareCo/executor) by Rhys Sullivan (@RhysSullivan). Thanks Rhys.
 
+### Fixed
+- Brought MCP Apps UI hosting in line with the current spec: provider HTML now runs in a real sandbox, gets a restrictive default CSP even when the resource omits one, and `_meta.ui.visibility` is honored so app-only tools stay out of the model tool list while model-only tools cannot be called from the UI.
+
 ## [2.17.0] - 2026-07-31
 
 ### Added

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -52,6 +52,8 @@ describe("buildHostHtmlTemplate", () => {
       const html = buildHostHtmlTemplate(createMinimalInput());
 
       expect(html).toContain('<iframe id="mcp-app"');
+      expect(html).toContain('sandbox="allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads"');
+      expect(html).not.toContain("allow-same-origin");
       expect(html).toContain('referrerpolicy="no-referrer"');
     });
 
@@ -173,9 +175,9 @@ describe("buildHostHtmlTemplate", () => {
         "font-src 'self' https://esm.sh",
         "img-src 'self' data: https://esm.sh",
         "media-src 'self' data: https://esm.sh",
-        "connect-src 'self' https://api.example.com",
+        "connect-src https://api.example.com",
         "frame-src 'none'",
-        "worker-src 'self' blob: https://esm.sh",
+        "worker-src 'none'",
         "object-src 'none'",
         "base-uri 'self'",
       ].join("; "));
@@ -204,7 +206,7 @@ describe("buildHostHtmlTemplate", () => {
       });
 
       expect(csp).toContain("https://safe.example.com");
-      expect(csp?.match(/https:\/\/safe\.example\.com/g)).toHaveLength(6);
+      expect(csp?.match(/https:\/\/safe\.example\.com/g)).toHaveLength(5);
       expect(csp).not.toContain("evil.example.com");
       expect(csp).not.toContain("nul-evil.example.com");
       expect(csp).not.toContain("del-evil.example.com");
@@ -227,7 +229,7 @@ describe("buildHostHtmlTemplate", () => {
         resourceDomains: ["https://safe.example.com", ...rejectedSources],
       });
 
-      expect(csp?.match(/https:\/\/safe\.example\.com/g)).toHaveLength(6);
+      expect(csp?.match(/https:\/\/safe\.example\.com/g)).toHaveLength(5);
       for (const source of rejectedSources) {
         expect(csp).not.toContain(source);
       }
@@ -248,9 +250,9 @@ describe("buildHostHtmlTemplate", () => {
         "font-src 'self'",
         "img-src 'self' data:",
         "media-src 'self' data:",
-        "connect-src 'self'",
+        "connect-src 'none'",
         "frame-src 'none'",
-        "worker-src 'self' blob:",
+        "worker-src 'none'",
         "object-src 'none'",
         "base-uri 'self'",
       ].join("; "));
@@ -270,10 +272,22 @@ describe("buildHostHtmlTemplate", () => {
       expect(csp?.match(/https:\/\/base\.example\.com/g)).toHaveLength(1);
     });
 
-    it("returns undefined when the app declares no CSP metadata", async () => {
+    it("returns a restrictive default when the app declares no CSP metadata", async () => {
       const { buildCspMetaContent } = await import("../host-html-template.ts");
 
-      expect(buildCspMetaContent(undefined)).toBeUndefined();
+      expect(buildCspMetaContent(undefined)).toBe([
+        "default-src 'none'",
+        "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
+        "font-src 'self'",
+        "img-src 'self' data:",
+        "media-src 'self' data:",
+        "connect-src 'none'",
+        "frame-src 'none'",
+        "worker-src 'none'",
+        "object-src 'none'",
+        "base-uri 'self'",
+      ].join("; "));
     });
 
 

--- a/__tests__/ui-integration.test.ts
+++ b/__tests__/ui-integration.test.ts
@@ -147,6 +147,7 @@ function createIntegrationManager(): McpServerManager {
     ["save_file", { result: { saved: true, path: "/tmp/file.txt" } }],
     ["slow_operation", { result: { completed: true }, delay: 100 }],
   ]);
+  const toolDefinitions = [...tools.keys()].map((name) => ({ name }));
 
   return {
     getConnection: vi.fn().mockReturnValue({
@@ -161,6 +162,7 @@ function createIntegrationManager(): McpServerManager {
           return { content: [{ type: "text", text: JSON.stringify(tool.result) }] };
         }),
       },
+      tools: toolDefinitions,
     }),
     touch: vi.fn(),
     incrementInFlight: vi.fn(),
@@ -453,6 +455,7 @@ describe("MCP UI Integration", () => {
           client: {
             callTool: vi.fn().mockRejectedValue(new Error("MCP server error")),
           },
+          tools: [{ name: "failing_tool" }],
         }),
       } as unknown as McpServerManager;
 

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -444,7 +444,7 @@ describe("UiResourceHandler", () => {
 
       expect(result.meta.csp).toEqual({});
       expect(buildCspMetaContent(result.meta.csp)).toBe(
-        "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'self'; frame-src 'none'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'",
+        "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; frame-src 'none'; worker-src 'none'; object-src 'none'; base-uri 'self'",
       );
     });
 

--- a/__tests__/ui-server-session-recovery.test.ts
+++ b/__tests__/ui-server-session-recovery.test.ts
@@ -76,11 +76,13 @@ describe("UiServer /proxy/tools/call session recovery", () => {
       status: "connected",
       transport: { sessionId: "session-1" },
       client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const fresh = {
       status: "connected",
       transport: { sessionId: "session-2" },
       client: { callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "tool result" }] }) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
 
     const manager = {
@@ -125,11 +127,13 @@ describe("UiServer /proxy/tools/call session recovery", () => {
       status: "connected",
       transport: { sessionId: "session-1" },
       client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const needsAuth = {
       status: "needs-auth",
       transport: { sessionId: "session-2" },
       client: { callTool: vi.fn() },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
 
     const manager = {
@@ -170,16 +174,19 @@ describe("UiServer /proxy/tools/call session recovery", () => {
       status: "connected",
       transport: { sessionId: "session-1" },
       client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const needsAuth = {
       status: "needs-auth",
       transport: { sessionId: "session-2" },
       client: { callTool: vi.fn() },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const fresh = {
       status: "connected",
       transport: { sessionId: "session-3" },
       client: { callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "after auth" }] }) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
 
     const manager = {
@@ -221,6 +228,7 @@ describe("UiServer /proxy/tools/call session recovery", () => {
       status: "connected",
       transport: { sessionId: "session-1" },
       client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
 
     const manager = {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -117,6 +117,7 @@ function createMockManager(overrides: Partial<McpServerManager> = {}): McpServer
       client: {
         callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "result" }] }),
       },
+      tools: [{ name: "some_tool" }],
     }),
     touch: vi.fn(),
     incrementInFlight: vi.fn(),
@@ -532,7 +533,11 @@ describe("UiServer", () => {
       };
       const requestOptions = { timeout: 4321 };
       const manager = createMockManager({
-        getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [{ name: "some_tool" }],
+        }),
         getRequestOptions: vi.fn().mockReturnValue(requestOptions),
       });
       handle = await startUiServer(createServerOptions({ manager }));
@@ -564,7 +569,11 @@ describe("UiServer", () => {
     it("returns a gated iframe call as an approval_denied tool result", async () => {
       const mockClient = { callTool: vi.fn() };
       const manager = createMockManager({
-        getConnection: vi.fn().mockReturnValue({ status: "connected", client: mockClient }),
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [{ name: "some_tool" }],
+        }),
       });
       const config: McpConfig = {
         mcpServers: { "test-server": { command: "demo", approveTools: true } },
@@ -653,6 +662,54 @@ describe("UiServer", () => {
 
       expect(res.status).toBe(403);
       expect(res.body).toEqual({ ok: false, error: 'MCP tool "model_only" is not callable by apps' });
+      expect(mockClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it("rejects app calls when the tool definition is unavailable", async () => {
+      const mockClient = { callTool: vi.fn() };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "unlisted", arguments: {} },
+        },
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ ok: false, error: 'MCP tool "unlisted" is not callable by apps' });
+      expect(mockClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it("rejects app calls when the tool list is unavailable", async () => {
+      const mockClient = { callTool: vi.fn() };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: undefined,
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "unknown", arguments: {} },
+        },
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ ok: false, error: 'MCP tool "unknown" is not callable by apps' });
       expect(mockClient.callTool).not.toHaveBeenCalled();
     });
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -279,7 +279,7 @@ describe("UiServer", () => {
       expect(cspHeader).toContain("default-src 'none'");
       expect(cspHeader).toContain("script-src 'self' 'unsafe-inline' https://esm.sh");
       expect(cspHeader).toContain("style-src 'self' 'unsafe-inline' https://esm.sh");
-      expect(cspHeader).toContain("connect-src 'self' https://api.excalidraw.com");
+      expect(cspHeader).toContain("connect-src https://api.excalidraw.com");
       expect(res.body).toBe(appHtml);
     });
 
@@ -327,13 +327,14 @@ describe("UiServer", () => {
       expect(res.body).toBe(appHtml);
     });
 
-    it("omits the CSP response header when metadata is undefined", async () => {
+    it("emits restrictive default CSP when metadata is undefined", async () => {
       handle = await startUiServer(createServerOptions());
       const url = `http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`;
 
       const res = await request(url);
 
-      expect(res.headers["content-security-policy"]).toBeUndefined();
+      expect(res.headers["content-security-policy"]).toContain("default-src 'none'");
+      expect(res.headers["content-security-policy"]).toContain("connect-src 'none'");
       expect(res.body).toBe("<h1>Test App</h1>");
     });
   });
@@ -629,6 +630,30 @@ describe("UiServer", () => {
 
       expect(res.status).toBe(503);
       expect((res.body as { error: string }).error).toContain("not connected");
+    });
+
+    it("rejects app calls to tools that omit app visibility", async () => {
+      const mockClient = { callTool: vi.fn() };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [{ name: "model_only", _meta: { ui: { visibility: ["model"] } } }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "model_only", arguments: {} },
+        },
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ ok: false, error: 'MCP tool "model_only" is not callable by apps' });
+      expect(mockClient.callTool).not.toHaveBeenCalled();
     });
 
     it("returns 400 for invalid params", async () => {

--- a/__tests__/ui-tool-visibility.test.ts
+++ b/__tests__/ui-tool-visibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { reconstructToolMetadata, serializeTools } from "../metadata-cache.ts";
+import { buildToolMetadata } from "../tool-metadata.ts";
+import type { McpTool, ServerCacheEntry } from "../types.ts";
+
+const tools: McpTool[] = [
+  { name: "visible", description: "Visible" },
+  { name: "app_only", description: "App only", _meta: { ui: { visibility: ["app"] } } },
+  { name: "both", description: "Both", _meta: { ui: { visibility: ["model", "app"] } } },
+];
+
+describe("MCP Apps tool visibility", () => {
+  it("omits app-only tools from live model metadata", () => {
+    const { metadata } = buildToolMetadata(tools, [], {}, "demo", "server");
+
+    expect(metadata.map((tool) => tool.originalName)).toEqual(["visible", "both"]);
+    expect(metadata.find((tool) => tool.originalName === "both")?.uiVisibility).toEqual(["model", "app"]);
+  });
+
+  it("omits cached app-only tools when reconstructing model metadata", () => {
+    const entry: ServerCacheEntry = {
+      configHash: "hash",
+      tools: serializeTools(tools),
+      resources: [],
+      cachedAt: Date.now(),
+    };
+
+    const metadata = reconstructToolMetadata("demo", entry, "server", {});
+
+    expect(metadata.map((tool) => tool.originalName)).toEqual(["visible", "both"]);
+  });
+});

--- a/__tests__/ui-tool-visibility.test.ts
+++ b/__tests__/ui-tool-visibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { reconstructToolMetadata, serializeTools } from "../metadata-cache.ts";
 import { buildToolMetadata } from "../tool-metadata.ts";
+import { extractUiToolVisibility, isUiToolCallableByApp, isUiToolVisibleToModel } from "../ui-tool-visibility.ts";
 import type { McpTool, ServerCacheEntry } from "../types.ts";
 
 const tools: McpTool[] = [
@@ -28,5 +29,19 @@ describe("MCP Apps tool visibility", () => {
     const metadata = reconstructToolMetadata("demo", entry, "server", {});
 
     expect(metadata.map((tool) => tool.originalName)).toEqual(["visible", "both"]);
+  });
+
+  it("fails closed for malformed visibility metadata", () => {
+    const visibility = extractUiToolVisibility({ ui: { visibility: ["app", "mdoel"] } });
+
+    expect(visibility).toEqual([]);
+    expect(isUiToolVisibleToModel(visibility)).toBe(false);
+    expect(isUiToolCallableByApp(visibility)).toBe(false);
+
+    const { metadata } = buildToolMetadata([
+      { name: "bad", _meta: { ui: { visibility: ["app", "mdoel"] } } },
+    ], [], {}, "demo", "server");
+
+    expect(metadata).toEqual([]);
   });
 });

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -98,7 +98,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     </div>
   </header>
   <main>
-    <iframe id="mcp-app" referrerpolicy="no-referrer"></iframe>
+    <iframe id="mcp-app" sandbox="allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads" referrerpolicy="no-referrer"></iframe>
   </main>
   <div class="overlay" id="error-overlay">
     <div class="panel">
@@ -353,13 +353,11 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
 </html>`;
 }
 
-export function buildCspMetaContent(csp: UiResourceCsp | undefined): string | undefined {
-  if (!csp) return undefined;
-
-  const resourceDomains = sanitizeCspDomains(csp.resourceDomains);
-  const connectDomains = sanitizeCspDomains(csp.connectDomains);
-  const frameDomains = sanitizeCspDomains(csp.frameDomains);
-  const baseUriDomains = sanitizeCspDomains(csp.baseUriDomains);
+export function buildCspMetaContent(csp: UiResourceCsp | undefined): string {
+  const resourceDomains = sanitizeCspDomains(csp?.resourceDomains);
+  const connectDomains = sanitizeCspDomains(csp?.connectDomains);
+  const frameDomains = sanitizeCspDomains(csp?.frameDomains);
+  const baseUriDomains = sanitizeCspDomains(csp?.baseUriDomains);
 
   return [
     "default-src 'none'",
@@ -368,11 +366,13 @@ export function buildCspMetaContent(csp: UiResourceCsp | undefined): string | un
     toDirective("font-src", ["'self'"], resourceDomains),
     toDirective("img-src", ["'self'", "data:"], resourceDomains),
     toDirective("media-src", ["'self'", "data:"], resourceDomains),
-    toDirective("connect-src", ["'self'"], connectDomains),
+    connectDomains.length > 0
+      ? `connect-src ${connectDomains.join(" ")}`
+      : "connect-src 'none'",
     frameDomains.length > 0
       ? `frame-src ${frameDomains.join(" ")}`
       : "frame-src 'none'",
-    toDirective("worker-src", ["'self'", "blob:"], resourceDomains),
+    "worker-src 'none'",
     "object-src 'none'",
     baseUriDomains.length > 0
       ? `base-uri ${baseUriDomains.join(" ")}`

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -28,6 +28,7 @@ import {
   resolveConfigPath,
   resolveServerUrl,
 } from "./utils.ts";
+import { extractUiToolVisibility, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 
 const CACHE_VERSION = 1;
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -183,6 +184,9 @@ export function reconstructToolMetadata(
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
+    if (!isUiToolVisibleToModel(tool.uiVisibility)) {
+      continue;
+    }
     if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
       continue;
     }
@@ -199,6 +203,7 @@ export function reconstructToolMetadata(
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
       uiResourceUri: tool.uiResourceUri,
+      uiVisibility: tool.uiVisibility,
       uiStreamMode: tool.uiStreamMode,
     });
   }
@@ -237,6 +242,7 @@ export function serializeTools(tools: McpTool[]): CachedTool[] {
       description: t.description,
       inputSchema: t.inputSchema,
       uiResourceUri: tryGetToolUiResourceUri(t),
+      uiVisibility: extractUiToolVisibility(t._meta),
       uiStreamMode: extractToolUiStreamMode(t._meta),
     }));
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "mcp-setup-panel.ts",
     "types.ts",
     "ui-stream-types.ts",
+    "ui-tool-visibility.ts",
     "config.ts",
     "server-manager.ts",
     "unix-socket-transport.ts",

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -4,6 +4,7 @@ import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from
 import { formatToolName, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
+import { extractUiToolVisibility, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 
 export function buildToolMetadata(
   tools: McpTool[],
@@ -30,6 +31,11 @@ export function buildToolMetadata(
     if (seenNames.has(name)) {
       continue;
     }
+
+    const uiVisibility = extractUiToolVisibility(tool._meta);
+    if (!isUiToolVisibleToModel(uiVisibility)) {
+      continue;
+    }
     seenNames.add(name);
 
     let uiResourceUri: string | undefined;
@@ -44,6 +50,7 @@ export function buildToolMetadata(
       description: tool.description ?? "",
       inputSchema: tool.inputSchema,
       uiResourceUri,
+      uiVisibility,
       uiStreamMode: extractToolUiStreamMode(tool._meta),
     });
   }

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@
 import type { Transport as McpTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
+import type { UiToolVisibility } from "./ui-tool-visibility.ts";
 
 export type Transport = McpTransport;
 
@@ -474,6 +475,7 @@ export interface ToolMetadata {
   description: string;
   resourceUri?: string;   // For resource tools: the URI to read
   uiResourceUri?: string; // For app-enabled tools: the UI resource URI
+  uiVisibility?: UiToolVisibility[];
   inputSchema?: unknown;  // JSON Schema for parameters (stored for describe/errors)
   uiStreamMode?: UiStreamMode;
 }
@@ -514,6 +516,7 @@ export interface CachedTool {
   description?: string;
   inputSchema?: unknown;
   uiResourceUri?: string;
+  uiVisibility?: UiToolVisibility[];
   uiStreamMode?: "eager" | "stream-first";
 }
 

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -16,6 +16,7 @@ import type { McpServerManager } from "./server-manager.ts";
 import type { McpExtensionState } from "./state.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
+import { extractUiToolVisibility, isUiToolCallableByApp } from "./ui-tool-visibility.ts";
 import {
   extractUiPromptText,
   getVisualizationStreamEnvelope,
@@ -359,6 +360,13 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           return;
         }
 
+        const toolDefinition = connection.tools?.find((tool) => tool.name === callParams.name);
+        const uiVisibility = extractUiToolVisibility(toolDefinition?._meta);
+        if (!isUiToolCallableByApp(uiVisibility)) {
+          sendJson(res, 403, { ok: false, error: `MCP tool "${callParams.name}" is not callable by apps` });
+          return;
+        }
+
         const callArgs = {
           name: callParams.name,
           arguments:
@@ -369,7 +377,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         const toolMeta = {
           name: callParams.name,
           originalName: callParams.name,
-          description: "",
+          description: toolDefinition?.description ?? "",
+          inputSchema: toolDefinition?.inputSchema,
+          uiVisibility,
         };
         const approval = options.state
           ? await ensureToolCallApproved(

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -360,8 +360,13 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           return;
         }
 
-        const toolDefinition = connection.tools?.find((tool) => tool.name === callParams.name);
-        const uiVisibility = extractUiToolVisibility(toolDefinition?._meta);
+        const toolDefinitions = Array.isArray(connection.tools) ? connection.tools : [];
+        const toolDefinition = toolDefinitions.find((tool) => tool.name === callParams.name);
+        if (!toolDefinition) {
+          sendJson(res, 403, { ok: false, error: `MCP tool "${callParams.name}" is not callable by apps` });
+          return;
+        }
+        const uiVisibility = extractUiToolVisibility(toolDefinition._meta);
         if (!isUiToolCallableByApp(uiVisibility)) {
           sendJson(res, 403, { ok: false, error: `MCP tool "${callParams.name}" is not callable by apps` });
           return;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -309,7 +309,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         res.writeHead(200, {
           "Content-Type": "text/html; charset=utf-8",
           "Cache-Control": "no-store",
-          ...(cspContent ? { "Content-Security-Policy": cspContent } : {}),
+          "Content-Security-Policy": cspContent,
         });
         res.end(options.resource.html);
         return;

--- a/ui-tool-visibility.ts
+++ b/ui-tool-visibility.ts
@@ -1,0 +1,24 @@
+export type UiToolVisibility = "model" | "app";
+
+export function extractUiToolVisibility(meta: Record<string, unknown> | undefined): UiToolVisibility[] | undefined {
+  if (!meta || typeof meta !== "object") return undefined;
+  const ui = meta.ui;
+  if (!ui || typeof ui !== "object" || Array.isArray(ui)) return undefined;
+  const visibility = (ui as Record<string, unknown>).visibility;
+  if (!Array.isArray(visibility)) return undefined;
+
+  const values: UiToolVisibility[] = [];
+  for (const entry of visibility) {
+    if (entry !== "model" && entry !== "app") return undefined;
+    if (!values.includes(entry)) values.push(entry);
+  }
+  return values;
+}
+
+export function isUiToolVisibleToModel(visibility: readonly UiToolVisibility[] | undefined): boolean {
+  return visibility === undefined || visibility.includes("model");
+}
+
+export function isUiToolCallableByApp(visibility: readonly UiToolVisibility[] | undefined): boolean {
+  return visibility === undefined || visibility.includes("app");
+}

--- a/ui-tool-visibility.ts
+++ b/ui-tool-visibility.ts
@@ -5,11 +5,12 @@ export function extractUiToolVisibility(meta: Record<string, unknown> | undefine
   const ui = meta.ui;
   if (!ui || typeof ui !== "object" || Array.isArray(ui)) return undefined;
   const visibility = (ui as Record<string, unknown>).visibility;
-  if (!Array.isArray(visibility)) return undefined;
+  if (visibility === undefined) return undefined;
+  if (!Array.isArray(visibility)) return [];
 
   const values: UiToolVisibility[] = [];
   for (const entry of visibility) {
-    if (entry !== "model" && entry !== "app") return undefined;
+    if (entry !== "model" && entry !== "app") return [];
     if (!values.includes(entry)) values.push(entry);
   }
   return values;


### PR DESCRIPTION
This brings the MCP Apps UI hosting path in line with the current spec/security audit findings.

What changed:
- runs provider HTML in a sandboxed iframe without `allow-same-origin`
- emits a restrictive default CSP for UI app resources, including `connect-src 'none'` and `worker-src 'none'` when no CSP metadata is provided
- parses and preserves `_meta.ui.visibility`
- hides app-only tools from model-facing metadata, including reconstructed cache metadata
- rejects app iframe tool calls when the tool visibility omits `app`

Validation:
- `npx tsc --noEmit`
- `npx vitest run __tests__/package-manifest.test.ts __tests__/host-html-template.test.ts __tests__/tool-metadata.test.ts __tests__/ui-tool-visibility.test.ts __tests__/ui-resource-handler.test.ts __tests__/direct-tools.test.ts __tests__/ui-server.test.ts`
- `npx vitest run __tests__/metadata-cache-instructions.test.ts`

A full local `npx vitest run` was attempted earlier and only failed because the interactive-visualizer example dist artifacts were not built in this worktree.