### PR TITLE
fix: improve MCP UI Moshi access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 
 ### Fixed
 - Brought MCP Apps UI hosting in line with the current spec: provider HTML now runs in a real sandbox, gets a restrictive default CSP even when the resource omits one, and `_meta.ui.visibility` is honored so app-only tools stay out of the model tool list while model-only tools cannot be called from the UI.
-- MCP Apps UI sessions are now easier to open from Moshi and remote terminals: the local UI server uses Moshi-discoverable low ports, answers preview discovery probes, serves a loopback-only landing shell, prints Moshi/SSH access hints for remote sessions, and fits the host shell better in narrow in-app browsers.
+- MCP Apps UI sessions are now easier to open from Moshi and remote terminals: the local UI server uses Moshi-discoverable low ports, answers preview discovery probes, serves a loopback-only landing shell, prints Moshi/SSH access hints for remote sessions, and fits the host shell better in narrow in-app browsers. UI-submitted model context is now captured as a bounded handoff, wakes the agent like prompts and intents, and remains available through `mcp({ action: "ui-messages" })` after the UI closes.
 
 ## [2.17.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 
 ### Fixed
 - Brought MCP Apps UI hosting in line with the current spec: provider HTML now runs in a real sandbox, gets a restrictive default CSP even when the resource omits one, and `_meta.ui.visibility` is honored so app-only tools stay out of the model tool list while model-only tools cannot be called from the UI.
+- MCP Apps UI sessions are now easier to open from Moshi and remote terminals: the local UI server uses Moshi-discoverable low ports, answers preview discovery probes, serves a loopback-only landing shell, prints Moshi/SSH access hints for remote sessions, and fits the host shell better in narrow in-app browsers.
 
 ## [2.17.0] - 2026-07-31
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -63,6 +63,16 @@ describe("buildHostHtmlTemplate", () => {
       expect(html).toContain('id="done-btn"');
       expect(html).toContain('id="cancel-btn"');
     });
+
+    it("includes mobile and in-app-browser host shell affordances", () => {
+      const html = buildHostHtmlTemplate(createMinimalInput());
+
+      expect(html).toContain("min-height: 100dvh");
+      expect(html).toContain("env(safe-area-inset-top");
+      expect(html).toContain("@media (max-width: 640px)");
+      expect(html).toContain('id="completion-overlay"');
+      expect(html).toContain("closeOrShowDone");
+    });
   });
 
   describe("data injection", () => {

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -72,6 +72,7 @@ describe("buildHostHtmlTemplate", () => {
       expect(html).toContain("@media (max-width: 640px)");
       expect(html).toContain('id="completion-overlay"');
       expect(html).toContain("closeOrShowDone");
+      expect(html).toContain("visibilitychange");
     });
   });
 

--- a/__tests__/proxy-modes-ui-messages.test.ts
+++ b/__tests__/proxy-modes-ui-messages.test.ts
@@ -69,4 +69,26 @@ describe("executeUiMessages", () => {
       intents: [],
     });
   });
+
+  it("returns submitted model context updates", () => {
+    const state = createState([]);
+    state.completedUiSessions[0].messages.contexts = [{
+      payload: { content: [{ type: "text", text: "Selected node A" }] },
+      summary: '{"content":[{"type":"text","text":"Selected node A"}]}',
+      truncated: false,
+    }];
+
+    const result = executeUiMessages(state);
+
+    expect(result.content[0]).toMatchObject({
+      text: expect.stringContaining("### Context updates:\n- {\"content\":[{\"type\":\"text\",\"text\":\"Selected node A\"}]}"),
+    });
+    expect(result.details).toMatchObject({
+      contexts: [{
+        payload: { content: [{ type: "text", text: "Selected node A" }] },
+        truncated: false,
+      }],
+      cleared: true,
+    });
+  });
 });

--- a/__tests__/proxy-modes-ui-messages.test.ts
+++ b/__tests__/proxy-modes-ui-messages.test.ts
@@ -14,6 +14,7 @@ function createState(prompts: string[]): McpExtensionState {
           prompts,
           notifications: [],
           intents: [],
+          contexts: [],
         },
       },
     ],
