### PR TITLE
feat: add stable MCP SDK v2 with dual-era negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added the stable MCP SDK v2 client. It negotiates MCP `2026-07-28` with modern servers and retains the 2025 handshake for legacy servers. Per-server `protocolMode` can select `legacy` or require `2026-07-28`.
+- Added modern multi-round input handling with a five-round limit. SDK-managed `subscriptions/listen` calls track tool, prompt, and resource list changes.
+- Added protocol-aware metadata caching. Disk persistence requires an explicit public scope and a positive TTL from every relevant modern response. Private entries remain in memory.
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
 - Ranked, paginated MCP tool search: best matches come first in a short page of 12 instead of an unranked dump of every match with full schemas, so the model stops guessing and each search costs a fraction of the tokens. Misses on describe/call now return top-5 "Did you mean" suggestions, letting the model self-correct a typo or missing prefix in the same turn instead of burning a round trip.
 - Optional `approveTools` patterns (global and per-server) add the missing middle tier between "tool runs instantly" and "tool hidden entirely": flag risky tools and Pi asks before running them — Allow once / Allow for session / Deny — across proxy, direct, resource, and iframe-originated calls. Safe tools keep full speed; a deny is a normal result the model adapts to, not a crash.
-- Opt-in `mcp_script` trusted JavaScript MCP scripting turns N-step jobs into one call: loop, filter, and chain tools for tool-restricted subagents where every round trip costs child context. Scripts discover tools with `await tools.search({ query })`, inspect exact shapes with `await tools.describe({ path })`, and call them with `tools.call(path, args)` — no more guessing names from outside the script. A runaway script can never freeze Pi itself: scripts run isolated from the main process and are force-stopped at their time limit, even if stuck in an infinite loop. Result details include a `calls` trace of every invoked path and outcome, and a bundled `mcp-scripting` skill teaches the full workflow on demand. Every scripted call still goes through auth, output guarding, and the approval gate.
+- Opt-in `mcp_script` trusted JavaScript MCP scripting turns N-step jobs into one call: loop, filter, and chain tools for tool-restricted subagents where every round trip costs child context. Scripts discover tools with `await tools.search({ query })`, inspect exact parameter contracts with `await tools.describe({ path })`, and call them with `tools.call(path, args)` — no more guessing names from outside the script. A runaway script can never freeze Pi itself: scripts run isolated from the main process and are force-stopped at their time limit, even if stuck in an infinite loop. Result details include a `calls` trace of every invoked path and outcome, and a bundled `mcp-scripting` skill teaches the full workflow on demand. Every scripted call still goes through auth, output guarding, and the approval gate.
 - HTTP connection failures are now probe-classified into a plain-language diagnosis (for example "endpoint returned HTML (200) — this URL does not appear to speak MCP") instead of an opaque "fetch failed", so setup mistakes are fixed in seconds. Healthy connections are never probed.
-- Tool parameters render as compact TypeScript shapes (`{ query: string; limit?: number }`) in describe and search, replacing multi-line schema dumps — the model reads less and acts sooner, with the previous formatting kept as a fallback for exotic schemas.
+- Tool parameters render as compact TypeScript signatures (`{ query: string; limit?: number }`) in describe and search, replacing multi-line schema dumps — the model reads less and acts sooner, with the previous formatting kept as a fallback for exotic schemas.
 - `/mcp setup` gained curated one-click presets (DeepWiki, Context7, Notion, GitHub, Chrome DevTools): pick, preview the exact config write, confirm — new servers in under a minute with no hand-typed setup.
 
