### PR TITLE
Enrich mcp_script traces and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `mcp_script` now records each search, describe, and call with its input, outcome, and duration in result details; emitted, returned, and console values retain readable Maps, Sets, cycles, functions, symbols, and BigInts. Its docs now lead with the plain JavaScript agents write and position it as the primary MCP multi-call workflow surface.
 - Added `settings.freezeDirectTools` to keep direct MCP tool registration stable after initial sync while preserving explicit reconnect refreshes. Thanks @ddfourtwo for PR #254.
 - Added best-effort Linux OAuth credential recovery when Pi inherits a revoked session keyring, allowing explicit re-authentication through a fresh `keyctl` session helper. Thanks @anthod0 for issue #248 and the validation prototype.
 - Ranked, paginated MCP tool search: best matches come first in a short page of 12 instead of an unranked dump of every match with full schemas, so the model stops guessing and each search costs a fraction of the tokens. Misses on describe/call now return top-5 "Did you mean" suggestions, letting the model self-correct a typo or missing prefix in the same turn instead of burning a round trip.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — t
 
 ### MCP Scripting
 
-`mcp_script({ code, timeoutMs? })` is registered by default for requests that need multiple MCP tool calls with JavaScript logic between them: loop, filter, chain, or fan out, then return one result. For a single MCP call, search, describe, status check, or auth action, use `mcp` instead. Set `settings.scriptMode` to `false` to hide the scripting tool.
+For multi-call MCP work, write ordinary JavaScript: discover, inspect, call, loop, filter, chain, or fan out, then return one result. Run that code with the default-on `mcp_script` tool. For a single MCP call, search, describe, status check, or auth action, use `mcp` instead. Set `settings.scriptMode` to `false` to hide the scripting tool.
 
 The bundled `mcp-scripting` skill is a separate Pi package resource. To hide that skill while keeping the adapter extension installed, replace the package entry in Pi settings with the object form and disable package skills:
 
@@ -353,15 +353,23 @@ The bundled `mcp-scripting` skill is a separate Pi package resource. To hide tha
 
 Preserve any version pin in `source` if your existing package entry has one. You can also disable package resources through `pi config`.
 
-See the bundled `mcp-scripting` skill for the complete workflow guide. The canonical API is ordinary JavaScript with `await tools.search({ query, server?, limit?, offset? })`, `await tools.describe({ path })`, `tools.call(path, args)`, direct flat calls, `emit(value)`, and a captured `console`. Use ordinary JavaScript loops and Promise utilities for composition; fluent helpers such as `tools.find(...).one()`, `tools.parallel(...)`, and `tools.retry(...)` are not provided. MCP calls return `{ ok: true, data }` or `{ ok: false, error: { code, message } }`, so a failed call does not stop the rest of the script. Result details include a concise `calls` trace with each invoked path and outcome. Emitted values and console output appear before the script's final return value, and the combined result uses the normal MCP output guard. The default timeout is 30 seconds; each script runs in a worker thread that is terminated at the deadline, including for infinite loops.
+For example, this is the JavaScript passed as the `code` argument to `mcp_script`:
 
 ```js
-const first = await tools.github_search_issues({ query: "is:open label:bug" });
-if (!first.ok) return first;
-const selected = first.data.content.filter((item) => item.type === "text");
-emit({ searched: true });
-return selected;
+const { items } = await tools.search({ query: "search issues", server: "github" });
+const candidate = items[0];
+if (!candidate) return { error: "No matching tool" };
+
+const details = await tools.describe({ path: candidate.path });
+if (details.error) return details;
+
+const result = await tools.call(details.path, { query: "is:open label:bug" });
+if (!result.ok) return result;
+emit({ tool: details.path, completed: true });
+return result.data;
 ```