@@ -72,11 +73,11 @@ describe("executeUiMessages", () => {
 
   it("returns submitted model context updates", () => {
     const state = createState([]);
-    state.completedUiSessions[0].messages.contexts = [{
+    state.completedUiSessions[0].messages.contexts.push({
       payload: { content: [{ type: "text", text: "Selected node A" }] },
       summary: '{"content":[{"type":"text","text":"Selected node A"}]}',
       truncated: false,
-    }];
+    });
 
     const result = executeUiMessages(state);
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -1075,7 +1075,7 @@ describe("UiServer", () => {
   });
 
   describe("POST /proxy/ui/context", () => {
-    it("forwards context to callback", async () => {
+    it("stores and forwards context updates", async () => {
       const onContextUpdate = vi.fn();
       handle = await startUiServer(createServerOptions({ onContextUpdate }));
 
@@ -1089,6 +1089,28 @@ describe("UiServer", () => {
 
       expect(res.status).toBe(200);
       expect(onContextUpdate).toHaveBeenCalledWith({ content: "some context data" });
+      expect(handle.getSessionMessages().contexts).toEqual([{
+        payload: { content: "some context data" },
+        summary: '{"content":"some context data"}',
+        truncated: false,
+      }]);
+    });
+
+    it("bounds oversized context updates", async () => {
+      handle = await startUiServer(createServerOptions());
+
+      const res = await request(`http://localhost:${handle.port}/proxy/ui/context`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { content: "x".repeat(12_100) },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(handle.getSessionMessages().contexts?.[0]).toMatchObject({ truncated: true });
+      expect(handle.getSessionMessages().contexts?.[0].summary.length).toBeLessThanOrEqual(12_000);
+      expect(handle.getSessionMessages().contexts?.[0].payload).toBeUndefined();
     });
   });
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -173,10 +173,11 @@ describe("UiServer", () => {
   });
 
   describe("startUiServer", () => {
-    it("starts server on random port", async () => {
+    it("starts server on a Moshi-discoverable low port by default", async () => {
       handle = await startUiServer(createServerOptions());
 
-      expect(handle.port).toBeGreaterThan(0);
+      expect(handle.port).toBeGreaterThanOrEqual(8377);
+      expect(handle.port).toBeLessThanOrEqual(8396);
       expect(handle.url).toContain(`http://localhost:${handle.port}`);
       expect(handle.sessionToken).toBeTruthy();
     });
@@ -235,13 +236,37 @@ describe("UiServer", () => {
       expect(res.body).toEqual({ ok: false, error: "Invalid session" });
     });
 
-    it("rejects missing session token", async () => {
+    it("serves a tokenless loopback landing shell for Moshi preview", async () => {
       handle = await startUiServer(createServerOptions());
       const url = `http://localhost:${handle.port}/`;
 
       const res = await request(url);
 
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expect(res.body).toContain("location.replace");
+      expect(res.body).toContain(encodeURIComponent(handle.sessionToken));
+    });
+
+    it("answers HEAD discovery probes without a session token", async () => {
+      handle = await startUiServer(createServerOptions());
+      const url = `http://localhost:${handle.port}/`;
+
+      const res = await request(url, { method: "HEAD" });
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expect(res.body).toBe("");
+    });
+
+    it("rejects non-loopback Host headers before serving tokenless landing", async () => {
+      handle = await startUiServer(createServerOptions());
+      const url = `http://localhost:${handle.port}/`;
+
+      const res = await request(url, { headers: { Host: "attacker.example" } });
+
       expect(res.status).toBe(403);
+      expect(res.body).toBe("Invalid host");
     });
   });
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -1093,17 +1093,35 @@ describe("UiServer", () => {
         method: "POST",
         body: {
           token: handle.sessionToken,
-          params: { content: "some context data" },
+          params: { content: [{ type: "text", text: "some context data" }] },
         },
       });
 
       expect(res.status).toBe(200);
-      expect(onContextUpdate).toHaveBeenCalledWith({ content: "some context data" });
+      expect(onContextUpdate).toHaveBeenCalledWith({ content: [{ type: "text", text: "some context data" }] });
       expect(handle.getSessionMessages().contexts).toEqual([{
-        payload: { content: "some context data" },
-        summary: '{"content":"some context data"}',
+        payload: { content: [{ type: "text", text: "some context data" }] },
+        summary: '{"content":[{"type":"text","text":"some context data"}]}',
         truncated: false,
       }]);
+    });
+
+    it("rejects malformed context updates", async () => {
+      const onContextUpdate = vi.fn();
+      handle = await startUiServer(createServerOptions({ onContextUpdate }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/ui/context`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { content: "some context data" },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ ok: false, error: "Invalid update-model-context params" });
+      expect(onContextUpdate).not.toHaveBeenCalled();
+      expect(handle.getSessionMessages().contexts).toEqual([]);
     });
 
     it("bounds oversized context updates", async () => {
@@ -1113,7 +1131,7 @@ describe("UiServer", () => {
         method: "POST",
         body: {
           token: handle.sessionToken,
-          params: { content: "x".repeat(12_100) },
+          params: { content: [{ type: "text", text: "x".repeat(12_100) }] },
         },
       });
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -268,6 +268,16 @@ describe("UiServer", () => {
       expect(res.status).toBe(403);
       expect(res.body).toBe("Invalid host");
     });
+
+    it("accepts bracketed IPv6 loopback Host headers", async () => {
+      handle = await startUiServer(createServerOptions());
+      const url = `http://localhost:${handle.port}/`;
+
+      const res = await request(url, { headers: { Host: `[::1]:${handle.port}` } });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toContain("location.replace");
+    });
   });
 
   describe("GET /ui-app", () => {
@@ -1108,9 +1118,9 @@ describe("UiServer", () => {
       });
 
       expect(res.status).toBe(200);
-      expect(handle.getSessionMessages().contexts?.[0]).toMatchObject({ truncated: true });
-      expect(handle.getSessionMessages().contexts?.[0].summary.length).toBeLessThanOrEqual(12_000);
-      expect(handle.getSessionMessages().contexts?.[0].payload).toBeUndefined();
+      expect(handle.getSessionMessages().contexts[0]).toMatchObject({ truncated: true });
+      expect(handle.getSessionMessages().contexts[0].summary.length).toBeLessThanOrEqual(12_000);
+      expect(handle.getSessionMessages().contexts[0].payload).toBeUndefined();
     });
   });
 

--- a/__tests__/ui-session-messages.test.ts
+++ b/__tests__/ui-session-messages.test.ts
@@ -8,6 +8,7 @@ describe("UiSessionMessages", () => {
         prompts: [],
         notifications: [],
         intents: [],
+        contexts: [],
       };
 
       expect(messages.prompts).toHaveLength(0);
@@ -20,6 +21,7 @@ describe("UiSessionMessages", () => {
         prompts: ["What is the weather?", "Tell me more"],
         notifications: [],
         intents: [],
+        contexts: [],
       };
 
       expect(messages.prompts).toHaveLength(2);
@@ -31,6 +33,7 @@ describe("UiSessionMessages", () => {
         prompts: [],
         notifications: ["Task completed", "Error occurred"],
         intents: [],
+        contexts: [],
       };
 
       expect(messages.notifications).toHaveLength(2);
@@ -44,6 +47,7 @@ describe("UiSessionMessages", () => {
           { intent: "get_forecast", params: { days: 7, location: "NYC" } },
           { intent: "refresh" },
         ],
+        contexts: [],
       };
 
       expect(messages.intents).toHaveLength(2);
@@ -62,8 +66,8 @@ describe("UiSessionMessages", () => {
       };
 
       expect(messages.contexts).toHaveLength(1);
-      expect(messages.contexts?.[0]).toMatchObject({ truncated: false });
-      expect(messages.contexts?.[0].summary).toContain("selection");
+      expect(messages.contexts[0]).toMatchObject({ truncated: false });
+      expect(messages.contexts[0].summary).toContain("selection");
     });
   });
 

--- a/__tests__/ui-session-messages.test.ts
+++ b/__tests__/ui-session-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseUiPromptHandoff, type UiSessionMessages } from "../types.ts";
+import { createUiModelContextUpdate, parseUiPromptHandoff, type UiSessionMessages } from "../types.ts";
 
 describe("UiSessionMessages", () => {
   describe("type structure", () => {
@@ -50,6 +50,20 @@ describe("UiSessionMessages", () => {
       expect(messages.intents[0].intent).toBe("get_forecast");
       expect(messages.intents[0].params).toEqual({ days: 7, location: "NYC" });
       expect(messages.intents[1].params).toBeUndefined();
+    });
+
+    it("can store bounded model context updates", () => {
+      const update = createUiModelContextUpdate({ content: [{ type: "text", text: "selection" }] });
+      const messages: UiSessionMessages = {
+        prompts: [],
+        notifications: [],
+        intents: [],
+        contexts: update ? [update] : [],
+      };
+
+      expect(messages.contexts).toHaveLength(1);
+      expect(messages.contexts?.[0]).toMatchObject({ truncated: false });
+      expect(messages.contexts?.[0].summary).toContain("selection");
     });
   });
 

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -133,8 +133,9 @@ describe("MCP UI context submissions", () => {
       toolArgs: {},
       uiResourceUri: "ui://app",
     });
+    if (!runtime) throw new Error("expected UI runtime");
 
-    await fetch(`${runtime!.url.replace(/\/?\?.*$/, "")}/proxy/ui/context`, {
+    await fetch(`${runtime.url.replace(/\/?\?.*$/, "")}/proxy/ui/context`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token: state.uiServer.sessionToken, params: { content: [{ type: "text", text: "Use this selection" }] } }),
@@ -149,7 +150,7 @@ describe("MCP UI context submissions", () => {
       { triggerTurn: true },
     );
 
-    runtime?.close("test-cleanup");
+    runtime.close("test-cleanup");
   });
 });
 

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -56,6 +56,7 @@ function makeState() {
     uiServer: null,
     completedUiSessions: [],
     openBrowser: vi.fn(async () => undefined),
+    sendMessage: vi.fn(),
     ui: {
       notify: vi.fn(),
       setStatus: vi.fn(),
@@ -92,6 +93,37 @@ describe("remote MCP UI viewers", () => {
     expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("This looks like a remote session"), "info");
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("SSH: run `ssh -L"), "info");
+
+    runtime?.close("test-cleanup");
+  });
+});
+
+describe("MCP UI context submissions", () => {
+  it("triggers an agent turn when the UI updates model context", async () => {
+    process.env.MCP_UI_VIEWER = "none";
+    const { state } = makeState();
+
+    const runtime = await maybeStartUiSession(state, {
+      serverName: "demo",
+      toolName: "app",
+      toolArgs: {},
+      uiResourceUri: "ui://app",
+    });
+
+    await fetch(`${runtime!.url.replace(/\/?\?.*$/, "")}/proxy/ui/context`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: state.uiServer.sessionToken, params: { content: [{ type: "text", text: "Use this selection" }] } }),
+    });
+
+    expect(state.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "mcp-ui-context",
+        content: [{ type: "text", text: expect.stringContaining("Use this selection") }],
+        display: "UI Context submitted",
+      }),
+      { triggerTurn: true },
+    );
 
     runtime?.close("test-cleanup");
   });

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -68,8 +68,33 @@ function makeState() {
 
 afterEach(() => {
   delete process.env.MCP_UI_VIEWER;
+  delete process.env.SSH_CONNECTION;
+  delete process.env.SSH_TTY;
   glimpseMocks.isGlimpseAvailable.mockClear();
   glimpseMocks.openGlimpseWindow.mockClear();
+});
+
+describe("remote MCP UI viewers", () => {
+  it("skips Glimpse and prints a remote access hint for SSH sessions", async () => {
+    process.env.SSH_CONNECTION = "192.0.2.10 55555 127.0.0.1 22";
+    const { state } = makeState();
+
+    const runtime = await maybeStartUiSession(state, {
+      serverName: "demo",
+      toolName: "app",
+      toolArgs: {},
+      uiResourceUri: "ui://app",
+    });
+
+    expect(runtime).toMatchObject({ viewer: "browser", windowOpen: true });
+    expect(state.openBrowser).toHaveBeenCalledWith(expect.stringContaining("http://localhost:"));
+    expect(glimpseMocks.isGlimpseAvailable).not.toHaveBeenCalled();
+    expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("This looks like a remote session"), "info");
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("SSH: run `ssh -L"), "info");
+
+    runtime?.close("test-cleanup");
+  });
 });
 
 describe("MCP_UI_VIEWER=none", () => {

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { execFile } from "node:child_process";
 import { ConsentManager } from "../consent-manager.ts";
 import { createDirectToolExecutor } from "../direct-tools.ts";
 import { executeCall } from "../proxy-modes.ts";
@@ -10,6 +11,9 @@ const glimpseMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../glimpse-ui.ts", () => glimpseMocks);
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn((_command, _options, callback) => callback(null, "")),
+}));
 
 function textOf(result: any): string {
   return result.content.map((entry: any) => entry.text ?? "").join("\n");
@@ -71,6 +75,7 @@ afterEach(() => {
   delete process.env.MCP_UI_VIEWER;
   delete process.env.SSH_CONNECTION;
   delete process.env.SSH_TTY;
+  vi.mocked(execFile).mockImplementation((_command: any, _options: any, callback: any) => callback(null, "") as any);
   glimpseMocks.isGlimpseAvailable.mockClear();
   glimpseMocks.openGlimpseWindow.mockClear();
 });
@@ -93,6 +98,25 @@ describe("remote MCP UI viewers", () => {
     expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("This looks like a remote session"), "info");
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("SSH: run `ssh -L"), "info");
+
+    runtime?.close("test-cleanup");
+  });
+
+  it("uses local-window wording when a remote login is active but Glimpse opened", async () => {
+    vi.mocked(execFile).mockImplementation((_command: any, _options: any, callback: any) => callback(null, "nico ttys001 2026-08-02 08:00 (192.0.2.10)\n") as any);
+    const { state } = makeState();
+    glimpseMocks.openGlimpseWindow.mockResolvedValueOnce({ close: vi.fn() });
+
+    const runtime = await maybeStartUiSession(state, {
+      serverName: "demo",
+      toolName: "app",
+      toolArgs: {},
+      uiResourceUri: "ui://app",
+    });
+
+    expect(runtime).toMatchObject({ viewer: "glimpse", windowOpen: true });
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("MCP UI opened on this host"), "info");
+    expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("If you're controlling this session remotely"), "info");
 
     runtime?.close("test-cleanup");
   });

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -159,15 +159,25 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
       setStatus("Error", true);
     };
 