-The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint shape probe, TypeScript-shaped schemas, and codemode design in this release are adapted from [Executor](https://github.com/UsefulSoftwareCo/executor) by Rhys Sullivan (@RhysSullivan). Thanks Rhys.
+The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint response probe, compact TypeScript schemas, and codemode design in this release are adapted from [Executor](https://github.com/UsefulSoftwareCo/executor) by Rhys Sullivan (@RhysSullivan). Thanks Rhys.
+
+### Changed
+- Raised the minimum Node.js version to 22.19 to match the current Pi host runtime.
 
 ### Fixed
+- Limited deprecated SSE fallback to HTTP responses that identify an unsupported transport. Authentication failures, rate limits, server errors, timeouts, and network failures now propagate without a downgrade.
+- Kept the concrete stdio transport instance when protocol tracing is enabled. Automatic negotiation can restart legacy servers that exit on `server/discover`.
+- Kept OAuth issuer binding and RFC 9207 callback validation. Native loopback dynamic client registration remains supported. Legacy MCP `2025-03-26` issuer-metadata fallback now requires `protocolMode: "legacy"`.
 - Brought MCP Apps UI hosting in line with the current spec: provider HTML now runs in a real sandbox, gets a restrictive default CSP even when the resource omits one, and `_meta.ui.visibility` is honored so app-only tools stay out of the model tool list while model-only tools cannot be called from the UI.
 - MCP Apps UI sessions are now easier to open from Moshi and remote terminals: the local UI server uses Moshi-discoverable low ports, answers preview discovery probes, serves a loopback-only landing shell, prints Moshi/SSH access hints for remote sessions, and fits the host shell better in narrow in-app browsers. UI-submitted model context is now captured as a bounded handoff, wakes the agent like prompts and intents, and remains available through `mcp({ action: "ui-messages" })` after the UI closes.
 
@@ -75,7 +84,7 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 - Added a versioned, sanitized MCP runtime status snapshot on Pi's shared event bus for extensions, without connecting lazy servers or exposing SDK internals. Thanks Ludev (@ludevdot) for issue #110.
 - Added opt-in host-specific MCP config discovery with source/provenance and conflict reporting. Standard shared and Pi-owned config precedence remains unchanged, and external host files are never written or silently executed. Thanks @lsmir2 for issue #169.
 - Added opt-in metadata-only JSONL MCP protocol tracing with bounded per-session files and redaction. Thanks @66-firebat for issue #45.
-- Added per-server `includeTools` allowlists with exact-name and glob matching for proxy, direct-tool, and `/mcp` panel surfaces. Thanks Finn (@finnvyrn) for issue #136.
+- Added per-server `includeTools` allowlists with exact-name and glob matching for proxy tools, direct tools, and the `/mcp` panel. Thanks Finn (@finnvyrn) for issue #136.
 - Made `mcp({ connect: "server" })` refresh an already connected server instead of reusing stale tool metadata. Thanks Sebastiano Poggi (@rock3r) for issue #28 and @theflysurfer for the refresh analysis.
 - Added a plug icon prefix to MCP footer status text. Thanks Felipe Cadal (@cadal-cw) for issue #145.
 - Discovered user-global MCP configs from `~/.agents/mcp.json` and `~/.agents/mcp/mcp.json`. Thanks David Jadczyk (@davidjadczyk) for issue #117.
@@ -107,14 +116,14 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 - Migrated the MCP client and interactive visualizer to the exact-pinned MCP SDK v2 beta.5 packages, with automatic protocol negotiation and client conformance coverage. Thanks Matt Carey (@mattzcarey) for PR #210.
 - Added disabled MCP server definitions plus `/mcp disable` and `/mcp enable` project-local overrides that preserve visibility while preventing execution. Thanks Ömer Ulusoy (@ulusoyomer) for PR #61.
 - Added argument completions for `/mcp` subcommands and reconnect/logout server names. Thanks @sting8k for PR #8.
-- Surfaced MCP connection failure reasons from bounded stdio diagnostics in status output and the `/mcp` panel, with a shortcut to copy the selected failure. Thanks @parkuman for PR #197.
+- Reported MCP connection failure reasons from bounded stdio diagnostics in status output and the `/mcp` panel, with a shortcut to copy the selected failure. Thanks @parkuman for PR #197.
 - Added Codex MCP imports from `.codex/config.toml`, with fallback to the existing JSON config. Thanks @npo-mmenke for PR #31.
 - Added explicit OpenCode V1 MCP imports from global and project `opencode.json` files, including nested config merging and environment interpolation. Thanks @NicoAvanzDev for PR #25.
 - Added environment-variable interpolation for HTTP MCP server URLs, with missing URL variables failing closed before requests are sent. Thanks @ozeias for PR #206.
 - Added `settings.oauthDir` to store MCP OAuth credentials in a project-specific directory, with `MCP_OAUTH_DIR` still taking precedence. Thanks @Termina1 for PR #105.
 - Added `lazy-keep-alive` lifecycle mode for MCP servers that should start on first use and then stay resident with health-check reconnects. Thanks @ricardoraposo for PR #143.
 - Added `MCP_UI_VIEWER=none` / `off` / `disabled` to suppress MCP UI browser or Glimpse windows while keeping inline tool results available. Thanks @stevekrouse for PR #172.
-- Surfaced MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
+- Presented MCP server `instructions` from the initialize handshake: captured at connect time, cached alongside tool metadata, shown as a truncated head in the `mcp` proxy tool description, previewed in `mcp({ server: "name" })` listings, and available in full via the new `mcp({ instructions: "name" })` mode. Thanks @JeongJuhyeon for issue #188 and PR #189.
 - Added `createMcpAdapter({ config, configPath })` for isolated SDK configuration and file-path overrides. Thanks @Cansiny0320 for PR #86.
 
 ### Changed
@@ -303,7 +312,7 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 - OAuth callback server now calls `unref()` after successful bind so it no longer keeps sub-agent processes alive by itself.
 - Strict OAuth port mode now rebinds to the configured callback port when safe, while refusing to switch ports when authorizations are still pending.
 - Added focused lifecycle/callback-server regression coverage for teardown, `unref()`, strict rebinding, and pending-auth guardrails.
-- Thanks @blai for the investigation and PR #43 that surfaced the sub-agent hang/root lifecycle issues.
+- Thanks @blai for the investigation and PR #43 that revealed the sub-agent hang/root lifecycle issues.
 
 ## [2.3.4] - 2026-04-12
 
@@ -348,7 +357,7 @@ The ranked search scoring, did-you-mean suggestions, approval patterns, endpoint
 ### Fixed
 - Session lifecycle teardown now handles repeated `session_start` transitions safely and prevents stale async init results from replacing newer state.
 - Shutdown now still runs `gracefulShutdown()` even if metadata cache flushing throws, avoiding leaked MCP processes.
-- Proxy/direct tool init error paths now preserve and surface underlying error messages instead of returning generic failures.
+- Proxy/direct tool init error paths now preserve and return underlying error messages instead of returning generic failures.
 - Invalid `mcp` tool `args` now fail by throwing with parse/type context instead of returning non-failing tool payloads.
 - Added focused lifecycle regressions tests for stale init cleanup and init-error visibility.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Mario wrote about [why you might not need MCP](https://mariozechner.at/posts/202
 
 His take: skip MCP entirely, write simple CLI tools instead.
 
-But the MCP ecosystem has useful stuff - databases, browsers, APIs. This adapter gives you access without the bloat. One proxy tool (~200 tokens) instead of hundreds. The agent discovers what it needs on-demand. Servers only start when you actually use them.
+MCP servers provide database, browser, and API integrations. This adapter exposes them through one proxy tool (~200 tokens) instead of adding every server tool to the prompt. The agent discovers tools on demand, and lazy servers start on first use.
+
+The default `protocolMode`, `auto`, requests MCP `2026-07-28`. A response with definitive legacy evidence selects the 2025 protocol family. Set `protocolMode` per server to force legacy behavior or require the modern revision.
 
 ## Install
 
@@ -22,7 +24,7 @@ But the MCP ecosystem has useful stuff - databases, browsers, APIs. This adapter
 pi install npm:pi-mcp-adapter
 ```
 
-Restart Pi after installation.
+Restart Pi after installation. This release requires Node.js 22.19 or newer, matching the current Pi host runtime.
 
 ## What happens on first run
 
@@ -69,9 +71,9 @@ Precedence is:
 5. `.mcp.json`
 6. `.pi/mcp.json`
 
-`/mcp disable <server>` and `/mcp enable <server>` persist only the `disabled` field in the project-local `.pi/mcp.json`, which is the highest-precedence Pi layer. Enabling removes the project flag when lower layers are enabled, or writes `false` when needed to override a disabled lower source. This applies even when the effective server came from a shared global/project file, an imported host config, or `configPath`; the source file is never rewritten and credentials are never copied. Run `/reload` after changing the flag so registered tool surfaces are refreshed. The manual equivalent is to add `{ "disabled": true }` to a server in any normal MCP config. Supplied in-memory `createMcpAdapter({ config })` configurations are isolated and do not read or write this project override; the commands are unavailable in that mode.
+`/mcp disable <server>` and `/mcp enable <server>` persist only the `disabled` field in the project-local `.pi/mcp.json`, which is the highest-precedence Pi layer. Enabling removes the project flag when lower layers are enabled, or writes `false` when needed to override a disabled lower source. This applies even when the effective server came from a shared global/project file, an imported host config, or `configPath`; the source file is never rewritten and credentials are never copied. Run `/reload` after changing the flag so registered tools are refreshed. The manual equivalent is to add `{ "disabled": true }` to a server in any normal MCP config. Supplied in-memory `createMcpAdapter({ config })` configurations are isolated and do not read or write this project override; the commands are unavailable in that mode.
 
-Servers are **lazy by default** — they won't connect until you actually call one of their tools. The adapter caches tool metadata so search and describe work without live connections.
+Servers are **lazy by default** — they won't connect until you actually call one of their tools. The adapter caches tool metadata so search and describe work without live connections. A modern server must mark metadata `public` and provide a positive TTL before the adapter writes it to disk. Private modern metadata remains in memory.
 
 ```
 mcp({ search: "screenshot" })
@@ -174,10 +176,11 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 |-------|-------------|
 | `command` | Executable for stdio transport; mutually exclusive with `url` and `socket` |
 | `args` | Command arguments |
-| `socket` | Explicit `rmcp-mux` Unix-domain socket path; supports `${VAR}`, `$env:VAR`, and `~` expansion and is mutually exclusive with `command` and `url` |
+| `socket` | Explicit legacy-only `rmcp-mux` Unix-domain socket path; supports `${VAR}`, `$env:VAR`, and `~` expansion and is mutually exclusive with `command` and `url` |
 | `env` | Environment variables; supports `${VAR}` and `$env:VAR` interpolation. A value beginning with `!` runs a command when the stdio server connects; use `!!` for a literal leading `!`. |
 | `cwd` | Working directory; supports `${VAR}`, `$env:VAR`, and `~` expansion |
-| `url` | HTTP endpoint (StreamableHTTP with SSE fallback); supports raw `${VAR}` and `$env:VAR` interpolation, and missing URL variables fail before any request is sent |
+| `url` | HTTP endpoint (Streamable HTTP, with deprecated SSE fallback only when the HTTP response identifies an unsupported transport); supports raw `${VAR}` and `$env:VAR` interpolation, and missing URL variables fail before any request is sent |
+| `protocolMode` | `"auto"` (default), `"legacy"`, or `"2026-07-28"`; `auto` negotiates modern first and conservatively falls back, while Unix sockets require `legacy` |
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation. A value beginning with `!` runs a command when the HTTP server connects or OAuth authenticates; use `!!` for a literal leading `!`. |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
@@ -200,7 +203,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `trace` | Enable metadata-only JSONL protocol tracing for this server; payloads, prompts, tool arguments/results, authorization data, and URLs are never persisted |
 | `disabled` | Keep the server visible in config and status, but prevent connections, authentication, tools, and resource calls (only literal `true` disables it) |
 
-For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
+For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port. An MCP `2025-03-26` server that omits protected-resource metadata and publishes path-based issuer metadata must use `protocolMode: "legacy"`; automatic and modern modes retain strict issuer validation.
 
 Secret values in `headers`, `bearerToken`, `oauth.clientSecret`, and stdio `env` may use a leading `!command` to obtain their value at connection or authentication time. The command runs with stdin and stderr suppressed, stdout is limited to 1 MiB and trimmed, and it must finish within 10 seconds with non-empty output; failures stop the connection or authentication flow. Commands are not run during OAuth discovery or while reading, merging, previewing, hashing, or rendering configuration. Use `!!` to escape a literal leading `!`; ordinary and escaped values retain environment interpolation.
 
@@ -456,7 +459,7 @@ Each direct tool costs ~150-300 tokens in the system prompt (name + description 
 
 Direct tools register from the metadata cache in the Pi agent dir (`~/.pi/agent/mcp-cache.json` by default, or `$PI_CODING_AGENT_DIR/mcp-cache.json` when set), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only while the cache populates, then the extension hot-loads the refreshed direct tools into the current session. Servers that advertise MCP list-change notifications refresh the current session when their tool or resource list changes. On Pi versions that expose `pi.unregisterTool()`, stale direct tools are removed from the registry during refresh; older Pi versions still deactivate them from the active tool set. To force a refresh: `/mcp reconnect <server>`.
 
-If prompt-cache stability matters more than automatic direct-tool hot-loading, set `settings.freezeDirectTools` to `true`. The initial direct-tool sync still runs, but later automatic reconnects, lazy-connects, and list-change notifications keep the registered tool surface unchanged. Deliberate refreshes through `mcp({ connect: "server" })` or `/mcp reconnect <server>` still update direct tools.
+If prompt-cache stability matters more than automatic direct-tool hot-loading, set `settings.freezeDirectTools` to `true`. The initial direct-tool sync still runs, but later automatic reconnects, lazy-connects, and list-change notifications keep the registered tool set unchanged. Deliberate refreshes through `mcp({ connect: "server" })` or `/mcp reconnect <server>` still update direct tools.
 
 When you change direct-tool toggles in `/mcp`, the extension updates direct tool registration in the current session. Broader setup writes from `/mcp setup` still use Pi's normal reload flow because they can add or restructure MCP config files.
 
@@ -568,17 +571,17 @@ Search includes both MCP tools and Pi tools (from extensions). Pi tools appear f
 
 Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`. When `describe` or `tool` cannot resolve a name, the result includes top suggestions so the agent can correct a typo or missing prefix in the same turn.
 
-When `includeSchemas` is enabled, search and describe render common JSON Schema parameters as compact TypeScript shapes like `{ query: string; limit?: number; }`, with the older schema formatter retained as a fallback for unsupported schemas.
+When `includeSchemas` is enabled, search and describe render common JSON Schema parameters as compact TypeScript signatures like `{ query: string; limit?: number; }`, with the older schema formatter retained as a fallback for unsupported schemas.
 
-For HTTP servers, failed connects run a one-request shape probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
+For HTTP servers, failed connects run a one-request response probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
 
-Servers that provide usage guidance via the MCP `instructions` field surface it at three levels: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
+Servers that provide usage guidance via the MCP `instructions` field present it in three locations: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 
 ## Commands
 
 | Command | What it does |
 |---------|--------------|
-| `/mcp` | Interactive panel and first-run onboarding surface |
+| `/mcp` | Interactive panel and first-run onboarding interface |
 | `/mcp setup` | Guided setup for imports, a minimal `.mcp.json`, curated known servers, RepoPrompt quick-add, and config-path inspection |
 | `/mcp tools` | List all tools |
 | `/mcp prompts` | List all MCP prompts registered as slash commands |

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -71,7 +71,6 @@ describe("AbortSignal propagation", () => {
     expect(result.details.error).toBe("aborted");
     expect(callTool).toHaveBeenCalledWith(
       { name: "slow", arguments: {}, _meta: undefined },
-      undefined,
       { signal: controller.signal },
     );
     expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
@@ -91,7 +90,6 @@ describe("AbortSignal propagation", () => {
     expect(result.details.error).toBe("aborted");
     expect(callTool).toHaveBeenCalledWith(
       { name: "slow", arguments: {}, _meta: undefined },
-      undefined,
       { signal: controller.signal },
     );
     expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -110,7 +110,6 @@ describe("direct tools auto auth", () => {
         arguments: { q: "hello" },
         _meta: undefined,
       },
-      undefined,
       { timeout: 4321 },
     );
     expect(result.content[0].text).toContain("ok");
@@ -157,7 +156,6 @@ describe("direct tools auto auth", () => {
     expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
     expect(connection.client.callTool).toHaveBeenCalledWith(
       { name: "search", arguments: {}, _meta: undefined },
-      undefined,
       requestOptions,
     );
     expect(result.details).toMatchObject({ error: "aborted", server: "demo" });
@@ -246,7 +244,7 @@ describe("direct tools auto auth", () => {
   });
 
   it("runs URL elicitations returned by a URL-required tool error", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
     const error = new UrlElicitationRequiredError([{
       mode: "url",

--- a/__tests__/fixtures/modern-only-server.mjs
+++ b/__tests__/fixtures/modern-only-server.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+// Strict MCP 2026-07-28 stdio fixture. It rejects legacy initialization and
+// validates that every post-discovery request carries the negotiated revision.
+import readline from "node:readline";
+
+const MODERN_REVISION = "2026-07-28";
+const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
+const SUBSCRIPTION_ID_META_KEY = "io.modelcontextprotocol/subscriptionId";
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function result(id, value) {
+  send({ jsonrpc: "2.0", id, result: { resultType: "complete", ...value } });
+}
+
+function error(id, code, message) {
+  send({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", line => {
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (message.method === "server/discover") {
+    result(message.id, {
+      supportedVersions: [MODERN_REVISION],
+      capabilities: { tools: { listChanged: true } },
+      ttlMs: 0,
+      cacheScope: "private",
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "modern-only-test-server",
+          version: "1.0.0",
+        },
+      },
+    });
+    return;
+  }
+
+  if (message.method === "initialize") {
+    error(message.id, -32601, "Legacy initialize is not supported");
+    return;
+  }
+
+  if (message.method === "subscriptions/listen") {
+    if (message.params?.notifications?.toolsListChanged !== true) {
+      error(message.id, -32602, "tools list-change subscription missing");
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      method: "notifications/subscriptions/acknowledged",
+      params: {
+        notifications: message.params.notifications,
+        _meta: { [SUBSCRIPTION_ID_META_KEY]: message.id },
+      },
+    });
+    return;
+  }
+
+  if (message.method === "tools/list") {
+    if (message.params?._meta?.[PROTOCOL_VERSION_META_KEY] !== MODERN_REVISION) {
+      error(message.id, -32602, "Missing negotiated protocol metadata");
+      return;
+    }
+
+    result(message.id, {
+      tools: [{
+        name: "modern_tool",
+        description: "Tool exposed only through the modern protocol",
+        inputSchema: { type: "object", properties: {} },
+      }],
+      ttlMs: 60_000,
+      cacheScope: "public",
+    });
+    return;
+  }
+
+  if (message.method === "tools/call") {
+    const inputResponse = message.params?.inputResponses?.profile;
+    if (inputResponse === undefined) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          resultType: "input_required",
+          inputRequests: {
+            profile: {
+              method: "elicitation/create",
+              params: {
+                mode: "form",
+                message: "Provide a profile name",
+                requestedSchema: {
+                  type: "object",
+                  properties: { name: { type: "string", title: "Name" } },
+                  required: ["name"],
+                },
+              },
+            },
+          },
+          requestState: "modern-state-1",
+        },
+      });
+      return;
+    }
+
+    if (message.params?.requestState !== "modern-state-1") {
+      error(message.id, -32602, "requestState was not echoed");
+      return;
+    }
+    const name = inputResponse.action === "accept" ? inputResponse.content?.name : undefined;
+    result(message.id, {
+      content: [{ type: "text", text: `accepted:${name ?? inputResponse.action}` }],
+    });
+    return;
+  }
+
+  if (message.id !== undefined) {
+    error(message.id, -32601, `Unsupported method: ${message.method}`);
+  }
+});

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 
 class MockUnauthorizedError extends Error {}
 
-vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   auth: mocks.sdkAuth,
   extractWWWAuthenticateParams: (response: Response) => {
@@ -141,6 +141,10 @@ describe("mcp-auth-flow explicit auth", () => {
       `code=auth-code&state=${oauthState}&iss=${encodeURIComponent("https://auth.example.com")}`,
     )).resolves.toBe("authenticated");
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(2);
+    expect(mocks.sdkAuth.mock.calls[1]?.[1]).toMatchObject({
+      authorizationCode: "auth-code",
+      iss: "https://auth.example.com",
+    });
     expect(hasPendingAuth("rfc9207-missing")).toBe(false);
   });
 
@@ -867,6 +871,26 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.stopCallbackServer).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps issuer metadata validation for a modern-pinned server", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("modern-auth", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+      protocolMode: "2026-07-28",
+      oauth: {
+        grantType: "client_credentials",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      },
+    });
+
+    expect(mocks.sdkAuth).toHaveBeenCalledWith(expect.anything(), {
+      serverUrl: "https://api.example.com/mcp",
+    });
+  });
+
   it("releases reserved callback state after direct completeAuth", async () => {
     const resourceMetadataUrl = "https://api.example.com/.well-known/oauth-protected-resource";
     mocks.fetch.mockResolvedValueOnce(new Response(null, {
@@ -893,7 +917,10 @@ describe("mcp-auth-flow explicit auth", () => {
 
     const probeInit = mocks.fetch.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(probeInit.headers).get("x-tenant")).toBe("tenant-a");
-    expect(JSON.parse(String(probeInit.body)).params.clientInfo.name).toBe("pi-mcp-adapter");
+    const probeRequest = JSON.parse(String(probeInit.body));
+    expect(probeRequest.method).toBe("server/discover");
+    expect(probeRequest.params._meta["io.modelcontextprotocol/protocolVersion"]).toBe("2026-07-28");
+    expect(probeRequest.params._meta["io.modelcontextprotocol/clientInfo"].name).toBe("pi-mcp-adapter");
     expect(mocks.sdkAuth).toHaveBeenNthCalledWith(1, expect.anything(), {
       serverUrl: "https://api.example.com/mcp",
       resourceMetadataUrl: new URL(resourceMetadataUrl),

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { UnauthorizedError } from "@modelcontextprotocol/client";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
 import { getAuthForUrl, saveAuthEntry } from "../mcp-auth.ts";
 

--- a/__tests__/mcp-trace.test.ts
+++ b/__tests__/mcp-trace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Transport } from "@modelcontextprotocol/client";
 import {
   createMcpTraceEvent,
   isMcpTraceEnabled,
@@ -127,9 +127,10 @@ describe("MCP protocol tracing", () => {
   });
 
   it("does not let a throwing observer break transport callbacks", async () => {
-    const underlying = fakeTransport();
+    const underlying = fakeTransport({ hasPerRequestStream: true });
     const observer = { record: () => { throw new Error("trace failure"); } };
     const wrapped = wrapTransportWithMcpTrace(underlying, "demo", "stdio", observer);
+    expect(wrapped.hasPerRequestStream).toBe(true);
     const incoming = vi.fn();
     wrapped.onmessage = incoming;
     underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/ping", params: {} });

--- a/__tests__/metadata-cache-instructions.test.ts
+++ b/__tests__/metadata-cache-instructions.test.ts
@@ -38,6 +38,29 @@ describe("metadata cache instructions", () => {
     );
   });
 
+  it("removes persisted metadata when a modern result is private", () => {
+    const legacyEntry: ServerCacheEntry = {
+      configHash: "hash",
+      tools: [],
+      resources: [],
+      cachedAt: Date.now(),
+    };
+    saveMetadataCache({ version: 1, servers: { demo: legacyEntry } });
+
+    saveMetadataCache({
+      version: 1,
+      servers: {
+        demo: {
+          ...legacyEntry,
+          protocolEra: "modern",
+          cacheScope: "private",
+        },
+      },
+    });
+
+    expect(loadMetadataCache()?.servers.demo).toBeUndefined();
+  });
+
   it("omits instructions from the cache file when a server provides none", () => {
     const entry: ServerCacheEntry = {
       configHash: "hash",

--- a/__tests__/metadata-cache-modern-persistence.test.ts
+++ b/__tests__/metadata-cache-modern-persistence.test.ts
@@ -1,0 +1,67 @@
+// Verifies that adapter persistence defaults modern metadata to private.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { updateMetadataCache } from "../init.ts";
+import { loadMetadataCache } from "../metadata-cache.ts";
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+let agentDir: string;
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-modern-cache-"));
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+});
+
+afterEach(() => {
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+  rmSync(agentDir, { recursive: true, force: true });
+});
+
+describe("modern metadata persistence", () => {
+  it("persists public modern metadata until the server expiry", () => {
+    const expiresAt = Date.now() + 60_000;
+    const connection = {
+      status: "connected",
+      protocolEra: "modern",
+      metadataCachePolicy: { cacheScope: "public", expiresAt },
+      tools: [],
+      resources: [],
+      prompts: [],
+      promptDiscoveryFailed: false,
+    };
+    const state = {
+      manager: { getConnection: () => connection },
+      config: { mcpServers: { demo: { command: "node" } } },
+    };
+
+    updateMetadataCache(state as never, "demo");
+
+    expect(loadMetadataCache()?.servers.demo).toMatchObject({
+      protocolEra: "modern",
+      cacheScope: "public",
+      expiresAt,
+    });
+  });
+
+  it("does not persist metadata without an explicit public cache hint", () => {
+    const connection = {
+      status: "connected",
+      protocolEra: "modern",
+      tools: [],
+      resources: [],
+      prompts: [],
+      promptDiscoveryFailed: false,
+    };
+    const state = {
+      manager: { getConnection: () => connection },
+      config: { mcpServers: { demo: { command: "node" } } },
+    };
+
+    updateMetadataCache(state as never, "demo");
+
+    expect(loadMetadataCache()?.servers.demo).toBeUndefined();
+  });
+});

--- a/__tests__/metadata-cache-scope.test.ts
+++ b/__tests__/metadata-cache-scope.test.ts
@@ -1,0 +1,44 @@
+// Verifies that persistent metadata honors MCP 2026 cache scope and expiry.
+import { describe, expect, it } from "vitest";
+import { computeServerHash, isServerCacheValid } from "../metadata-cache.ts";
+import type { ServerCacheEntry, ServerEntry } from "../types.ts";
+
+const definition: ServerEntry = { command: "node", args: ["server.js"] };
+
+function entry(overrides: Partial<ServerCacheEntry> = {}): ServerCacheEntry {
+  return {
+    configHash: computeServerHash(definition),
+    tools: [],
+    resources: [],
+    cachedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("modern metadata cache policy", () => {
+  it("invalidates metadata when protocol mode changes", () => {
+    expect(computeServerHash({ ...definition, protocolMode: "legacy" })).not.toBe(
+      computeServerHash({ ...definition, protocolMode: "2026-07-28" }),
+    );
+  });
+
+  it("never reuses private modern metadata", () => {
+    expect(isServerCacheValid(entry({
+      protocolEra: "modern",
+      cacheScope: "private",
+    }), definition)).toBe(false);
+  });
+
+  it("reuses public modern metadata only before its server expiry", () => {
+    expect(isServerCacheValid(entry({
+      protocolEra: "modern",
+      cacheScope: "public",
+      expiresAt: Date.now() + 60_000,
+    }), definition)).toBe(true);
+    expect(isServerCacheValid(entry({
+      protocolEra: "modern",
+      cacheScope: "public",
+      expiresAt: Date.now() - 1,
+    }), definition)).toBe(false);
+  });
+});

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -7,12 +7,21 @@ const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8")) as {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  engines?: Record<string, string>;
   files?: string[];
   peerDependencies?: Record<string, string>;
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   exports?: Record<string, unknown>;
   types?: string;
 };
+
+const visualizerPackageJson = JSON.parse(
+  readFileSync(join(repoRoot, "examples/interactive-visualizer/package.json"), "utf-8"),
+) as { dependencies?: Record<string, string> };
+const visualizerServerSource = readFileSync(
+  join(repoRoot, "examples/interactive-visualizer/src/server.ts"),
+  "utf-8",
+);
 
 const hostPeerPackages = {
   "@earendil-works/pi-ai": "0.74.2",
@@ -50,6 +59,10 @@ describe("package.json files", () => {
 });
 
 describe("package.json dependency policy", () => {
+  it("requires the Node runtime supported by the Pi host", () => {
+    expect(packageJson.engines?.node).toBe(">=22.19.0");
+  });
+
   it("treats Pi host packages as optional wildcard peers with exact dev pins", () => {
     const entries = Object.entries(hostPeerPackages);
 
@@ -61,10 +74,25 @@ describe("package.json dependency policy", () => {
     }
   });
 
-  it("uses the SDK v1 dependency without the SDK v2 beta packages", () => {
+  it("builds the interactive visualizer server with stable SDK v2", () => {
+    expect(visualizerPackageJson.dependencies?.["@modelcontextprotocol/server"]).toBe("2.0.0");
+    expect(visualizerPackageJson.dependencies?.["@modelcontextprotocol/sdk"]).toBeUndefined();
+    expect(visualizerServerSource).toContain("@modelcontextprotocol/server");
+    expect(visualizerServerSource).not.toContain("@modelcontextprotocol/sdk");
+  });
+
+  it("uses stable SDK v2 while retaining v1 only for ext-apps compatibility", () => {
+    expect(packageJson.dependencies?.["@modelcontextprotocol/client"]).toBe("2.0.0");
+    expect(packageJson.dependencies?.["@modelcontextprotocol/core"]).toBe("2.0.0");
+    expect(packageJson.devDependencies?.["@modelcontextprotocol/server"]).toBe("2.0.0");
     expect(packageJson.dependencies?.["@modelcontextprotocol/ext-apps"]).toBeDefined();
     expect(packageJson.dependencies?.["@modelcontextprotocol/sdk"]).toBe("^1.30.0");
-    expect(packageJson.dependencies?.["@modelcontextprotocol/client"]).toBeUndefined();
-    expect(packageJson.devDependencies?.["@modelcontextprotocol/server"]).toBeUndefined();
+  });
+
+  const runtimeModules = readdirSync(repoRoot)
+    .filter(entry => entry.endsWith(".ts") && !entry.endsWith(".test.ts"));
+
+  it.each(runtimeModules)("keeps v1 SDK imports out of runtime module %s", entry => {
+    expect(readFileSync(join(repoRoot, entry), "utf8")).not.toContain("@modelcontextprotocol/sdk");
   });
 });

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -37,7 +37,7 @@ vi.mock("../init.ts", () => ({
   recordFailure: mocks.recordFailure,
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -48,6 +48,8 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
       mocks.connectImpl(transport, requestOptions)
     );
     this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
+    this.getProtocolEra = vi.fn(() => "legacy");
+    this.getNegotiatedProtocolVersion = vi.fn(() => "2025-11-25");
     this.listTools = vi.fn((params: unknown, requestOptions: unknown) =>
       mocks.listToolsImpl(params, requestOptions)
     );
@@ -64,7 +66,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);
@@ -260,7 +262,7 @@ describe("proxy auto auth", () => {
   });
 
   it("runs URL elicitations returned by proxy tool calls", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { executeCall } = await import("../proxy-modes.ts");
     const error = new UrlElicitationRequiredError([{
       mode: "url",
@@ -374,7 +376,6 @@ describe("proxy auto auth", () => {
         arguments: { q: "hello" },
         _meta: undefined,
       },
-      undefined,
       { timeout: 1234 },
     );
     expect(result.content[0].text).toContain("ok");
@@ -452,7 +453,6 @@ describe("proxy auto auth", () => {
     expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
     expect(connection.client.callTool).toHaveBeenCalledWith(
       { name: "search", arguments: {}, _meta: undefined },
-      undefined,
       requestOptions,
     );
     expect(result.details).toMatchObject({ error: "aborted", message: "request aborted" });
@@ -549,6 +549,9 @@ describe("proxy auto auth", () => {
     const client = mocks.clients[0];
     expect(client.connect).toHaveBeenCalledTimes(1);
     expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 5000 });
+    expect(client.options).toMatchObject({
+      versionNegotiation: { probe: { timeoutMs: 5000, maxRetries: 0 } },
+    });
     expect(client.listTools).toHaveBeenCalledTimes(1);
     expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 5000 });
     expect(client.listResources).toHaveBeenCalledTimes(1);
@@ -556,13 +559,11 @@ describe("proxy auto auth", () => {
     expect(client.callTool).toHaveBeenNthCalledWith(
       1,
       { name: "search", arguments: { q: "one" }, _meta: undefined },
-      undefined,
       { timeout: 5000 },
     );
     expect(client.callTool).toHaveBeenNthCalledWith(
       2,
       { name: "search", arguments: { q: "two" }, _meta: undefined },
-      undefined,
       { timeout: 5000 },
     );
     expect(first.content[0].text).toContain("ok");

--- a/__tests__/resources-capability.test.ts
+++ b/__tests__/resources-capability.test.ts
@@ -11,7 +11,11 @@ describe("resources capability negotiation", () => {
 
   it("skips resources/list for servers that omit the capability", async () => {
     const listResources = vi.fn(async () => ({ resources: [{ name: "unreachable", uri: "test://unreachable" }] }));
-    const client = { getServerCapabilities: () => ({ tools: {} }), listResources };
+    const client = {
+      getServerCapabilities: () => ({ tools: {} }),
+      getProtocolEra: () => "legacy",
+      listResources,
+    };
     const manager = new McpServerManager({} as any);
 
     await expect((manager as any).fetchAllResources(client)).resolves.toEqual([]);
@@ -21,7 +25,11 @@ describe("resources capability negotiation", () => {
   it("lists resources for servers that advertise the capability", async () => {
     const resource = { name: "readme", uri: "test://readme" };
     const listResources = vi.fn(async () => ({ resources: [resource] }));
-    const client = { getServerCapabilities: () => ({ tools: {}, resources: {} }), listResources };
+    const client = {
+      getServerCapabilities: () => ({ tools: {}, resources: {} }),
+      getProtocolEra: () => "legacy",
+      listResources,
+    };
     const manager = new McpServerManager({} as any);
 
     await expect((manager as any).fetchAllResources(client)).resolves.toEqual([resource]);

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
   httpTransports: [] as HttpTransportMock[],
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation((info: unknown, options: ClientOptions) => {
     const client = {
@@ -38,6 +38,9 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
       setRequestHandler: vi.fn(),
       setNotificationHandler: vi.fn(),
       connect: vi.fn(async () => undefined),
+      getProtocolEra: vi.fn(() => "legacy"),
+      getNegotiatedProtocolVersion: vi.fn(() => "2025-11-25"),
+      getServerCapabilities: vi.fn(() => ({ tools: {}, resources: {} })),
       listTools: vi.fn(async () => ({ tools: [] })),
       listResources: vi.fn(async () => ({ resources: [] })),
       close: vi.fn(async () => undefined),
@@ -45,6 +48,12 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     mocks.clients.push(client);
     return client;
   }),
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
+    const transport = { url, options, close: vi.fn(async () => undefined) };
+    mocks.httpTransports.push(transport);
+    return transport;
+  }),
+  SSEClientTransport: vi.fn(),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOriginal) => ({
@@ -58,7 +67,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOrigi
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: vi.fn() }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn(),
 }));
 
@@ -220,7 +229,7 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(authProvider?.clientMetadata?.client_uri).toBe("https://example.com/custom-mcp");
   });
 
-  it("applies the configured timeout to the HTTP probe connect", async () => {
+  it("applies the configured timeout to v2 discovery without a probe client", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
 
     const manager = new McpServerManager();
@@ -230,7 +239,11 @@ describe("McpServerManager HTTP bearer auth", () => {
       requestTimeoutMs: 5000,
     });
 
-    expect(mocks.clients[1].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
-    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[1], { timeout: 5000 });
+    expect(mocks.clients).toHaveLength(1);
+    expect(mocks.clients[0].options).toMatchObject({
+      versionNegotiation: { probe: { timeoutMs: 5000, maxRetries: 0 } },
+    });
+    // SDK v2 applies the same timeout to connect through ConnectOptions.
+    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
   });
 });

--- a/__tests__/server-manager-instructions.test.ts
+++ b/__tests__/server-manager-instructions.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   instructions: undefined as string | undefined,
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -13,6 +13,9 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     this.setRequestHandler = vi.fn();
     this.setNotificationHandler = vi.fn();
     this.connect = vi.fn(async () => undefined);
+    this.getProtocolEra = vi.fn(() => "legacy");
+    this.getNegotiatedProtocolVersion = vi.fn(() => "2025-11-25");
+    this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
     this.getInstructions = vi.fn(() => mocks.instructions);
@@ -23,7 +26,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);

--- a/__tests__/server-manager-legacy-handshake.test.ts
+++ b/__tests__/server-manager-legacy-handshake.test.ts
@@ -1,15 +1,62 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { McpServerManager } from "../server-manager.ts";
 
 const managers: McpServerManager[] = [];
+const tempDirs: string[] = [];
+const legacyExitOnDiscoverServer = `
+  const readline = require("node:readline");
+  const lines = readline.createInterface({ input: process.stdin });
+  const send = message => process.stdout.write(JSON.stringify(message) + "\\n");
+  lines.on("line", line => {
+    const message = JSON.parse(line);
+    if (message.method === "server/discover") process.exit(0);
+    if (message.method === "initialize") {
+      send({ jsonrpc: "2.0", id: message.id, result: {
+        protocolVersion: "2025-11-25",
+        capabilities: { tools: {} },
+        serverInfo: { name: "legacy-exit", version: "1.0.0" },
+      } });
+      return;
+    }
+    if (message.method === "notifications/initialized") return;
+    if (message.method === "tools/list") {
+      send({ jsonrpc: "2.0", id: message.id, result: { tools: [] } });
+      return;
+    }
+    if (message.id !== undefined) {
+      send({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "Method not found" } });
+    }
+  });
+`;
 
 afterEach(async () => {
   await Promise.all(managers.map(manager => manager.closeAll()));
   managers.length = 0;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 describe("McpServerManager legacy handshake", () => {
+  it("restarts an exit-on-discover legacy stdio server when tracing is enabled", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-traced-legacy-"));
+    tempDirs.push(dir);
+    const manager = new McpServerManager(dir);
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    manager.setTraceConfig({ enabled: true, file: "trace.jsonl" });
+
+    const connection = await manager.connect("legacy-traced", {
+      command: process.execPath,
+      args: ["-e", legacyExitOnDiscoverServer],
+    });
+
+    expect(connection.protocolEra).toBe("legacy");
+    expect(connection.status).toBe("connected");
+  }, 5_000);
+
   it("reaches classic initialize when the server rejects server/discover", async () => {
     const manager = new McpServerManager();
     managers.push(manager);

--- a/__tests__/server-manager-modern-handshake.test.ts
+++ b/__tests__/server-manager-modern-handshake.test.ts
@@ -1,0 +1,158 @@
+// Verifies MCP 2026-07-28 negotiation through the manager's public connection API.
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { McpServerManager } from "../server-manager.ts";
+
+const managers: McpServerManager[] = [];
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(managers.map(manager => manager.closeAll()));
+  await Promise.all(servers.map(server => new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  })));
+  managers.length = 0;
+  servers.length = 0;
+});
+
+describe("McpServerManager modern handshake", () => {
+  it("rejects an unsupported protocol mode before starting a server", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+
+    await expect(manager.connect("invalid-mode", {
+      command: process.execPath,
+      args: [fileURLToPath(new URL("./fixtures/modern-only-server.mjs", import.meta.url))],
+      protocolMode: "future" as "auto",
+    })).rejects.toThrow(/protocolMode.*auto.*legacy.*2026-07-28/);
+  });
+
+  it("prefers modern mode by default on a dual-era HTTP server", async () => {
+    const methods: string[] = [];
+    const server = http.createServer(async (request, response) => {
+      if (request.method !== "POST") {
+        response.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+        return;
+      }
+
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      const message = JSON.parse(body) as {
+        id?: string | number;
+        method?: string;
+        params?: { _meta?: Record<string, unknown> };
+      };
+      methods.push(message.method ?? "");
+
+      const sendResult = (value: Record<string, unknown>) => {
+        response.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: { resultType: "complete", ...value },
+        }));
+      };
+
+      if (message.method === "server/discover") {
+        sendResult({
+          supportedVersions: ["2026-07-28"],
+          capabilities: { tools: {}, resources: {} },
+          ttlMs: 3 * 24 * 60 * 60 * 1000,
+          cacheScope: "public",
+          _meta: {
+            "io.modelcontextprotocol/serverInfo": { name: "modern-http", version: "1.0.0" },
+          },
+        });
+        return;
+      }
+      if (message.method === "initialize") {
+        response.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: "2025-11-25",
+            capabilities: { tools: {} },
+            serverInfo: { name: "legacy-http", version: "1.0.0" },
+          },
+        }));
+        return;
+      }
+      if (message.method === "tools/list") {
+        sendResult({
+          tools: [{ name: "http_modern_tool", inputSchema: { type: "object", properties: {} } }],
+          ttlMs: 2 * 24 * 60 * 60 * 1000,
+          cacheScope: "public",
+        });
+        return;
+      }
+      if (message.method === "resources/list") {
+        sendResult({
+          resources: [],
+          ttlMs: 25 * 60 * 60 * 1000,
+          cacheScope: "public",
+        });
+        return;
+      }
+      response.writeHead(400, { "content-type": "application/json" }).end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32601, message: `Unsupported method: ${message.method}` },
+      }));
+    });
+    servers.push(server);
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server did not bind");
+
+    const manager = new McpServerManager();
+    managers.push(manager);
+    const connectedAt = Date.now();
+    const connection = await manager.connect("modern-http", {
+      url: `http://127.0.0.1:${address.port}/mcp`,
+      auth: false,
+    });
+
+    expect(connection.tools.map(tool => tool.name)).toEqual(["http_modern_tool"]);
+    expect(connection.protocolEra).toBe("modern");
+    expect(connection.metadataCachePolicy?.cacheScope).toBe("public");
+    expect(connection.metadataCachePolicy?.expiresAt).toBeGreaterThan(
+      connectedAt + 23 * 60 * 60 * 1000,
+    );
+    expect(connection.metadataCachePolicy?.expiresAt).toBeLessThanOrEqual(
+      Date.now() + 24 * 60 * 60 * 1000,
+    );
+    expect(methods.filter(method => method === "server/discover")).toHaveLength(1);
+    expect(methods).not.toContain("initialize");
+  });
+
+  it("connects to a strict MCP 2026-07-28 stdio server without initialize", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const answers = ["Continue", "Enter value", "Submit"];
+    manager.setElicitationConfig({
+      allowUrl: false,
+      ui: {
+        select: async () => answers.shift(),
+        input: async () => "modern-user",
+        notify: () => {},
+      } as never,
+    });
+
+    const connection = await manager.connect("modern", {
+      command: process.execPath,
+      args: [fileURLToPath(new URL("./fixtures/modern-only-server.mjs", import.meta.url))],
+      protocolMode: "2026-07-28",
+    });
+
+    expect(connection.status).toBe("connected");
+    expect(connection.tools.map(tool => tool.name)).toEqual(["modern_tool"]);
+    expect(connection.protocolEra).toBe("modern");
+    expect(connection.protocolVersion).toBe("2026-07-28");
+    expect(connection.metadataCachePolicy).toEqual({ cacheScope: "private" });
+    expect(connection.client.autoOpenedSubscription).toBeDefined();
+
+    const result = await connection.client.callTool({ name: "modern_tool", arguments: {} });
+    expect(result.content).toEqual([{ type: "text", text: "accepted:modern-user" }]);
+  }, 5_000);
+});

