### PR TITLE
fix: pin Chrome DevTools MCP preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict TypeScript typecheck command and CI gate.
 
 ### Fixed
+- Pinned the Chrome DevTools setup preset and README examples to `chrome-devtools-mcp@1.6.0` instead of `@latest`, so reviewed scaffolded commands stay stable. Thanks @fitchmultz for issue #274.
 - Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and the app response enforces sandboxing even when opened as a top-level page.
 
 ## [2.19.0] - 2026-08-03

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Preferred project config: `.mcp.json`
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest"]
+      "args": ["-y", "chrome-devtools-mcp@1.6.0"]
     }
   }
 }
@@ -404,7 +404,7 @@ Per-server:
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest"],
+      "args": ["-y", "chrome-devtools-mcp@1.6.0"],
       "directTools": true
     },
     "github": {

--- a/config.ts
+++ b/config.ts
@@ -56,7 +56,7 @@ export const KNOWN_SERVER_PRESETS: readonly KnownServerPreset[] = [
     id: "chrome-devtools",
     name: "Chrome DevTools",
     summary: "Inspect and automate a local Chrome browser.",
-    entry: { command: "npx", args: ["-y", "chrome-devtools-mcp@latest"] },
+    entry: { command: "npx", args: ["-y", "chrome-devtools-mcp@1.6.0"] },
   },
 ];
 

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -540,7 +540,7 @@ export class McpSetupPanel {
           '  "mcpServers": {',
           '    "chrome-devtools": {',
           '      "command": "npx",',
-          '      "args": ["-y", "chrome-devtools-mcp@latest"]',
+          '      "args": ["-y", "chrome-devtools-mcp@1.6.0"]',
           "    }",
           "  }",
           "}",


### PR DESCRIPTION
## Summary

- pin the Chrome DevTools setup preset to `chrome-devtools-mcp@1.6.0`
- update the README examples and `/mcp setup` preview to match
- credit @fitchmultz for #274 in the changelog

Fixes #274.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/commands-onboarding.test.ts __tests__/package-manifest.test.ts`
- `git diff --check`
- fresh read-only review: no issues found
