### PR TITLE
build: strengthen TypeScript checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
         run: |
           npm install --prefix examples/interactive-visualizer --no-package-lock --no-audit --no-fund
           npm run --prefix examples/interactive-visualizer build
-      - run: npx tsc --noEmit
+      - name: Typecheck
+        run: npm run typecheck
       - run: npm test
       - run: npm run test:oauth
       - run: npm run test:conformance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a strict TypeScript typecheck command and CI gate.
+
 ## [2.19.0] - 2026-08-03
 
 ### Added

--- a/commands.ts
+++ b/commands.ts
@@ -277,8 +277,8 @@ export async function authenticateServer(
           "info"
         );
       },
-      signal,
-      runtime,
+      ...(signal ? { signal } : {}),
+      ...(runtime ? { runtime } : {}),
     });
     if (signal?.aborted) signal.throwIfAborted();
 

--- a/config.ts
+++ b/config.ts
@@ -417,10 +417,12 @@ function getConfigSources(overridePath?: string, cwd = process.cwd()): ConfigSou
 }
 
 function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
+  const imports = mergeImports(base.imports, next.imports);
+  const settings = next.settings ? { ...base.settings, ...next.settings } : base.settings;
   return {
     mcpServers: mergeServerMaps(base.mcpServers, next.mcpServers),
-    imports: mergeImports(base.imports, next.imports),
-    settings: next.settings ? { ...base.settings, ...next.settings } : base.settings,
+    ...(imports !== undefined ? { imports } : {}),
+    ...(settings !== undefined ? { settings } : {}),
   };
 }
 
@@ -499,7 +501,7 @@ function expandImports(config: McpConfig, cwd = process.cwd()): McpConfig {
 
   return {
     imports: config.imports,
-    settings: config.settings,
+    ...(config.settings !== undefined ? { settings: config.settings } : {}),
     mcpServers: mergeServerMaps(importedServers, config.mcpServers),
   };
 }
@@ -609,8 +611,8 @@ function validateConfig(raw: unknown): McpConfig {
 
   return {
     mcpServers: servers as Record<string, ServerEntry>,
-    imports: Array.isArray(obj.imports) ? (obj.imports as ImportKind[]) : undefined,
-    settings: obj.settings as McpSettings | undefined,
+    ...(Array.isArray(obj.imports) ? { imports: obj.imports as ImportKind[] } : {}),
+    ...(obj.settings !== undefined ? { settings: obj.settings as McpSettings } : {}),
   };
 }
 
@@ -708,8 +710,10 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
 
       if (raw.type === "local" && Array.isArray(raw.command) && raw.command.length > 0 && raw.command.every((value): value is string => typeof value === "string")) {
         const env = toStringRecord(raw.environment);
+        const command = raw.command[0];
+        if (command === undefined) continue;
         const mapped: ServerEntry = {
-          command: raw.command[0],
+          command,
           args: raw.command.slice(1),
           ...(env ? { env } : {}),
           ...(typeof raw.cwd === "string" ? { cwd: raw.cwd } : {}),
@@ -789,9 +793,12 @@ function buildUnifiedDiff(beforeText: string, afterText: string): string {
 
   for (let i = rows - 1; i >= 0; i--) {
     for (let j = cols - 1; j >= 0; j--) {
-      lcs[i][j] = before[i] === after[j]
-        ? lcs[i + 1][j + 1] + 1
-        : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      const row = lcs[i];
+      const nextRow = lcs[i + 1];
+      if (!row || !nextRow) continue;
+      row[j] = before[i] === after[j]
+        ? (nextRow[j + 1] ?? 0) + 1
+        : Math.max(nextRow[j] ?? 0, row[j + 1] ?? 0);
     }
   }
 
@@ -805,7 +812,7 @@ function buildUnifiedDiff(beforeText: string, afterText: string): string {
       j++;
       continue;
     }
-    if (j < cols && (i === rows || lcs[i][j + 1] >= lcs[i + 1][j])) {
+    if (j < cols && (i === rows || (lcs[i]?.[j + 1] ?? 0) >= (lcs[i + 1]?.[j] ?? 0))) {
       lines.push(`+ ${after[j]}`);
       j++;
       continue;
@@ -1108,7 +1115,7 @@ export function getServerProvenance(overridePath?: string, cwd = process.cwd()):
       provenance.set(name, {
         path: source.writePath,
         kind: source.kind,
-        importKind: source.importKind,
+        ...(source.importKind !== undefined ? { importKind: source.importKind } : {}),
       });
     }
   }

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
@@ -18,6 +19,8 @@ import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./u
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
+
+type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
@@ -92,7 +95,10 @@ async function attemptDirectAutoAuth(
           : { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime },
       );
     } else {
-      await authenticate(serverName, serverUrl, definition, { signal, runtime: state.oauthRuntime });
+      await authenticate(serverName, serverUrl, definition, {
+        ...(signal ? { signal } : {}),
+        runtime: state.oauthRuntime,
+      });
     }
     return { status: "success" };
   } catch (error) {
@@ -162,9 +168,9 @@ export function resolveDirectTools(
         originalName: tool.name,
         prefixedName,
         description: tool.description ?? "",
-        inputSchema: tool.inputSchema,
-        uiResourceUri: tool.uiResourceUri,
-        uiStreamMode: tool.uiStreamMode,
+        ...(tool.inputSchema !== undefined ? { inputSchema: tool.inputSchema } : {}),
+        ...(tool.uiResourceUri !== undefined ? { uiResourceUri: tool.uiResourceUri } : {}),
+        ...(tool.uiStreamMode !== undefined ? { uiStreamMode: tool.uiStreamMode } : {}),
       });
     }
 