--- a/__tests__/server-manager-reconnect.test.ts
+++ b/__tests__/server-manager-reconnect.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   httpTransports: [] as HttpTransportMock[],
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation((info: unknown, options: unknown) => {
     const client: any = {
@@ -25,6 +25,9 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
       setRequestHandler: vi.fn(),
       setNotificationHandler: vi.fn(),
       connect: vi.fn(async () => undefined),
+      getProtocolEra: vi.fn(() => "legacy"),
+      getNegotiatedProtocolVersion: vi.fn(() => "2025-11-25"),
+      getServerCapabilities: vi.fn(() => ({ tools: {}, resources: {} })),
       listTools: vi.fn(async () => ({ tools: [] })),
       listResources: vi.fn(async () => ({ resources: [] })),
       close: vi.fn(async () => undefined),
@@ -32,6 +35,12 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     mocks.clients.push(client);
     return client;
   }),
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
+    const transport = { url, options, close: vi.fn(async () => undefined) };
+    mocks.httpTransports.push(transport);
+    return transport;
+  }),
+  SSEClientTransport: vi.fn(),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOriginal) => ({
@@ -45,7 +54,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOrigi
 
 vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: vi.fn() }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn(),
 }));
 
@@ -59,10 +68,6 @@ describe("McpServerManager.reconnect", () => {
     mocks.httpTransports.length = 0;
   });
 