+    let completionPending = false;
+    const showCompletion = () => {
+      completionOverlay.classList.add("visible");
+      setStatus("Complete");
+    };
     const closeOrShowDone = () => {
+      completionPending = true;
       window.close();
       setTimeout(() => {
         if (!document.hidden) {
-          completionOverlay.classList.add("visible");
-          setStatus("Complete");
+          showCompletion();
         }
       }, 1000);
     };
+    document.addEventListener("visibilitychange", () => {
+      if (completionPending && !document.hidden) {
+        showCompletion();
+      }
+    });
 
     const post = async (endpoint, params) => {
       const response = await fetch(endpoint, {

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -63,8 +63,8 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     }
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; height: 100%; font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
-    body { display: flex; flex-direction: column; min-height: 100vh; }
-    header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 10px 14px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    body { display: flex; flex-direction: column; min-height: 100vh; min-height: 100dvh; }
+    header { background: var(--surface); border-bottom: 1px solid var(--border); padding: calc(10px + env(safe-area-inset-top, 0px)) calc(14px + env(safe-area-inset-right, 0px)) 10px calc(14px + env(safe-area-inset-left, 0px)); display: flex; align-items: center; justify-content: space-between; gap: 10px; }
     .title { display: flex; gap: 8px; align-items: baseline; min-width: 0; }
     .server { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; }
     .tool { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -75,13 +75,24 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     button.primary { border-color: color-mix(in srgb, var(--good) 40%, var(--border) 60%); color: var(--good); }
     button.danger { border-color: color-mix(in srgb, var(--bad) 40%, var(--border) 60%); color: var(--bad); }
     button:hover { background: color-mix(in srgb, var(--surface) 75%, var(--accent) 25%); }
-    main { flex: 1; min-height: 0; padding: 10px; display: flex; }
+    main { flex: 1; min-height: 0; padding: 10px; padding-inline: calc(10px + env(safe-area-inset-left, 0px)) calc(10px + env(safe-area-inset-right, 0px)); padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px)); display: flex; }
     iframe { width: 100%; height: 100%; border: 1px solid var(--border); border-radius: 10px; background: white; }
-    .overlay { position: fixed; inset: 0; background: color-mix(in srgb, var(--bg) 90%, black 10%); display: none; align-items: center; justify-content: center; z-index: 2; }
+    .overlay { position: fixed; inset: 0; background: color-mix(in srgb, var(--bg) 90%, black 10%); display: none; align-items: center; justify-content: center; z-index: 2; padding: 16px; }
     .overlay.visible { display: flex; }
     .panel { width: min(680px, calc(100vw - 40px)); background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 18px; }
     .panel h2 { margin: 0 0 8px; font-size: 16px; }
     .panel p { margin: 0; color: var(--muted); line-height: 1.4; font-size: 14px; white-space: pre-wrap; }
+    @media (max-width: 640px) {
+      header { align-items: stretch; flex-direction: column; gap: 8px; }
+      .title { flex-wrap: wrap; row-gap: 4px; }
+      .server { flex-basis: 100%; }
+      .controls { width: 100%; }
+      .status { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+      button { min-height: 44px; padding: 10px 14px; }
+      main { padding: 6px; padding-inline: calc(6px + env(safe-area-inset-left, 0px)) calc(6px + env(safe-area-inset-right, 0px)); padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px)); }
+      iframe { border-radius: 6px; }
+      .panel { width: 100%; }
+    }
   </style>
 </head>
 <body>
