### PR TITLE
fix: keep MCP UI capability tokens private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict TypeScript typecheck command and CI gate.
 
 ### Fixed
-- Stopped tokenless MCP UI discovery requests from receiving the session capability token; Moshi discovery now serves a non-sensitive landing page while authenticated UI routes remain token-gated.
+- Stopped tokenless discovery requests and sandboxed MCP app documents from receiving the session capability token; discovery now serves a non-sensitive landing page, and app HTML loads with a separate resource-only token.
 
 ## [2.19.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict TypeScript typecheck command and CI gate.
 
 ### Fixed
-- Stopped tokenless discovery requests and sandboxed MCP app documents from receiving the session capability token; discovery now serves a non-sensitive landing page, and app HTML loads with a separate resource-only token.
+- Stopped tokenless discovery requests, sandboxed MCP app documents, and unrelated child windows from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, and host messages accept only the app frame as their source.
 
 ## [2.19.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict TypeScript typecheck command and CI gate.
 
 ### Fixed
-- Stopped tokenless discovery requests, sandboxed MCP app documents, and unrelated child windows from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, and host messages accept only the app frame as their source.
+- Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and popups remain sandboxed.
 
 ## [2.19.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a strict TypeScript typecheck command and CI gate.
 
+### Fixed
+- Stopped tokenless MCP UI discovery requests from receiving the session capability token; Moshi discovery now serves a non-sensitive landing page while authenticated UI routes remain token-gated.
+
 ## [2.19.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict TypeScript typecheck command and CI gate.
 
 ### Fixed
-- Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and popups remain sandboxed.
+- Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and the app response enforces sandboxing even when opened as a top-level page.
 
 ## [2.19.0] - 2026-08-03
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -58,6 +58,14 @@ describe("buildHostHtmlTemplate", () => {
       expect(html).toContain('referrerpolicy="no-referrer"');
     });
 