-  // For an HTTP server, connect() creates a probe client+transport and then
-  // a real one; the real client (used as connection.client) is always
-  // mocks.clients[0] for a given connect() call because createClient() runs
-  // before the probe is created inside createHttpTransport().
   const def = { url: "https://example.test/mcp" };
 
   it("is single-flight: concurrent reconnects for the same server share one underlying reconnect", async () => {
@@ -79,9 +84,8 @@ describe("McpServerManager.reconnect", () => {
     ]);
 
     expect(c1).toBe(c2);
-    // Exactly one new connection was established (probe client + real
-    // client == 2), not two (which would be 4).
-    expect(mocks.clients.length).toBe(2);
+    // Automatic negotiation and the live connection share one client.
+    expect(mocks.clients.length).toBe(1);
     expect(manager.getConnection("remote")).toBe(c1);
   });
 

--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -14,7 +14,7 @@ function gate() {
   return { promise, resolve };
 }
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any) {
     this.setRequestHandler = vi.fn();
@@ -23,6 +23,9 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
       if (mocks.connectError) throw mocks.connectError;
       await mocks.connectGate?.promise;
     });
+    this.getProtocolEra = vi.fn(() => "legacy");
+    this.getNegotiatedProtocolVersion = vi.fn(() => "2025-11-25");
+    this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
     this.close = vi.fn(async () => undefined);
@@ -31,7 +34,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   StreamableHTTPClientTransport: vi.fn(),
   SSEClientTransport: vi.fn(),
 }));
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any) {
     this.close = vi.fn(async () => undefined);
     mocks.transports.push(this);

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("open", () => ({ default: mocks.open }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -19,6 +19,8 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     this.setNotificationHandler = vi.fn();
     this.connect = vi.fn(async () => undefined);
     this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
+    this.getProtocolEra = vi.fn(() => "legacy");
+    this.getNegotiatedProtocolVersion = vi.fn(() => "2025-11-25");
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
     this.close = vi.fn(async () => undefined);
@@ -28,7 +30,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);
@@ -138,10 +140,10 @@ describe("McpServerManager sampling", () => {
         url: "https://example.com/connect",
       },
     });
-    const completionHandler = client.setNotificationHandler.mock.calls[0][1];
-    completionHandler({ params: { elicitationId: "unknown-id" } });
-    completionHandler({ params: { elicitationId: "known-id" } });
-    completionHandler({ params: { elicitationId: "known-id" } });
+    const completionHandler = client.setNotificationHandler.mock.calls[0][2];
+    completionHandler({ elicitationId: "unknown-id" });
+    completionHandler({ elicitationId: "known-id" });
+    completionHandler({ elicitationId: "known-id" });
 
     expect(ui.notify).toHaveBeenCalledWith("Opened browser for MCP elicitation.", "info");
     expect(ui.notify).toHaveBeenCalledWith(
@@ -152,7 +154,7 @@ describe("McpServerManager sampling", () => {
   });
 
   it("handles every URL in a URL-required error", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { McpServerManager } = await import("../server-manager.ts");
     const ui = {
       select: vi.fn().mockResolvedValue("Open"),
@@ -223,6 +225,12 @@ describe("McpServerManager sampling", () => {
     await manager.close("demo");
     await manager.connect("demo", { command: "node", args: ["server.js"] });
     const freshClient = mocks.clients[1];
+    const freshConnection = manager.getConnection("demo")!;
+    freshConnection.protocolEra = "modern";
+    freshConnection.metadataCachePolicy = {
+      cacheScope: "public",
+      expiresAt: Date.now() + 60_000,
+    };
     const freshTools = [{ name: "fresh_tool", description: "Fresh tool" }];
     const freshResources = [{ uri: "file://fresh", name: "Fresh resource" }];
 
@@ -236,6 +244,7 @@ describe("McpServerManager sampling", () => {
     freshClient.options.listChanged.resources.onChanged(null, freshResources);
     expect(manager.getConnection("demo")?.tools).toEqual(freshTools);
     expect(manager.getConnection("demo")?.resources).toEqual(freshResources);
+    expect(manager.getConnection("demo")?.metadataCachePolicy).toEqual({ cacheScope: "private" });
     expect(metadataChanged).toHaveBeenCalledWith("demo", "tools-list-changed");
     expect(metadataChanged).toHaveBeenCalledWith("demo", "resources-list-changed");
   });
@@ -307,6 +316,9 @@ describe("McpServerManager sampling", () => {
 
     const client = mocks.clients[0];
     expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 2500 });
+    expect(client.options).toMatchObject({
+      versionNegotiation: { probe: { timeoutMs: 2500, maxRetries: 0 } },
+    });
     expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 2500 });
     expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 2500 });
   });
@@ -320,6 +332,9 @@ describe("McpServerManager sampling", () => {
 
     const client = mocks.clients[0];
     expect(client.connect).toHaveBeenCalledWith(mocks.transports[0], { timeout: 5000 });
+    expect(client.options).toMatchObject({
+      versionNegotiation: { probe: { timeoutMs: 5000, maxRetries: 0 } },
+    });
     expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 5000 });
     expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 5000 });
   });

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   connectImpl: null as null | ((transport: any) => Promise<void>),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any) {
     this.setRequestHandler = vi.fn();
@@ -14,6 +14,9 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     this.connect = vi.fn(async (transport: any) => {
       if (mocks.connectImpl) return mocks.connectImpl(transport);
     });
+    this.getProtocolEra = vi.fn(() => "legacy");
+    this.getNegotiatedProtocolVersion = vi.fn(() => "2025-11-25");
+    this.getServerCapabilities = vi.fn(() => ({ tools: {}, resources: {} }));
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
     this.close = vi.fn(async () => undefined);
@@ -28,7 +31,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   }),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: any) {
     this.options = options;
     this.stderr = options?.stderr === "pipe" ? new PassThrough() : null;

--- a/__tests__/server-manager-streamable-http.test.ts
+++ b/__tests__/server-manager-streamable-http.test.ts
@@ -47,6 +47,14 @@ describe("McpServerManager StreamableHTTP transport", () => {
         let body = "";
         for await (const chunk of req) body += chunk;
         const message = JSON.parse(body) as { id?: string | number; method?: string };
+        if (message.method === "server/discover") {
+          res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+            jsonrpc: "2.0",
+            id: message.id,
+            error: { code: -32601, message: "Method not found" },
+          }));
+          return;
+        }
         const result = message.method === "initialize"
           ? {
               protocolVersion: "2025-06-18",
@@ -110,6 +118,26 @@ describe("McpServerManager StreamableHTTP transport", () => {
     });
   });
 