+
+See the bundled `mcp-scripting` skill for the complete workflow guide. The API is `await tools.search({ query, server?, limit?, offset? })`, `await tools.describe({ path })`, `tools.call(path, args)`, direct flat calls, `emit(value)`, and a captured `console`. Use ordinary JavaScript loops and Promise utilities for composition; fluent helpers such as `tools.find(...).one()`, `tools.parallel(...)`, and `tools.retry(...)` are not provided. MCP calls return `{ ok: true, data }` or `{ ok: false, error: { code, message } }`, so a failed call does not stop the rest of the script. Result details include a concise `calls` trace with each operation, its path or query, outcome, and duration. Emitted values and console output appear before the script's final return value, and the combined result uses the normal MCP output guard. The default timeout is 30 seconds; each script runs in a worker thread that is terminated at the deadline, including for infinite loops.
 
 For a tool-restricted subagent, launch the child Pi with its tool allowlist set to `["mcp_script"]`. Have the parent discover MCP tool names with `mcp({ search: "..." })` and include the relevant prefixed names in the child's task; the child can then loop, filter, and chain those MCP calls without filesystem, shell, or edit tools. The adapter's ordinary lazy connection, authentication, output guard, abort handling, and approval gates still apply to every call.
 

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -131,6 +131,21 @@ describe("runMcpScript", () => {
     });
   });
 