@@ -106,6 +117,12 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
       <p id="error-message"></p>
     </div>
   </div>
+  <div class="overlay" id="completion-overlay">
+    <div class="panel">
+      <h2>Done</h2>
+      <p>MCP UI session finished. You can close this page and return to Pi.</p>
+    </div>
+  </div>
   <script type="module">
     import { AppBridge, PostMessageTransport } from ${moduleUrl};
 
@@ -125,6 +142,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const doneBtn = document.getElementById("done-btn");
     const cancelBtn = document.getElementById("cancel-btn");
     const errorOverlay = document.getElementById("error-overlay");
+    const completionOverlay = document.getElementById("completion-overlay");
     const errorMessage = document.getElementById("error-message");
 
     document.getElementById("server-name").textContent = SERVER_NAME;
@@ -139,6 +157,16 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
       errorMessage.textContent = message;
       errorOverlay.classList.add("visible");
       setStatus("Error", true);
+    };
+
+    const closeOrShowDone = () => {
+      window.close();
+      setTimeout(() => {
+        if (!document.hidden) {
+          completionOverlay.classList.add("visible");
+          setStatus("Complete");
+        }
+      }, 1000);
     };
 
     const post = async (endpoint, params) => {
@@ -315,7 +343,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     eventSource.addEventListener("session-complete", async () => {
       await bridge.teardownResource({}).catch(() => {});
       eventSource.close();
-      window.close();
+      closeOrShowDone();
     });
     eventSource.onerror = () => {
       setStatus("Connection lost", true);
@@ -334,7 +362,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
       } catch {}
       clearInterval(heartbeat);
       eventSource.close();
-      window.close();
+      closeOrShowDone();
     };
 
     doneBtn.addEventListener("click", () => complete("done"));

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -171,7 +171,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 
   const allPrompts: string[] = [];
   const allIntents = sessions.flatMap((session) => session.messages.intents);
-  const allContexts = sessions.flatMap((session) => session.messages.contexts ?? []);
+  const allContexts = sessions.flatMap((session) => session.messages.contexts);
   const parsedHandoffs: Array<{ intent: string; params: Record<string, unknown>; raw: string }> = [];
 
   for (const session of sessions) {
@@ -212,7 +212,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
       }
     }
 