+  it("does not downgrade to SSE after a Streamable HTTP server failure", async () => {
+    const requests: string[] = [];
+    const server = http.createServer((req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      res.writeHead(503, { "content-type": "text/plain" }).end("Unavailable");
+    });
+    servers.push(server);
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port");
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("unavailable", {
+      url: `http://127.0.0.1:${address.port}/mcp`,
+      auth: false,
+    })).rejects.toThrow(/503|Unavailable/);
+
+    expect(requests.some(request => request.startsWith("GET "))).toBe(false);
+  });
+
   it("resolves command-backed HTTP secrets without falling back to SSE on GET 405", async () => {
     const requests: string[] = [];
     const server = http.createServer(async (req, res) => {
@@ -133,6 +161,15 @@ describe("McpServerManager StreamableHTTP transport", () => {
       let body = "";
       for await (const chunk of req) body += chunk;
       const message = JSON.parse(body) as { id?: string | number; method?: string };
+
+      if (message.method === "server/discover") {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: { code: -32601, message: "Method not found" },
+        }));
+        return;
+      }
 
       if (message.method === "initialize") {
         res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
@@ -200,8 +237,8 @@ describe("McpServerManager StreamableHTTP transport", () => {
       expect(connection.tools).toEqual([]);
       expect(connection.resources).toEqual([]);
       expect(requests).toContain("GET /mcp");
-      // The SDK probes the optional GET stream once, then keeps the successful
-      // POST-based session without an SSE fallback or retry storm.
+      // One SDK client owns negotiation and the optional GET stream, without
+      // a probe connection or an SSE retry.
       expect(requests.filter(request => request === "GET /mcp")).toHaveLength(1);
 
       await manager.close("post-only");
@@ -209,7 +246,7 @@ describe("McpServerManager StreamableHTTP transport", () => {
         .trim()
         .split("\n")
         .map(line => JSON.parse(line) as { direction: string; method?: string });
-      expect(traceLines.filter(event => event.direction === "outbound" && event.method === "initialize")).toHaveLength(2);
+      expect(traceLines.filter(event => event.direction === "outbound" && event.method === "initialize")).toHaveLength(1);
     } finally {
       await manager.close("post-only").catch(() => {});
     }

--- a/__tests__/server-manager-unix-socket.test.ts
+++ b/__tests__/server-manager-unix-socket.test.ts
@@ -23,6 +23,14 @@ afterEach(async () => {
 });
 
 describe("McpServerManager Unix socket transport", () => {
+  it("rejects modern negotiation because Unix sockets are legacy-only", async () => {
+    const manager = new McpServerManager();
+    await expect(manager.connect("modern-socket", {
+      socket: "/tmp/pi-mcp-modern.sock",
+      protocolMode: "auto",
+    })).rejects.toThrow(/legacy-only/);
+  });
+
   it("connects to an rmcp-mux-compatible socket and discovers tools", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pi-mcp-socket-"));
     temporaryDirectories.push(directory);

--- a/__tests__/session-recovery-integration.test.ts
+++ b/__tests__/session-recovery-integration.test.ts
@@ -1,4 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ProtocolError as McpError,
+  SdkErrorCode,
+  SdkHttpError,
+} from "@modelcontextprotocol/client";
+
+class StreamableHTTPError extends SdkHttpError {
+  constructor(status: number, message: string) {
+    super(SdkErrorCode.ClientHttpUnexpectedContent, message, { status });
+  }
+}
 
 // direct-tools.ts calls lazyConnect() before touching the connection; mock
 // it the same way __tests__/direct-tools-auto-auth.test.ts does so we can
@@ -38,6 +49,15 @@ describe("session recovery — Streamable HTTP wire path", () => {
       let body = "";
       for await (const chunk of req) body += chunk;
       const message = JSON.parse(body) as { id?: string | number; method?: string };
+
+      if (message.method === "server/discover") {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: { code: -32601, message: "Method not found" },
+        }));
+        return;
+      }
 
       if (message.method === "initialize") {
         res.writeHead(200, {
@@ -129,7 +149,6 @@ describe("session recovery — Streamable HTTP wire path", () => {
 describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
   it("recovers a terminated Streamable HTTP session transparently mid tool-call", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected" as const,
@@ -176,7 +195,6 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("recovers a server-not-initialized MCP error transparently mid tool-call", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
 
     const stale = {
       status: "connected" as const,
@@ -223,7 +241,6 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("gives up after one reconnect attempt: a second server-not-initialized MCP error propagates as call_failed", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
 
     const stale = {
       status: "connected" as const,
@@ -265,7 +282,6 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected" as const,
@@ -314,7 +330,6 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("recovers a terminated Streamable HTTP session transparently for a direct tool call", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected" as const,
@@ -365,7 +380,6 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("recovers a server-not-initialized MCP error transparently for a direct tool call", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
 
     const stale = {
       status: "connected" as const,
@@ -416,7 +430,6 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected" as const,

--- a/__tests__/session-recovery.test.ts
+++ b/__tests__/session-recovery.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ProtocolError as McpError,
+  SdkErrorCode,
+  SdkHttpError,
+} from "@modelcontextprotocol/client";
+
+class StreamableHTTPError extends SdkHttpError {
+  constructor(status: number, message: string) {
+    super(SdkErrorCode.ClientHttpUnexpectedContent, message, { status });
+  }
+}
 import { SessionRecoveryAuthRequiredError, isTerminatedSession, withSessionRecovery } from "../session-recovery.ts";
 import type { ServerConnection } from "../server-manager.ts";
 import type { McpConfig } from "../types.ts";
@@ -19,6 +28,15 @@ function makeConnection(sessionId: string | undefined): ServerConnection {
 }
 
 describe("isTerminatedSession", () => {
+  it("is true for a v2 HTTP 404 carrying a session id", () => {
+    const err = new SdkHttpError(
+      SdkErrorCode.ClientHttpUnexpectedContent,
+      "Session not found",
+      { status: 404 },
+    );
+    expect(isTerminatedSession(err, true)).toBe(true);
+  });
+
   it("is true for a 404 StreamableHTTPError carrying a session id", () => {
     const err = new StreamableHTTPError(404, "Session not found");
     expect(isTerminatedSession(err, true)).toBe(true);
@@ -295,6 +313,17 @@ describe("withSessionRecovery", () => {
     const connection = makeConnection(undefined);
     const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
     const err = new StreamableHTTPError(404, "Not found");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(manager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("does not run legacy session recovery for modern connections", async () => {
+    const connection = { ...makeConnection("unexpected-session"), protocolEra: "modern" as const };
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const err = new StreamableHTTPError(404, "Session not found");
     const fn = vi.fn().mockRejectedValue(err);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UiResourceHandler } from "../ui-resource-handler.ts";
 import { buildCspMetaContent } from "../host-html-template.ts";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  SdkErrorCode,
+  SdkHttpError,
+  UrlElicitationRequiredError,
+} from "@modelcontextprotocol/client";
 import type { McpServerManager } from "../server-manager.ts";
 
 // Mock the manager
@@ -38,7 +42,11 @@ describe("UiResourceHandler", () => {
     });
 
     it("recovers a terminated HTTP session while loading a UI resource", async () => {
-      const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+      const StreamableHTTPError = class extends SdkHttpError {
+        constructor(status: number, message: string) {
+          super(SdkErrorCode.ClientHttpUnexpectedContent, message, { status });
+        }
+      };
       const stale = {
         status: "connected" as const,
         transport: { sessionId: "session-1" },

--- a/__tests__/ui-server-session-recovery.test.ts
+++ b/__tests__/ui-server-session-recovery.test.ts
@@ -4,6 +4,13 @@ import { startUiServer, type UiServerHandle, type UiServerOptions } from "../ui-
 import type { McpServerManager, ServerConnection } from "../server-manager.ts";
 import type { ConsentManager } from "../consent-manager.ts";
 import type { UiResourceContent, McpConfig } from "../types.ts";
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+
+class StreamableHTTPError extends SdkHttpError {
+  constructor(status: number, message: string) {
+    super(SdkErrorCode.ClientHttpUnexpectedContent, message, { status });
+  }
+}
 
 // Same HTTP helper as __tests__/ui-server.test.ts.
 async function request(
@@ -70,7 +77,6 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("recovers a terminated Streamable HTTP session transparently, when config is supplied", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected",
@@ -121,7 +127,6 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("returns auth guidance when recovery reconnect needs auth and no callback can refresh it", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected",
@@ -168,7 +173,6 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("uses the supplied auth callback when recovery reconnect returns needs-auth", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected",
@@ -222,7 +226,6 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("runs without recovery (unchanged pre-existing behavior) when config is not supplied", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     const stale = {
       status: "connected",

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -596,7 +596,6 @@ describe("UiServer", () => {
           name: "some_tool",
           arguments: { arg1: "value1" },
         },
-        undefined,
         requestOptions,
       );
     });

--- a/__tests__/ui-streaming.test.ts
+++ b/__tests__/ui-streaming.test.ts
@@ -198,11 +198,9 @@ describe("UI Streaming", () => {
         attachAdapterNotificationHandlers: (serverName: string, client: { setNotificationHandler: typeof client.setNotificationHandler }) => void;
       }).attachAdapterNotificationHandlers(serverName, client);
       expect(client.setNotificationHandler).toHaveBeenCalledOnce();
-      const handler = client.setNotificationHandler.mock.calls[0][1] as (notification: {
-        params: {
-          streamToken: string;
-          result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
-        };
+      const handler = client.setNotificationHandler.mock.calls[0][2] as (params: {
+        streamToken: string;
+        result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
       }) => void;
       return (notification: {
         method: string;
@@ -210,7 +208,7 @@ describe("UI Streaming", () => {
           streamToken: string;
           result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
         };
-      }) => handler(notification);
+      }) => handler(notification.params);
     }
 
     it("routes notifications to the matching listener", () => {

--- a/conformance/driver.ts
+++ b/conformance/driver.ts
@@ -22,7 +22,7 @@
  */
 
 import { rmSync } from "node:fs"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { UnauthorizedError } from "@modelcontextprotocol/client"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { McpServerManager } from "../server-manager.ts"
 import {
@@ -117,7 +117,9 @@ const debugLog = (message: string): void => {
   if (process.env.CONFORMANCE_DRIVER_DEBUG) console.error(`[driver] ${message}`)
 }
 
-const definition: ServerEntry = { url: serverUrl }
+// Published conformance 0.1.x profiles the legacy protocol family. Keep this
+// regression driver pinned so legacy OAuth compatibility is explicit.
+const definition: ServerEntry = { url: serverUrl, protocolMode: "legacy" }
 if (context.client_id) {
   definition.oauth = {
     clientId: context.client_id,

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError } from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
@@ -466,9 +466,9 @@ export function createDirectToolExecutor(
           name: spec.originalName,
           arguments: params ?? {},
           _meta: uiSession?.requestMeta,
-        }, undefined, requestOptions), ownedSignal),
+        }, requestOptions), ownedSignal),
       );
-      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
+      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -1,16 +1,15 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
-  ElicitRequestSchema,
-  ErrorCode,
-  McpError,
+  ProtocolError,
+  ProtocolErrorCode,
+  type Client,
   type ElicitRequest,
   type ElicitRequestFormParams,
   type ElicitRequestURLParams,
   type ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
-import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation/types.js";
+  type JsonSchemaType,
+} from "@modelcontextprotocol/client";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
 import open from "open";
 
 export type ElicitationValue = string | number | boolean | string[] | undefined;
@@ -28,7 +27,7 @@ export interface ElicitationHandlerOptions {
 export type ServerElicitationConfig = Omit<ElicitationHandlerOptions, "serverName" | "onUrlAccepted">;
 
 export function registerElicitationHandler(client: Client, options: ElicitationHandlerOptions): void {
-  client.setRequestHandler(ElicitRequestSchema, request =>
+  client.setRequestHandler("elicitation/create", request =>
     handleElicitationRequest(options, request));
 }
 
@@ -303,18 +302,18 @@ function formatReview(
 
 export async function handleUrlElicitation(
   options: ElicitationHandlerOptions,
-  params: ElicitRequestURLParams,
+  params: ElicitRequestURLParams & { elicitationId?: string },
 ): Promise<ElicitResult> {
-  if (!options.allowUrl) throw new McpError(ErrorCode.InvalidParams, "URL elicitation is not supported");
+  if (!options.allowUrl) throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation is not supported");
 
   let parsed: URL;
   try {
     parsed = new URL(params.url);
   } catch {
-    throw new McpError(ErrorCode.InvalidParams, "URL elicitation supplied an invalid URL");
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation supplied an invalid URL");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new McpError(ErrorCode.InvalidParams, "URL elicitation only supports HTTP and HTTPS URLs");
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation only supports HTTP and HTTPS URLs");
   }
 
   const decision = await options.ui.select([
@@ -337,7 +336,7 @@ export async function handleUrlElicitation(
     options.ui.notify(`Could not open MCP elicitation URL: ${error instanceof Error ? error.message : String(error)}`, "error");
     return { action: "cancel" };
   }
-  options.onUrlAccepted?.(params.elicitationId);
+  if (params.elicitationId) options.onUrlAccepted?.(params.elicitationId);
   options.ui.notify("Opened browser for MCP elicitation.", "info");
   return { action: "accept" };
 }

--- a/examples/interactive-visualizer/package.json
+++ b/examples/interactive-visualizer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.2.0",
-    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "chart.js": "^4.5.1",
     "mermaid": "^11.12.0",
     "zod": "^4.1.0"

--- a/examples/interactive-visualizer/src/server.ts
+++ b/examples/interactive-visualizer/src/server.ts
@@ -1,5 +1,5 @@
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/init.ts
+++ b/init.ts
@@ -482,6 +482,15 @@ export function updateMetadataCache(
 
   const entry: ServerCacheEntry = {
     configHash,
+    ...(connection.protocolEra !== undefined ? { protocolEra: connection.protocolEra } : {}),
+    ...(connection.protocolEra === "modern"
+      ? {
+          cacheScope: connection.metadataCachePolicy?.cacheScope ?? "private",
+          ...(connection.metadataCachePolicy?.expiresAt !== undefined
+            ? { expiresAt: connection.metadataCachePolicy.expiresAt }
+            : {}),
+        }
+      : {}),
     tools,
     resources,
     ...(prompts !== undefined ? { prompts } : {}),

--- a/json-schema-validator.ts
+++ b/json-schema-validator.ts
@@ -1,12 +1,12 @@
 import { Ajv } from "ajv";
 import Ajv2020Import from "ajv/dist/2020.js";
 import addFormatsImport from "ajv-formats";
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
 import type {
   JsonSchemaType,
   JsonSchemaValidator,
   jsonSchemaValidator as JsonSchemaValidatorProvider,
-} from "@modelcontextprotocol/sdk/validation/types.js";
+} from "@modelcontextprotocol/client";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
 
 // ajv-formats types target its bundled ajv; the runtime accepts both instances.
 const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -5,11 +5,14 @@
  */
 
 import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  UnauthorizedError,
   auth as runSdkAuth,
   extractWWWAuthenticateParams,
-  UnauthorizedError,
-} from "@modelcontextprotocol/sdk/client/auth.js"
-import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
+} from "@modelcontextprotocol/client"
+import { MCP_2026_PROTOCOL_VERSION } from "./mcp-client.ts"
 import open from "open"
 import { McpOAuthProvider, type McpOAuthConfig } from "./mcp-oauth-provider.ts"
 import {
@@ -55,6 +58,7 @@ export interface AuthenticateOptions {
 type AuthDiscovery = {
   resourceMetadataUrl?: URL
   scope?: string
+  skipIssuerMetadataValidation?: boolean
 }
 
 function applyConfiguredScope(discovery: AuthDiscovery, config: McpOAuthConfig): AuthDiscovery {
@@ -225,25 +229,40 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
 
   try {
     headers.set("accept", "application/json, text/event-stream")
+    headers.set("mcp-method", "server/discover")
+    headers.set("mcp-protocol-version", MCP_2026_PROTOCOL_VERSION)
 
     const response = await fetch(new URL(serverUrl), {
       method: "POST",
       headers,
       body: JSON.stringify({
         jsonrpc: "2.0",
-        id: 0,
-        method: "initialize",
+        id: "oauth-server-discover",
+        method: "server/discover",
         params: {
-          protocolVersion: LATEST_PROTOCOL_VERSION,
-          capabilities: {},
-          clientInfo: { name: "pi-mcp-adapter", version: "2.11.0" },
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: MCP_2026_PROTOCOL_VERSION,
+            [CLIENT_INFO_META_KEY]: { name: "pi-mcp-adapter", version: "2.17.0" },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
         },
       }),
       signal: discoverySignal,
     })
     const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response)
     await response.body?.cancel().catch(() => {})
-    return { ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}), ...(scope ? { scope } : {}) }
+    return {
+      ...(resourceMetadataUrl ? { resourceMetadataUrl } : {}),
+      ...(scope ? { scope } : {}),
+      // MCP 2025-03-26 servers can omit protected-resource metadata and
+      // publish authorization metadata at the resource origin even when its
+      // issuer has a path. Keep this opt-out confined to that legacy fallback.
+      ...(response.status === 401
+        && !resourceMetadataUrl
+        && definition?.protocolMode === "legacy"
+        ? { skipIssuerMetadataValidation: true }
+        : {}),
+    }
   } catch (error) {
     if (signal?.aborted) throwIfAborted(signal)
     return {}
@@ -606,6 +625,7 @@ export async function completeAuth(
     const result = await abortable(runSdkAuth(pendingAuth.authProvider, {
       serverUrl: pendingAuth.serverUrl,
       authorizationCode: code,
+      ...(iss !== undefined ? { iss } : {}),
       ...pendingAuth.discovery,
     }), signal)
     throwIfAborted(signal)

--- a/mcp-client.ts
+++ b/mcp-client.ts
@@ -1,0 +1,61 @@
+import type { ClientOptions } from "@modelcontextprotocol/client";
+import type { ProtocolMode, ServerDefinition } from "./types.ts";
+
+export const MCP_2026_PROTOCOL_VERSION = "2026-07-28" as const;
+export const DEFAULT_MCP_LIST_MAX_PAGES = 64;
+export const DEFAULT_MCP_INPUT_REQUIRED_MAX_ROUNDS = 5;
+
+const PROTOCOL_MODES = new Set<ProtocolMode>([
+  "auto",
+  "legacy",
+  MCP_2026_PROTOCOL_VERSION,
+]);
+
+type ManagedClientOptions = Pick<
+  ClientOptions,
+  "capabilities" | "jsonSchemaValidator" | "listChanged"
+>;
+
+/** Build protocol-sensitive SDK options in one place for every managed client. */
+export function buildManagedClientOptions(
+  definition: ServerDefinition,
+  requestTimeoutMs: number | undefined,
+  options: ManagedClientOptions,
+): ClientOptions {
+  const protocolMode = resolveProtocolMode(definition);
+  const mode = protocolMode === MCP_2026_PROTOCOL_VERSION
+    ? { pin: MCP_2026_PROTOCOL_VERSION } as const
+    : protocolMode;
+
+  return {
+    ...options,
+    versionNegotiation: {
+      mode,
+      probe: {
+        ...(requestTimeoutMs !== undefined ? { timeoutMs: requestTimeoutMs } : {}),
+        maxRetries: 0,
+      },
+    },
+    inputRequired: {
+      autoFulfill: true,
+      maxRounds: DEFAULT_MCP_INPUT_REQUIRED_MAX_ROUNDS,
+    },
+    listMaxPages: DEFAULT_MCP_LIST_MAX_PAGES,
+  };
+}
+
+export function resolveProtocolMode(definition: ServerDefinition): ProtocolMode {
+  const configuredMode = definition.protocolMode;
+  if (configuredMode === undefined) {
+    return definition.socket ? "legacy" : "auto";
+  }
+  if (!PROTOCOL_MODES.has(configuredMode)) {
+    throw new Error(
+      `Invalid protocolMode "${String(configuredMode)}"; expected auto, legacy, or ${MCP_2026_PROTOCOL_VERSION}`,
+    );
+  }
+  if (definition.socket && configuredMode !== "legacy") {
+    throw new Error('Unix socket servers are legacy-only; protocolMode must be "legacy"');
+  }
+  return configuredMode;
+}

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -22,8 +22,11 @@ import {
   type McpOAuthConfig,
 } from "./mcp-oauth-provider.ts"
 import { getAuthForUrl, saveAuthEntry } from "./mcp-auth.ts"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
-import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
+import {
+  UnauthorizedError,
+  type OAuthClientInformationFull,
+  type OAuthTokens,
+} from "@modelcontextprotocol/client"
 
 describe("McpOAuthProvider", () => {
   const serverName = "test-server"
@@ -107,6 +110,7 @@ describe("McpOAuthProvider", () => {
       assert.deepStrictEqual(metadata.grant_types, ["authorization_code", "refresh_token"])
       assert.deepStrictEqual(metadata.response_types, ["code"])
       assert.strictEqual(metadata.token_endpoint_auth_method, "none")
+      assert.strictEqual(metadata.application_type, "native")
     })
 
     it("should return correct metadata for confidential client", () => {
@@ -143,12 +147,13 @@ describe("McpOAuthProvider", () => {
   })
 
   describe("clientInformation", () => {
-    it("should return config clientId when provided", async () => {
+    it("should bind configured client information to the v2 issuer context", async () => {
       const provider = createProvider({ clientId: "config-client", clientSecret: "config-secret" })
-      const info = await provider.clientInformation()
+      const info = await provider.clientInformation({ issuer: "https://auth.example.com" })
 
       assert.strictEqual(info?.client_id, "config-client")
       assert.strictEqual(info?.client_secret, "config-secret")
+      assert.strictEqual((info as { issuer?: string } | undefined)?.issuer, "https://auth.example.com")
     })
 
     it("should return stored client info when no config", async () => {
@@ -277,9 +282,10 @@ describe("McpOAuthProvider", () => {
         client_secret_expires_at: futureTime,
       }
 
-      await provider.saveClientInformation(info)
+      await provider.saveClientInformation(info, { issuer: "https://auth.example.com" })
+      assert.strictEqual(getAuthForUrl(serverName, serverUrl)?.clientInfo?.issuer, "https://auth.example.com")
 
-      const storedInfo = await provider.clientInformation()
+      const storedInfo = await provider.clientInformation({ issuer: "https://auth.example.com" })
       assert.strictEqual(storedInfo?.client_id, "new-client")
       assert.strictEqual(storedInfo?.client_secret, "new-secret")
       assert.deepStrictEqual(getAuthForUrl(serverName, serverUrl)?.clientInfo?.redirectUris, ["http://localhost:3118/callback"])
@@ -328,8 +334,9 @@ describe("McpOAuthProvider", () => {
         scope: "read write",
       }
 
-      await provider.saveTokens(tokens)
-      const stored = await provider.tokens()
+      await provider.saveTokens(tokens, { issuer: "https://auth.example.com" })
+      assert.strictEqual(getAuthForUrl(serverName, serverUrl)?.tokens?.issuer, "https://auth.example.com")
+      const stored = await provider.tokens({ issuer: "https://auth.example.com" })
 
       assert.strictEqual(stored?.access_token, "access-123")
       assert.strictEqual(stored?.refresh_token, "refresh-456")

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -8,14 +8,13 @@
 import {
   UnauthorizedError,
   type AddClientAuthentication,
+  type OAuthClientInformationContext,
+  type OAuthClientInformationMixed,
+  type OAuthClientMetadata,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
-} from "@modelcontextprotocol/sdk/client/auth.js"
-import type {
-  OAuthClientInformationMixed,
-  OAuthClientMetadata,
-  OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js"
+  type OAuthTokens,
+} from "@modelcontextprotocol/client"
 import {
   getAuthForUrl,
   updateTokens,
@@ -214,6 +213,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
+      application_type: oauthApplicationType(redirectUrl),
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
       ...(this.config.scope !== undefined ? { scope: this.config.scope } : {}),
     }
@@ -223,8 +223,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Get client information (for pre-registered or dynamically registered clients).
    * Returns undefined if no client info exists or if the server URL has changed.
    */
-  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
-    const issuer = this.discoveredIssuer
+  async clientInformation(
+    context?: OAuthClientInformationContext,
+  ): Promise<OAuthClientInformationMixed | undefined> {
+    const issuer = context?.issuer ?? this.discoveredIssuer
     const stored = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     this.assertStoredIssuerBindings(stored, issuer)
 
@@ -312,9 +314,14 @@ export class McpOAuthProvider implements OAuthClientProvider {
   /**
    * Save client information from dynamic registration.
    */
-  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+  async saveClientInformation(
+    info: OAuthClientInformationMixed,
+    context?: OAuthClientInformationContext,
+  ): Promise<void> {
     this.throwIfInactive()
-    const issuer = this.discoveredIssuer ?? (info as IssuerBoundClientInformation).issuer
+    const issuer = context?.issuer
+      ?? this.discoveredIssuer
+      ?? (info as IssuerBoundClientInformation).issuer
     if (this.config.clientId && info.client_id === this.config.clientId) {
       updateClientInfo(
         this.serverName,
@@ -343,11 +350,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Get stored OAuth tokens.
    * Returns undefined if no tokens exist or if the server URL has changed.
    */
-  async tokens(): Promise<OAuthTokens | undefined> {
+  async tokens(context?: OAuthClientInformationContext): Promise<OAuthTokens | undefined> {
     // Use getAuthForUrl to validate tokens are for the current server URL.
     const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     if (!entry?.tokens) return undefined
-    const issuer = this.discoveredIssuer
+    const issuer = context?.issuer ?? this.discoveredIssuer
     this.assertStoredIssuerBindings(entry, issuer)
     if (issuer && entry.tokens.issuer === undefined) {
       entry.tokens.issuer = issuer
@@ -369,7 +376,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
   /**
    * Save OAuth tokens.
    */
-  async saveTokens(tokens: OAuthTokens): Promise<void> {
+  async saveTokens(
+    tokens: OAuthTokens,
+    context?: OAuthClientInformationContext,
+  ): Promise<void> {
     const storedTokens: StoredTokens = {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token,
@@ -378,7 +388,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       // being persisted as never-expiring.
       expiresAt: tokens.expires_in !== undefined ? Date.now() / 1000 + tokens.expires_in : undefined,
       scope: tokens.scope,
-      issuer: this.discoveredIssuer ?? (tokens as IssuerBoundTokens).issuer,
+      issuer: context?.issuer ?? this.discoveredIssuer ?? (tokens as IssuerBoundTokens).issuer,
     }
     this.throwIfInactive()
     updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)
@@ -565,6 +575,14 @@ export class McpOAuthProvider implements OAuthClientProvider {
       params.set("scope", requestedScope)
     }
     return params
+  }
+}
+
+function oauthApplicationType(redirectUrl: string): "native" | "web" {
+  try {
+    return new URL(redirectUrl).protocol === "https:" ? "web" : "native"
+  } catch {
+    throw new Error(`Invalid OAuth redirect URI: ${redirectUrl}`)
   }
 }
 

--- a/mcp-trace.ts
+++ b/mcp-trace.ts
@@ -1,8 +1,7 @@
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { Buffer } from "node:buffer";
 import { dirname, isAbsolute, resolve } from "node:path";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONRPCMessage, MessageExtraInfo, Transport } from "@modelcontextprotocol/client";
 
 export const MCP_TRACE_SCHEMA_VERSION = 1;
 export const DEFAULT_MCP_TRACE_MAX_BYTES = 256 * 1024;
@@ -237,7 +236,8 @@ export function wrapTransportWithMcpTrace<T extends Transport>(
   transportKind: McpTraceTransport,
   observer: McpTraceObserver,
 ): T {
-  let messageHandler: Transport["onmessage"];
+  let messageHandler = transport.onmessage;
+  const originalSend = transport.send.bind(transport);
   const record = (event: McpTraceEvent): void => {
     try {
       observer.record(event);
@@ -245,60 +245,43 @@ export function wrapTransportWithMcpTrace<T extends Transport>(
       // An observer failure must never alter SDK transport behavior.
     }
   };
-  const traced: Transport = {
-    start: () => transport.start(),
-    send: async (message, options) => {
-      const started = performance.now();
-      const messages = Array.isArray(message) ? message : [message];
-      try {
-        await transport.send(message, options);
-        for (const item of messages) {
-          record(createMcpTraceEvent("outbound", server, transportKind, item, "sent", {
-            durationMs: performance.now() - started,
-          }));
-        }
-      } catch (error) {
-        for (const item of messages) {
-          record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
-            durationMs: performance.now() - started,
-          }));
-        }
-        throw error;
+
+  transport.send = async (message, options) => {
+    const started = performance.now();
+    const messages = Array.isArray(message) ? message : [message];
+    try {
+      await originalSend(message, options);
+      for (const item of messages) {
+        record(createMcpTraceEvent("outbound", server, transportKind, item, "sent", {
+          durationMs: performance.now() - started,
+        }));
       }
-    },
-    close: () => transport.close(),
-    get onclose() {
-      return transport.onclose;
-    },
-    set onclose(handler) {
-      transport.onclose = handler;
-    },
-    get onerror() {
-      return transport.onerror;
-    },
-    set onerror(handler) {
-      transport.onerror = handler;
-    },
-    get onmessage() {
-      return messageHandler;
-    },
-    set onmessage(handler) {
-      messageHandler = handler;
-      transport.onmessage = handler
-        ? ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
-            record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
-            handler(message, extra);
-          }) as Transport["onmessage"]
-        : undefined;
-    },
-    get sessionId() {
-      return transport.sessionId;
-    },
-    setProtocolVersion: transport.setProtocolVersion
-      ? version => transport.setProtocolVersion!(version)
-      : undefined,
+    } catch (error) {
+      for (const item of messages) {
+        record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
+          durationMs: performance.now() - started,
+        }));
+      }
+      throw error;
+    }
   };
-  return traced as T;
+
+  const tracedMessageHandler = ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
+    record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
+    messageHandler?.(message, extra);
+  }) as Transport["onmessage"];
+  Object.defineProperty(transport, "onmessage", {
+    configurable: true,
+    enumerable: true,
+    get: () => messageHandler ? tracedMessageHandler : undefined,
+    set: (handler: Transport["onmessage"]) => {
+      if (handler !== tracedMessageHandler) messageHandler = handler;
+    },
+  });
+
+  // Preserve the concrete transport instance. SDK v2 uses stdio transport
+  // identity to probe legacy servers in a disposable sibling process.
+  return transport;
 }
 
 export function traceTransportKind(definition: { command?: string; url?: string; socket?: string }, transport: Transport): McpTraceTransport {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -71,11 +71,24 @@ export function saveMetadataCache(cache: MetadataCache): void {
   }
 
   merged.version = CACHE_VERSION;
-  merged.servers = { ...merged.servers, ...cache.servers };
+  for (const [serverName, entry] of Object.entries(cache.servers)) {
+    if (shouldPersistServerEntry(entry)) {
+      merged.servers[serverName] = entry;
+    } else {
+      delete merged.servers[serverName];
+    }
+  }
 
   const tmpPath = `${cachePath}.${process.pid}.tmp`;
   writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8");
   renameSync(tmpPath, cachePath);
+}
+
+function shouldPersistServerEntry(entry: ServerCacheEntry): boolean {
+  if (entry.protocolEra !== "modern") return true;
+  return entry.cacheScope === "public"
+    && Number.isFinite(entry.expiresAt)
+    && entry.expiresAt! > Date.now();
 }
 
 export function computeServerHash(definition: ServerEntry): string {
@@ -86,6 +99,7 @@ export function computeServerHash(definition: ServerEntry): string {
     command: definition.command,
     args: definition.args,
     socket: resolveConfigPath(definition.socket),
+    protocolMode: definition.protocolMode,
     env: interpolateEnvRecord(definition.env),
     cwd: resolveConfigPath(definition.cwd),
     url: resolveServerUrl(definition),
@@ -113,6 +127,10 @@ export function isServerCacheValid(
     return false;
   }
   if (!entry || entry.configHash !== configHash) return false;
+  if (entry.protocolEra === "modern") {
+    if (entry.cacheScope !== "public") return false;
+    if (!Number.isFinite(entry.expiresAt) || entry.expiresAt! <= Date.now()) return false;
+  }
   if (!entry.cachedAt || typeof entry.cachedAt !== "number") return false;
   if (maxAgeMs > 0 && Date.now() - entry.cachedAt > maxAgeMs) return false;
   return true;

--- a/oauth-handler.ts
+++ b/oauth-handler.ts
@@ -1,5 +1,5 @@
 // oauth-handler.ts - OAuth token compatibility helpers for MCP servers
-import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { StoredOAuthTokens } from "@modelcontextprotocol/client";
 import { getAuthEntry } from "./mcp-auth.ts";
 
 /**
@@ -9,7 +9,7 @@ import { getAuthEntry } from "./mcp-auth.ts";
  * Persistent credentials are read from the OS secure credential store. Legacy
  * plaintext entries are imported through mcp-auth.ts before this returns.
  */
-export function getStoredTokens(serverName: string): OAuthTokens | undefined {
+export function getStoredTokens(serverName: string): StoredOAuthTokens | undefined {
   const tokens = getAuthEntry(serverName)?.tokens;
   if (!tokens) return undefined;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.17.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@napi-rs/keyring": "^1.3.0",
@@ -19,7 +21,7 @@
         "recheck": "^4.5.0",
         "smol-toml": "^1.6.1",
         "strip-json-comments": "^5.0.3",
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^4.2.0"
       },
       "bin": {
         "pi-mcp-adapter": "cli.js"
@@ -29,6 +31,7 @@
         "@earendil-works/pi-coding-agent": "0.79.10",
         "@earendil-works/pi-tui": "0.74.2",
         "@modelcontextprotocol/conformance": "0.1.16",
+        "@modelcontextprotocol/server": "2.0.0",
         "@types/bun": "^1.0.0",
         "@types/node": "^20.0.0",
         "@types/open": "^6.2.1",
@@ -38,13 +41,13 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.19.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-tui": "*",
         "typebox": "*",
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^4.2.0"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-ai": {
@@ -2953,6 +2956,24 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/conformance": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.1.16.tgz",
@@ -2972,6 +2993,18 @@
       },
       "bin": {
         "conformance": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
@@ -3041,6 +3074,20 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/keyring": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "author": "Nico Bailon",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.19.0"
   },
   "bin": {
     "pi-mcp-adapter": "cli.js"
@@ -77,6 +77,7 @@
     "prompts.ts",
     "onboarding-state.ts",
     "mcp-setup-panel.ts",
+    "mcp-client.ts",
     "types.ts",
     "ui-stream-types.ts",
     "ui-tool-visibility.ts",
@@ -122,6 +123,8 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/core": "2.0.0",
     "@modelcontextprotocol/ext-apps": "^1.2.2",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@napi-rs/keyring": "^1.3.0",
@@ -132,13 +135,13 @@
     "recheck": "^4.5.0",
     "smol-toml": "^1.6.1",
     "strip-json-comments": "^5.0.3",
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^4.2.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-tui": "*",
     "typebox": "*",
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^4.2.0"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-ai": {
@@ -156,6 +159,7 @@
     "@earendil-works/pi-coding-agent": "0.79.10",
     "@earendil-works/pi-tui": "0.74.2",
     "@modelcontextprotocol/conformance": "0.1.16",
+    "@modelcontextprotocol/server": "2.0.0",
     "@types/bun": "^1.0.0",
     "@types/node": "^20.0.0",
     "@types/open": "^6.2.1",

--- a/prompts.ts
+++ b/prompts.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import type {
   GetPromptResult,
   PromptMessage,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpConfig, type PromptMetadata } from "./types.ts";
 import { formatPromptCommandName } from "./types.ts";

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError } from "@modelcontextprotocol/client";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
@@ -1120,11 +1120,11 @@ export async function executeCall(
         name: toolMeta.originalName,
         arguments: args ?? {},
         _meta: uiSession?.requestMeta,
-      }, undefined, requestOptions), ownedSignal),
+      }, requestOptions), ownedSignal),
     );
 
     if (toolMeta.uiResourceUri) {
-      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
+      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -2,15 +2,14 @@ import { complete, type Api, type AssistantMessage, type Message, type Model, ty
 import { truncateAtWord } from "./utils.ts";
 import { throwIfAborted } from "./abort.ts";
 import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import {
-  CreateMessageRequestSchema,
-  type CreateMessageRequest,
-  type CreateMessageResult,
-  type ModelPreferences,
-  type SamplingMessage,
-  type SamplingMessageContentBlock,
-} from "@modelcontextprotocol/sdk/types.js";
+import type {
+  Client,
+  CreateMessageRequest,
+  CreateMessageResult,
+  ModelPreferences,
+  SamplingMessage,
+  SamplingMessageContentBlock,
+} from "@modelcontextprotocol/client";
 
 export interface SamplingHandlerOptions {
   serverName: string;
@@ -24,7 +23,7 @@ export interface SamplingHandlerOptions {
 export type ServerSamplingConfig = Omit<SamplingHandlerOptions, "serverName">;
 
 export function registerSamplingHandler(client: Client, options: SamplingHandlerOptions): void {
-  client.setRequestHandler(CreateMessageRequestSchema, request => {
+  client.setRequestHandler("sampling/createMessage", request => {
     return handleSamplingRequest(options, request);
   });
 }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,18 +1,18 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
+  Client,
+  MAX_CACHE_TTL_MS,
+  SdkHttpError,
+  SSEClientTransport,
   StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import {
-  ElicitationCompleteNotificationSchema,
+  UnauthorizedError,
   type GetPromptResult,
+  type ProtocolEra,
   type ReadResourceResult,
+  type RequestOptions,
   type UrlElicitationRequiredError,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
+import { ElicitationCompleteNotificationSchema } from "@modelcontextprotocol/core";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { UnixSocketClientTransport } from "./unix-socket-transport.ts";
 import { probeMcpEndpoint } from "./mcp-probe.ts";
 import {
@@ -24,10 +24,12 @@ import {
   type ServerStreamResultPatchNotification,
   type Transport,
   type McpTraceSettings,
+  SERVER_STREAM_RESULT_PATCH_METHOD,
   serverStreamResultPatchNotificationSchema,
 } from "./types.ts";
 import { resolveNpxBinary } from "./npx-resolver.ts";
 import { createJsonSchemaValidator } from "./json-schema-validator.ts";
+import { buildManagedClientOptions } from "./mcp-client.ts";
 import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
@@ -67,7 +69,14 @@ type HttpAuthProviderState =
   | { status: "implicit-challenged"; provider: McpOAuthProvider };
 
 function isUnauthorizedHttpError(error: unknown): boolean {
-  return error instanceof UnauthorizedError || (error instanceof StreamableHTTPError && error.code === 401);
+  return error instanceof UnauthorizedError || (error instanceof SdkHttpError && error.status === 401);
+}
+
+const DEPRECATED_SSE_HTTP_STATUSES = new Set([404, 405, 406, 415]);
+
+function shouldFallbackToSse(error: unknown, definition: ServerDefinition): boolean {
+  if (definition.protocolMode === "2026-07-28") return false;
+  return error instanceof SdkHttpError && DEPRECATED_SSE_HTTP_STATUSES.has(error.status);
 }
 
 function boundedStderrChunk(chunk: Buffer | string): Buffer {
@@ -97,6 +106,11 @@ function appendStderrTail(tail: Buffer, chunk: Buffer | string): Buffer {
     : combined;
 }
 
+interface MetadataCachePolicy {
+  cacheScope: "public" | "private";
+  expiresAt?: number;
+}
+
 export interface ServerConnection {
   client: Client;
   transport: Transport;
@@ -106,6 +120,9 @@ export interface ServerConnection {
   prompts: McpPrompt[];
   /** True when prompts were advertised but prompts/list failed. */
   promptDiscoveryFailed?: boolean;
+  protocolEra?: ProtocolEra;
+  protocolVersion?: string;
+  metadataCachePolicy?: MetadataCachePolicy;
   instructions?: string;
   lastUsedAt: number;
   inFlight: number;
@@ -126,6 +143,7 @@ export class McpServerManager {
   private authStorageOptions: AuthStorageOptions = {};
   private oauthRuntime: McpOAuthRuntime | undefined;
   private acceptedUrlElicitations = new Map<string, Set<string>>();
+  private metadataCachePolicies = new WeakMap<Client, MetadataCachePolicy>();
   private defaultRequestTimeoutMs: number | undefined;
   private runtimeSignal: AbortSignal | undefined;
   private closePromises = new Map<string, Promise<void>>();
@@ -307,7 +325,7 @@ export class McpServerManager {
     requestSignal?: AbortSignal,
   ): Promise<ServerConnection> {
     throwIfAborted(signal);
-    const client = this.createClient(name);
+    let client: Client;
 
     const tracingEnabled = isMcpTraceEnabled(definition, this.traceSettings);
     const traceWriter = tracingEnabled
@@ -318,6 +336,7 @@ export class McpServerManager {
       : undefined;
 
     let transport: Transport;
+    let isClientConnected = false;
     let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
     const configuredTransports = [definition.command, definition.url, definition.socket]
       .filter(value => typeof value === "string" && value.length > 0);
@@ -326,6 +345,7 @@ export class McpServerManager {
     }
 
     if (definition.command) {
+      client = this.createClient(name, definition);
       let command = definition.command;
       let args = definition.args ?? [];
 
@@ -355,13 +375,16 @@ export class McpServerManager {
       }
       transport = stdioTransport;
     } else if (definition.url) {
-      // HTTP transport with fallback
-      transport = await this.createHttpTransport(definition, name, signal, requestSignal, traceObserver);
+      const connected = await this.createHttpTransport(definition, name, signal, requestSignal, traceObserver);
+      client = connected.client;
+      transport = connected.transport;
+      isClientConnected = true;
     } else {
+      client = this.createClient(name, definition);
       transport = new UnixSocketClientTransport(resolveConfigPath(definition.socket!)!);
     }
 
-    if (traceObserver) {
+    if (traceObserver && !isClientConnected) {
       const traceTransportKindValue = traceTransportKind(definition, transport);
       transport = wrapTransportWithMcpTrace(transport, name, traceTransportKindValue, traceObserver);
     }
@@ -370,7 +393,9 @@ export class McpServerManager {
     const requestOptions = this.buildRequestOptions(definition, requestSignal);
 
     try {
-      await this.connectClientWithAbort(client, transport, requestOptions, signal);
+      if (!isClientConnected) {
+        await this.connectClientWithAbort(client, transport, requestOptions, signal);
+      }
       this.attachAdapterNotificationHandlers(name, client);
 
       const connection: ServerConnection = {
@@ -380,11 +405,17 @@ export class McpServerManager {
         tools: [],
         resources: [],
         prompts: [],
+        protocolEra: client.getProtocolEra(),
+        protocolVersion: client.getNegotiatedProtocolVersion(),
         instructions: client.getInstructions?.(),
         lastUsedAt: Date.now(),
         inFlight: 0,
         status: "connected",
       };
+      if (connection.protocolEra === "modern") {
+        const discovery = client.getDiscoverResult();
+        if (discovery) this.captureMetadataCachePolicy(client, discovery);
+      }
 
       // Reflect the SDK's own close signal in connection status, guarded by
       // identity so a stale connection's late close (e.g. the old
@@ -411,6 +442,11 @@ export class McpServerManager {
       ]);
       connection.tools = tools;
       connection.resources = resources;
+      if (connection.protocolEra === "modern") {
+        connection.metadataCachePolicy = this.metadataCachePolicies.get(client)
+          ?? { cacheScope: "private" };
+        this.metadataCachePolicies.delete(client);
+      }
       connection.prompts = promptResult.prompts;
       connection.promptDiscoveryFailed = promptResult.failed;
 
@@ -515,12 +551,12 @@ export class McpServerManager {
     };
   }
 
-  private createClient(serverName: string): Client {
+  private createClient(serverName: string, definition: ServerDefinition): Client {
     const capabilities = this.buildClientCapabilities();
     let client: Client;
     client = new Client(
       { name: `pi-mcp-${serverName}`, version: "1.0.0" },
-      {
+      buildManagedClientOptions(definition, this.getResolvedRequestTimeoutMs(definition), {
         jsonSchemaValidator: createJsonSchemaValidator(),
         ...(Object.keys(capabilities).length > 0 ? { capabilities } : {}),
         listChanged: {
@@ -540,7 +576,7 @@ export class McpServerManager {
             },
           },
         },
-      },
+      }),
     );
     if (this.samplingConfig) {
       registerSamplingHandler(client, { ...this.samplingConfig, serverName });
@@ -552,15 +588,19 @@ export class McpServerManager {
         onUrlAccepted: elicitationId => this.rememberUrlElicitation(serverName, elicitationId),
       });
       if (this.elicitationConfig.allowUrl) {
-        client.setNotificationHandler(ElicitationCompleteNotificationSchema, notification => {
-          if (this.runtimeSignal?.aborted) return;
+        client.setNotificationHandler(
+          "notifications/elicitation/complete",
+          { params: ElicitationCompleteNotificationSchema.shape.params },
+          params => {
+          if (client.getProtocolEra() !== "legacy" || this.runtimeSignal?.aborted) return;
           const accepted = this.acceptedUrlElicitations.get(serverName);
-          if (!accepted?.delete(notification.params.elicitationId)) return;
+          if (!accepted?.delete(params.elicitationId)) return;
           this.elicitationConfig?.ui.notify(
             `MCP browser interaction for ${serverName} completed. You can retry the tool now.`,
             "info",
           );
-        });
+          },
+        );
       }
     }
     return client;
@@ -580,6 +620,7 @@ export class McpServerManager {
     const connection = this.connections.get(serverName);
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.tools = tools;
+    this.invalidateModernMetadataCachePolicy(connection);
     this.metadataListChangedListener?.(serverName, "tools-list-changed");
   }
 
@@ -598,6 +639,7 @@ export class McpServerManager {
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.prompts = prompts;
     connection.promptDiscoveryFailed = false;
+    this.invalidateModernMetadataCachePolicy(connection);
     this.metadataListChangedListener?.(serverName, "prompts-list-changed");
   }
 
@@ -615,7 +657,14 @@ export class McpServerManager {
     const connection = this.connections.get(serverName);
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.resources = resources;
+    this.invalidateModernMetadataCachePolicy(connection);
     this.metadataListChangedListener?.(serverName, "resources-list-changed");
+  }
+
+  private invalidateModernMetadataCachePolicy(connection: ServerConnection): void {
+    if (connection.protocolEra === "modern") {
+      connection.metadataCachePolicy = { cacheScope: "private" };
+    }
   }
 
   async handleUrlElicitationRequired(
@@ -650,7 +699,7 @@ export class McpServerManager {
     signal?: AbortSignal,
     requestSignal?: AbortSignal,
     traceObserver?: McpTraceObserver,
-  ): Promise<Transport> {
+  ): Promise<{ client: Client; transport: Transport }> {
     throwIfAborted(signal);
     const serverUrl = resolveServerUrl(definition)!;
     const url = new URL(serverUrl);
@@ -715,7 +764,7 @@ export class McpServerManager {
       const probeTransport = traceObserver
         ? wrapTransportWithMcpTrace(streamableTransport, serverName, "streamable-http", traceObserver)
         : streamableTransport;
-      const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
+      const testClient = this.createClient(serverName, definition);
       let probeCleanupAttempted = false;
       try {
         await this.connectClientWithAbort(
@@ -724,15 +773,7 @@ export class McpServerManager {
           this.buildRequestOptions(definition, requestSignal),
           signal,
         );
-        probeCleanupAttempted = true;
-        try {
-          await testClient.close();
-        } catch (cleanupError) {
-          throw new AggregateError([cleanupError], "MCP HTTP probe cleanup failed");
-        }
-
-        // StreamableHTTP works - create fresh transport for actual use
-        return new StreamableHTTPClientTransport(url, { requestInit, authProvider });
+        return { client: testClient, transport: probeTransport };
       } catch (error) {
         if (error instanceof AggregateError && (
           error.message === "MCP connection abort cleanup failed" ||
@@ -766,13 +807,25 @@ export class McpServerManager {
           continue;
         }
 
-        // If this was an UnauthorizedError, don't try SSE - the server needs auth
-        if (isUnauthorizedHttpError(error)) {
+        // Authorization, server, rate-limit, timeout, and network failures are
+        // not evidence that the endpoint uses the deprecated SSE transport.
+        if (isUnauthorizedHttpError(error) || !shouldFallbackToSse(error, definition)) {
           throw error;
         }
 
-        // SSE is the legacy transport
-        return new SSEClientTransport(url, { requestInit, authProvider });
+        // A failed client cannot be reused for the deprecated SSE fallback.
+        const fallbackClient = this.createClient(serverName, definition);
+        const sseTransport = new SSEClientTransport(url, { requestInit, authProvider });
+        const fallbackTransport = traceObserver
+          ? wrapTransportWithMcpTrace(sseTransport, serverName, "sse", traceObserver)
+          : sseTransport;
+        await this.connectClientWithAbort(
+          fallbackClient,
+          fallbackTransport,
+          this.buildRequestOptions(definition, requestSignal),
+          signal,
+        );
+        return { client: fallbackClient, transport: fallbackTransport };
       }
     }
   }
@@ -783,11 +836,34 @@ export class McpServerManager {
 
     do {
       const result = await client.listTools(cursor ? { cursor } : undefined, requestOptions);
+      this.captureMetadataCachePolicy(client, result);
       allTools.push(...(result.tools ?? []));
       cursor = result.nextCursor;
     } while (cursor);
 
     return allTools;
+  }
+
+  private captureMetadataCachePolicy(client: Client, result: object): void {
+    if (client.getProtocolEra() !== "modern") return;
+    const current = this.metadataCachePolicies.get(client);
+    if (current?.cacheScope === "private") return;
+    const cacheHint = result as { cacheScope?: unknown; ttlMs?: unknown };
+    if (
+      cacheHint.cacheScope !== "public"
+      || typeof cacheHint.ttlMs !== "number"
+      || !Number.isFinite(cacheHint.ttlMs)
+      || cacheHint.ttlMs <= 0
+    ) {
+      this.metadataCachePolicies.set(client, { cacheScope: "private" });
+      return;
+    }
+
+    const expiresAt = Date.now() + Math.min(cacheHint.ttlMs, MAX_CACHE_TTL_MS);
+    this.metadataCachePolicies.set(client, {
+      cacheScope: "public",
+      expiresAt: current?.expiresAt === undefined ? expiresAt : Math.min(current.expiresAt, expiresAt),
+    });
   }
 
   private async fetchAllPrompts(
@@ -802,6 +878,7 @@ export class McpServerManager {
       let cursor: string | undefined;
       do {
         const result = await client.listPrompts(cursor ? { cursor } : undefined, requestOptions);
+        this.captureMetadataCachePolicy(client, result);
         prompts.push(...(result.prompts ?? []));
         cursor = result.nextCursor;
       } while (cursor);
@@ -824,6 +901,7 @@ export class McpServerManager {
 
       do {
         const result = await client.listResources(cursor ? { cursor } : undefined, requestOptions);
+        this.captureMetadataCachePolicy(client, result);
         allResources.push(...(result.resources ?? []));
         cursor = result.nextCursor;
       } while (cursor);
@@ -839,11 +917,15 @@ export class McpServerManager {
   }
 
   private attachAdapterNotificationHandlers(serverName: string, client: Client): void {
-    client.setNotificationHandler(serverStreamResultPatchNotificationSchema, notification => {
-      const listener = this.uiStreamListeners.get(notification.params.streamToken);
-      if (!listener) return;
-      listener(serverName, notification.params);
-    });
+    client.setNotificationHandler(
+      SERVER_STREAM_RESULT_PATCH_METHOD,
+      { params: serverStreamResultPatchNotificationSchema.shape.params },
+      params => {
+        const listener = this.uiStreamListeners.get(params.streamToken);
+        if (!listener) return;
+        listener(serverName, params);
+      },
+    );
   }
 
   registerUiStreamListener(streamToken: string, listener: UiStreamListener): void {

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -20,8 +20,8 @@
 //     many things other than "your session is gone"
 //   - treat generic -32000/ConnectionClosed errors as session expiry
 //   - treat AbortError/cancellation as a session failure
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+const SERVER_NOT_INITIALIZED_ERROR_CODE = -32000;
+import { ProtocolError, SdkHttpError } from "@modelcontextprotocol/client";
 import { logger } from "./logger.ts";
 import { throwIfAborted } from "./abort.ts";
 import { isServerDisabled, type McpConfig } from "./types.ts";
@@ -39,20 +39,22 @@ import type { McpServerManager, ServerConnection } from "./server-manager.ts";
  * before the call rather than rely on catch-time transport state.
  */
 const SERVER_NOT_INITIALIZED_MCP_MESSAGES = new Set([
-  `MCP error ${ErrorCode.ConnectionClosed}: Server not initialized`,
-  `MCP error ${ErrorCode.ConnectionClosed}: Bad Request: Server not initialized`,
+  "Server not initialized",
+  "Bad Request: Server not initialized",
+  `MCP error ${SERVER_NOT_INITIALIZED_ERROR_CODE}: Server not initialized`,
+  `MCP error ${SERVER_NOT_INITIALIZED_ERROR_CODE}: Bad Request: Server not initialized`,
 ]);
 
 export function isTerminatedSession(err: unknown, hadSessionId: boolean): boolean {
   if (!hadSessionId) return false;
-  if (err instanceof StreamableHTTPError) {
-    return err.code === 404
-      || (err.code === 400
+  if (err instanceof SdkHttpError) {
+    return err.status === 404
+      || (err.status === 400
         && /"code"\s*:\s*-32000/.test(err.message)
         && /"message"\s*:\s*"Bad Request: Server not initialized"/.test(err.message));
   }
-  return err instanceof McpError
-    && err.code === ErrorCode.ConnectionClosed
+  return err instanceof ProtocolError
+    && err.code === SERVER_NOT_INITIALIZED_ERROR_CODE
     && SERVER_NOT_INITIALIZED_MCP_MESSAGES.has(err.message);
 }
 
@@ -100,6 +102,10 @@ export async function withSessionRecovery<T>(
   const connection = deps.manager.getConnection(serverName);
   if (!connection) {
     throw new Error(`Server "${serverName}" is not connected`);
+  }
+
+  if (connection.protocolEra === "modern") {
+    return fn(connection);
   }
 
   const hadSessionId = hasSessionId(connection);

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,5 @@
 // types.ts - Core type definitions
-import type { Transport as McpTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { ContentBlock as McpContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import type { ContentBlock as McpContentBlock, Transport as McpTransport } from "@modelcontextprotocol/client";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
 import type { UiToolVisibility } from "./ui-tool-visibility.ts";
@@ -343,6 +342,8 @@ export interface OAuthConfig {
 }
 
 // Server configuration
+export type ProtocolMode = "auto" | "legacy" | "2026-07-28";
+
 export interface ServerEntry {
   command?: string;
   args?: string[];
@@ -372,6 +373,8 @@ export interface ServerEntry {
   lifecycle?: "keep-alive" | "lazy" | "lazy-keep-alive" | "eager";
   idleTimeout?: number; // minutes, overrides global setting
   requestTimeoutMs?: number; // milliseconds, overrides global request timeout when > 0
+  /** Protocol negotiation policy. Defaults to auto except for Unix sockets. */
+  protocolMode?: ProtocolMode;
   // Resource handling
   exposeResources?: boolean;
   // Direct tool registration
@@ -559,6 +562,9 @@ export interface CachedPrompt {
 
 export interface ServerCacheEntry {
   configHash: string;
+  protocolEra?: "legacy" | "modern";
+  cacheScope?: "public" | "private";
+  expiresAt?: number;
   tools: CachedTool[];
   resources: CachedResource[];
   prompts?: CachedPrompt[];

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -1,5 +1,5 @@
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/client";
 import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -3,11 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge";
-import {
-  ContentBlockSchema,
-  type CallToolRequest,
-  type CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolRequest, CallToolResult } from "@modelcontextprotocol/client";
+import { ContentBlockSchema } from "@modelcontextprotocol/core";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
 import { formatAuthRequiredMessage } from "./utils.ts";
@@ -451,9 +448,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
             ? await withSessionRecovery(
                 { manager: options.manager, config: options.config, onNeedsAuth: options.onNeedsAuth },
                 options.serverName,
-                (conn) => conn.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName)),
+                (conn) => conn.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName)),
               )
-            : await connection.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName));
+            : await connection.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName));
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import net from "node:net";
-import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import {
   createUiModelContextUpdate,

--- a/unix-socket-transport.ts
+++ b/unix-socket-transport.ts
@@ -1,7 +1,10 @@
 import { createConnection, type Socket } from "node:net";
-import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ReadBuffer,
+  serializeMessage,
+  type JSONRPCMessage,
+  type Transport,
+} from "@modelcontextprotocol/client";
 
 /** MCP JSONL transport for an explicitly configured Unix-domain socket. */
 export class UnixSocketClientTransport implements Transport {


### PR DESCRIPTION
## Summary

This PR migrates pi-mcp-adapter from the MCP SDK v1 runtime to the stable split SDK v2 packages. Automatic negotiation prefers MCP `2026-07-28` and retains support for deployed 2025-era servers. SDK v1 remains installed only for the `@modelcontextprotocol/ext-apps` compatibility boundary; manifest tests reject v1 imports from root runtime modules.

## Protocol behavior

Each server can set `protocolMode` to `auto`, `legacy`, or `2026-07-28`. Automatic mode attempts the modern protocol first for stdio and HTTP servers, then uses the SDK's restartable fallback when a server only supports the legacy handshake. Modern responses may request more input over several rounds; the adapter preserves request state and enforces a five-round limit. SDK-managed `subscriptions/listen` calls track modern list changes, while legacy notifications continue to work. Paginated list requests have a fixed bound and retain first-page metadata.

Deprecated HTTP SSE fallback is limited to status codes `404`, `405`, `406`, and `415`, which indicate an unsupported transport. Authentication failures and rate limits propagate directly. The same rule applies to server failures and request interruptions. Unix sockets remain legacy-only because their custom transport cannot safely restart modern negotiation.

## Cache and authorization safeguards

Modern metadata reaches disk only when every relevant response marks it public and supplies a finite positive TTL. The persisted TTL cannot exceed 24 hours. Private entries stay in memory, expired entries are removed, and a protocol-mode change invalidates the cache hash.

OAuth retains issuer binding, PKCE, state verification, RFC 9207 callback checks, protected-resource discovery, and per-adapter credential isolation. The compatibility exception for 2025 issuer metadata requires explicit `protocolMode: "legacy"`. Automatic and modern modes continue to validate the issuer strictly.

The runtime now uses exact `2.0.0` releases of `@modelcontextprotocol/client` and `@modelcontextprotocol/core`. Tests and the interactive visualizer use `@modelcontextprotocol/server@2.0.0`. The minimum Node.js version is now `22.19.0`, matching the current Pi runtime and its nested Undici dependency.

## Verification

Validation ran under Node.js `22.23.2` with these commands:

```sh
npx tsc --noEmit
npm test
npm run test:oauth
npm run test:conformance
npm --prefix examples/interactive-visualizer run build
npm pack --dry-run
git diff --check
```

The unit suite passed 955 tests across 93 files, and the OAuth suite passed 113 tests. Reviewed conformance outcomes either passed or matched the fail-closed baseline. Coverage includes strict-modern stdio, modern-first dual-era HTTP, legacy restart fallback, multi-round input, list subscriptions, downgrade restrictions, issuer validation, cache policy, tracing, session recovery, and Unix socket mode enforcement.

## Conformance and release scope

`@modelcontextprotocol/conformance@0.1.16` has no MCP `2026-07-28` client profile. Its driver is pinned to `protocolMode: "legacy"` and remains a regression suite for the 2025 protocol family. This PR does not claim official 2026 conformance. Local protocol fixtures cover strict-modern and dual-era behavior until an official profile is published.

This branch is intended for a prerelease before a stable adapter release. Existing deployments can pin adapter `2.17.0`; individual servers can select `protocolMode: "legacy"` when compatibility requires it.