@@ -223,7 +229,7 @@ export function buildProxyDescription(
   const serverSummaries: string[] = [];
   for (const serverName of Object.keys(config.mcpServers)) {
     const definition = config.mcpServers[serverName];
-    if (isServerDisabled(definition)) continue;
+    if (!definition || isServerDisabled(definition)) continue;
     const entry = cache?.servers?.[serverName];
     const effectivePrefix = resolveToolPrefix(definition, prefix);
     const toolCount = (entry?.tools ?? []).filter(
@@ -377,10 +383,10 @@ export function createDirectToolExecutor(
       name: spec.prefixedName,
       originalName: spec.originalName,
       description: spec.description,
-      inputSchema: spec.inputSchema,
-      resourceUri: spec.resourceUri,
-      uiResourceUri: spec.uiResourceUri,
-      uiStreamMode: spec.uiStreamMode,
+      ...(spec.inputSchema !== undefined ? { inputSchema: spec.inputSchema } : {}),
+      ...(spec.resourceUri !== undefined ? { resourceUri: spec.resourceUri } : {}),
+      ...(spec.uiResourceUri !== undefined ? { uiResourceUri: spec.uiResourceUri } : {}),
+      ...(spec.uiStreamMode !== undefined ? { uiStreamMode: spec.uiStreamMode } : {}),
     }, params, ownedSignal);
     if (approval.ok === false) {
       const denied = approval.reason === "denied";
@@ -431,7 +437,12 @@ export function createDirectToolExecutor(
 
       if (spec.resourceUri) {
         const result = await withSessionRecovery(
-          { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
+          {
+            manager: state.manager,
+            config: state.config,
+            ...(ownedSignal ? { signal: ownedSignal } : {}),
+            onNeedsAuth: recoverAuthConnection,
+          },
           spec.serverName,
           (conn) => conn.client.readResource({ uri: spec.resourceUri! }, requestOptions),
         );
@@ -453,14 +464,19 @@ export function createDirectToolExecutor(
             toolName: spec.originalName,
             toolArgs: params ?? {},
             uiResourceUri: spec.uiResourceUri!,
-            streamMode: spec.uiStreamMode,
-            signal,
+            ...(spec.uiStreamMode !== undefined ? { streamMode: spec.uiStreamMode } : {}),
+            ...(signal ? { signal } : {}),
             onNeedsAuth: recoverAuthConnection,
           })
         : null;
 
-      const result = await withSessionRecovery(
-        { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
+      const result = await withSessionRecovery<ClientCallToolResult>(
+        {
+          manager: state.manager,
+          config: state.config,
+          ...(ownedSignal ? { signal: ownedSignal } : {}),
+          onNeedsAuth: recoverAuthConnection,
+        },
         spec.serverName,
         (conn) => abortable(conn.client.callTool({
           name: spec.originalName,

--- a/errors.ts
+++ b/errors.ts
@@ -17,8 +17,8 @@ export interface McpUiErrorContext {
 export class McpUiError extends Error {
   readonly code: string;
   readonly context: McpUiErrorContext;
-  readonly recoveryHint?: string;
-  readonly cause?: Error;
+  readonly recoveryHint: string | undefined;
+  readonly cause: Error | undefined;
 
   constructor(
     message: string,
@@ -65,9 +65,9 @@ export class ResourceFetchError extends McpUiError {
   ) {
     super(`Failed to fetch UI resource "${uri}": ${reason}`, {
       code: "RESOURCE_FETCH_ERROR",
-      context: { uri, server: options?.server },
+      context: { uri, ...(options?.server !== undefined ? { server: options.server } : {}) },
       recoveryHint: "Check that the MCP server is connected and the resource URI is valid.",
-      cause: options?.cause,
+      ...(options?.cause !== undefined ? { cause: options.cause } : {}),
     });
     this.name = "ResourceFetchError";
   }
@@ -84,7 +84,11 @@ export class ResourceParseError extends McpUiError {
   ) {
     super(`Invalid UI resource "${uri}": ${reason}`, {
       code: "RESOURCE_PARSE_ERROR",
-      context: { uri, server: options?.server, mimeType: options?.mimeType },
+      context: {
+        uri,
+        ...(options?.server !== undefined ? { server: options.server } : {}),
+        ...(options?.mimeType !== undefined ? { mimeType: options.mimeType } : {}),
+      },
       recoveryHint: "Ensure the resource returns valid HTML with the correct MIME type.",
     });
     this.name = "ResourceParseError";
@@ -98,9 +102,9 @@ export class BridgeConnectionError extends McpUiError {
   constructor(reason: string, options?: { session?: string; cause?: Error }) {
     super(`AppBridge connection failed: ${reason}`, {
       code: "BRIDGE_CONNECTION_ERROR",
-      context: { session: options?.session },
+      context: options?.session !== undefined ? { session: options.session } : {},
       recoveryHint: "Check browser console for detailed errors. The iframe may have failed to load.",
-      cause: options?.cause,
+      ...(options?.cause !== undefined ? { cause: options.cause } : {}),
     });
     this.name = "BridgeConnectionError";
   }
@@ -142,9 +146,9 @@ export class SessionError extends McpUiError {
   ) {
     super(`Session error: ${reason}`, {
       code: "SESSION_ERROR",
-      context: { session: options?.session },
+      context: options?.session !== undefined ? { session: options.session } : {},
       recoveryHint: "The session may have expired or been closed. Try opening the UI again.",
-      cause: options?.cause,
+      ...(options?.cause !== undefined ? { cause: options.cause } : {}),
     });
     this.name = "SessionError";
   }
@@ -160,9 +164,9 @@ export class ServerError extends McpUiError {
   ) {
     super(`UI server error: ${reason}`, {
       code: "SERVER_ERROR",
-      context: { port: options?.port },
+      context: options?.port !== undefined ? { port: options.port } : {},
       recoveryHint: "Check if the port is available. Another process may be using it.",
-      cause: options?.cause,
+      ...(options?.cause !== undefined ? { cause: options.cause } : {}),
     });
     this.name = "ServerError";
   }
@@ -179,9 +183,9 @@ export class McpServerError extends McpUiError {
   ) {
     super(`MCP server "${server}" error: ${reason}`, {
       code: "MCP_SERVER_ERROR",
-      context: { server, tool: options?.tool },
+      context: { server, ...(options?.tool !== undefined ? { tool: options.tool } : {}) },
       recoveryHint: "Check that the MCP server is running and responsive.",
-      cause: options?.cause,
+      ...(options?.cause !== undefined ? { cause: options.cause } : {}),
     });
     this.name = "McpServerError";
   }
@@ -196,8 +200,8 @@ export function wrapError(error: unknown, context?: McpUiErrorContext): McpUiErr
     return new McpUiError(error.message, {
       code: error.code,
       context: { ...error.context, ...context },
-      recoveryHint: error.recoveryHint,
-      cause: error.cause,
+      ...(error.recoveryHint !== undefined ? { recoveryHint: error.recoveryHint } : {}),
+      ...(error.cause !== undefined ? { cause: error.cause } : {}),
     });
   }
 
@@ -206,8 +210,8 @@ export function wrapError(error: unknown, context?: McpUiErrorContext): McpUiErr
 
   return new McpUiError(message, {
     code: "UNKNOWN_ERROR",
-    context,
-    cause,
+    ...(context !== undefined ? { context } : {}),
+    ...(cause !== undefined ? { cause } : {}),
   });
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
+import type { AgentToolUpdateCallback, ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata } from "./types.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
@@ -259,7 +259,10 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   function startInitialization(ctx: ExtensionContext, owner: McpRuntimeOwner, oauthRuntime: McpOAuthRuntime, generation: number, staleReason: string): Promise<void> {
     const promise = initializeMcp(pi, ctx, owner, {
       ...(programmaticConfig || options.configPath !== undefined
-        ? { configPath: earlyConfigPath, config: sessionConfig }
+        ? {
+            ...(earlyConfigPath !== undefined ? { configPath: earlyConfigPath } : {}),
+            ...(sessionConfig !== undefined ? { config: sessionConfig } : {}),
+          }
         : {}),
       oauthRuntime,
       statusEvents: pi.events,
@@ -427,7 +430,11 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
 
       const [, subcommand, argumentPrefix] = argumentMatch;
-      if ((subcommand !== "reconnect" && subcommand !== "logout" && subcommand !== "disable" && subcommand !== "enable") || !state) return null;
+      if (
+        (subcommand !== "reconnect" && subcommand !== "logout" && subcommand !== "disable" && subcommand !== "enable")
+        || argumentPrefix === undefined
+        || !state
+      ) return null;
 
       const servers = Object.keys(state.config.mcpServers)
         .filter((serverName) => serverName.startsWith(argumentPrefix.trimStart()))
@@ -619,7 +626,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         timeoutMs: Type.Optional({ type: "number", minimum: 1, description: "Execution timeout in milliseconds (default: 30000)" } as any),
       }),
       renderResult: renderMcpToolResult,
-      async execute(_toolCallId, params: { code: string; timeoutMs?: number }, signal) {
+      async execute(_toolCallId: string, params: { code: string; timeoutMs?: number }, signal: AbortSignal | undefined) {
         const executeOwner = currentOwner;
         if (!state && initPromise) {
           try {
@@ -682,7 +689,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
       }),
       renderResult: renderMcpToolResult,
-      async execute(_toolCallId, params: {
+      async execute(_toolCallId: string, params: {
         tool?: string;
         args?: string | Record<string, unknown>;
         connect?: string;
@@ -695,7 +702,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         offset?: number;
         server?: string;
         action?: string;
-      }, signal, _onUpdate, _ctx) {
+      }, signal: AbortSignal | undefined, _onUpdate: AgentToolUpdateCallback<Record<string, unknown>> | undefined, _ctx: ExtensionContext) {
         const executeOwner = currentOwner;
         let parsedArgs: Record<string, unknown> | undefined;
         if (params.args !== undefined && params.args !== "") {
@@ -849,8 +856,8 @@ export function createMcpAdapter(options: McpAdapterOptions = {}) {
   const factoryConfig = options.config !== undefined ? cloneMcpConfig(options.config) : undefined;
   return function mcpAdapter(pi: ExtensionAPI) {
     installMcpAdapter(pi, {
-      configPath: options.configPath,
-      config: factoryConfig !== undefined ? cloneMcpConfig(factoryConfig) : undefined,
+      ...(options.configPath !== undefined ? { configPath: options.configPath } : {}),
+      ...(factoryConfig !== undefined ? { config: cloneMcpConfig(factoryConfig) } : {}),
     });
   };
 }

--- a/init.ts
+++ b/init.ts
@@ -124,7 +124,7 @@ export async function initializeMcp(
   if (config.settings?.sampling !== false && (hasUI || samplingAutoApprove)) {
     manager.setSamplingConfig({
       autoApprove: samplingAutoApprove,
-      ui,
+      ...(ui !== undefined ? { ui } : {}),
       modelRegistry,
       getCurrentModel: () => owner.isActive() ? ctx.model : undefined,
       getSignal: () => owner.isActive()
@@ -175,12 +175,12 @@ export async function initializeMcp(
       await openUrl(pi, url, process.env.BROWSER, owner.signal);
       owner.throwIfInactive();
     },
-    ui,
+    ...(ui !== undefined ? { ui } : {}),
     sendMessage: (message, options) => {
       if (!owner.isActive()) return;
       pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options);
     },
-    statusEvents: options.statusEvents,
+    ...(options.statusEvents !== undefined ? { statusEvents: options.statusEvents } : {}),
   };
   if (ownsOAuthRuntime) owner.addCleanup(() => shutdownOAuth(oauthRuntime));
   manager.setMetadataListChangedListener?.((serverName, reason) => {
@@ -345,8 +345,9 @@ export async function initializeMcp(
         missingCacheServers.filter(name => !results.some(r => r.name === name && r.connection)),
         10,
         async (name) => {
-          const definition = config.mcpServers[name];
           try {
+            const definition = config.mcpServers[name];
+            if (!definition) throw new Error(`MCP server "${name}" is not configured`);
             const connection = await manager.connect(name, definition, runtimeSignal);
             if (connection.status === "needs-auth") {
               return { name, ok: false };
@@ -412,8 +413,8 @@ export async function initializeMcp(
 
 export function markKeepAliveAfterConnect(state: McpExtensionState, serverName: string): void {
   const definition = state.config.mcpServers[serverName];
-  if (isServerDisabled(definition)) return;
-  if ((definition?.lifecycle ?? "lazy") === "lazy-keep-alive") {
+  if (!definition || isServerDisabled(definition)) return;
+  if ((definition.lifecycle ?? "lazy") === "lazy-keep-alive") {
     state.lifecycle.markKeepAlive(serverName, definition);
   }
 }
@@ -485,7 +486,7 @@ export function updateMetadataCache(
     tools,
     resources,
     ...(prompts !== undefined ? { prompts } : {}),
-    instructions: connection.instructions,
+    ...(connection.instructions !== undefined ? { instructions: connection.instructions } : {}),
     cachedAt: Date.now(),
   };
 

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -12,15 +12,15 @@ export class McpLifecycleManager {
   private allServers = new Map<string, ServerDefinition>();
   private serverSettings = new Map<string, { idleTimeout?: number }>();
   private globalIdleTimeout = 10 * 60 * 1000;
-  private healthCheckInterval?: NodeJS.Timeout;
-  private onReconnect?: ReconnectCallback;
-  private onReconnectFailure?: ReconnectFailureCallback;
-  private onIdleShutdown?: (serverName: string) => void;
-  private activeHealthCheck?: Promise<void>;
-  private shutdownPromise?: Promise<void>;
+  private healthCheckInterval: NodeJS.Timeout | undefined;
+  private onReconnect: ReconnectCallback | undefined;
+  private onReconnectFailure: ReconnectFailureCallback | undefined;
+  private onIdleShutdown: ((serverName: string) => void) | undefined;
+  private activeHealthCheck: Promise<void> | undefined;
+  private shutdownPromise: Promise<void> | undefined;
   private stopped = false;
-  private healthSignal?: AbortSignal;
-  private removeHealthAbortListener?: () => void;
+  private healthSignal: AbortSignal | undefined;
+  private removeHealthAbortListener: (() => void) | undefined;
 
   constructor(
     private readonly manager: McpServerManager,

--- a/logger.ts
+++ b/logger.ts
@@ -69,7 +69,7 @@ class Logger {
       level,
       message,
       context: { ...this.defaultContext, ...context },
-      error,
+      ...(error !== undefined ? { error } : {}),
       timestamp: new Date(),
     };
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -239,7 +239,7 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
           clientInfo: { name: "pi-mcp-adapter", version: "2.11.0" },
         },
       }),
-      signal: discoverySignal,
+      ...(discoverySignal ? { signal: discoverySignal } : {}),
     })
     const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response)
     await response.body?.cancel().catch(() => {})
@@ -658,7 +658,11 @@ export async function authenticate(
 
   const operation = (async (): Promise<AuthStatus> => {
     // Start auth flow
-    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, { ...options, signal, runtime })
+    const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, {
+      ...options,
+      ...(signal ? { signal } : {}),
+      runtime,
+    })
 
     // If no auth URL needed, already authenticated
     if (!authorizationUrl) {
@@ -701,7 +705,11 @@ export async function authenticate(
       throwIfAborted(signal)
 
       // Complete the auth
-      return await completeAuth(serverName, callbackResult, { ...options, signal, runtime })
+      return await completeAuth(serverName, callbackResult, {
+        ...options,
+        ...(signal ? { signal } : {}),
+        runtime,
+      })
     } catch (error) {
       if (oauthState) cancelPendingCallback(oauthState)
       try {

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -172,9 +172,9 @@ export async function runMcpScript(
       if (query.trim() === "") {
         return { items: [], total: 0, hasMore: false, nextOffset: null };
       }
-      const server = typeof input.server === "string" ? input.server : undefined;
-      const limit = typeof input.limit === "number" ? input.limit : 12;
-      const offset = typeof input.offset === "number" ? input.offset : 0;
+      const server = typeof input?.server === "string" ? input.server : undefined;
+      const limit = typeof input?.limit === "number" ? input.limit : 12;
+      const offset = typeof input?.offset === "number" ? input.offset : 0;
       const page = paginate(rankToolMatches(state, query, server), offset, limit);
       return {
         ...page,

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -318,7 +318,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.config.clientId && info.client_id === this.config.clientId) {
       updateClientInfo(
         this.serverName,
-        { clientId: info.client_id, issuer, configPreRegistered: true },
+        {
+          clientId: info.client_id,
+          ...(issuer !== undefined ? { issuer } : {}),
+          configPreRegistered: true,
+        },
         this.serverUrl,
         this.storageOptions,
       )
@@ -329,11 +333,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
       ?? (this.redirectUrl ? [this.redirectUrl] : undefined)
     const clientInfo: StoredClientInfo = {
       clientId: info.client_id,
-      clientSecret: info.client_secret,
-      clientIdIssuedAt: info.client_id_issued_at,
-      clientSecretExpiresAt: info.client_secret_expires_at,
-      redirectUris,
-      issuer,
+      ...(info.client_secret !== undefined ? { clientSecret: info.client_secret } : {}),
+      ...(info.client_id_issued_at !== undefined ? { clientIdIssuedAt: info.client_id_issued_at } : {}),
+      ...(info.client_secret_expires_at !== undefined ? { clientSecretExpiresAt: info.client_secret_expires_at } : {}),
+      ...(redirectUris !== undefined ? { redirectUris } : {}),
+      ...(issuer !== undefined ? { issuer } : {}),
     }
     this.flowClientInfo = clientInfo
     updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
@@ -370,15 +374,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Save OAuth tokens.
    */
   async saveTokens(tokens: OAuthTokens): Promise<void> {
+    const issuer = this.discoveredIssuer ?? (tokens as IssuerBoundTokens).issuer
     const storedTokens: StoredTokens = {
       accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token,
+      ...(tokens.refresh_token !== undefined ? { refreshToken: tokens.refresh_token } : {}),
       // Preserve expiry even when expires_in is 0 (e.g. the SDK re-saving an
       // already-expired token) so expired tokens stay expired instead of
       // being persisted as never-expiring.
-      expiresAt: tokens.expires_in !== undefined ? Date.now() / 1000 + tokens.expires_in : undefined,
-      scope: tokens.scope,
-      issuer: this.discoveredIssuer ?? (tokens as IssuerBoundTokens).issuer,
+      ...(tokens.expires_in !== undefined ? { expiresAt: Date.now() / 1000 + tokens.expires_in } : {}),
+      ...(tokens.scope !== undefined ? { scope: tokens.scope } : {}),
+      ...(issuer !== undefined ? { issuer } : {}),
     }
     this.throwIfInactive()
     updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -107,7 +107,7 @@ export async function guardMcpOutput(
   if (options.enabled === false) {
     return {
       content: addAffixes(normalizedContent, prefix, suffix),
-      mcpResult: options.rawMcpResult,
+      ...(options.rawMcpResult !== undefined ? { mcpResult: options.rawMcpResult } : {}),
     };
   }
 
@@ -138,8 +138,8 @@ export async function guardMcpOutput(
       originalLines: stats.lines,
       returnedLines: finalStats.lines,
       ...(imageBlocks.length > 0 ? { imageBlocksPassedThrough: imageBlocks.length } : {}),
-      fullOutputPath,
-      writeError,
+      ...(fullOutputPath !== undefined ? { fullOutputPath } : {}),
+      ...(writeError !== undefined ? { writeError } : {}),
     };
   }
 
@@ -147,7 +147,11 @@ export async function guardMcpOutput(
     ? undefined
     : await boundMcpResult(options.rawMcpResult, detailsMaxBytes);
 
-  return { content: guardedContent, outputGuard, mcpResult };
+  return {
+    content: guardedContent,
+    ...(outputGuard ? { outputGuard } : {}),
+    ...(mcpResult !== undefined ? { mcpResult } : {}),
+  };
 }
 
 function sanitizeContent(content: ContentBlock[]): ContentBlock[] {
@@ -177,7 +181,7 @@ function addAffixes(content: ContentBlock[], prefix: string, suffix: string): Co
   if (prefix) {
     const index = next.findIndex((block) => block.type === "text");
     const block = next[index];
-    if (index >= 0 && block.type === "text") {
+    if (block?.type === "text") {
       next[index] = { ...block, text: `${prefix}${block.text}` };
     } else {
       next.unshift({ type: "text", text: prefix });
@@ -187,13 +191,13 @@ function addAffixes(content: ContentBlock[], prefix: string, suffix: string): Co
   if (suffix) {
     let index = -1;
     for (let i = next.length - 1; i >= 0; i--) {
-      if (next[i].type === "text") {
+      if (next[i]?.type === "text") {
         index = i;
         break;
       }
     }
     const block = next[index];
-    if (index >= 0 && block.type === "text") {
+    if (block?.type === "text") {
       next[index] = { ...block, text: `${block.text}${suffix}` };
     } else {
       next.push({ type: "text", text: suffix });
@@ -239,8 +243,8 @@ function truncateHead(text: string, maxBytes: number, maxLines: number): { conte
 function truncateStringToBytes(value: string, maxBytes: number): string {
   if (byteLength(value) <= maxBytes) return value;
   const buffer = Buffer.from(value, "utf8");
-  let end = Math.max(0, maxBytes);
-  while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
+  let end = Number.isFinite(maxBytes) ? Math.max(0, Math.floor(maxBytes)) : 0;
+  while (end > 0 && (buffer.readUInt8(end) & 0xc0) === 0x80) end--;
   return buffer.subarray(0, end).toString("utf8");
 }
 
@@ -280,8 +284,8 @@ async function summarizeMcpResult(result: unknown, raw: string, rawBytes: number
     contentBlocks: content.length,
     contentSummary: summarizeContent(content),
     rawResultBytes: rawBytes,
-    fullResultPath,
-    resultWriteError,
+    ...(fullResultPath !== undefined ? { fullResultPath } : {}),
+    ...(resultWriteError !== undefined ? { resultWriteError } : {}),
   };
 
   if (record && "structuredContent" in record) {

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -52,6 +52,7 @@ function rainbowProgress(filled: number, total: number): string {
   const dots: string[] = [];
   for (let i = 0; i < total; i++) {
     const color = RAINBOW_COLORS[i % RAINBOW_COLORS.length];
+    if (!color) continue;
     dots.push(fg(color, i < filled ? "●" : "○"));
   }
   return dots.join(" ");
@@ -220,7 +221,10 @@ class McpPanel {
             }
 
             const isDirect = toolFilter === true || (Array.isArray(toolFilter) && toolFilter.includes(baseName));
-            const ct: CachedTool = { name: baseName, description: resource.description };
+            const ct: CachedTool = {
+              name: baseName,
+              ...(resource.description !== undefined ? { description: resource.description } : {}),
+            };
             tools.push({
               name: baseName,
               description: resource.description ?? `Read resource: ${resource.uri}`,
@@ -239,9 +243,9 @@ class McpPanel {
         name: serverName,
         expanded: false,
         source: prov?.kind ?? "user",
-        importKind: prov?.importKind,
-        includeTools: definition.includeTools,
-        excludeTools: definition.excludeTools,
+        ...(prov?.importKind !== undefined ? { importKind: prov.importKind } : {}),
+        ...(definition.includeTools !== undefined ? { includeTools: definition.includeTools } : {}),
+        ...(definition.excludeTools !== undefined ? { excludeTools: definition.excludeTools } : {}),
         exposeResources: definition.exposeResources !== false,
         connectionStatus: status,
         failureMessage,
@@ -276,6 +280,7 @@ class McpPanel {
     this.visibleItems = [];
     for (let si = 0; si < this.servers.length; si++) {
       const server = this.servers[si];
+      if (!server) continue;
       if (query && this.authOnly) {
         const score = mode === "name" ? fuzzyScore(query, server.name) : 0;
         if (score > 0) {
@@ -288,6 +293,7 @@ class McpPanel {
       if (server.expanded || query) {
         for (let ti = 0; ti < server.tools.length; ti++) {
           const tool = server.tools[ti];
+          if (!tool) continue;
           if (query) {
             const score = mode === "name"
               ? Math.max(
@@ -422,6 +428,7 @@ class McpPanel {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
       const server = this.servers[item.serverIndex];
+      if (!server) return;
       if (item.type === "server") {
         if (server.connectionStatus === "disabled") return;
         if (this.authOnly || server.connectionStatus === "needs-auth") {
@@ -433,6 +440,7 @@ class McpPanel {
         this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1));
       } else if (item.toolIndex !== undefined) {
         const tool = server.tools[item.toolIndex];
+        if (!tool) return;
         tool.isDirect = !tool.isDirect;
         if (tool.isDirect && server.source === "import") {
           this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
@@ -451,7 +459,8 @@ class McpPanel {
     if (matchesKey(data, "ctrl+r")) {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
-      this.reconnectServer(this.servers[item.serverIndex]);
+      const server = this.servers[item.serverIndex];
+      if (server) this.reconnectServer(server);
       return;
     }
 
@@ -459,7 +468,7 @@ class McpPanel {
       const item = this.visibleItems[this.cursorIndex];
       if (!item) return;
       const server = this.servers[item.serverIndex];
-      if (server.connectionStatus !== "failed" || !server.failureMessage) return;
+      if (!server || server.connectionStatus !== "failed" || !server.failureMessage) return;
       const serverName = sanitizeDisplayText(server.name);
       const failureMessage = sanitizeDisplayText(server.failureMessage);
       copyToClipboard(failureMessage).then(() => {
@@ -502,7 +511,8 @@ class McpPanel {
   }
 
   private authenticateSelectedServer(item: VisibleItem): void {
-    this.authenticateServer(this.servers[item.serverIndex]);
+    const server = this.servers[item.serverIndex];
+    if (server) this.authenticateServer(server);
   }
 
   private authenticateServer(server: ServerState): void {
@@ -574,6 +584,7 @@ class McpPanel {
   private toggleItem(item: VisibleItem): void {
     if (this.authOnly) return;
     const server = this.servers[item.serverIndex];
+    if (!server) return;
     if (item.type === "server") {
       const newState = !server.tools.every((t) => t.isDirect);
       if (server.source === "import" && newState) {
@@ -582,6 +593,7 @@ class McpPanel {
       for (const t of server.tools) t.isDirect = newState;
     } else if (item.toolIndex !== undefined) {
       const tool = server.tools[item.toolIndex];
+      if (!tool) return;
       tool.isDirect = !tool.isDirect;
       if (tool.isDirect && server.source === "import") {
         this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
@@ -654,7 +666,10 @@ class McpPanel {
 
         const prev = existingState.get(baseName);
         const isDirect = prev !== undefined ? prev : false;
-        const ct: CachedTool = { name: baseName, description: resource.description };
+        const ct: CachedTool = {
+          name: baseName,
+          ...(resource.description !== undefined ? { description: resource.description } : {}),
+        };
         newTools.push({
           name: baseName,
           description: resource.description ?? `Read resource: ${resource.uri}`,
@@ -724,8 +739,10 @@ class McpPanel {
 
       for (let i = startIdx; i < endIdx; i++) {
         const item = this.visibleItems[i];
+        if (!item) continue;
         const isCursor = i === this.cursorIndex;
         const server = this.servers[item.serverIndex];
+        if (!server) continue;
 
         if (item.type === "server") {
           lines.push(row(this.renderServerRow(server, isCursor)));
@@ -735,7 +752,8 @@ class McpPanel {
             }
           }
         } else if (item.toolIndex !== undefined) {
-          lines.push(row(this.renderToolRow(server.tools[item.toolIndex], isCursor, innerW)));
+          const tool = server.tools[item.toolIndex];
+          if (tool) lines.push(row(this.renderToolRow(tool, isCursor, innerW)));
         }
       }
 
@@ -871,7 +889,7 @@ class McpPanel {
     const item = this.visibleItems[this.cursorIndex];
     if (!item) return false;
     const server = this.servers[item.serverIndex];
-    return server.connectionStatus === "failed" && !!server.failureMessage;
+    return server?.connectionStatus === "failed" && !!server.failureMessage;
   }
 
   private wrapText(text: string, width: number): string[] {
@@ -884,11 +902,11 @@ class McpPanel {
       while (visibleWidth(rest) > max) {
         let take = "";
         let index = 0;
-        while (index < rest.length && visibleWidth(take + rest[index]) <= max) {
-          take += rest[index];
+        while (index < rest.length && visibleWidth(take + rest.charAt(index)) <= max) {
+          take += rest.charAt(index);
           index++;
         }
-        if (!take) take = rest[0];
+        if (!take) take = rest.charAt(0);
         lines.push(take);
         rest = rest.slice(take.length);
       }

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -169,9 +169,9 @@ export class McpSetupPanel {
     return [...new Set(paths)];
   }
 
-  private getSelectedAction(): Action | null {
+  private getSelectedAction(): Action | undefined {
     const actions = this.getActions();
-    return actions[this.actionCursor] ?? null;
+    return actions[this.actionCursor];
   }
 
   handleInput(data: string): void {
@@ -414,6 +414,7 @@ export class McpSetupPanel {
     }
     for (let index = start; index < end; index++) {
       const action = actions[index];
+      if (!action) continue;
       if (action.id === "add-known-server" && (index === start || actions[index - 1]?.id !== "add-known-server")) {
         lines.push(this.padLine(fg(this.t.title, "Add a known server"), innerW));
       }
@@ -442,6 +443,7 @@ export class McpSetupPanel {
     lines.push(this.padLine("", innerW));
     for (let index = 0; index < this.discovery.imports.length; index++) {
       const entry = this.discovery.imports[index];
+      if (!entry) continue;
       const selected = this.selectedImports.has(entry.kind) ? "[x]" : "[ ]";
       const cursor = index === this.importCursor ? fg(this.t.selected, "›") : " ";
       lines.push(this.padLine(`${cursor} ${selected} ${entry.kind}  ${entry.path}`, innerW));
@@ -462,7 +464,8 @@ export class McpSetupPanel {
     const paths = this.getDetectedPaths();
     for (let index = 0; index < paths.length; index++) {
       const cursor = index === this.pathCursor ? fg(this.t.selected, "›") : " ";
-      lines.push(this.padLine(`${cursor} ${paths[index]}`, innerW));
+      const path = paths[index];
+      if (path !== undefined) lines.push(this.padLine(`${cursor} ${path}`, innerW));
     }
     return lines;
   }

--- a/mcp-trace.ts
+++ b/mcp-trace.ts
@@ -95,6 +95,7 @@ export function createMcpTraceEvent(
   options?: { relatedRequestId?: unknown; durationMs?: number },
 ): McpTraceEvent {
   const kind = messageKind(message);
+  const bytes = messageBytes(message);
   const event: McpTraceEvent = {
     version: MCP_TRACE_SCHEMA_VERSION,
     timestamp: new Date().toISOString(),
@@ -103,7 +104,7 @@ export function createMcpTraceEvent(
     transport,
     kind,
     status,
-    bytes: messageBytes(message),
+    ...(bytes !== undefined ? { bytes } : {}),
   };
   if ("method" in message) event.method = redactTraceText(message.method, 120);
   if ("id" in message) event.id = traceId(message.id) ?? null;
@@ -210,8 +211,8 @@ export function createMcpTraceWriter(
     : resolve(sessionCwd ?? process.cwd(), ".pi", "mcp-traces", `mcp-${timestamp}-${randomSuffix}.jsonl`);
   return new McpTraceWriter({
     filePath,
-    maxBytes: settings.maxBytes,
-    maxEvents: settings.maxEvents,
+    ...(settings.maxBytes !== undefined ? { maxBytes: settings.maxBytes } : {}),
+    ...(settings.maxEvents !== undefined ? { maxEvents: settings.maxEvents } : {}),
   });
 }
 
@@ -231,12 +232,12 @@ export function isMcpTraceEnabled(
  * assigns `onmessage` during connect, so the setter must keep the observer in
  * front of whichever callback the SDK installs.
  */
-export function wrapTransportWithMcpTrace<T extends Transport>(
-  transport: T,
+export function wrapTransportWithMcpTrace(
+  transport: Transport,
   server: string,
   transportKind: McpTraceTransport,
   observer: McpTraceObserver,
-): T {
+): Transport {
   let messageHandler: Transport["onmessage"];
   const record = (event: McpTraceEvent): void => {
     try {
@@ -245,9 +246,9 @@ export function wrapTransportWithMcpTrace<T extends Transport>(
       // An observer failure must never alter SDK transport behavior.
     }
   };
-  const traced: Transport = {
+  const traced = {
     start: () => transport.start(),
-    send: async (message, options) => {
+    send: async (message: JSONRPCMessage, options?: Parameters<Transport["send"]>[1]) => {
       const started = performance.now();
       const messages = Array.isArray(message) ? message : [message];
       try {
@@ -270,35 +271,35 @@ export function wrapTransportWithMcpTrace<T extends Transport>(
     get onclose() {
       return transport.onclose;
     },
-    set onclose(handler) {
-      transport.onclose = handler;
+    set onclose(handler: Transport["onclose"]) {
+      Reflect.set(transport, "onclose", handler);
     },
     get onerror() {
       return transport.onerror;
     },
-    set onerror(handler) {
-      transport.onerror = handler;
+    set onerror(handler: Transport["onerror"]) {
+      Reflect.set(transport, "onerror", handler);
     },
     get onmessage() {
       return messageHandler;
     },
-    set onmessage(handler) {
+    set onmessage(handler: Transport["onmessage"]) {
       messageHandler = handler;
-      transport.onmessage = handler
+      Reflect.set(transport, "onmessage", handler
         ? ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
             record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
             handler(message, extra);
-          }) as Transport["onmessage"]
-        : undefined;
+          })
+        : undefined);
     },
     get sessionId() {
       return transport.sessionId;
     },
     setProtocolVersion: transport.setProtocolVersion
-      ? version => transport.setProtocolVersion!(version)
+      ? (version: string) => transport.setProtocolVersion?.(version)
       : undefined,
   };
-  return traced as T;
+  return traced as Transport;
 }
 
 export function traceTransportKind(definition: { command?: string; url?: string; socket?: string }, transport: Transport): McpTraceTransport {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -201,10 +201,10 @@ export function reconstructToolMetadata(
       name,
       originalName: tool.name,
       description: tool.description ?? "",
-      inputSchema: tool.inputSchema,
-      uiResourceUri: tool.uiResourceUri,
-      uiVisibility: tool.uiVisibility,
-      uiStreamMode: tool.uiStreamMode,
+      ...(tool.inputSchema !== undefined ? { inputSchema: tool.inputSchema } : {}),
+      ...(tool.uiResourceUri !== undefined ? { uiResourceUri: tool.uiResourceUri } : {}),
+      ...(tool.uiVisibility !== undefined ? { uiVisibility: tool.uiVisibility } : {}),
+      ...(tool.uiStreamMode !== undefined ? { uiStreamMode: tool.uiStreamMode } : {}),
     });
   }
 
@@ -237,14 +237,19 @@ export function reconstructToolMetadata(
 export function serializeTools(tools: McpTool[]): CachedTool[] {
   return tools
     .filter(t => t?.name)
-    .map(t => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-      uiResourceUri: tryGetToolUiResourceUri(t),
-      uiVisibility: extractUiToolVisibility(t._meta),
-      uiStreamMode: extractToolUiStreamMode(t._meta),
-    }));
+    .map(t => {
+      const uiResourceUri = tryGetToolUiResourceUri(t);
+      const uiVisibility = extractUiToolVisibility(t._meta);
+      const uiStreamMode = extractToolUiStreamMode(t._meta);
+      return {
+        name: t.name,
+        ...(t.description !== undefined ? { description: t.description } : {}),
+        ...(t.inputSchema !== undefined ? { inputSchema: t.inputSchema } : {}),
+        ...(uiResourceUri !== undefined ? { uiResourceUri } : {}),
+        ...(uiVisibility !== undefined ? { uiVisibility } : {}),
+        ...(uiStreamMode !== undefined ? { uiStreamMode } : {}),
+      };
+    });
 }
 
 export function serializeResources(resources: McpResource[]): CachedResource[] {
@@ -253,7 +258,7 @@ export function serializeResources(resources: McpResource[]): CachedResource[] {
     .map(r => ({
       uri: r.uri,
       name: r.name,
-      description: r.description,
+      ...(r.description !== undefined ? { description: r.description } : {}),
     }));
 }
 
@@ -262,15 +267,17 @@ export function serializePrompts(prompts: McpPrompt[]): CachedPrompt[] {
     .filter(prompt => prompt?.name)
     .map(prompt => ({
       name: prompt.name,
-      title: prompt.title,
-      description: prompt.description,
-      arguments: Array.isArray(prompt.arguments)
-        ? prompt.arguments.filter(argument => argument?.name).map(argument => ({
-            name: argument.name,
-            description: argument.description,
-            required: argument.required,
-          }))
-        : undefined,
+      ...(prompt.title !== undefined ? { title: prompt.title } : {}),
+      ...(prompt.description !== undefined ? { description: prompt.description } : {}),
+      ...(Array.isArray(prompt.arguments)
+        ? {
+            arguments: prompt.arguments.filter(argument => argument?.name).map(argument => ({
+              name: argument.name,
+              ...(argument.description !== undefined ? { description: argument.description } : {}),
+              ...(argument.required !== undefined ? { required: argument.required } : {}),
+            })),
+          }
+        : {}),
     }));
 }
 
@@ -285,15 +292,15 @@ export function reconstructPromptMetadata(
     const args: McpPromptArgument[] = Array.isArray(prompt.arguments)
       ? prompt.arguments.filter(argument => argument?.name).map(argument => ({
           name: argument.name,
-          description: argument.description,
-          required: argument.required,
+          ...(argument.description !== undefined ? { description: argument.description } : {}),
+          ...(argument.required !== undefined ? { required: argument.required } : {}),
         }))
       : [];
     return {
       serverName,
       originalName: prompt.name,
       commandName: formatPromptCommandName(prompt.name, serverName, effectivePrefix),
-      title: prompt.title,
+      ...(prompt.title !== undefined ? { title: prompt.title } : {}),
       description: prompt.description ?? "",
       arguments: args,
     };

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -95,6 +95,7 @@ function parseNpxArgs(args: string[]): ParsedInvocation | null {
 
   for (let i = 0; i < before.length; i++) {
     const arg = before[i];
+    if (arg === undefined) return null;
     if (foundFirstPositional) {
       positionals.push(arg);
       continue;
@@ -149,6 +150,7 @@ function parseNpmExecArgs(args: string[]): ParsedInvocation | null {
   let packageSpec: string | undefined;
   for (let i = 0; i < before.length; i++) {
     const arg = before[i];
+    if (arg === undefined) return null;
     if (arg === "-y" || arg === "--yes") continue;
     if (arg === "--package") {
       const value = before[i + 1];
@@ -239,7 +241,7 @@ function resolveFromNpmCache(packageSpec: string, binName?: string): NpxCacheEnt
   return {
     resolvedBin,
     resolvedAt: Date.now(),
-    packageVersion: pkg?.version,
+    ...(pkg?.version !== undefined ? { packageVersion: pkg.version } : {}),
     isJs,
   };
 }
@@ -329,9 +331,9 @@ function parsePackageSpec(spec: string): ParsedPackageSpec | null {
   const normalizedVersion = requestedVersion?.replace(/^=/, "").replace(/^v/i, "");
   return {
     packageName,
-    exactVersion: normalizedVersion && EXACT_PACKAGE_VERSION_RE.test(normalizedVersion)
-      ? normalizedVersion
-      : undefined,
+    ...(normalizedVersion && EXACT_PACKAGE_VERSION_RE.test(normalizedVersion)
+      ? { exactVersion: normalizedVersion }
+      : {}),
   };
 }
 

--- a/onboarding-state.ts
+++ b/onboarding-state.ts
@@ -30,7 +30,9 @@ export function loadOnboardingState(): McpOnboardingState {
       version: 1,
       sharedConfigHintShown: raw.sharedConfigHintShown === true,
       setupCompleted: raw.setupCompleted === true,
-      lastDiscoveryFingerprint: typeof raw.lastDiscoveryFingerprint === "string" ? raw.lastDiscoveryFingerprint : undefined,
+      ...(typeof raw.lastDiscoveryFingerprint === "string"
+        ? { lastDiscoveryFingerprint: raw.lastDiscoveryFingerprint }
+        : {}),
     };
   } catch {
     return { ...DEFAULT_STATE };
@@ -52,17 +54,23 @@ export function updateOnboardingState(updater: (state: McpOnboardingState) => Mc
 }
 
 export function markSharedConfigHintShown(fingerprint?: string): McpOnboardingState {
-  return updateOnboardingState((state) => ({
-    ...state,
-    sharedConfigHintShown: true,
-    lastDiscoveryFingerprint: fingerprint ?? state.lastDiscoveryFingerprint,
-  }));
+  return updateOnboardingState((state) => {
+    const lastDiscoveryFingerprint = fingerprint ?? state.lastDiscoveryFingerprint;
+    return {
+      ...state,
+      sharedConfigHintShown: true,
+      ...(lastDiscoveryFingerprint !== undefined ? { lastDiscoveryFingerprint } : {}),
+    };
+  });
 }
 
 export function markSetupCompleted(fingerprint?: string): McpOnboardingState {
-  return updateOnboardingState((state) => ({
-    ...state,
-    setupCompleted: true,
-    lastDiscoveryFingerprint: fingerprint ?? state.lastDiscoveryFingerprint,
-  }));
+  return updateOnboardingState((state) => {
+    const lastDiscoveryFingerprint = fingerprint ?? state.lastDiscoveryFingerprint;
+    return {
+      ...state,
+      setupCompleted: true,
+      ...(lastDiscoveryFingerprint !== undefined ? { lastDiscoveryFingerprint } : {}),
+    };
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,11 +30,12 @@
         "@earendil-works/pi-tui": "0.74.2",
         "@modelcontextprotocol/conformance": "0.1.16",
         "@types/bun": "^1.0.0",
-        "@types/node": "^20.0.0",
+        "@types/cross-spawn": "6.0.6",
+        "@types/node": "20.19.43",
         "@types/open": "^6.2.1",
         "tsx": "^4.21.0",
         "typebox": "1.3.3",
-        "typescript": "^5.0.0",
+        "typescript": "5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -4047,6 +4048,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pi-mcp-adapter": "cli.js"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -157,11 +158,12 @@
     "@earendil-works/pi-tui": "0.74.2",
     "@modelcontextprotocol/conformance": "0.1.16",
     "@types/bun": "^1.0.0",
-    "@types/node": "^20.0.0",
+    "@types/cross-spawn": "6.0.6",
+    "@types/node": "20.19.43",
     "@types/open": "^6.2.1",
     "tsx": "^4.21.0",
     "typebox": "1.3.3",
-    "typescript": "^5.0.0",
+    "typescript": "5.9.3",
     "vitest": "^3.0.0"
   }
 }

--- a/prompts.ts
+++ b/prompts.ts
@@ -117,7 +117,7 @@ function findUnquotedEquals(token: string): number {
 }
 
 function stripQuotes(value: string): string {
-  if (value.length >= 2 && (value.startsWith('"') || value.startsWith("'")) && value.endsWith(value[0])) {
+  if (value.length >= 2 && (value.startsWith('"') || value.startsWith("'")) && value.endsWith(value.charAt(0))) {
     return value.slice(1, -1);
   }
   return value;

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
@@ -20,6 +21,7 @@ import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts"
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
+type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
 const require = createRequire(import.meta.url);
 const MAX_REGEX_SEARCH_QUERY_LENGTH = 256;
@@ -1086,7 +1088,12 @@ export async function executeCall(
 
     if (toolMeta.resourceUri) {
       const result = await withSessionRecovery(
-        { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
+        {
+          manager: state.manager,
+          config: state.config,
+          ...(ownedSignal ? { signal: ownedSignal } : {}),
+          onNeedsAuth: recoverAuthConnection,
+        },
         serverName,
         (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
       );
@@ -1107,14 +1114,19 @@ export async function executeCall(
           toolName: toolMeta.originalName,
           toolArgs: args ?? {},
           uiResourceUri: toolMeta.uiResourceUri,
-          streamMode: toolMeta.uiStreamMode,
-          signal,
+          ...(toolMeta.uiStreamMode !== undefined ? { streamMode: toolMeta.uiStreamMode } : {}),
+          ...(signal ? { signal } : {}),
           onNeedsAuth: recoverAuthConnection,
         })
       : null;
 
-    const result = await withSessionRecovery(
-      { manager: state.manager, config: state.config, signal: ownedSignal, onNeedsAuth: recoverAuthConnection },
+    const result = await withSessionRecovery<ClientCallToolResult>(
+      {
+        manager: state.manager,
+        config: state.config,
+        ...(ownedSignal ? { signal: ownedSignal } : {}),
+        onNeedsAuth: recoverAuthConnection,
+      },
       serverName,
       (conn) => abortable(conn.client.callTool({
         name: toolMeta.originalName,

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -66,16 +66,16 @@ export async function handleSamplingRequest(
   const result = await complete(
     model,
     {
-      systemPrompt: params.systemPrompt,
+      ...(params.systemPrompt !== undefined ? { systemPrompt: params.systemPrompt } : {}),
       messages,
     },
     {
-      apiKey,
-      headers,
+      ...(apiKey !== undefined ? { apiKey } : {}),
+      ...(headers !== undefined ? { headers } : {}),
       maxTokens: params.maxTokens,
-      temperature: params.temperature,
-      metadata: params.metadata as Record<string, unknown> | undefined,
-      signal,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+      ...(params.metadata !== undefined ? { metadata: params.metadata as Record<string, unknown> } : {}),
+      ...(signal ? { signal } : {}),
     },
   );
 
@@ -160,7 +160,11 @@ async function resolveSamplingModel(
       errors.push(`${model.provider}/${model.id}: ${auth.error}`);
       continue;
     }
-    return { model, apiKey: auth.apiKey, headers: auth.headers };
+    return {
+      model,
+      ...(auth.apiKey !== undefined ? { apiKey: auth.apiKey } : {}),
+      ...(auth.headers !== undefined ? { headers: auth.headers } : {}),
+    };
   }
 
   if (errors.length > 0) {

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -82,7 +82,8 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
   if (!phraseMatched && (queryTokens.length <= 2 ? coverage !== 1 : coverage < 0.6)) return null;
 
   score += coverage === 1 ? 25 : Math.round(coverage * 10);
-  if (tokenize(fields.name).includes(queryTokens[0])) score += 8;
+  const firstQueryToken = queryTokens[0];
+  if (firstQueryToken !== undefined && tokenize(fields.name).includes(firstQueryToken)) score += 8;
   if (wholeFieldExact) score += 20;
   return score;
 }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -70,6 +70,12 @@ function isUnauthorizedHttpError(error: unknown): boolean {
   return error instanceof UnauthorizedError || (error instanceof StreamableHTTPError && error.code === 401);
 }
 
+function asSdkTransport(transport: StreamableHTTPClientTransport): Transport {
+  // SDK 1.30 declares its class field as `sessionId?: string` in a way that is
+  // structurally incompatible with its own Transport interface under exact optional types.
+  return transport as Transport;
+}
+
 function boundedStderrChunk(chunk: Buffer | string): Buffer {
   if (Buffer.isBuffer(chunk)) {
     const start = Math.max(0, chunk.byteLength - MAX_CAPTURED_STDERR_BYTES);
@@ -339,11 +345,12 @@ export class McpServerManager {
       }
       throwIfAborted(signal);
 
+      const cwd = resolveConfigPath(definition.cwd) ?? this.defaultCwd;
       const stdioTransport = new StdioClientTransport({
         command,
         args,
         env: resolveEnv(definition.env, name),
-        cwd: resolveConfigPath(definition.cwd) ?? this.defaultCwd,
+        ...(cwd !== undefined ? { cwd } : {}),
         stderr: definition.debug ? "inherit" : "pipe",
       });
       // Keep non-debug child diagnostics available for connection failures without
@@ -373,6 +380,7 @@ export class McpServerManager {
       await this.connectClientWithAbort(client, transport, requestOptions, signal);
       this.attachAdapterNotificationHandlers(name, client);
 
+      const instructions = client.getInstructions?.();
       const connection: ServerConnection = {
         client,
         transport,
@@ -380,7 +388,7 @@ export class McpServerManager {
         tools: [],
         resources: [],
         prompts: [],
-        instructions: client.getInstructions?.(),
+        ...(instructions !== undefined ? { instructions } : {}),
         lastUsedAt: Date.now(),
         inFlight: 0,
         status: "connected",
@@ -708,10 +716,10 @@ export class McpServerManager {
     // creating the provider until the server proves that authentication is needed.
     for (;;) {
       const authProvider = "provider" in authState ? authState.provider : undefined;
-      const streamableTransport = new StreamableHTTPClientTransport(url, {
-        requestInit,
-        authProvider,
-      });
+      const streamableTransport = asSdkTransport(new StreamableHTTPClientTransport(url, {
+        ...(requestInit !== undefined ? { requestInit } : {}),
+        ...(authProvider !== undefined ? { authProvider } : {}),
+      }));
       const probeTransport = traceObserver
         ? wrapTransportWithMcpTrace(streamableTransport, serverName, "streamable-http", traceObserver)
         : streamableTransport;
@@ -732,7 +740,10 @@ export class McpServerManager {
         }
 
         // StreamableHTTP works - create fresh transport for actual use
-        return new StreamableHTTPClientTransport(url, { requestInit, authProvider });
+        return asSdkTransport(new StreamableHTTPClientTransport(url, {
+          ...(requestInit !== undefined ? { requestInit } : {}),
+          ...(authProvider !== undefined ? { authProvider } : {}),
+        }));
       } catch (error) {
         if (error instanceof AggregateError && (
           error.message === "MCP connection abort cleanup failed" ||
@@ -772,7 +783,10 @@ export class McpServerManager {
         }
 
         // SSE is the legacy transport
-        return new SSEClientTransport(url, { requestInit, authProvider });
+        return new SSEClientTransport(url, {
+          ...(requestInit !== undefined ? { requestInit } : {}),
+          ...(authProvider !== undefined ? { authProvider } : {}),
+        });
       }
     }
   }

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -44,14 +44,15 @@ export function buildToolMetadata(
     } catch {
       failedTools.push(tool.name);
     }
+    const uiStreamMode = extractToolUiStreamMode(tool._meta);
     metadata.push({
       name,
       originalName: tool.name,
       description: tool.description ?? "",
-      inputSchema: tool.inputSchema,
-      uiResourceUri,
-      uiVisibility,
-      uiStreamMode: extractToolUiStreamMode(tool._meta),
+      ...(tool.inputSchema !== undefined ? { inputSchema: tool.inputSchema } : {}),
+      ...(uiResourceUri !== undefined ? { uiResourceUri } : {}),
+      ...(uiVisibility !== undefined ? { uiVisibility } : {}),
+      ...(uiStreamMode !== undefined ? { uiStreamMode } : {}),
     });
   }
 

--- a/ts-shape.ts
+++ b/ts-shape.ts
@@ -39,7 +39,10 @@ export function renderTsShape(inputSchema: unknown): string | null {
         if (typeof schema.$ref !== "string") return null;
         const match = schema.$ref.match(/^#\/(\$defs|definitions)\/([^/]+)$/);
         if (!match) return null;
-        const definitionKey = `${match[1]}/${decodePointerToken(match[2])}`;
+        const definitionGroup = match[1];
+        const definitionName = match[2];
+        if (definitionGroup === undefined || definitionName === undefined) return null;
+        const definitionKey = `${definitionGroup}/${decodePointerToken(definitionName)}`;
         if (!definitions.has(definitionKey)) return null;
         return aliasFor(definitionKey);
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
-    "strict": false,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "noEmit": true,
     "resolveJsonModule": true

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,11 @@
 // types.ts - Core type definitions
 import type { Transport as McpTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { ContentBlock as McpContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  ContentBlock as McpContentBlock,
+  ListPromptsResult,
+  ListResourcesResult,
+  ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
 import type { UiToolVisibility } from "./ui-tool-visibility.ts";
@@ -48,36 +53,41 @@ export type ImportKind =
   | "windsurf" 
   | "vscode";
 
-// Tool definition from MCP server
+type SdkTool = ListToolsResult["tools"][number];
+type SdkResource = ListResourcesResult["resources"][number];
+type SdkPrompt = ListPromptsResult["prompts"][number];
+type SdkPromptArgument = NonNullable<SdkPrompt["arguments"]>[number];
+
+// MCP wire definitions derive their field types from the installed SDK while
+// retaining the adapter's deliberately smaller public surface.
 export interface McpTool {
-  name: string;
-  title?: string;
-  description?: string;
-  inputSchema?: unknown; // JSON Schema
-  _meta?: Record<string, unknown>;
+  name: SdkTool["name"];
+  title?: SdkTool["title"];
+  description?: SdkTool["description"];
+  inputSchema?: SdkTool["inputSchema"]; // JSON Schema
+  _meta?: SdkTool["_meta"];
 }
 
-// Resource definition from MCP server
 export interface McpResource {
-  uri: string;
-  name: string;
-  description?: string;
-  mimeType?: string;
-  _meta?: Record<string, unknown>;
+  uri: SdkResource["uri"];
+  name: SdkResource["name"];
+  description?: SdkResource["description"];
+  mimeType?: SdkResource["mimeType"];
+  _meta?: SdkResource["_meta"];
 }
 
 export interface McpPromptArgument {
-  name: string;
-  description?: string;
-  required?: boolean;
+  name: SdkPromptArgument["name"];
+  description?: SdkPromptArgument["description"];
+  required?: SdkPromptArgument["required"];
 }
 
 export interface McpPrompt {
-  name: string;
-  title?: string;
-  description?: string;
-  arguments?: McpPromptArgument[];
-  _meta?: Record<string, unknown>;
+  name: SdkPrompt["name"];
+  title?: SdkPrompt["title"];
+  description?: SdkPrompt["description"];
+  arguments?: SdkPrompt["arguments"];
+  _meta?: SdkPrompt["_meta"];
 }
 
 export interface UiResourceMeta {

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -4,7 +4,7 @@ import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import type { McpServerManager } from "./server-manager.ts";
-import { isServerDisabled, type McpConfig, type UiResourceContent, type UiResourceCsp, type UiResourceMeta } from "./types.ts";
+import { isServerDisabled, type McpConfig, type UiResourceContent, type UiResourceCsp, type UiResourceMeta, type UiResourcePermissions } from "./types.ts";
 
 interface ResourceContentRecord {
   uri?: string;
@@ -23,7 +23,7 @@ interface ReadUiResourceOptions {
 export class UiResourceHandler {
   private log = logger.child({ component: "UiResourceHandler" });
 
-  constructor(private manager: McpServerManager, private config?: McpConfig) {}
+  constructor(private manager: McpServerManager, private config: McpConfig | undefined = undefined) {}
 
   async readUiResource(serverName: string, uri: string, options: ReadUiResourceOptions = {}): Promise<UiResourceContent> {
     const log = this.log.child({ server: serverName, uri });
@@ -45,7 +45,12 @@ export class UiResourceHandler {
         this.manager.incrementInFlight(serverName);
         try {
           result = await withSessionRecovery(
-            { manager: this.manager, config, signal: options.signal, onNeedsAuth: options.onNeedsAuth },
+            {
+              manager: this.manager,
+              config,
+              ...(options.signal ? { signal: options.signal } : {}),
+              ...(options.onNeedsAuth ? { onNeedsAuth: options.onNeedsAuth } : {}),
+            },
             serverName,
             (connection) => connection.client.readResource({ uri }, this.manager.getRequestOptions(serverName, options.signal)),
           );
@@ -62,7 +67,7 @@ export class UiResourceHandler {
       log.error("Failed to read resource", error instanceof Error ? error : undefined);
       throw new ResourceFetchError(uri, message, {
         server: serverName,
-        cause: error instanceof Error ? error : undefined,
+        ...(error instanceof Error ? { cause: error } : {}),
       });
     }
 
@@ -97,10 +102,14 @@ export class UiResourceHandler {
       html,
       mimeType: mimeType ?? RESOURCE_MIME_TYPE,
       meta: {
-        csp: contentMeta.csp ?? listMeta.csp,
-        permissions: contentMeta.permissions ?? listMeta.permissions,
-        domain: contentMeta.domain ?? listMeta.domain,
-        prefersBorder: contentMeta.prefersBorder ?? listMeta.prefersBorder,
+        ...((contentMeta.csp ?? listMeta.csp) !== undefined ? { csp: contentMeta.csp ?? listMeta.csp } : {}),
+        ...((contentMeta.permissions ?? listMeta.permissions) !== undefined
+          ? { permissions: contentMeta.permissions ?? listMeta.permissions }
+          : {}),
+        ...((contentMeta.domain ?? listMeta.domain) !== undefined ? { domain: contentMeta.domain ?? listMeta.domain } : {}),
+        ...((contentMeta.prefersBorder ?? listMeta.prefersBorder) !== undefined
+          ? { prefersBorder: contentMeta.prefersBorder ?? listMeta.prefersBorder }
+          : {}),
       },
     };
   }
@@ -128,7 +137,11 @@ function selectContent(result: ReadResourceResult, preferredUri: string): Resour
   );
   if (byHtmlMime) return byHtmlMime;
 
-  return contents[0];
+  const firstContent = contents[0];
+  if (!firstContent) {
+    throw new Error(`No contents returned for UI resource: ${preferredUri}`);
+  }
+  return firstContent;
 }
 
 function isHtmlMimeType(mimeType: string): boolean {
@@ -192,7 +205,7 @@ function extractUiMeta(meta: Record<string, unknown> | undefined): UiResourceMet
   }
 
   if (ui && isRecord(ui.permissions)) {
-    out.permissions = ui.permissions as UiResourceMeta["permissions"];
+    out.permissions = ui.permissions as UiResourcePermissions;
   }
   if (ui && typeof ui.domain === "string") {
     out.domain = ui.domain;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -164,7 +164,8 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       streamSummary.phases.push(envelope.phase);
     }
     streamSummary.finalStatus = envelope.status;
-    streamSummary.lastMessage = envelope.message;
+    if (envelope.message !== undefined) streamSummary.lastMessage = envelope.message;
+    else delete streamSummary.lastMessage;
   };
 
   const serializeEvent = (eventId: number, name: string, payload: unknown): string => {
@@ -174,6 +175,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
   const getLatestCheckpointIndex = () => {
     for (let index = eventLog.length - 1; index >= 0; index -= 1) {
       const entry = eventLog[index];
+      if (!entry) continue;
       const envelope = getVisualizationStreamEnvelope((entry.payload as { structuredContent?: unknown } | null)?.structuredContent);
       if (envelope?.frameType === "checkpoint" || envelope?.frameType === "final") {
         return index;
@@ -411,8 +413,8 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           name: callParams.name,
           originalName: callParams.name,
           description: toolDefinition?.description ?? "",
-          inputSchema: toolDefinition?.inputSchema,
-          uiVisibility,
+          ...(toolDefinition?.inputSchema !== undefined ? { inputSchema: toolDefinition.inputSchema } : {}),
+          ...(uiVisibility !== undefined ? { uiVisibility } : {}),
         };
         const approval = options.state
           ? await ensureToolCallApproved(
@@ -449,7 +451,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           options.manager.incrementInFlight(options.serverName);
           const result = options.config
             ? await withSessionRecovery(
-                { manager: options.manager, config: options.config, onNeedsAuth: options.onNeedsAuth },
+                {
+                  manager: options.manager,
+                  config: options.config,
+                  ...(options.onNeedsAuth ? { onNeedsAuth: options.onNeedsAuth } : {}),
+                },
                 options.serverName,
                 (conn) => conn.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName)),
               )
@@ -481,9 +487,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         } else if (msgParams.type === "intent" || msgParams.intent) {
           const intentName = msgParams.intent ?? "";
           if (intentName) {
-            sessionMessages.intents.push({ 
-              intent: intentName, 
-              params: msgParams.params 
+            sessionMessages.intents.push({
+              intent: intentName,
+              ...(msgParams.params !== undefined ? { params: msgParams.params } : {}),
             });
             log.debug("UI intent received", { intent: intentName });
           }
@@ -639,7 +645,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         return;
       }
       log.error("Failed to start server", error);
-      reject(new ServerError(error.message, { port: candidates[candidateIndex], cause: error }));
+      const port = candidates[candidateIndex];
+      reject(new ServerError(error.message, {
+        ...(port !== undefined ? { port } : {}),
+        cause: error,
+      }));
     };
 
     const onListening = () => {

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -239,10 +239,10 @@ export async function maybeStartUiSession(
         serverName: request.serverName,
         toolName: request.toolName,
         reused: true,
-        streamId,
-        streamToken,
-        streamMode,
-        requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
+        ...(streamId !== undefined ? { streamId } : {}),
+        ...(streamToken !== undefined ? { streamToken } : {}),
+        ...(streamMode !== undefined ? { streamMode } : {}),
+        ...(streamToken ? { requestMeta: { [UI_STREAM_REQUEST_META_KEY]: streamToken } } : {}),
         url: existingHandle.url,
         viewer: existingHandle.viewer ?? "browser",
         windowOpen: existingHandle.windowOpen ?? true,
@@ -326,9 +326,9 @@ export async function maybeStartUiSession(
       manager: state.manager,
       config: state.config,
       state,
-      onNeedsAuth: request.onNeedsAuth,
+      ...(request.onNeedsAuth ? { onNeedsAuth: request.onNeedsAuth } : {}),
       consentManager: state.consentManager,
-      hostContext,
+      ...(hostContext !== undefined ? { hostContext } : {}),
 
       onMessage: (params: UiMessageParams) => {
         const prompt = extractUiPromptText(params);
@@ -410,7 +410,7 @@ export async function maybeStartUiSession(
               completedAt: new Date(),
               reason,
               messages,
-              stream,
+              ...(stream !== undefined ? { stream } : {}),
             });
 
             while (state.completedUiSessions.length > MAX_COMPLETED_SESSIONS) {
@@ -527,10 +527,10 @@ export async function maybeStartUiSession(
       serverName: request.serverName,
       toolName: request.toolName,
       reused: false,
-      streamId,
-      streamToken,
-      streamMode,
-      requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
+      ...(streamId !== undefined ? { streamId } : {}),
+      ...(streamToken !== undefined ? { streamToken } : {}),
+      ...(streamMode !== undefined ? { streamMode } : {}),
+      ...(streamToken ? { requestMeta: { [UI_STREAM_REQUEST_META_KEY]: streamToken } } : {}),
       url: handle.url,
       viewer,
       windowOpen,

--- a/unix-socket-transport.ts
+++ b/unix-socket-transport.ts
@@ -5,7 +5,7 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 /** MCP JSONL transport for an explicitly configured Unix-domain socket. */
 export class UnixSocketClientTransport implements Transport {
-  private socket?: Socket;
+  private socket: Socket | undefined;
   private readonly readBuffer = new ReadBuffer();
 
   onclose?: () => void;

--- a/utils.ts
+++ b/utils.ts
@@ -8,14 +8,18 @@ async function execOpen(pi: ExtensionAPI, target: string, browser?: string, sign
   const os = platform();
 
   if (os === "darwin") {
-    return browser ? pi.exec("open", ["-a", browser, target], { signal }) : pi.exec("open", [target], { signal });
+    return browser
+      ? pi.exec("open", ["-a", browser, target], signal ? { signal } : {})
+      : pi.exec("open", [target], signal ? { signal } : {});
   }
   if (os === "win32") {
     return browser
-      ? pi.exec("cmd", ["/c", "start", "", browser, target], { signal })
-      : pi.exec("cmd", ["/c", "start", "", target], { signal });
+      ? pi.exec("cmd", ["/c", "start", "", browser, target], signal ? { signal } : {})
+      : pi.exec("cmd", ["/c", "start", "", target], signal ? { signal } : {});
   }
-  return browser ? pi.exec(browser, [target], { signal }) : pi.exec("xdg-open", [target], { signal });
+  return browser
+    ? pi.exec(browser, [target], signal ? { signal } : {})
+    : pi.exec("xdg-open", [target], signal ? { signal } : {});
 }
 
 export async function openUrl(pi: ExtensionAPI, url: string, browser?: string, signal?: AbortSignal): Promise<void> {
@@ -38,12 +42,14 @@ export async function parallelLimit<T, R>(
   fn: (item: T) => Promise<R>
 ): Promise<R[]> {
   const results: R[] = [];
-  let index = 0;
+  const iterator = items.entries();
 
   async function worker() {
-    while (index < items.length) {
-      const i = index++;
-      results[i] = await fn(items[i]);
+    while (true) {
+      const next = iterator.next();
+      if (next.done) return;
+      const [index, item] = next.value;
+      results[index] = await fn(item);
     }
   }
 
@@ -106,6 +112,9 @@ const COMMAND_SECRET_TIMEOUT_MS = 10_000;
 const COMMAND_SECRET_MAX_OUTPUT_BYTES = 1024 * 1024;
 
 /** Resolve a secret value, executing only a single leading `!` command marker. */
+export function resolveCommandSecret(value: string, context: string): string;
+export function resolveCommandSecret(value: undefined, context: string): undefined;
+export function resolveCommandSecret(value: string | undefined, context: string): string | undefined;
 export function resolveCommandSecret(value: string | undefined, context: string): string | undefined {
   if (value === undefined) return undefined;
   if (value.startsWith("!!")) return interpolateEnvVars(value.slice(1));


### PR DESCRIPTION
## Summary

- enable the full strict TypeScript quality gate, including `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
- update source construction patterns to omit absent optional fields and guard indexed access
- pin TypeScript/Node typings and add the missing `cross-spawn` types so CI runs the same compiler contract

## Validation

- `npm run typecheck`
- `npx vitest run --exclude __tests__/server-manager-streamable-http.test.ts` — 884 passed
- `npm run test:oauth` — 113 passed
- `npm run test:conformance`
- `npm pack --dry-run`
- `git diff --check`

Note: local Node 25 full `npm test` still hits the pre-existing `server-manager-streamable-http.test.ts` expectation mismatch; the same failure reproduces from clean `HEAD` before this change.