-    const contexts = session.messages.contexts ?? [];
+    const contexts = session.messages.contexts;
     if (contexts.length > 0) {
       output.push("\n### Context updates:");
       for (const context of contexts) {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -171,6 +171,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 
   const allPrompts: string[] = [];
   const allIntents = sessions.flatMap((session) => session.messages.intents);
+  const allContexts = sessions.flatMap((session) => session.messages.contexts ?? []);
   const parsedHandoffs: Array<{ intent: string; params: Record<string, unknown>; raw: string }> = [];
 
   for (const session of sessions) {
@@ -211,6 +212,14 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
       }
     }
 
+    const contexts = session.messages.contexts ?? [];
+    if (contexts.length > 0) {
+      output.push("\n### Context updates:");
+      for (const context of contexts) {
+        output.push(`- ${context.summary}${context.truncated ? " (truncated)" : ""}`);
+      }
+    }
+
     if (session.messages.notifications.length > 0) {
       output.push("\n### Notifications:");
       for (const notification of session.messages.notifications) {
@@ -228,6 +237,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
       sessions: count,
       prompts: allPrompts,
       intents: [...allIntents, ...parsedHandoffs.map(({ intent, params }) => ({ intent, params }))],
+      contexts: allContexts,
       handoffs: parsedHandoffs,
       cleared: true,
     },

--- a/types.ts
+++ b/types.ts
@@ -257,12 +257,36 @@ export interface UiSessionMessages {
   prompts: string[];
   notifications: string[];
   intents: Array<{ intent: string; params?: Record<string, unknown> }>;
+  contexts?: UiModelContextUpdate[];
+}
+
+export interface UiModelContextUpdate {
+  summary: string;
+  truncated: boolean;
+  payload?: Record<string, unknown>;
 }
 
 export interface UiModelContextParams {
   content?: unknown[];
   structuredContent?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+export function createUiModelContextUpdate(params: UiModelContextParams, maxChars = 12_000): UiModelContextUpdate | undefined {
+  const payload = Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined),
+  );
+  if (Object.keys(payload).length === 0) return undefined;
+
+  const serialized = JSON.stringify(payload);
+  if (serialized.length <= maxChars) {
+    return { payload, summary: serialized, truncated: false };
+  }
+
+  return {
+    summary: `${serialized.slice(0, Math.max(0, maxChars - 1))}…`,
+    truncated: true,
+  };
 }
 
 export interface UiOpenLinkResult {

--- a/types.ts
+++ b/types.ts
@@ -257,7 +257,7 @@ export interface UiSessionMessages {
   prompts: string[];
   notifications: string[];
   intents: Array<{ intent: string; params?: Record<string, unknown> }>;
-  contexts?: UiModelContextUpdate[];
+  contexts: UiModelContextUpdate[];
 }
 
 export interface UiModelContextUpdate {

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,6 @@
 // types.ts - Core type definitions
 import type { Transport as McpTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { ContentBlock as McpContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
 import type { UiToolVisibility } from "./ui-tool-visibility.ts";
@@ -267,9 +268,8 @@ export interface UiModelContextUpdate {
 }
 
 export interface UiModelContextParams {
-  content?: unknown[];
+  content?: McpContentBlock[];
   structuredContent?: Record<string, unknown>;
-  [key: string]: unknown;
 }
 
 export function createUiModelContextUpdate(params: UiModelContextParams, maxChars = 12_000): UiModelContextUpdate | undefined {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -40,6 +40,9 @@ const MAX_BODY_SIZE = 2 * 1024 * 1024;
 const ABANDONED_GRACE_MS = 60_000;
 const WATCHDOG_INTERVAL_MS = 5_000;
 const MAX_EVENT_LOG = 128;
+const MOSHI_DISCOVERY_PORT_START = 8377;
+const MOSHI_DISCOVERY_PORT_END = 8396;
+let nextMoshiDiscoveryPort = MOSHI_DISCOVERY_PORT_START;
 
 export interface UiServerOptions {
   serverName: string;
@@ -250,9 +253,30 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
   const server = http.createServer(async (req, res) => {
     try {
       const method = req.method || "GET";
-      const url = new URL(req.url || "/", `http://${req.headers.host || "127.0.0.1"}`);
+      const hostHeader = req.headers.host;
+      const url = new URL(req.url || "/", `http://${hostHeader || "127.0.0.1"}`);
+      if (hostHeader !== undefined && !isAllowedHost(url.hostname)) {
+        sendText(res, 403, "Invalid host");
+        return;
+      }
+
+      if (method === "HEAD" && url.pathname === "/") {
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end();
+        return;
+      }
 
       if (method === "GET" && url.pathname === "/") {
+        if (!url.searchParams.has("session") && isLoopbackAddress(req.socket.remoteAddress)) {
+          const dest = `/?session=${encodeURIComponent(sessionToken)}`;
+          res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+          res.end(
+            `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(`MCP UI - ${options.serverName} / ${options.toolName}`)}</title>` +
+              `<noscript><meta http-equiv="refresh" content="0;url=${dest}"></noscript></head>` +
+              `<body><script>location.replace(${JSON.stringify(dest)});</script></body></html>`,
+          );
+          return;
+        }
         if (!validateTokenQuery(url, sessionToken, res)) return;
         touchHeartbeat();
 
@@ -576,13 +600,26 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
   watchdog.unref();
 
   return new Promise((resolve, reject) => {
-    const onError = (error: Error) => {
-      log.error("Failed to start server", error);
-      reject(new ServerError(error.message, { port: options.port, cause: error }));
+    const candidates = resolvePortCandidates(options.port);
+    let candidateIndex = 0;
+
+    const listen = () => {
+      server.once("error", onError);
+      server.listen(candidates[candidateIndex], "127.0.0.1", onListening);
     };
 
-    server.once("error", onError);
-    server.listen(options.port ?? 0, "127.0.0.1", () => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off("listening", onListening);
+      if (error.code === "EADDRINUSE" && candidateIndex < candidates.length - 1) {
+        candidateIndex += 1;
+        listen();
+        return;
+      }
+      log.error("Failed to start server", error);
+      reject(new ServerError(error.message, { port: candidates[candidateIndex], cause: error }));
+    };
+
+    const onListening = () => {
       server.off("error", onError);
       const address = server.address();
       if (!address || typeof address === "string") {
@@ -593,6 +630,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       }
 
       log.debug("Server started", { port: address.port });
+      rememberMoshiDiscoveryPort(address.port);
 
       const handle: UiServerHandle = {
         url: `http://localhost:${address.port}/?session=${sessionToken}`,
@@ -628,7 +666,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       };
 
       resolve(handle);
-    });
+    };
+
+    listen();
   });
 }
 
@@ -676,6 +716,40 @@ function readBody(req: IncomingMessage): Promise<unknown> {
   });
 }
 
+function resolvePortCandidates(port: number | undefined): number[] {
+  if (port !== undefined) return [port];
+  const candidates: number[] = [];
+  const count = MOSHI_DISCOVERY_PORT_END - MOSHI_DISCOVERY_PORT_START + 1;
+  for (let offset = 0; offset < count; offset += 1) {
+    const candidate = MOSHI_DISCOVERY_PORT_START + ((nextMoshiDiscoveryPort - MOSHI_DISCOVERY_PORT_START + offset) % count);
+    candidates.push(candidate);
+  }
+  candidates.push(0);
+  return candidates;
+}
+
+function rememberMoshiDiscoveryPort(port: number): void {
+  if (port < MOSHI_DISCOVERY_PORT_START || port > MOSHI_DISCOVERY_PORT_END) return;
+  nextMoshiDiscoveryPort = port >= MOSHI_DISCOVERY_PORT_END ? MOSHI_DISCOVERY_PORT_START : port + 1;
+}
+
+function isAllowedHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function validateTokenQuery(url: URL, expected: string, res: ServerResponse): boolean {
   const token = url.searchParams.get("session");
   if (token !== expected) {
@@ -707,4 +781,12 @@ function sendJson<T>(
     "Cache-Control": "no-store",
   });
   res.end(JSON.stringify(payload));
+}
+
+function sendText(res: ServerResponse, status: number, text: string): void {
+  res.writeHead(status, {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(text);
 }

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -18,6 +18,7 @@ import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionReco
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 import { extractUiToolVisibility, isUiToolCallableByApp } from "./ui-tool-visibility.ts";
 import {
+  createUiModelContextUpdate,
   extractUiPromptText,
   getVisualizationStreamEnvelope,
   isServerDisabled,
@@ -40,6 +41,7 @@ const MAX_BODY_SIZE = 2 * 1024 * 1024;
 const ABANDONED_GRACE_MS = 60_000;
 const WATCHDOG_INTERVAL_MS = 5_000;
 const MAX_EVENT_LOG = 128;
+const MAX_CONTEXT_UPDATES = 20;
 const MOSHI_DISCOVERY_PORT_START = 8377;
 const MOSHI_DISCOVERY_PORT_END = 8396;
 let nextMoshiDiscoveryPort = MOSHI_DISCOVERY_PORT_START;
@@ -115,6 +117,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     prompts: [],
     notifications: [],
     intents: [],
+    contexts: [],
   };
 
   const hostContext: UiHostContext = {
@@ -498,7 +501,15 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
       if (url.pathname === "/proxy/ui/context") {
         const ctxParams = params as UiModelContextParams;
-        log.debug("UI context update", { hasContent: !!ctxParams.content });
+        const update = createUiModelContextUpdate(ctxParams);
+        if (update) {
+          sessionMessages.contexts ??= [];
+          sessionMessages.contexts.push(update);
+          while (sessionMessages.contexts.length > MAX_CONTEXT_UPDATES) {
+            sessionMessages.contexts.shift();
+          }
+        }
+        log.debug("UI context update", { hasContent: !!ctxParams.content, hasUpdate: !!update });
         await options.onContextUpdate?.(ctxParams);
         sendJson(res, 200, { ok: true, result: {} });
         return;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -503,7 +503,6 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         const ctxParams = params as UiModelContextParams;
         const update = createUiModelContextUpdate(ctxParams);
         if (update) {
-          sessionMessages.contexts ??= [];
           sessionMessages.contexts.push(update);
           while (sessionMessages.contexts.length > MAX_CONTEXT_UPDATES) {
             sessionMessages.contexts.shift();
@@ -745,7 +744,7 @@ function rememberMoshiDiscoveryPort(port: number): void {
 }
 
 function isAllowedHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }
 
 function isLoopbackAddress(address: string | undefined): boolean {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -745,7 +745,7 @@ function rememberMoshiDiscoveryPort(port: number): void {
 }
 
 function isAllowedHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
 function isLoopbackAddress(address: string | undefined): boolean {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -3,9 +3,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type {
-  CallToolRequest,
-  CallToolResult,
+import {
+  ContentBlockSchema,
+  type CallToolRequest,
+  type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
@@ -500,7 +501,19 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       }
 
       if (url.pathname === "/proxy/ui/context") {
-        const ctxParams = params as UiModelContextParams;
+        const content = params.content;
+        const structuredContent = params.structuredContent;
+        if (
+          (content !== undefined && (!Array.isArray(content) || content.some((block) => !ContentBlockSchema.safeParse(block).success))) ||
+          (structuredContent !== undefined && (!structuredContent || typeof structuredContent !== "object" || Array.isArray(structuredContent)))
+        ) {
+          sendJson(res, 400, { ok: false, error: "Invalid update-model-context params" });
+          return;
+        }
+        const ctxParams: UiModelContextParams = {
+          ...(content !== undefined ? { content: content as NonNullable<UiModelContextParams["content"]> } : {}),
+          ...(structuredContent !== undefined ? { structuredContent: structuredContent as Record<string, unknown> } : {}),
+        };
         const update = createUiModelContextUpdate(ctxParams);
         if (update) {
           sessionMessages.contexts.push(update);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -1,4 +1,6 @@
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import net from "node:net";
 import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { McpExtensionState } from "./state.ts";
 import {
@@ -121,18 +123,66 @@ function withStreamEnvelope(
   };
 }
 
-async function openInBrowser(state: McpExtensionState, url: string, signal: AbortSignal): Promise<void> {
+async function openInBrowser(state: McpExtensionState, url: string, signal: AbortSignal): Promise<string | null> {
   throwIfAborted(signal);
   try {
     await state.openBrowser(url);
     throwIfAborted(signal);
+    return null;
   } catch (error) {
     if (isAbortError(error, signal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
-    if (state.owner?.isActive() === false) return;
+    if (state.owner?.isActive() === false) return null;
     state.ui?.notify(`MCP UI browser open failed: ${message}`, "warning");
-    state.ui?.notify(`Open manually: ${url}`, "info");
+    return message;
   }
+}
+
+function isRemoteSession(): boolean {
+  return Boolean(process.env.SSH_CONNECTION || process.env.SSH_TTY);
+}
+
+function hasActiveRemoteLogin(): boolean {
+  try {
+    const out = execFileSync("who", { encoding: "utf8", timeout: 2000 });
+    return /\(.+\)\s*$/m.test(out);
+  } catch {
+    return false;
+  }
+}
+
+function probeMoshiGateway(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: "127.0.0.1", port: 24543 });
+    const done = (ok: boolean) => {
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(300);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+  });
+}
+
+function remoteAccessHint(opts: { url: string; port: number; moshi: boolean; openError: string | null }): string {
+  const lines = [
+    opts.openError === null
+      ? "This looks like a remote session - if no MCP UI appeared, open it from your own device:"
+      : "Couldn't open MCP UI here. Open it from your own device:",
+    `  ${opts.url}`,
+  ];
+  if (opts.openError !== null) {
+    lines.push(`Browser launch failed: ${opts.openError}`);
+  }
+  if (opts.moshi) {
+    lines.push("Moshi: tap the preview button in the terminal title bar and pick this MCP UI server.");
+  }
+  lines.push(
+    `SSH: run \`ssh -L ${opts.port}:127.0.0.1:${opts.port} <this-host>\` on your local machine, then open the URL above.`,
+    "mosh can't forward ports - run that ssh command in a separate terminal.",
+  );
+  return lines.join("\n");
 }
 
 export async function maybeStartUiSession(
@@ -388,6 +438,16 @@ export async function maybeStartUiSession(
 
     let viewer: UiSessionViewer = "browser";
     let windowOpen = true;
+    const remoteByEnv = isRemoteSession();
+    const remoteLikely = remoteByEnv || hasActiveRemoteLogin();
+    const emitRemoteHint = async (openError: string | null) => {
+      state.ui?.notify(remoteAccessHint({
+        url: handle.url,
+        port: handle.port,
+        moshi: await probeMoshiGateway(),
+        openError,
+      }), openError === null ? "info" : "warning");
+    };
 
     if (uiSuppressed) {
       viewer = "suppressed";
@@ -395,9 +455,9 @@ export async function maybeStartUiSession(
       state.ui?.notify(`MCP UI window suppressed (MCP_UI_VIEWER=${viewerPref}). Open manually: ${handle.url}`, "info");
       log.info("Suppressing MCP UI window (MCP_UI_VIEWER=" + viewerPref + ")", { url: handle.url });
     } else {
-      const glimpseDetected = isGlimpseAvailable();
-      const useGlimpse = viewerPref === "glimpse" ||
-        (viewerPref !== "browser" && glimpseDetected);
+      const glimpseDetected = !remoteByEnv && isGlimpseAvailable();
+      const useGlimpse = !remoteByEnv && (viewerPref === "glimpse" ||
+        (viewerPref !== "browser" && glimpseDetected));
 
       if (useGlimpse) {
         try {
@@ -417,15 +477,24 @@ export async function maybeStartUiSession(
           }
           activeGlimpseWindow = glimpseWindow;
           viewer = "glimpse";
+          if (remoteLikely) {
+            await emitRemoteHint(null);
+          }
         } catch (error) {
           log.debug("Glimpse unavailable, using browser", {
             error: error instanceof Error ? error.message : String(error),
           });
-          await openInBrowser(state, handle.url, runtimeSignal!);
+          const openError = await openInBrowser(state, handle.url, runtimeSignal!);
+          if (openError !== null || remoteLikely) {
+            await emitRemoteHint(openError);
+          }
           viewer = "browser";
         }
       } else {
-        await openInBrowser(state, handle.url, runtimeSignal!);
+        const openError = await openInBrowser(state, handle.url, runtimeSignal!);
+        if (openError !== null || remoteLikely) {
+          await emitRemoteHint(openError);
+        }
       }
     }
 

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -310,7 +310,7 @@ export async function maybeStartUiSession(
 
     let active = true;
     let nextStreamSequence = 0;
-    let handle: UiServerHandle | null = null;
+    let handle: UiServerHandle;
 
     const cleanupStreamListener = () => {
       if (streamToken) {
@@ -400,7 +400,7 @@ export async function maybeStartUiSession(
             messages.prompts.length > 0 ||
             messages.intents.length > 0 ||
             messages.notifications.length > 0 ||
-            (messages.contexts?.length ?? 0) > 0 ||
+            messages.contexts.length > 0 ||
             !!stream;
 
           if (hasContent) {
@@ -422,7 +422,7 @@ export async function maybeStartUiSession(
               prompts: messages.prompts.length,
               intents: messages.intents.length,
               notifications: messages.notifications.length,
-              contexts: messages.contexts?.length ?? 0,
+              contexts: messages.contexts.length,
               streamFrames: stream?.frames ?? 0,
             });
           }
@@ -438,7 +438,6 @@ export async function maybeStartUiSession(
 
     if (state.owner?.isActive() === false || runtimeSignal.aborted) {
       handle.close("runtime_owner_stopped");
-      handle = null;
       throwIfAborted(runtimeSignal);
       throw new Error("MCP UI session became stale before registration");
     }
@@ -460,16 +459,6 @@ export async function maybeStartUiSession(
     let viewer: UiSessionViewer = "browser";
     let windowOpen = true;
     const remoteByEnv = isRemoteSession();
-    const remoteLikely = remoteByEnv || await hasActiveRemoteLogin();
-    const emitRemoteHint = async (openError: string | null, openedOnHost = false) => {
-      state.ui?.notify(remoteAccessHint({
-        url: handle.url,
-        port: handle.port,
-        moshi: await probeMoshiGateway(),
-        openError,
-        openedOnHost,
-      }), openError === null ? "info" : "warning");
-    };
 
     if (uiSuppressed) {
       viewer = "suppressed";
@@ -477,6 +466,16 @@ export async function maybeStartUiSession(
       state.ui?.notify(`MCP UI window suppressed (MCP_UI_VIEWER=${viewerPref}). Open manually: ${handle.url}`, "info");
       log.info("Suppressing MCP UI window (MCP_UI_VIEWER=" + viewerPref + ")", { url: handle.url });
     } else {
+      const remoteLikely = remoteByEnv || await hasActiveRemoteLogin();
+      const emitRemoteHint = async (openError: string | null, openedOnHost = false) => {
+        state.ui?.notify(remoteAccessHint({
+          url: handle.url,
+          port: handle.port,
+          moshi: await probeMoshiGateway(),
+          openError,
+          openedOnHost,
+        }), openError === null ? "info" : "warning");
+      };
       const glimpseDetected = !remoteByEnv && isGlimpseAvailable();
       const useGlimpse = !remoteByEnv && (viewerPref === "glimpse" ||
         (viewerPref !== "browser" && glimpseDetected));
@@ -506,14 +505,14 @@ export async function maybeStartUiSession(
           log.debug("Glimpse unavailable, using browser", {
             error: error instanceof Error ? error.message : String(error),
           });
-          const openError = await openInBrowser(state, handle.url, runtimeSignal!);
+          const openError = await openInBrowser(state, handle.url, runtimeSignal);
           if (openError !== null || remoteLikely) {
             await emitRemoteHint(openError);
           }
           viewer = "browser";
         }
       } else {
-        const openError = await openInBrowser(state, handle.url, runtimeSignal!);
+        const openError = await openInBrowser(state, handle.url, runtimeSignal);
         if (openError !== null || remoteLikely) {
           await emitRemoteHint(openError);
         }

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { McpExtensionState } from "./state.ts";
 import {
+  createUiModelContextUpdate,
   extractUiPromptText,
   UI_STREAM_HOST_CONTEXT_KEY,
   UI_STREAM_REQUEST_META_KEY,
@@ -364,10 +365,23 @@ export async function maybeStartUiSession(
       },
 
       onContextUpdate: (params: UiModelContextParams) => {
+        const update = createUiModelContextUpdate(params);
         log.debug("Model context update from UI", {
           hasContent: !!params.content,
           hasStructured: !!params.structuredContent,
+          hasUpdate: !!update,
         });
+        if (update && state.sendMessage) {
+          state.sendMessage(
+            {
+              customType: "mcp-ui-context",
+              content: [{ type: "text", text: `User submitted model context from ${request.serverName} UI:\n${update.summary}` }],
+              display: "UI Context submitted",
+              details: { server: request.serverName, tool: request.toolName, context: update },
+            },
+            { triggerTurn: true },
+          );
+        }
       },
 
       onComplete: (reason: string) => {
@@ -381,6 +395,7 @@ export async function maybeStartUiSession(
             messages.prompts.length > 0 ||
             messages.intents.length > 0 ||
             messages.notifications.length > 0 ||
+            (messages.contexts?.length ?? 0) > 0 ||
             !!stream;
 
           if (hasContent) {
@@ -402,6 +417,7 @@ export async function maybeStartUiSession(
               prompts: messages.prompts.length,
               intents: messages.intents.length,
               notifications: messages.notifications.length,
+              contexts: messages.contexts?.length ?? 0,
               streamFrames: stream?.frames ?? 0,
             });
           }

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import net from "node:net";
 import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -143,13 +143,16 @@ function isRemoteSession(): boolean {
   return Boolean(process.env.SSH_CONNECTION || process.env.SSH_TTY);
 }
 
-function hasActiveRemoteLogin(): boolean {
-  try {
-    const out = execFileSync("who", { encoding: "utf8", timeout: 2000 });
-    return /\(.+\)\s*$/m.test(out);
-  } catch {
-    return false;
-  }
+function hasActiveRemoteLogin(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile("who", { encoding: "utf8", timeout: 2000 }, (error, out) => {
+      if (error) {
+        resolve(false);
+        return;
+      }
+      resolve(/\(.+\)\s*$/m.test(out));
+    });
+  });
 }
 
 function probeMoshiGateway(): Promise<boolean> {
@@ -166,11 +169,13 @@ function probeMoshiGateway(): Promise<boolean> {
   });
 }
 
-function remoteAccessHint(opts: { url: string; port: number; moshi: boolean; openError: string | null }): string {
+function remoteAccessHint(opts: { url: string; port: number; moshi: boolean; openError: string | null; openedOnHost?: boolean }): string {
   const lines = [
-    opts.openError === null
-      ? "This looks like a remote session - if no MCP UI appeared, open it from your own device:"
-      : "Couldn't open MCP UI here. Open it from your own device:",
+    opts.openError !== null
+      ? "Couldn't open MCP UI here. Open it from your own device:"
+      : opts.openedOnHost
+        ? "MCP UI opened on this host. If you're controlling this session remotely, open it from your own device:"
+        : "This looks like a remote session - if no MCP UI appeared, open it from your own device:",
     `  ${opts.url}`,
   ];
   if (opts.openError !== null) {
@@ -455,13 +460,14 @@ export async function maybeStartUiSession(
     let viewer: UiSessionViewer = "browser";
     let windowOpen = true;
     const remoteByEnv = isRemoteSession();
-    const remoteLikely = remoteByEnv || hasActiveRemoteLogin();
-    const emitRemoteHint = async (openError: string | null) => {
+    const remoteLikely = remoteByEnv || await hasActiveRemoteLogin();
+    const emitRemoteHint = async (openError: string | null, openedOnHost = false) => {
       state.ui?.notify(remoteAccessHint({
         url: handle.url,
         port: handle.port,
         moshi: await probeMoshiGateway(),
         openError,
+        openedOnHost,
       }), openError === null ? "info" : "warning");
     };
 
@@ -494,7 +500,7 @@ export async function maybeStartUiSession(
           activeGlimpseWindow = glimpseWindow;
           viewer = "glimpse";
           if (remoteLikely) {
-            await emitRemoteHint(null);
+            await emitRemoteHint(null, true);
           }
         } catch (error) {
           log.debug("Glimpse unavailable, using browser", {


### PR DESCRIPTION
This follows up PR #262 by aligning MCP UI sessions with the Moshi/browser handling patterns used in pi-interview-tool.

What changed:
- prefer Moshi-discoverable local ports 8377-8396 before falling back to ephemeral ports
- answer `HEAD /` discovery probes with 200 without touching session heartbeat
- serve a loopback-only tokenless `GET /` landing shell that redirects to the tokenized MCP UI URL
- reject non-loopback Host headers before the landing shell to avoid DNS rebinding exposure
- skip Glimpse for clear SSH/mosh sessions and print Moshi/SSH remote access hints when useful
- improve the host shell on narrow in-app browsers with `100dvh`, safe-area padding, wrapping controls, larger tap targets, and a completion overlay when `window.close()` is ignored

Validation:
- `npx tsc --noEmit`
- `npx vitest run __tests__/package-manifest.test.ts __tests__/host-html-template.test.ts __tests__/ui-server.test.ts __tests__/ui-viewer-none.test.ts __tests__/ui-integration.test.ts __tests__/ui-streaming.test.ts __tests__/ui-server-session-recovery.test.ts`

Reviewer note: a fresh reviewer subagent timed out before producing findings, so I completed a parent-owned review and kept the PR scoped to the Moshi/mobile follow-up.