+  it("records operation metadata and timing for search, describe, and calls", async () => {
+    const result = await runMcpScript(
+      state,
+      'await tools.search({ query: "fixture" }); await tools.describe({ path: "fixture_echo" }); return await tools.call("fixture_echo", { value: "traced" });',
+    );
+
+    expect(result.details).toMatchObject({
+      calls: [
+        { operation: "search", query: "fixture", ok: true, durationMs: expect.any(Number) },
+        { operation: "describe", path: "fixture_echo", ok: true, durationMs: expect.any(Number) },
+        { operation: "call", path: "fixture_echo", ok: true, durationMs: expect.any(Number) },
+      ],
+    });
+  });
+
   it("calls exact paths and returns an invalid-path envelope without throwing", async () => {
     const result = await runMcpScript(
       state,
@@ -275,6 +290,25 @@ describe("runMcpScript", () => {
     );
 
     expect(textBlocks(result)).toEqual(["first", "[console.log] second", "last"]);
+  });
+
+  it("formats non-JSON values in emitted, returned, and console output", async () => {
+    const result = await runMcpScript(
+      state,
+      `const cycle = {}; cycle.self = cycle;
+      const value = { map: new Map([["key", 1]]), set: new Set(["value"]), cycle, fn: function named() {}, symbol: Symbol("token"), bigint: 1n };
+      emit(value); console.log(new Map([["console", 2]])); return value;`,
+    );
+
+    for (const block of [textBlocks(result)[0], textBlocks(result).at(-1)!]) {
+      expect(block).toContain("Map(1)");
+      expect(block).toContain("Set(1)");
+      expect(block).toContain("[Circular");
+      expect(block).toContain("[Function: named]");
+      expect(block).toContain("Symbol(token)");
+      expect(block).toContain("1n");
+    }
+    expect(textBlocks(result)[1]).toContain("Map(1) { 'console' => 2 }");
   });
 
   it("rejects tools enumeration with discovery guidance without exposing host globals", async () => {

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -312,6 +312,17 @@ describe("runMcpScript", () => {
     expect(textBlocks(result)[1]).toContain("Map(1) { 'console' => 2 }");
   });
 
+  it("does not format shared acyclic references as circular", async () => {
+    const result = await runMcpScript(
+      state,
+      'const shared = { id: "same" }; return { first: shared, second: shared };',
+    );
+
+    const block = textBlocks(result).at(-1)!;
+    expect(block).not.toContain("Circular");
+    expect(JSON.parse(block)).toEqual({ first: { id: "same" }, second: { id: "same" } });
+  });
+
   it("rejects tools enumeration with discovery guidance without exposing host globals", async () => {
     const result = await runMcpScript(
       state,

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -134,13 +134,14 @@ describe("runMcpScript", () => {
   it("records operation metadata and timing for search, describe, and calls", async () => {
     const result = await runMcpScript(
       state,
-      'await tools.search({ query: "fixture" }); await tools.describe({ path: "fixture_echo" }); return await tools.call("fixture_echo", { value: "traced" });',
+      'await tools.search({ query: "fixture" }); await tools.describe({ path: "fixture_echo" }); await tools.describe({ path: "fixture_missing" }); return await tools.call("fixture_echo", { value: "traced" });',
     );
 
     expect(result.details).toMatchObject({
       calls: [
         { operation: "search", query: "fixture", ok: true, durationMs: expect.any(Number) },
         { operation: "describe", path: "fixture_echo", ok: true, durationMs: expect.any(Number) },
+        { operation: "describe", path: "fixture_missing", ok: false, error: "tool_not_found", durationMs: expect.any(Number) },
         { operation: "call", path: "fixture_echo", ok: true, durationMs: expect.any(Number) },
       ],
     });

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -31,13 +31,17 @@ type WorkerMessage =
 
 type WorkerResultMessage = { type: "result"; id: number; envelope: unknown };
 
-function needsInspectableFormatting(value: unknown, seen = new WeakSet<object>()): boolean {
+function needsInspectableFormatting(value: unknown, stack = new WeakSet<object>()): boolean {
   if (value === undefined || typeof value === "bigint" || typeof value === "function" || typeof value === "symbol") return true;
   if (typeof value !== "object" || value === null) return false;
-  if (seen.has(value)) return true;
+  if (stack.has(value)) return true;
   if (value instanceof Map || value instanceof Set || value instanceof WeakMap || value instanceof WeakSet) return true;
-  seen.add(value);
-  return Object.values(value).some((entry) => needsInspectableFormatting(entry, seen));
+  stack.add(value);
+  try {
+    return Object.values(value).some((entry) => needsInspectableFormatting(entry, stack));
+  } finally {
+    stack.delete(value);
+  }
 }
 
 function formatValue(value: unknown): string {

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -1,4 +1,5 @@
 import type { ToolInfo } from "@earendil-works/pi-coding-agent";
+import { formatWithOptions } from "node:util";
 import { Worker } from "node:worker_threads";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { executeCall } from "./proxy-modes.ts";
@@ -30,17 +31,25 @@ type WorkerMessage =
 
 type WorkerResultMessage = { type: "result"; id: number; envelope: unknown };
 
+function needsInspectableFormatting(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (value === undefined || typeof value === "bigint" || typeof value === "function" || typeof value === "symbol") return true;
+  if (typeof value !== "object" || value === null) return false;
+  if (seen.has(value)) return true;
+  if (value instanceof Map || value instanceof Set || value instanceof WeakMap || value instanceof WeakSet) return true;
+  seen.add(value);
+  return Object.values(value).some((entry) => needsInspectableFormatting(entry, seen));
+}
+
 function formatValue(value: unknown): string {
   if (typeof value === "string") return value;
-  if (value === undefined) return "undefined";
   try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[unserializable value]";
+    if (!needsInspectableFormatting(value)) {
+      const json = JSON.stringify(value, null, 2);
+      if (json !== undefined) return json;
     }
+    return formatWithOptions({ colors: false, depth: 6 }, value);
+  } catch {
+    return "[unserializable value]";
   }
 }
 
@@ -106,12 +115,26 @@ export async function runMcpScript(
   const timeoutController = new AbortController();
   const callSignal = combineAbortSignals(externalSignal, timeoutController.signal);
 
-  type ScriptCall = { path: string; ok: true } | { path: string; ok: false; error: string };
-  const calls: ScriptCall[] = [];
-  let callsSnapshot: ScriptCall[] | undefined;
+  type ScriptOperation =
+    | { operation: "call"; path: string; ok: true; durationMs: number }
+    | { operation: "call"; path: string; ok: false; error: string; durationMs: number }
+    | { operation: "search"; query: string; ok: true; durationMs: number }
+    | { operation: "search"; query: string; ok: false; error: string; durationMs: number }
+    | { operation: "describe"; path: string; ok: true; durationMs: number }
+    | { operation: "describe"; path: string; ok: false; error: string; durationMs: number };
+  type TrackedScriptOperation = ScriptOperation & { startedAt: number };
+  const calls: TrackedScriptOperation[] = [];
+  const snapshotCalls = (): ScriptOperation[] => calls.map(({ startedAt, ...operation }) => ({
+    ...operation,
+    durationMs: "error" in operation && operation.error === "incomplete"
+      ? Math.max(0, Date.now() - startedAt)
+      : operation.durationMs,
+  }));
+  let callsSnapshot: ScriptOperation[] | undefined;
   const callTool = async (path: string, args?: Record<string, unknown>) => {
     // Record before dispatch so calls still in flight at timeout/abort appear in the trace.
-    const index = calls.push({ path, ok: false, error: "incomplete" }) - 1;
+    const startedAt = Date.now();
+    const index = calls.push({ operation: "call", path, ok: false, error: "incomplete", durationMs: 0, startedAt }) - 1;
     const result = await executeCall(state, path, args, undefined, getPiTools, callSignal);
     const details = result.details;
     if (details.error !== undefined) {
@@ -124,13 +147,13 @@ export async function runMcpScript(
         : typeof details.message === "string"
           ? details.message
           : textFromContent(result.content);
-      calls[index] = { path, ok: false, error: errorCode };
+      calls[index] = { operation: "call", path, ok: false, error: errorCode, durationMs: Date.now() - startedAt, startedAt };
       return {
         ok: false as const,
         error: { code: errorCode, message },
       };
     }
-    calls[index] = { path, ok: true };
+    calls[index] = { operation: "call", path, ok: true, durationMs: Date.now() - startedAt, startedAt };
     return {
       ok: true as const,
       data: details.mcpResult !== undefined ? details.mcpResult : textFromContent(result.content),
@@ -138,48 +161,71 @@ export async function runMcpScript(
   };
 
   const searchTools = (input?: SearchInput) => {
-    if (typeof input?.query !== "string" || input.query.trim() === "") {
-      return { items: [], total: 0, hasMore: false, nextOffset: null };
+    const startedAt = Date.now();
+    const query = typeof input?.query === "string" ? input.query : "";
+    let error: unknown;
+    try {
+      if (query.trim() === "") {
+        return { items: [], total: 0, hasMore: false, nextOffset: null };
+      }
+      const server = typeof input.server === "string" ? input.server : undefined;
+      const limit = typeof input.limit === "number" ? input.limit : 12;
+      const offset = typeof input.offset === "number" ? input.offset : 0;
+      const page = paginate(rankToolMatches(state, query, server), offset, limit);
+      return {
+        ...page,
+        items: page.items.map(({ server: matchServer, tool, score }) => ({
+          path: tool.name,
+          name: tool.originalName,
+          server: matchServer,
+          ...(tool.description ? { description: tool.description } : {}),
+          score,
+        })),
+      };
+    } catch (caught) {
+      error = caught;
+      throw caught;
+    } finally {
+      calls.push(error === undefined
+        ? { operation: "search", query, ok: true, durationMs: Date.now() - startedAt, startedAt }
+        : { operation: "search", query, ok: false, error: error instanceof Error ? error.message : String(error), durationMs: Date.now() - startedAt, startedAt });
     }
-    const server = typeof input.server === "string" ? input.server : undefined;
-    const limit = typeof input.limit === "number" ? input.limit : 12;
-    const offset = typeof input.offset === "number" ? input.offset : 0;
-    const page = paginate(rankToolMatches(state, input.query, server), offset, limit);
-    return {
-      ...page,
-      items: page.items.map(({ server: matchServer, tool, score }) => ({
-        path: tool.name,
-        name: tool.originalName,
-        server: matchServer,
-        ...(tool.description ? { description: tool.description } : {}),
-        score,
-      })),
-    };
   };
 
   const describeTool = (input?: DescribeInput) => {
+    const startedAt = Date.now();
     const path = typeof input?.path === "string" ? input.path : "";
-    for (const [server, metadata] of state.toolMetadata) {
-      const tool = findToolByName(metadata, path);
-      if (!tool) continue;
-      const inputTypeScript = tool.inputSchema ? renderTsShape(tool.inputSchema) : null;
+    let error: unknown;
+    try {
+      for (const [server, metadata] of state.toolMetadata) {
+        const tool = findToolByName(metadata, path);
+        if (!tool) continue;
+        const inputTypeScript = tool.inputSchema ? renderTsShape(tool.inputSchema) : null;
+        return {
+          path: tool.name,
+          name: tool.originalName,
+          server,
+          ...(tool.description ? { description: tool.description } : {}),
+          ...(inputTypeScript ? { inputTypeScript } : {}),
+        };
+      }
+      const suggestions = path ? rankSuggestions(state, path, 5) : [];
       return {
-        path: tool.name,
-        name: tool.originalName,
-        server,
-        ...(tool.description ? { description: tool.description } : {}),
-        ...(inputTypeScript ? { inputTypeScript } : {}),
+        path,
+        error: {
+          code: "tool_not_found",
+          message: `Tool not found: ${path}`,
+          suggestions,
+        },
       };
+    } catch (caught) {
+      error = caught;
+      throw caught;
+    } finally {
+      calls.push(error === undefined
+        ? { operation: "describe", path, ok: true, durationMs: Date.now() - startedAt, startedAt }
+        : { operation: "describe", path, ok: false, error: error instanceof Error ? error.message : String(error), durationMs: Date.now() - startedAt, startedAt });
     }
-    const suggestions = path ? rankSuggestions(state, path, 5) : [];
-    return {
-      path,
-      error: {
-        code: "tool_not_found",
-        message: `Tool not found: ${path}`,
-        suggestions,
-      },
-    };
   };
 
   let worker: Worker | undefined;
@@ -240,7 +286,7 @@ export async function runMcpScript(
     const timeoutError = new McpScriptTimeoutError(resolvedTimeoutMs);
     const timeout = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
-        callsSnapshot = [...calls];
+        callsSnapshot = snapshotCalls();
         timeoutController.abort(timeoutError);
         void activeWorker.terminate();
         reject(timeoutError);
@@ -249,7 +295,7 @@ export async function runMcpScript(
     const aborted = externalSignal
       ? new Promise<never>((_resolve, reject) => {
           const onAbort = () => {
-            callsSnapshot = [...calls];
+            callsSnapshot = snapshotCalls();
             void activeWorker.terminate();
             reject(abortReasonError(externalSignal.reason));
           };
@@ -276,7 +322,7 @@ export async function runMcpScript(
     removeAbortListener();
     // "incomplete" means the call had not settled when the script finished
     // (deadline, abort, or early return). Snapshot before aborting stragglers.
-    callsSnapshot ??= [...calls];
+    callsSnapshot ??= snapshotCalls();
     // A script may finish without awaiting every call; abort leftovers so
     // parent-side dispatches do not outlive the script.
     timeoutController.abort(new Error("mcp_script finished"));
@@ -294,7 +340,7 @@ export async function runMcpScript(
       mode: "script",
       ...(errorCode ? { error: errorCode, message: errorMessage } : {}),
       timeoutMs: resolvedTimeoutMs,
-      ...((callsSnapshot ?? calls).length > 0 ? { calls: [...(callsSnapshot ?? calls)] } : {}),
+      ...(callsSnapshot.length > 0 ? { calls: callsSnapshot } : {}),
       ...guardedMcpDetails(guarded),
     },
   };

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -210,6 +210,7 @@ export async function runMcpScript(
         };
       }
       const suggestions = path ? rankSuggestions(state, path, 5) : [];
+      error = "tool_not_found";
       return {
         path,
         error: {

--- a/mcp-script-worker.mjs
+++ b/mcp-script-worker.mjs
@@ -5,17 +5,25 @@ import vm from "node:vm";
 const TOOLS_ENUMERATION_ERROR = "tools is not enumerable — use tools.search({ query })";
 const RESERVED_TOOL_PROPS = new Set(["then", "catch", "finally", "toJSON", "toString", "valueOf"]);
 
+function needsInspectableFormatting(value, seen = new WeakSet()) {
+  if (value === undefined || typeof value === "bigint" || typeof value === "function" || typeof value === "symbol") return true;
+  if (typeof value !== "object" || value === null) return false;
+  if (seen.has(value)) return true;
+  if (value instanceof Map || value instanceof Set || value instanceof WeakMap || value instanceof WeakSet) return true;
+  seen.add(value);
+  return Object.values(value).some((entry) => needsInspectableFormatting(entry, seen));
+}
+
 function formatValue(value) {
   if (typeof value === "string") return value;
-  if (value === undefined) return "undefined";
   try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    try {
-      return String(value);
-    } catch {
-      return "[unserializable value]";
+    if (!needsInspectableFormatting(value)) {
+      const json = JSON.stringify(value, null, 2);
+      if (json !== undefined) return json;
     }
+    return formatWithOptions({ colors: false, depth: 6 }, value);
+  } catch {
+    return "[unserializable value]";
   }
 }
 

--- a/mcp-script-worker.mjs
+++ b/mcp-script-worker.mjs
@@ -5,13 +5,18 @@ import vm from "node:vm";
 const TOOLS_ENUMERATION_ERROR = "tools is not enumerable — use tools.search({ query })";
 const RESERVED_TOOL_PROPS = new Set(["then", "catch", "finally", "toJSON", "toString", "valueOf"]);
 
-function needsInspectableFormatting(value, seen = new WeakSet()) {
+// Keep this formatting logic in sync with mcp-code.ts; the standalone worker cannot import the TypeScript host module.
+function needsInspectableFormatting(value, stack = new WeakSet()) {
   if (value === undefined || typeof value === "bigint" || typeof value === "function" || typeof value === "symbol") return true;
   if (typeof value !== "object" || value === null) return false;
-  if (seen.has(value)) return true;
+  if (stack.has(value)) return true;
   if (value instanceof Map || value instanceof Set || value instanceof WeakMap || value instanceof WeakSet) return true;
-  seen.add(value);
-  return Object.values(value).some((entry) => needsInspectableFormatting(entry, seen));
+  stack.add(value);
+  try {
+    return Object.values(value).some((entry) => needsInspectableFormatting(entry, stack));
+  } finally {
+    stack.delete(value);
+  }
 }
 
 function formatValue(value) {

--- a/skills/mcp-scripting/SKILL.md
+++ b/skills/mcp-scripting/SKILL.md
@@ -5,13 +5,9 @@ description: Write mcp_script JavaScript for discovering, inspecting, and callin
 
 # MCP scripting
 
-Use `mcp_script` when a task needs multiple MCP tool calls in one JavaScript request, with loops, filtering, chaining, fan-out, or other logic between calls. For a single MCP search, describe, status check, auth action, or tool call, use `mcp` instead.
+For multi-call MCP work, write ordinary JavaScript with loops, filtering, chaining, fan-out, or other logic between calls. Run that source with `mcp_script`; it is the primary MCP orchestration surface. For a single MCP search, describe, status check, auth action, or tool call, use `mcp` instead.
 
-## Workflow
-
-1. Find candidate tools with `await tools.search({ query, server?, limit?, offset? })`.
-2. Inspect the exact returned path with `await tools.describe({ path })`.
-3. Call it with `tools.call(path, args)`.
+Write the source naturally, then pass it as `mcp_script`'s `code` argument:
 
 ```js
 const { items } = await tools.search({ query: "search issues", server: "github" });
@@ -27,10 +23,16 @@ emit({ tool: details.path, completed: true });
 return result.data;
 ```
 
+## Workflow
+
+1. Find candidate tools with `await tools.search({ query, server?, limit?, offset? })`.
+2. Inspect the exact returned path with `await tools.describe({ path })`.
+3. Call it with `tools.call(path, args)`.
+
 Calls resolve to `{ ok: true, data }` or `{ ok: false, error }`; handle failed calls instead of expecting them to stop the script. `emit(value)` adds user-visible output before the final `return` value. `console` output is captured too.
 
 `tools` is a non-enumerable proxy: `Object.keys(tools)` throws. Always use `tools.search` for discovery. When a known flat path is a valid identifier, direct calls such as `tools.github_search_issues(args)` are supported; use bracket syntax for hyphenated names: `tools["server_tool-name"](args)`. `search`, `call`, `describe`, and promise/serialization names (`then`, `catch`, `finally`, `toJSON`, `toString`, `valueOf`) are reserved on the proxy; if a flat path collides with one, call it via `tools.call("exact-path", args)`.
 
-`tools.search` and `tools.describe` are asynchronous and must be awaited. The default script timeout is 30 seconds; the worker is terminated at the deadline, including for infinite loops. Every invocation still uses normal lazy connection, authentication, output guarding, and approval gates. Result details contain a concise `calls` trace with each path and outcome.
+`tools.search` and `tools.describe` are asynchronous and must be awaited. The default script timeout is 30 seconds; the worker is terminated at the deadline, including for infinite loops. Every invocation still uses normal lazy connection, authentication, output guarding, and approval gates. Result details contain a concise `calls` trace with every search, describe, and call operation; each entry includes its query or path, outcome, and duration.
 
 Use plain JavaScript loops and Promise utilities for composition. Fluent helpers such as `tools.find(...).one()`, `tools.parallel(...)`, and `tools.retry(...)` are not provided.


### PR DESCRIPTION
## Summary

- record search, describe, and call operation metadata with paths or queries, outcomes, and durations
- render non-JSON script values (including Maps, Sets, cycles, functions, symbols, and BigInts) informatively in emits, returns, and console output
- lead scripting docs with plain JavaScript and clarify `mcp_script` as the multi-call MCP workflow surface

## Validation

- `npx vitest run __tests__/mcp-code.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

No async run infrastructure, background lifecycle controls, durable artifacts, or default behavior changes are included.