+    it("rejects nested-frame protocol and raw messages by binding to the sandboxed app frame", () => {
+      const html = buildHostHtmlTemplate(createMinimalInput());
+
+      expect(html).toContain("new PostMessageTransport(iframe.contentWindow, iframe.contentWindow)");
+      expect(html).toContain("if (event.source !== iframe.contentWindow) return;");
+      expect(html).not.toContain("new PostMessageTransport(iframe.contentWindow, null)");
+    });
+
     it("includes control buttons", () => {
       const html = buildHostHtmlTemplate(createMinimalInput());
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -4,6 +4,7 @@ import { buildHostHtmlTemplate, type HostHtmlTemplateInput } from "../host-html-
 function createMinimalInput(overrides: Partial<HostHtmlTemplateInput> = {}): HostHtmlTemplateInput {
   return {
     sessionToken: "test-token-123",
+    uiResourceToken: "resource-token-456",
     serverName: "test-server",
     toolName: "test-tool",
     toolArgs: { arg1: "value1" },
@@ -77,12 +78,18 @@ describe("buildHostHtmlTemplate", () => {
   });
 
   describe("data injection", () => {
-    it("injects session token", () => {
+    it("keeps the session token out of the sandboxed app URL", () => {
       const html = buildHostHtmlTemplate(
-        createMinimalInput({ sessionToken: "secret-token-xyz" })
+        createMinimalInput({
+          sessionToken: "secret-session-token",
+          uiResourceToken: "app-resource-token",
+        })
       );
 
-      expect(html).toContain('"secret-token-xyz"');
+      expect(html).toContain('const SESSION_TOKEN = "secret-session-token"');
+      expect(html).toContain('const UI_RESOURCE_TOKEN = "app-resource-token"');
+      expect(html).toContain('iframe.src = "/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN)');
+      expect(html).not.toContain('iframe.src = "/ui-app?session="');
     });
 
     it("injects tool arguments", () => {

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -53,7 +53,8 @@ describe("buildHostHtmlTemplate", () => {
       const html = buildHostHtmlTemplate(createMinimalInput());
 
       expect(html).toContain('<iframe id="mcp-app"');
-      expect(html).toContain('sandbox="allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads"');
+      expect(html).toContain('sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads"');
+      expect(html).not.toContain("allow-popups-to-escape-sandbox");
       expect(html).not.toContain("allow-same-origin");
       expect(html).toContain('referrerpolicy="no-referrer"');
     });

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -197,6 +197,7 @@ describe("buildHostHtmlTemplate", () => {
 
       expect(csp).toBe([
         "default-src 'none'",
+        "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads",
         "script-src 'self' 'unsafe-inline' https://esm.sh",
         "style-src 'self' 'unsafe-inline' https://esm.sh",
         "font-src 'self' https://esm.sh",
@@ -272,6 +273,7 @@ describe("buildHostHtmlTemplate", () => {
 
       expect(csp).toBe([
         "default-src 'none'",
+        "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads",
         "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
         "font-src 'self'",
@@ -304,6 +306,7 @@ describe("buildHostHtmlTemplate", () => {
 
       expect(buildCspMetaContent(undefined)).toBe([
         "default-src 'none'",
+        "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads",
         "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
         "font-src 'self'",

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -444,7 +444,7 @@ describe("UiResourceHandler", () => {
 
       expect(result.meta.csp).toEqual({});
       expect(buildCspMetaContent(result.meta.csp)).toBe(
-        "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; frame-src 'none'; worker-src 'none'; object-src 'none'; base-uri 'self'",
+        "default-src 'none'; sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; frame-src 'none'; worker-src 'none'; object-src 'none'; base-uri 'self'",
       );
     });
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -312,7 +312,7 @@ describe("UiServer", () => {
       expect(manager.getConnection).not.toHaveBeenCalled();
     });
 
-    it("enforces metadata CSP with a response header while preserving app HTML", async () => {
+    it("enforces metadata CSP and response-level sandboxing while preserving app HTML", async () => {
       const appHtml = `<!-- decoy <head><meta http-equiv="Content-Security-Policy" content="default-src *"></head> -->
 <!doctype html>
 <html>
@@ -344,6 +344,9 @@ describe("UiServer", () => {
       expect(res.status).toBe(200);
       expect(res.headers["content-type"]).toContain("text/html");
       expect(cspHeader).toContain("default-src 'none'");
+      expect(cspHeader).toContain("sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads");
+      expect(cspHeader).not.toContain("allow-popups-to-escape-sandbox");
+      expect(cspHeader).not.toContain("allow-same-origin");
       expect(cspHeader).toContain("script-src 'self' 'unsafe-inline' https://esm.sh");
       expect(cspHeader).toContain("style-src 'self' 'unsafe-inline' https://esm.sh");
       expect(cspHeader).toContain("connect-src https://api.excalidraw.com");

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -236,7 +236,7 @@ describe("UiServer", () => {
       expect(res.body).toEqual({ ok: false, error: "Invalid session" });
     });
 
-    it("serves a tokenless loopback landing shell for Moshi preview", async () => {
+    it("serves a tokenless Moshi landing page without disclosing the session", async () => {
       handle = await startUiServer(createServerOptions());
       const url = `http://localhost:${handle.port}/`;
 
@@ -244,8 +244,10 @@ describe("UiServer", () => {
 
       expect(res.status).toBe(200);
       expect(res.headers["content-type"]).toContain("text/html");
-      expect(res.body).toContain("location.replace");
-      expect(res.body).toContain(encodeURIComponent(handle.sessionToken));
+      expect(res.body).toContain("Open the authenticated MCP UI URL shown by Pi");
+      expect(res.body).not.toContain("location.replace");
+      expect(res.body).not.toContain(handle.sessionToken);
+      expect(res.body).not.toContain(encodeURIComponent(handle.sessionToken));
     });
 
     it("answers HEAD discovery probes without a session token", async () => {
@@ -276,7 +278,8 @@ describe("UiServer", () => {
       const res = await request(url, { headers: { Host: `[::1]:${handle.port}` } });
 
       expect(res.status).toBe(200);
-      expect(res.body).toContain("location.replace");
+      expect(res.body).toContain("Open the authenticated MCP UI URL shown by Pi");
+      expect(res.body).not.toContain(handle.sessionToken);
     });
   });
 
@@ -776,6 +779,26 @@ describe("UiServer", () => {
       expect(res.status).toBe(403);
     });
 
+    it("rejects anonymous tool calls", async () => {
+      const callTool = vi.fn();
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{ name: "some_tool" }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { params: { name: "some_tool", arguments: {} } },
+      });
+
+      expect(res.status).toBe(403);
+      expect(callTool).not.toHaveBeenCalled();
+    });
+
     it("tracks in-flight requests", async () => {
       const manager = createMockManager();
       handle = await startUiServer(createServerOptions({ manager }));
@@ -795,6 +818,19 @@ describe("UiServer", () => {
   });
 
   describe("POST /proxy/ui/consent", () => {
+    it("rejects anonymous approval", async () => {
+      const consentManager = createMockConsentManager();
+      handle = await startUiServer(createServerOptions({ consentManager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/ui/consent`, {
+        method: "POST",
+        body: { params: { approved: true } },
+      });
+
+      expect(res.status).toBe(403);
+      expect(consentManager.registerDecision).not.toHaveBeenCalled();
+    });
+
     it("registers approval", async () => {
       const consentManager = createMockConsentManager();
       handle = await startUiServer(createServerOptions({ consentManager }));
@@ -831,6 +867,20 @@ describe("UiServer", () => {
   });
 
   describe("POST /proxy/ui/message", () => {
+    it("rejects anonymous messages", async () => {
+      const onMessage = vi.fn();
+      handle = await startUiServer(createServerOptions({ onMessage }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/ui/message`, {
+        method: "POST",
+        body: { params: { type: "prompt", prompt: "Injected" } },
+      });
+
+      expect(res.status).toBe(403);
+      expect(handle.getSessionMessages().prompts).toEqual([]);
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
     it("tracks prompt messages", async () => {
       const onMessage = vi.fn();
       handle = await startUiServer(createServerOptions({ onMessage }));

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -162,6 +162,15 @@ function createServerOptions(overrides: Partial<UiServerOptions> = {}): UiServer
   };
 }
 
+async function getUiAppUrl(handle: UiServerHandle): Promise<string> {
+  const host = await request(handle.url);
+  const match = typeof host.body === "string"
+    ? host.body.match(/const UI_RESOURCE_TOKEN = "([^"]+)";/)
+    : null;
+  if (!match?.[1]) throw new Error("UI resource token missing from host page");
+  return `http://localhost:${handle.port}/ui-app?resource=${encodeURIComponent(match[1])}`;
+}
+
 describe("UiServer", () => {
   let handle: UiServerHandle | null = null;
 
@@ -284,6 +293,25 @@ describe("UiServer", () => {
   });
 
   describe("GET /ui-app", () => {
+    it("does not accept the app resource token on privileged proxy routes", async () => {
+      const manager = createMockManager();
+      handle = await startUiServer(createServerOptions({ manager }));
+      const appUrl = new URL(await getUiAppUrl(handle));
+      const resourceToken = appUrl.searchParams.get("resource");
+
+      expect(resourceToken).toBeTruthy();
+      expect(resourceToken).not.toBe(handle.sessionToken);
+      expect((await request(`http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`)).status).toBe(403);
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { token: resourceToken, params: { name: "some_tool", arguments: {} } },
+      });
+
+      expect(res.status).toBe(403);
+      expect(manager.getConnection).not.toHaveBeenCalled();
+    });
+
     it("enforces metadata CSP with a response header while preserving app HTML", async () => {
       const appHtml = `<!-- decoy <head><meta http-equiv="Content-Security-Policy" content="default-src *"></head> -->
 <!doctype html>
@@ -308,7 +336,7 @@ describe("UiServer", () => {
           },
         }),
       }));
-      const url = `http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`;
+      const url = await getUiAppUrl(handle);
 
       const res = await request(url);
       const cspHeader = res.headers["content-security-policy"];
@@ -340,7 +368,7 @@ describe("UiServer", () => {
         }),
       }));
 
-      const res = await request(`http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`);
+      const res = await request(await getUiAppUrl(handle));
 
       expect(res.status).toBe(200);
       expect(res.headers["content-security-policy"]).toContain("https://safe.example.com");
@@ -358,7 +386,7 @@ describe("UiServer", () => {
         }),
       }));
 
-      const res = await request(`http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`);
+      const res = await request(await getUiAppUrl(handle));
 
       expect(res.status).toBe(200);
       expect(res.headers["content-security-policy"]).toContain("default-src 'none'");
@@ -368,7 +396,7 @@ describe("UiServer", () => {
 
     it("emits restrictive default CSP when metadata is undefined", async () => {
       handle = await startUiServer(createServerOptions());
-      const url = `http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`;
+      const url = await getUiAppUrl(handle);
 
       const res = await request(url);
 

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -2,6 +2,7 @@ import type { UiHostContext, UiResourceContent, UiResourceCsp } from "./types.ts
 
 // Use locally bundled AppBridge to avoid CDN Zod bundling issues
 const DEFAULT_APP_BRIDGE_MODULE_URL = "/app-bridge.bundle.js";
+const APP_SANDBOX = "allow-scripts allow-forms allow-modals allow-popups allow-downloads";
 
 export interface HostHtmlTemplateInput {
   sessionToken: string;
@@ -111,7 +112,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     </div>
   </header>
   <main>
-    <iframe id="mcp-app" sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads" referrerpolicy="no-referrer"></iframe>
+    <iframe id="mcp-app" sandbox="${APP_SANDBOX}" referrerpolicy="no-referrer"></iframe>
   </main>
   <div class="overlay" id="error-overlay">
     <div class="panel">
@@ -403,6 +404,7 @@ export function buildCspMetaContent(csp: UiResourceCsp | undefined): string {
 
   return [
     "default-src 'none'",
+    `sandbox ${APP_SANDBOX}`,
     toDirective("script-src", ["'self'", "'unsafe-inline'"], resourceDomains),
     toDirective("style-src", ["'self'", "'unsafe-inline'"], resourceDomains),
     toDirective("font-src", ["'self'"], resourceDomains),

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -239,6 +239,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     // Also listen for raw postMessage events with custom types (notify, prompt, intent, etc.)
     // These bypass the AppBridge protocol but are used by some MCP UI implementations
     window.addEventListener("message", async (event) => {
+      if (event.source !== iframe.contentWindow) return;
       const data = event.data;
       if (!data || typeof data !== "object") return;
       
@@ -303,7 +304,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
 
     // Connect bridge BEFORE loading iframe to ensure we're listening when the app sends ui/initialize
     try {
-      const transport = new PostMessageTransport(iframe.contentWindow, null);
+      const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow);
       await bridge.connect(transport);
     } catch (error) {
       console.error("[host] Bridge connection failed:", error);

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -5,6 +5,7 @@ const DEFAULT_APP_BRIDGE_MODULE_URL = "/app-bridge.bundle.js";
 
 export interface HostHtmlTemplateInput {
   sessionToken: string;
+  uiResourceToken: string;
   serverName: string;
   toolName: string;
   toolArgs: Record<string, unknown>;
@@ -20,6 +21,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
   const hostContext = input.hostContext ?? {};
 
   const sessionToken = safeInlineJSON(input.sessionToken);
+  const uiResourceToken = safeInlineJSON(input.uiResourceToken);
   const toolArgs = safeInlineJSON(input.toolArgs);
   const serverName = safeInlineJSON(input.serverName);
   const toolName = safeInlineJSON(input.toolName);
@@ -127,6 +129,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     import { AppBridge, PostMessageTransport } from ${moduleUrl};
 
     const SESSION_TOKEN = ${sessionToken};
+    const UI_RESOURCE_TOKEN = ${uiResourceToken};
     const SERVER_NAME = ${serverName};
     const TOOL_NAME = ${toolName};
     const TOOL_ARGS = ${toolArgs};
@@ -310,7 +313,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const iframeLoaded = new Promise((resolve) => {
       iframe.onload = resolve;
     });
-    iframe.src = "/ui-app?session=" + encodeURIComponent(SESSION_TOKEN);
+    iframe.src = "/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN);
     await iframeLoaded;
 
     const eventSource = new EventSource("/events?session=" + encodeURIComponent(SESSION_TOKEN));

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -111,7 +111,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     </div>
   </header>
   <main>
-    <iframe id="mcp-app" sandbox="allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads" referrerpolicy="no-referrer"></iframe>
+    <iframe id="mcp-app" sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads" referrerpolicy="no-referrer"></iframe>
   </main>
   <div class="overlay" id="error-overlay">
     <div class="panel">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2915,12 +2915,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -4888,9 +4888,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5166,9 +5166,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5245,9 +5245,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -273,13 +273,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       }
 
       if (method === "GET" && url.pathname === "/") {
-        if (!url.searchParams.has("session") && isLoopbackAddress(req.socket.remoteAddress)) {
-          const dest = `/?session=${encodeURIComponent(sessionToken)}`;
+        if (!url.searchParams.has("session")) {
           res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
           res.end(
-            `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(`MCP UI - ${options.serverName} / ${options.toolName}`)}</title>` +
-              `<noscript><meta http-equiv="refresh" content="0;url=${dest}"></noscript></head>` +
-              `<body><script>location.replace(${JSON.stringify(dest)});</script></body></html>`,
+            "<!doctype html><html><head><meta charset=\"utf-8\"><title>MCP UI</title></head>" +
+              "<body><p>Open the authenticated MCP UI URL shown by Pi.</p></body></html>",
           );
           return;
         }
@@ -768,19 +766,6 @@ function rememberMoshiDiscoveryPort(port: number): void {
 
 function isAllowedHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
-}
-
-function isLoopbackAddress(address: string | undefined): boolean {
-  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 function validateTokenQuery(url: URL, expected: string, res: ServerResponse): boolean {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -95,6 +95,7 @@ export interface UiServerHandle {
 
 export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {
   const sessionToken = options.sessionToken ?? randomUUID();
+  const uiResourceToken = randomUUID();
   const log = logger.child({ 
     component: "UiServer",
     server: options.serverName,
@@ -286,6 +287,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
         const html = buildHostHtmlTemplate({
           sessionToken,
+          uiResourceToken,
           serverName: options.serverName,
           toolName: options.toolName,
           toolArgs: options.toolArgs,
@@ -330,7 +332,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       }
 
       if (method === "GET" && url.pathname === "/ui-app") {
-        if (!validateTokenQuery(url, sessionToken, res)) return;
+        if (!validateTokenQuery(url, uiResourceToken, res, "resource")) return;
         touchHeartbeat();
         // Enforce host metadata independently of where app HTML places its document head.
         const cspContent = buildCspMetaContent(options.resource.meta.csp);
@@ -768,8 +770,13 @@ function isAllowedHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }
 
-function validateTokenQuery(url: URL, expected: string, res: ServerResponse): boolean {
-  const token = url.searchParams.get("session");
+function validateTokenQuery(
+  url: URL,
+  expected: string,
+  res: ServerResponse,
+  parameter = "session",
+): boolean {
+  const token = url.searchParams.get(parameter);
   if (token !== expected) {
     sendJson(res, 403, { ok: false, error: "Invalid session" });
     return false;


### PR DESCRIPTION
## Summary

- keep tokenless HEAD/GET discovery for Moshi, but serve only a static non-sensitive landing page
- require the authenticated URL generated by Pi before serving the MCP UI session
- load app HTML with an independent resource-only token instead of the privileged session token
- enforce the same sandbox policy in both the iframe attribute and the app response CSP
- accept AppBridge and raw UI messages only from the sandboxed app frame
- cover anonymous, resource-token, nested-frame, direct-popup, and host-opened-popup rejection on privileged paths
- refresh the production lockfile so a git install has no known production audit findings

The tokenless landing redirect introduced for Moshi included the session capability token in every loopback GET response. Any other local process could fetch a predictable discovery port, recover the token, approve the UI session, and call app-visible tools through the authenticated MCP connection. The same token also appeared in the sandboxed app document URL, while the host accepted privilege-bearing `postMessage` traffic from unrelated child windows. Popup paths could otherwise run the app resource as an unsandboxed top-level localhost page.

The host page still holds the session capability for its authenticated proxy calls. The app sees only a separate token accepted by `GET /ui-app`; that token cannot authorize proxy, consent, message, health, or event routes. Both the AppBridge transport and custom raw-message path bind inbound events to `iframe.contentWindow`. The `/ui-app` response itself carries a CSP `sandbox` directive matching the iframe restrictions, so direct and host-opened app pages remain sandboxed.

The lock refresh moves only already-allowed transitive ranges: `@hono/node-server` 2.0.12, `hono` 4.13.0, `fast-uri` 3.1.5, and `ip-address` 10.4.0. An isolated `pi install` of the exact git head now reports zero production vulnerabilities.

## Validation

- `npx vitest run __tests__/host-html-template.test.ts __tests__/ui-server.test.ts __tests__/ui-resource-handler.test.ts` (123 tests)
- `npm run typecheck`
- `npm test` (892 tests)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm --prefix examples/interactive-visualizer run build`
- isolated Pi 0.83.0 package-load smoke
- isolated `pi install git:github.com/fitchmultz/pi-mcp-adapter@cef3ed0c9670b04519ee0eeb5bb91fc346efff89 --no-approve` plus production audit (0 vulnerabilities)
- browser runtime checks:
  - sandbox loaded only `?resource=…`
  - a nested frame sent raw prompt and JSON-RPC tool-call messages; neither reached a privileged proxy or callback
  - a direct app-opened same-resource popup received `SecurityError` when reading `opener.parent.location` or DOM
  - AppBridge `ui/open-link` opened the known resource URL as a top-level page; response-level CSP sandboxing produced `SecurityError` on cookie/localStorage access and `opener=null`
  - no page errors or unexpected privileged network requests
- `npm pack --dry-run`
- `git diff --check`
