### PR TITLE
feat: add MCP protocol negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added opt-in per-server MCP protocol selection with `protocolVersion: "legacy" | "auto" | "2026-07-28"`. Legacy remains the default; auto negotiates the modern era with conservative legacy fallback, while the pinned mode fails instead of falling back. Thanks @mjfaga for PR #272.
 - Added a strict TypeScript typecheck command and CI gate.
+
+### Changed
+- Migrated the MCP client from the monolithic SDK v1 package to the stable modular `@modelcontextprotocol/client` and `@modelcontextprotocol/core` v2 packages. The stable release restores conservative legacy discovery fallback and declared JSON Schema dialect support while retaining strict OAuth issuer validation.
 
 ### Fixed
 - Pinned the Chrome DevTools setup preset and README examples to `chrome-devtools-mcp@1.6.0` instead of `@latest`, so reviewed scaffolded commands stay stable. Thanks @fitchmultz for issue #274.
+- Removed the adapter's throwaway Streamable HTTP initialize probe. HTTP connections now initialize once on the real client and use narrowly classified SSE fallback, avoiding duplicate sessions and preventing authentication, cancellation, timeout, negotiation, and server failures from being misclassified as transport incompatibility.
 - Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and the app response enforces sandboxing even when opened as a top-level page.
 
 ## [2.19.0] - 2026-08-03

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -304,15 +304,15 @@ The OAuth implementation uses the following modules:
 
 ## SDK Integration
 
-The implementation uses the MCP SDK v1 client and OAuth APIs:
+The implementation uses the stable modular MCP client and OAuth APIs:
 
 ```typescript
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
   auth,
+  StreamableHTTPClientTransport,
   UnauthorizedError,
   type OAuthClientProvider,
-} from "@modelcontextprotocol/sdk/client/auth.js"
+} from "@modelcontextprotocol/client"
 ```
 
 The `McpOAuthProvider` class implements `OAuthClientProvider` and is passed to `StreamableHTTPClientTransport`:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `lifecycle` | `"lazy"` (default), `"eager"`, `"keep-alive"`, or `"lazy-keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
 | `requestTimeoutMs` | Request timeout in milliseconds for live MCP calls (overrides global; if omitted or `<= 0`, the MCP SDK default timeout is used) |
+| `protocolVersion` | `"legacy"` (default), `"auto"`, or `"2026-07-28"`; modern negotiation is opt-in |
 | `exposeResources` | Expose MCP resources as tools (default: true) |
 | `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
 | `toolPrefix` | Override global `settings.toolPrefix` for this server (`"server"`, `"short"`, `"none"`, or `"mcp"`) |
@@ -199,6 +200,16 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `debug` | Show server stderr (default: false) |
 | `trace` | Enable metadata-only JSONL protocol tracing for this server; payloads, prompts, tool arguments/results, authorization data, and URLs are never persisted |
 | `disabled` | Keep the server visible in config and status, but prevent connections, authentication, tools, and resource calls (only literal `true` disables it) |
+
+#### Protocol version negotiation
+
+The adapter defaults to `protocolVersion: "legacy"`. Omitting the field uses the classic MCP initialize sequence without `server/discover` or 2026 headers, preserving compatibility with deployed 2025-era servers.
+
+Use `"auto"` to probe for MCP 2026-07-28 and conservatively fall back to the classic handshake when the server provides legacy evidence. For stdio servers, the SDK probes with a short-lived sibling process before starting the session process, so each fresh auto connection adds one process spawn and can wait for the configured request timeout. Explicit Unix sockets are custom transports and probe in place. HTTP auto negotiation uses the actual Streamable HTTP connection; the adapter falls back to legacy SSE only when the endpoint definitively rejects Streamable HTTP (for example 404/405/406/415), never for authentication failures, cancellation, timeouts, or server errors.
+
+Use `"2026-07-28"` to pin that revision. Pinning has no legacy or SSE fallback and fails if the server does not offer the requested version.
+
+The stable SDK handles era-specific request envelopes, result decoding, list-changed subscriptions, cancellation, and multi-round-trip sampling/elicitation. The adapter keeps strict OAuth issuer validation in every mode. Adapter-level roots support, standard MCP logging presentation, and configuration/UI for protocol cache hints are not yet implemented.
 
 For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
 

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -69,11 +69,7 @@ describe("AbortSignal propagation", () => {
     const result = await inFlight;
     expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
     expect(result.details.error).toBe("aborted");
-    expect(callTool).toHaveBeenCalledWith(
-      { name: "slow", arguments: {}, _meta: undefined },
-      undefined,
-      { signal: controller.signal },
-    );
+    expect(callTool).toHaveBeenCalledWith({ name: "slow", arguments: {}, _meta: undefined }, { signal: controller.signal });
     expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
   });
 
@@ -89,11 +85,7 @@ describe("AbortSignal propagation", () => {
     const result = await inFlight;
     expect(result.content[0].text).toContain("Failed to call tool: user cancelled");
     expect(result.details.error).toBe("aborted");
-    expect(callTool).toHaveBeenCalledWith(
-      { name: "slow", arguments: {}, _meta: undefined },
-      undefined,
-      { signal: controller.signal },
-    );
+    expect(callTool).toHaveBeenCalledWith({ name: "slow", arguments: {}, _meta: undefined }, { signal: controller.signal });
     expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
   });
 

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -104,15 +104,11 @@ describe("direct tools auto auth", () => {
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
     expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
-    expect(connected.client.callTool).toHaveBeenCalledWith(
-      {
-        name: "namespace.tool",
-        arguments: { q: "hello" },
-        _meta: undefined,
-      },
-      undefined,
-      { timeout: 4321 },
-    );
+    expect(connected.client.callTool).toHaveBeenCalledWith({
+      name: "namespace.tool",
+      arguments: { q: "hello" },
+      _meta: undefined,
+    }, { timeout: 4321 });
     expect(result.content[0].text).toContain("ok");
   });
 
@@ -155,11 +151,7 @@ describe("direct tools auto auth", () => {
     const result = await inFlight;
 
     expect(state.manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
-    expect(connection.client.callTool).toHaveBeenCalledWith(
-      { name: "search", arguments: {}, _meta: undefined },
-      undefined,
-      requestOptions,
-    );
+    expect(connection.client.callTool).toHaveBeenCalledWith({ name: "search", arguments: {}, _meta: undefined }, requestOptions);
     expect(result.details).toMatchObject({ error: "aborted", server: "demo" });
     expect(result.content[0].text).toContain("request aborted");
   });
@@ -246,7 +238,7 @@ describe("direct tools auto auth", () => {
   });
 
   it("runs URL elicitations returned by a URL-required tool error", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
     const error = new UrlElicitationRequiredError([{
       mode: "url",

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -171,6 +171,14 @@ describe("buildProxyDescription", () => {
 });
 
 describe("metadata cache hashing", () => {
+  it("invalidates metadata when the protocol era changes", () => {
+    const legacy = computeServerHash({ command: "node" });
+    const automatic = computeServerHash({ command: "node", protocolVersion: "auto" });
+    const modern = computeServerHash({ command: "node", protocolVersion: "2026-07-28" });
+
+    expect(new Set([legacy, automatic, modern]).size).toBe(3);
+  });
+
   it("hashes interpolated URLs", () => {
     process.env.MCP_HASH_URL = "https://one.example.test/mcp";
     const first = computeServerHash({ url: "${MCP_HASH_URL}" });

--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ElicitRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { ElicitRequest } from "@modelcontextprotocol/client";
 
 const mocks = vi.hoisted(() => ({
   open: vi.fn(async () => undefined),

--- a/__tests__/fixtures/legacy-exits-on-discover-server.mjs
+++ b/__tests__/fixtures/legacy-exits-on-discover-server.mjs
@@ -1,0 +1,43 @@
+import readline from "node:readline";
+
+const lines = readline.createInterface({ input: process.stdin });
+
+function respond(id, result) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function reject(id, message) {
+  process.stdout.write(`${JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message },
+  })}\n`);
+}
+
+lines.on("line", line => {
+  const request = JSON.parse(line);
+  if (request.method === "server/discover") {
+    process.exit(0);
+  }
+  if (request.method === "initialize") {
+    respond(request.id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "legacy-exits-on-discover", version: "1.0.0" },
+    });
+    return;
+  }
+  if (request.method === "tools/list") {
+    respond(request.id, {
+      tools: [{
+        name: "legacy_after_sibling_probe",
+        description: "Classic initialize completed after disposable probe exit",
+        inputSchema: { type: "object", properties: {} },
+      }],
+    });
+    return;
+  }
+  if (request.id !== undefined) {
+    reject(request.id, "Method not found");
+  }
+});

--- a/__tests__/fixtures/modern-discover-server.mjs
+++ b/__tests__/fixtures/modern-discover-server.mjs
@@ -1,0 +1,48 @@
+import readline from "node:readline";
+
+const lines = readline.createInterface({ input: process.stdin });
+
+function respond(id, result) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function reject(id, message) {
+  process.stdout.write(`${JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message },
+  })}\n`);
+}
+
+lines.on("line", line => {
+  const request = JSON.parse(line);
+  if (request.method === "server/discover") {
+    respond(request.id, {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "modern-discover",
+          version: "1.0.0",
+        },
+      },
+    });
+    return;
+  }
+  if (request.method === "tools/list") {
+    respond(request.id, {
+      resultType: "complete",
+      ttlMs: 0,
+      cacheScope: "private",
+      tools: [{
+        name: "modern_discovery_reached",
+        description: "MCP 2026-07-28 negotiation completed",
+        inputSchema: { type: "object", properties: {} },
+      }],
+    });
+    return;
+  }
+  if (request.id !== undefined) {
+    reject(request.id, "Method not found");
+  }
+});

--- a/__tests__/json-schema-validator.test.ts
+++ b/__tests__/json-schema-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation/types.js";
+import type { JsonSchemaType } from "@modelcontextprotocol/client";
 import { createJsonSchemaValidator } from "../json-schema-validator.ts";
 
 const draft07 = "http://json-schema.org/draft-07/schema#";

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 
 class MockUnauthorizedError extends Error {}
 
-vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   auth: mocks.sdkAuth,
   extractWWWAuthenticateParams: (response: Response) => {

--- a/__tests__/mcp-oauth-provider.test.ts
+++ b/__tests__/mcp-oauth-provider.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { UnauthorizedError } from "@modelcontextprotocol/client";
 import { McpOAuthProvider } from "../mcp-oauth-provider.ts";
 import { getAuthForUrl, saveAuthEntry } from "../mcp-auth.ts";
 

--- a/__tests__/mcp-trace.test.ts
+++ b/__tests__/mcp-trace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Transport } from "@modelcontextprotocol/client";
 import {
   createMcpTraceEvent,
   isMcpTraceEnabled,
@@ -116,6 +116,7 @@ describe("MCP protocol tracing", () => {
     const wrapped = wrapTransportWithMcpTrace(underlying, "demo", "stdio", {
       record: event => writer.write(event),
     });
+    expect(wrapped).toBe(underlying);
     wrapped.onmessage = incoming;
     underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/ping", params: {} });
     await wrapped.send({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
@@ -135,5 +136,21 @@ describe("MCP protocol tracing", () => {
     underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/ping", params: {} });
     await wrapped.send({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
     expect(incoming).toHaveBeenCalledOnce();
+  });
+
+  it("keeps transport behavior when onmessage cannot be redefined", async () => {
+    const sent = vi.fn(async () => undefined);
+    const underlying = fakeTransport({ send: sent });
+    Object.defineProperty(underlying, "onmessage", {
+      value: undefined,
+      writable: true,
+      configurable: false,
+    });
+
+    const wrapped = wrapTransportWithMcpTrace(underlying, "demo", "stdio", { record: vi.fn() });
+
+    expect(wrapped).toBe(underlying);
+    await wrapped.send({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
+    expect(sent).toHaveBeenCalledOnce();
   });
 });

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -61,10 +61,11 @@ describe("package.json dependency policy", () => {
     }
   });
 
-  it("uses the SDK v1 dependency without the SDK v2 beta packages", () => {
+  it("uses the stable modular SDK v2 client/core packages without the legacy monolithic SDK", () => {
     expect(packageJson.dependencies?.["@modelcontextprotocol/ext-apps"]).toBeDefined();
-    expect(packageJson.dependencies?.["@modelcontextprotocol/sdk"]).toBe("^1.30.0");
-    expect(packageJson.dependencies?.["@modelcontextprotocol/client"]).toBeUndefined();
+    expect(packageJson.dependencies?.["@modelcontextprotocol/sdk"]).toBeUndefined();
+    expect(packageJson.dependencies?.["@modelcontextprotocol/client"]).toBe("2.0.0");
+    expect(packageJson.dependencies?.["@modelcontextprotocol/core"]).toBe("2.0.0");
     expect(packageJson.devDependencies?.["@modelcontextprotocol/server"]).toBeUndefined();
   });
 });

--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
-import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+import type { GetPromptResult } from "@modelcontextprotocol/client";
 import {
   createPromptCommand,
   formatPromptResult,

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -37,7 +37,7 @@ vi.mock("../init.ts", () => ({
   recordFailure: mocks.recordFailure,
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -64,7 +64,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);
@@ -260,7 +260,7 @@ describe("proxy auto auth", () => {
   });
 
   it("runs URL elicitations returned by proxy tool calls", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { executeCall } = await import("../proxy-modes.ts");
     const error = new UrlElicitationRequiredError([{
       mode: "url",
@@ -368,15 +368,11 @@ describe("proxy auto auth", () => {
     );
     expect(manager.connect).toHaveBeenCalledTimes(1);
     expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
-    expect(connected.client.callTool).toHaveBeenCalledWith(
-      {
-        name: "search",
-        arguments: { q: "hello" },
-        _meta: undefined,
-      },
-      undefined,
-      { timeout: 1234 },
-    );
+    expect(connected.client.callTool).toHaveBeenCalledWith({
+      name: "search",
+      arguments: { q: "hello" },
+      _meta: undefined,
+    }, { timeout: 1234 });
     expect(result.content[0].text).toContain("ok");
   });
 
@@ -450,11 +446,7 @@ describe("proxy auto auth", () => {
     const result = await inFlight;
 
     expect(manager.getRequestOptions).toHaveBeenCalledWith("demo", controller.signal);
-    expect(connection.client.callTool).toHaveBeenCalledWith(
-      { name: "search", arguments: {}, _meta: undefined },
-      undefined,
-      requestOptions,
-    );
+    expect(connection.client.callTool).toHaveBeenCalledWith({ name: "search", arguments: {}, _meta: undefined }, requestOptions);
     expect(result.details).toMatchObject({ error: "aborted", message: "request aborted" });
     expect(result.content[0].text).toContain("request aborted");
   });
@@ -553,18 +545,8 @@ describe("proxy auto auth", () => {
     expect(client.listTools).toHaveBeenCalledWith(undefined, { timeout: 5000 });
     expect(client.listResources).toHaveBeenCalledTimes(1);
     expect(client.listResources).toHaveBeenCalledWith(undefined, { timeout: 5000 });
-    expect(client.callTool).toHaveBeenNthCalledWith(
-      1,
-      { name: "search", arguments: { q: "one" }, _meta: undefined },
-      undefined,
-      { timeout: 5000 },
-    );
-    expect(client.callTool).toHaveBeenNthCalledWith(
-      2,
-      { name: "search", arguments: { q: "two" }, _meta: undefined },
-      undefined,
-      { timeout: 5000 },
-    );
+    expect(client.callTool).toHaveBeenNthCalledWith(1, { name: "search", arguments: { q: "one" }, _meta: undefined }, { timeout: 5000 });
+    expect(client.callTool).toHaveBeenNthCalledWith(2, { name: "search", arguments: { q: "two" }, _meta: undefined }, { timeout: 5000 });
     expect(first.content[0].text).toContain("ok");
     expect(second.content[0].text).toContain("ok");
   });

--- a/__tests__/sampling-handler.test.ts
+++ b/__tests__/sampling-handler.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { CreateMessageRequest, ModelPreferences } from "@modelcontextprotocol/sdk/types.js";
+import type { CreateMessageRequest, ModelPreferences } from "@modelcontextprotocol/client";
 import type { SamplingHandlerOptions } from "../sampling-handler.ts";
 
 const mocks = vi.hoisted(() => ({

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -1,3 +1,4 @@
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type OAuthProviderLike = {
@@ -25,11 +26,14 @@ type HttpTransportMock = {
 };
 
 const mocks = vi.hoisted(() => ({
+  afterConnect: undefined as (() => void) | undefined,
   clients: [] as any[],
+  connectErrors: [] as unknown[],
   httpTransports: [] as HttpTransportMock[],
+  sseTransports: [] as HttpTransportMock[],
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation((info: unknown, options: ClientOptions) => {
     const client = {
@@ -37,7 +41,11 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
       options,
       setRequestHandler: vi.fn(),
       setNotificationHandler: vi.fn(),
-      connect: vi.fn(async () => undefined),
+      connect: vi.fn(async () => {
+        const error = mocks.connectErrors.shift();
+        if (error !== undefined) throw error;
+        mocks.afterConnect?.();
+      }),
       listTools: vi.fn(async () => ({ tools: [] })),
       listResources: vi.fn(async () => ({ resources: [] })),
       close: vi.fn(async () => undefined),
@@ -45,20 +53,19 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     mocks.clients.push(client);
     return client;
   }),
-}));
-
-vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
   StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
     const transport = { url, options, close: vi.fn(async () => undefined) };
     mocks.httpTransports.push(transport);
     return transport;
   }),
+  SSEClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
+    const transport = { url, options, close: vi.fn(async () => undefined) };
+    mocks.sseTransports.push(transport);
+    return transport;
+  }),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: vi.fn() }));
-
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn(),
 }));
 
@@ -74,8 +81,11 @@ describe("McpServerManager HTTP bearer auth", () => {
   };
 
   beforeEach(() => {
+    mocks.afterConnect = undefined;
     mocks.clients.length = 0;
+    mocks.connectErrors.length = 0;
     mocks.httpTransports.length = 0;
+    mocks.sseTransports.length = 0;
   });
 
   afterEach(() => {
@@ -220,7 +230,94 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(authProvider?.clientMetadata?.client_uri).toBe("https://example.com/custom-mcp");
   });
 
-  it("applies the configured timeout to the HTTP probe connect", async () => {
+  it("closes the HTTP transport when cancellation lands as connect resolves", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const controller = new AbortController();
+    const reason = new Error("cancel after connect");
+    mocks.afterConnect = () => controller.abort(reason);
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("cancelled", {
+      url: "https://example.test/mcp",
+      auth: false,
+    }, controller.signal)).rejects.toBe(reason);
+
+    expect(mocks.clients).toHaveLength(1);
+    expect(mocks.httpTransports[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to SSE only for a definitive Streamable HTTP endpoint mismatch", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "POST is not supported",
+      { status: 405 },
+    ));
+
+    const manager = new McpServerManager();
+    const connection = await manager.connect("legacy-sse", {
+      url: "https://example.test/mcp",
+    });
+
+    expect(connection.status).toBe("connected");
+    expect(mocks.httpTransports).toHaveLength(1);
+    expect(mocks.sseTransports).toHaveLength(1);
+    expect(mocks.clients).toHaveLength(2);
+  });
+
+  it.each([401, 403, 500])("does not fall back to SSE for HTTP %s", async status => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(new SdkHttpError(
+      status === 401 ? SdkErrorCode.ClientHttpAuthentication : SdkErrorCode.ClientHttpNotImplemented,
+      `HTTP ${status}`,
+      { status },
+    ));
+
+    const manager = new McpServerManager();
+    const pending = manager.connect(`http-${status}`, {
+      url: "https://example.test/mcp",
+      auth: false,
+    });
+
+    await expect(pending).rejects.toThrow(`HTTP ${status}`);
+    expect(mocks.sseTransports).toHaveLength(0);
+  });
+
+  it("does not fall back to SSE when 2026-07-28 is pinned", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "HTTP 405",
+      { status: 405 },
+    ));
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("modern-pinned", {
+      url: "https://example.test/mcp",
+      auth: false,
+      protocolVersion: "2026-07-28",
+    })).rejects.toThrow("HTTP 405");
+    expect(mocks.sseTransports).toHaveLength(0);
+  });
+
+  it("passes the configured protocol mode to the SDK client", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    await manager.connect("auto", {
+      url: "https://example.test/mcp",
+      protocolVersion: "auto",
+    });
+    await manager.connect("pin", {
+      url: "https://example.test/mcp",
+      protocolVersion: "2026-07-28",
+    });
+
+    expect(mocks.clients[0].options.versionNegotiation).toEqual({ mode: "auto" });
+    expect(mocks.clients[1].options.versionNegotiation).toEqual({ mode: { pin: "2026-07-28" } });
+  });
+
+  it("applies the configured timeout to the HTTP connection", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
 
     const manager = new McpServerManager();
@@ -230,7 +327,8 @@ describe("McpServerManager HTTP bearer auth", () => {
       requestTimeoutMs: 5000,
     });
 
-    expect(mocks.clients[1].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
-    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[1], { timeout: 5000 });
+    expect(mocks.clients).toHaveLength(1);
+    expect(mocks.httpTransports).toHaveLength(1);
+    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
   });
 });

--- a/__tests__/server-manager-instructions.test.ts
+++ b/__tests__/server-manager-instructions.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   instructions: undefined as string | undefined,
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -23,7 +23,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);

--- a/__tests__/server-manager-legacy-handshake.test.ts
+++ b/__tests__/server-manager-legacy-handshake.test.ts
@@ -9,18 +9,95 @@ afterEach(async () => {
   managers.length = 0;
 });
 
-describe("McpServerManager legacy handshake", () => {
-  it("reaches classic initialize when the server rejects server/discover", async () => {
+const legacyFixture = fileURLToPath(new URL("./fixtures/legacy-no-discover-server.mjs", import.meta.url));
+const legacyExitsOnDiscoverFixture = fileURLToPath(new URL("./fixtures/legacy-exits-on-discover-server.mjs", import.meta.url));
+const modernFixture = fileURLToPath(new URL("./fixtures/modern-discover-server.mjs", import.meta.url));
+
+describe("McpServerManager protocol negotiation", () => {
+  it("defaults to the classic initialize handshake without server/discover", async () => {
     const manager = new McpServerManager();
     managers.push(manager);
     manager.setDefaultRequestTimeoutMs(1_000);
 
     const connection = await manager.connect("legacy", {
       command: process.execPath,
-      args: [fileURLToPath(new URL("./fixtures/legacy-no-discover-server.mjs", import.meta.url))],
+      args: [legacyFixture],
     });
 
     expect(connection.status).toBe("connected");
+    expect(connection.client.getNegotiatedProtocolVersion()).not.toBe("2026-07-28");
     expect(connection.tools.map(tool => tool.name)).toEqual(["classic_initialize_reached"]);
   }, 5_000);
+
+  it("auto falls back to classic initialize for a legacy stdio server", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+
+    const connection = await manager.connect("legacy-auto", {
+      command: process.execPath,
+      args: [legacyFixture],
+      protocolVersion: "auto",
+    });
+
+    expect(connection.status).toBe("connected");
+    expect(connection.client.getNegotiatedProtocolVersion()).not.toBe("2026-07-28");
+    expect(connection.tools.map(tool => tool.name)).toEqual(["classic_initialize_reached"]);
+  }, 5_000);
+
+  it("keeps traced auto negotiation on the SDK disposable stdio probe path", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    manager.setTraceConfig({ enabled: true });
+
+    const connection = await manager.connect("legacy-auto-traced", {
+      command: process.execPath,
+      args: [legacyExitsOnDiscoverFixture],
+      protocolVersion: "auto",
+    });
+
+    expect(connection.status).toBe("connected");
+    expect(connection.client.getNegotiatedProtocolVersion()).not.toBe("2026-07-28");
+    expect(connection.tools.map(tool => tool.name)).toEqual(["legacy_after_sibling_probe"]);
+  }, 5_000);
+
+  it.each(["auto", "2026-07-28"] as const)("connects to a modern stdio server in %s mode", async protocolVersion => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+
+    const connection = await manager.connect(`modern-${protocolVersion}`, {
+      command: process.execPath,
+      args: [modernFixture],
+      protocolVersion,
+    });
+
+    expect(connection.status).toBe("connected");
+    expect(connection.client.getNegotiatedProtocolVersion()).toBe("2026-07-28");
+    expect(connection.tools.map(tool => tool.name)).toEqual(["modern_discovery_reached"]);
+  }, 5_000);
+
+  it("does not fall back when 2026-07-28 is pinned against a legacy server", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+
+    await expect(manager.connect("legacy-pinned", {
+      command: process.execPath,
+      args: [legacyFixture],
+      protocolVersion: "2026-07-28",
+    })).rejects.toThrow();
+  }, 5_000);
+
+  it("rejects an invalid runtime protocolVersion", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+
+    await expect(manager.connect("invalid", {
+      command: process.execPath,
+      args: [legacyFixture],
+      protocolVersion: "future" as never,
+    })).rejects.toThrow("Invalid MCP protocolVersion: future");
+  });
 });

--- a/__tests__/server-manager-reconnect.test.ts
+++ b/__tests__/server-manager-reconnect.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   httpTransports: [] as HttpTransportMock[],
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation((info: unknown, options: unknown) => {
     const client: any = {
@@ -32,20 +32,15 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
     mocks.clients.push(client);
     return client;
   }),
-}));
-
-vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
   StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
     const transport = { url, options, close: vi.fn(async () => undefined) };
     mocks.httpTransports.push(transport);
     return transport;
   }),
+  SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: vi.fn() }));
-
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn(),
 }));
 
@@ -59,10 +54,7 @@ describe("McpServerManager.reconnect", () => {
     mocks.httpTransports.length = 0;
   });
 
-  // For an HTTP server, connect() creates a probe client+transport and then
-  // a real one; the real client (used as connection.client) is always
-  // mocks.clients[0] for a given connect() call because createClient() runs
-  // before the probe is created inside createHttpTransport().
+  // Each HTTP connection uses one client and one Streamable HTTP transport.
   const def = { url: "https://example.test/mcp" };
 
   it("is single-flight: concurrent reconnects for the same server share one underlying reconnect", async () => {
@@ -79,9 +71,8 @@ describe("McpServerManager.reconnect", () => {
     ]);
 
     expect(c1).toBe(c2);
-    // Exactly one new connection was established (probe client + real
-    // client == 2), not two (which would be 4).
-    expect(mocks.clients.length).toBe(2);
+    // Exactly one new connection was established, not one per caller.
+    expect(mocks.clients.length).toBe(1);
     expect(manager.getConnection("remote")).toBe(c1);
   });
 

--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -14,7 +14,7 @@ function gate() {
   return { promise, resolve };
 }
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any) {
     this.setRequestHandler = vi.fn();
@@ -31,7 +31,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   StreamableHTTPClientTransport: vi.fn(),
   SSEClientTransport: vi.fn(),
 }));
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any) {
     this.close = vi.fn(async () => undefined);
     mocks.transports.push(this);

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("open", () => ({ default: mocks.open }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any, info: unknown, options: unknown) {
     this.info = info;
@@ -28,7 +28,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   SSEClientTransport: vi.fn(),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: unknown) {
     this.options = options;
     this.close = vi.fn(async () => undefined);
@@ -152,7 +152,7 @@ describe("McpServerManager sampling", () => {
   });
 
   it("handles every URL in a URL-required error", async () => {
-    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/sdk/types.js");
+    const { UrlElicitationRequiredError } = await import("@modelcontextprotocol/client");
     const { McpServerManager } = await import("../server-manager.ts");
     const ui = {
       select: vi.fn().mockResolvedValue("Open"),

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   connectImpl: null as null | ((transport: any) => Promise<void>),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => ({
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   Client: vi.fn().mockImplementation(function (this: any) {
     this.setRequestHandler = vi.fn();
@@ -28,7 +28,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", async (importOriginal) => (
   }),
 }));
 
-vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+vi.mock("@modelcontextprotocol/client/stdio", () => ({
   StdioClientTransport: vi.fn().mockImplementation(function (this: any, options: any) {
     this.options = options;
     this.stderr = options?.stderr === "pipe" ? new PassThrough() : null;

--- a/__tests__/server-manager-streamable-http.test.ts
+++ b/__tests__/server-manager-streamable-http.test.ts
@@ -209,7 +209,7 @@ describe("McpServerManager StreamableHTTP transport", () => {
         .trim()
         .split("\n")
         .map(line => JSON.parse(line) as { direction: string; method?: string });
-      expect(traceLines.filter(event => event.direction === "outbound" && event.method === "initialize")).toHaveLength(2);
+      expect(traceLines.filter(event => event.direction === "outbound" && event.method === "initialize")).toHaveLength(1);
     } finally {
       await manager.close("post-only").catch(() => {});
     }

--- a/__tests__/server-manager-unix-socket.test.ts
+++ b/__tests__/server-manager-unix-socket.test.ts
@@ -2,8 +2,8 @@ import { createServer, type Server } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
-import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/client";
+import type { JSONRPCMessage } from "@modelcontextprotocol/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { McpServerManager } from "../server-manager.ts";
 
@@ -23,7 +23,10 @@ afterEach(async () => {
 });
 
 describe("McpServerManager Unix socket transport", () => {
-  it("connects to an rmcp-mux-compatible socket and discovers tools", async () => {
+  it.each([
+    { label: "legacy default", protocolVersion: undefined },
+    { label: "auto in-place fallback", protocolVersion: "auto" as const },
+  ])("connects to an rmcp-mux-compatible socket and discovers tools ($label)", async ({ protocolVersion }) => {
     const directory = await mkdtemp(join(tmpdir(), "pi-mcp-socket-"));
     temporaryDirectories.push(directory);
     const socketPath = join(directory, "shared.sock");
@@ -61,7 +64,10 @@ describe("McpServerManager Unix socket transport", () => {
 
     const manager = new McpServerManager();
     managers.push(manager);
-    const connection = await manager.connect("shared", { socket: socketPath });
+    const connection = await manager.connect("shared", {
+      socket: socketPath,
+      ...(protocolVersion ? { protocolVersion } : {}),
+    });
 
     expect(connection.status).toBe("connected");
     expect(connection.tools.map(tool => tool.name)).toEqual(["shared_tool"]);

--- a/__tests__/session-recovery-integration.test.ts
+++ b/__tests__/session-recovery-integration.test.ts
@@ -1,4 +1,9 @@
+import { ProtocolError, SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function httpError(status: number, message: string): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, message, { status });
+}
 
 // direct-tools.ts calls lazyConnect() before touching the connection; mock
 // it the same way __tests__/direct-tools-auto-auth.test.ts does so we can
@@ -129,13 +134,13 @@ describe("session recovery — Streamable HTTP wire path", () => {
 describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
   it("recovers a terminated Streamable HTTP session transparently mid tool-call", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
       client: {
-        callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+        callTool: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")),
       },
     };
     const fresh = {
@@ -176,13 +181,13 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("recovers a server-not-initialized MCP error transparently mid tool-call", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
       client: {
-        callTool: vi.fn().mockRejectedValueOnce(new McpError(-32000, "Server not initialized")),
+        callTool: vi.fn().mockRejectedValueOnce(new ProtocolError(-32000, "Server not initialized")),
       },
     };
     const fresh = {
@@ -223,17 +228,17 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("gives up after one reconnect attempt: a second server-not-initialized MCP error propagates as call_failed", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValue(new McpError(-32000, "Server not initialized")) },
+      client: { callTool: vi.fn().mockRejectedValue(new ProtocolError(-32000, "Server not initialized")) },
     };
     const fresh = {
       status: "connected" as const,
       transport: { sessionId: "session-2" },
-      client: { callTool: vi.fn().mockRejectedValue(new McpError(-32000, "Server not initialized")) },
+      client: { callTool: vi.fn().mockRejectedValue(new ProtocolError(-32000, "Server not initialized")) },
     };
 
     const manager = {
@@ -265,17 +270,17 @@ describe("session recovery — proxy path (proxy-modes.ts executeCall)", () => {
 
   it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
     const { executeCall } = await import("../proxy-modes.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValue(httpError(404, "Session not found")) },
     };
     const fresh = {
       status: "connected" as const,
       transport: { sessionId: "session-2" },
-      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValue(httpError(404, "Session not found")) },
     };
 
     const manager = {
@@ -314,13 +319,13 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("recovers a terminated Streamable HTTP session transparently for a direct tool call", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
       client: {
-        callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+        callTool: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")),
       },
     };
     const fresh = {
@@ -365,13 +370,13 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("recovers a server-not-initialized MCP error transparently for a direct tool call", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { McpError } = await import("@modelcontextprotocol/sdk/types.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
       client: {
-        callTool: vi.fn().mockRejectedValueOnce(new McpError(-32000, "Server not initialized")),
+        callTool: vi.fn().mockRejectedValueOnce(new ProtocolError(-32000, "Server not initialized")),
       },
     };
     const fresh = {
@@ -416,17 +421,17 @@ describe("session recovery — direct-tools path (direct-tools.ts createDirectTo
 
   it("gives up after one reconnect attempt: a second terminated session propagates as call_failed", async () => {
     const { createDirectToolExecutor } = await import("../direct-tools.ts");
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected" as const,
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValue(httpError(404, "Session not found")) },
     };
     const fresh = {
       status: "connected" as const,
       transport: { sessionId: "session-2" },
-      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValue(httpError(404, "Session not found")) },
     };
 
     const manager = {

--- a/__tests__/session-recovery.test.ts
+++ b/__tests__/session-recovery.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { ProtocolError, SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 import { SessionRecoveryAuthRequiredError, isTerminatedSession, withSessionRecovery } from "../session-recovery.ts";
 import type { ServerConnection } from "../server-manager.ts";
 import type { McpConfig } from "../types.ts";
+
+function httpError(status: number, message: string): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, message, { status });
+}
 
 function makeConnection(sessionId: string | undefined): ServerConnection {
   return {
@@ -12,6 +15,7 @@ function makeConnection(sessionId: string | undefined): ServerConnection {
     definition: { url: "https://example.test/mcp" },
     tools: [],
     resources: [],
+    prompts: [],
     lastUsedAt: Date.now(),
     inFlight: 0,
     status: "connected",
@@ -20,42 +24,42 @@ function makeConnection(sessionId: string | undefined): ServerConnection {
 
 describe("isTerminatedSession", () => {
   it("is true for a 404 StreamableHTTPError carrying a session id", () => {
-    const err = new StreamableHTTPError(404, "Session not found");
+    const err = httpError(404, "Session not found");
     expect(isTerminatedSession(err, true)).toBe(true);
   });
 
   it("is false for a 404 with no session id (never initialized / wrong URL)", () => {
-    const err = new StreamableHTTPError(404, "Not found");
+    const err = httpError(404, "Not found");
     expect(isTerminatedSession(err, false)).toBe(false);
   });
 
   it("is true for a server-not-initialized MCP error carrying a session id", () => {
-    const err = new McpError(-32000, "Server not initialized");
+    const err = new ProtocolError(-32000, "Server not initialized");
     expect(isTerminatedSession(err, true)).toBe(true);
   });
 
   it("is true for the SDK's bad-request server-not-initialized MCP error", () => {
-    const err = new McpError(-32000, "Bad Request: Server not initialized");
+    const err = new ProtocolError(-32000, "Bad Request: Server not initialized");
     expect(isTerminatedSession(err, true)).toBe(true);
   });
 
   it("is true for the SDK's bad-request server-not-initialized HTTP error body", () => {
-    const err = new StreamableHTTPError(400, 'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}');
+    const err = httpError(400, 'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}');
     expect(isTerminatedSession(err, true)).toBe(true);
   });
 
   it("is false for other -32000 HTTP 400 error bodies", () => {
-    const err = new StreamableHTTPError(400, 'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Mcp-Session-Id header is required"},"id":null}');
+    const err = httpError(400, 'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Mcp-Session-Id header is required"},"id":null}');
     expect(isTerminatedSession(err, true)).toBe(false);
   });
 
   it("is false for server-not-initialized without a session id", () => {
-    const err = new McpError(-32000, "Server not initialized");
+    const err = new ProtocolError(-32000, "Server not initialized");
     expect(isTerminatedSession(err, false)).toBe(false);
   });
 
   it("is false for other -32000 MCP errors, even with a session id", () => {
-    const err = new McpError(-32000, "Connection closed");
+    const err = new ProtocolError(-32000, "Connection closed");
     expect(isTerminatedSession(err, true)).toBe(false);
   });
 
@@ -65,12 +69,12 @@ describe("isTerminatedSession", () => {
   });
 
   it("is false for the right message with the wrong MCP error code", () => {
-    const err = new McpError(-32603, "Server not initialized");
+    const err = new ProtocolError(-32603, "Server not initialized");
     expect(isTerminatedSession(err, true)).toBe(false);
   });
 
   it("is false for 400, even with a session id — ambiguous, never treated as expiry", () => {
-    const err = new StreamableHTTPError(400, "Bad request");
+    const err = httpError(400, "Bad request");
     expect(isTerminatedSession(err, true)).toBe(false);
   });
 
@@ -115,7 +119,7 @@ describe("withSessionRecovery", () => {
 
     const fn = vi.fn(async (conn: ServerConnection) => {
       if (conn === stale) {
-        throw new StreamableHTTPError(404, "Session not found");
+        throw httpError(404, "Session not found");
       }
       return "ok";
     });
@@ -140,7 +144,7 @@ describe("withSessionRecovery", () => {
 
     const fn = vi.fn(async (conn: ServerConnection) => {
       if (conn === stale) {
-        throw new McpError(-32000, "Server not initialized");
+        throw new ProtocolError(-32000, "Server not initialized");
       }
       return "ok";
     });
@@ -158,7 +162,7 @@ describe("withSessionRecovery", () => {
   it("does not recover unrelated -32000 MCP errors", async () => {
     const connection = makeConnection("session-1");
     const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
-    const err = new McpError(-32000, "Connection closed");
+    const err = new ProtocolError(-32000, "Connection closed");
     const fn = vi.fn().mockRejectedValue(err);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
@@ -178,7 +182,7 @@ describe("withSessionRecovery", () => {
 
     const fn = vi.fn(async (conn: ServerConnection) => {
       if (conn === stale) {
-        throw new StreamableHTTPError(404, "Session not found");
+        throw httpError(404, "Session not found");
       }
       return conn === authed ? "ok" : "wrong-connection";
     });
@@ -198,7 +202,7 @@ describe("withSessionRecovery", () => {
       reconnect: async () => needsAuth,
     });
     const fn = vi.fn(async () => {
-      throw new StreamableHTTPError(404, "Session not found");
+      throw httpError(404, "Session not found");
     });
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn))
@@ -215,7 +219,7 @@ describe("withSessionRecovery", () => {
     });
     const fn = vi.fn(async (conn: ServerConnection) => {
       if (conn === stale) {
-        throw new StreamableHTTPError(404, "Session not found");
+        throw httpError(404, "Session not found");
       }
       return "ok";
     });
@@ -235,7 +239,7 @@ describe("withSessionRecovery", () => {
     });
     const fn = vi.fn(async () => {
       controller.abort(reason);
-      throw new StreamableHTTPError(404, "Session not found");
+      throw httpError(404, "Session not found");
     });
 
     await expect(withSessionRecovery({ manager: manager as any, config, signal: controller.signal }, "demo", fn))
@@ -251,8 +255,8 @@ describe("withSessionRecovery", () => {
       reconnect: async () => fresh,
     });
 
-    const err1 = new McpError(-32000, "Server not initialized");
-    const err2 = new McpError(-32000, "Server not initialized");
+    const err1 = new ProtocolError(-32000, "Server not initialized");
+    const err2 = new ProtocolError(-32000, "Server not initialized");
     const fn = vi.fn().mockRejectedValueOnce(err1).mockRejectedValueOnce(err2);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err2);
@@ -269,8 +273,8 @@ describe("withSessionRecovery", () => {
       reconnect: async () => fresh,
     });
 
-    const err1 = new StreamableHTTPError(404, "Session not found");
-    const err2 = new StreamableHTTPError(404, "Session not found");
+    const err1 = httpError(404, "Session not found");
+    const err2 = httpError(404, "Session not found");
     const fn = vi.fn().mockRejectedValueOnce(err1).mockRejectedValueOnce(err2);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err2);
@@ -294,7 +298,7 @@ describe("withSessionRecovery", () => {
   it("does not recover a 404 without a session id (never initialized / wrong URL)", async () => {
     const connection = makeConnection(undefined);
     const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
-    const err = new StreamableHTTPError(404, "Not found");
+    const err = httpError(404, "Not found");
     const fn = vi.fn().mockRejectedValue(err);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
@@ -316,7 +320,7 @@ describe("withSessionRecovery", () => {
   it("does not recover a 400 (ambiguous status, never matched)", async () => {
     const connection = makeConnection("session-1");
     const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
-    const err = new StreamableHTTPError(400, "Bad request");
+    const err = httpError(400, "Bad request");
     const fn = vi.fn().mockRejectedValue(err);
 
     await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).rejects.toBe(err);
@@ -327,7 +331,7 @@ describe("withSessionRecovery", () => {
   it("rethrows the original error when the server was removed from config before reconnecting", async () => {
     const connection = makeConnection("session-1");
     const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
-    const err = new StreamableHTTPError(404, "Session not found");
+    const err = httpError(404, "Session not found");
     const fn = vi.fn().mockRejectedValue(err);
     const emptyConfig: McpConfig = { mcpServers: {} };
 
@@ -351,7 +355,7 @@ describe("withSessionRecovery", () => {
 
     const fn = vi.fn(async (conn: ServerConnection) => {
       if (conn === stale) {
-        throw new StreamableHTTPError(404, "Session not found");
+        throw httpError(404, "Session not found");
       }
       return conn === fresh ? "ok" : "unexpected";
     });

--- a/__tests__/ui-resource-handler.test.ts
+++ b/__tests__/ui-resource-handler.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UiResourceHandler } from "../ui-resource-handler.ts";
 import { buildCspMetaContent } from "../host-html-template.ts";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { SdkErrorCode, SdkHttpError, UrlElicitationRequiredError } from "@modelcontextprotocol/client";
 import type { McpServerManager } from "../server-manager.ts";
+
+function httpError(status: number, message: string): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, message, { status });
+}
 
 // Mock the manager
 function createMockManager(overrides: Partial<McpServerManager> = {}): McpServerManager {
@@ -38,12 +42,12 @@ describe("UiResourceHandler", () => {
     });
 
     it("recovers a terminated HTTP session while loading a UI resource", async () => {
-      const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
       const stale = {
         status: "connected" as const,
         transport: { sessionId: "session-1" },
         client: {
-          readResource: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")),
+          readResource: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")),
         },
         resources: [],
       };

--- a/__tests__/ui-server-session-recovery.test.ts
+++ b/__tests__/ui-server-session-recovery.test.ts
@@ -1,9 +1,14 @@
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import http from "node:http";
 import { startUiServer, type UiServerHandle, type UiServerOptions } from "../ui-server.ts";
 import type { McpServerManager, ServerConnection } from "../server-manager.ts";
 import type { ConsentManager } from "../consent-manager.ts";
 import type { UiResourceContent, McpConfig } from "../types.ts";
+
+function httpError(status: number, message: string): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, message, { status });
+}
 
 // Same HTTP helper as __tests__/ui-server.test.ts.
 async function request(
@@ -70,12 +75,12 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("recovers a terminated Streamable HTTP session transparently, when config is supplied", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected",
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")) },
       tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const fresh = {
@@ -121,12 +126,12 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("returns auth guidance when recovery reconnect needs auth and no callback can refresh it", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected",
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")) },
       tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const needsAuth = {
@@ -168,12 +173,12 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("uses the supplied auth callback when recovery reconnect returns needs-auth", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected",
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValueOnce(httpError(404, "Session not found")) },
       tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
     const needsAuth = {
@@ -222,12 +227,12 @@ describe("UiServer /proxy/tools/call session recovery", () => {
   });
 
   it("runs without recovery (unchanged pre-existing behavior) when config is not supplied", async () => {
-    const { StreamableHTTPError } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
 
     const stale = {
       status: "connected",
       transport: { sessionId: "session-1" },
-      client: { callTool: vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Session not found")) },
+      client: { callTool: vi.fn().mockRejectedValue(httpError(404, "Session not found")) },
       tools: [{ name: "some_tool" }],
     } as unknown as ServerConnection;
 

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -625,14 +625,10 @@ describe("UiServer", () => {
         result: { content: [{ type: "text", text: "tool result" }] },
       });
       expect(manager.getRequestOptions).toHaveBeenCalledWith("test-server");
-      expect(mockClient.callTool).toHaveBeenCalledWith(
-        {
-          name: "some_tool",
-          arguments: { arg1: "value1" },
-        },
-        undefined,
-        requestOptions,
-      );
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: "some_tool",
+        arguments: { arg1: "value1" },
+      }, requestOptions);
     });
 
     it("returns a gated iframe call as an approval_denied tool result", async () => {

--- a/__tests__/ui-streaming.test.ts
+++ b/__tests__/ui-streaming.test.ts
@@ -193,16 +193,19 @@ describe("UI Streaming", () => {
 
   describe("McpServerManager stream listeners", () => {
     function attachNotificationHandler(manager: McpServerManager, serverName = "test-server") {
-      const client = { setNotificationHandler: vi.fn() };
+      const setNotificationHandler = vi.fn();
+      const client = { setNotificationHandler };
       (manager as unknown as {
-        attachAdapterNotificationHandlers: (serverName: string, client: { setNotificationHandler: typeof client.setNotificationHandler }) => void;
+        attachAdapterNotificationHandlers: (
+          serverName: string,
+          client: { setNotificationHandler: (...args: unknown[]) => void },
+        ) => void;
       }).attachAdapterNotificationHandlers(serverName, client);
-      expect(client.setNotificationHandler).toHaveBeenCalledOnce();
-      const handler = client.setNotificationHandler.mock.calls[0][1] as (notification: {
-        params: {
-          streamToken: string;
-          result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
-        };
+      expect(setNotificationHandler).toHaveBeenCalledOnce();
+      expect(setNotificationHandler.mock.calls[0][0]).toBe(SERVER_STREAM_RESULT_PATCH_METHOD);
+      const handler = setNotificationHandler.mock.calls[0][2] as (params: {
+        streamToken: string;
+        result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
       }) => void;
       return (notification: {
         method: string;
@@ -210,7 +213,7 @@ describe("UI Streaming", () => {
           streamToken: string;
           result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
         };
-      }) => handler(notification);
+      }) => handler(notification.params);
     }
 
     it("routes notifications to the matching listener", () => {

--- a/conformance/baseline-client.yml
+++ b/conformance/baseline-client.yml
@@ -11,6 +11,12 @@ client:
   # challenge scope and requests only the original PRM scope.
   - auth/scope-step-up
 
+  # The 2025-03-26 fallback scenario serves authorization metadata whose issuer
+  # differs from the identifier used to fetch it. Stable SDK v2 rejects that
+  # mismatch per RFC 8414 §3.3; the adapter intentionally keeps the strict
+  # mix-up protection instead of enabling the SDK's security-weakening opt-out.
+  - auth/2025-03-26-oauth-metadata-backcompat
+
   # The adapter supports client_secret_basic client credentials, but its config
   # has no private-key JWT credentials or assertion signing hook.
   - auth/client-credentials-jwt

--- a/conformance/driver.ts
+++ b/conformance/driver.ts
@@ -22,7 +22,7 @@
  */
 
 import { rmSync } from "node:fs"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { UnauthorizedError } from "@modelcontextprotocol/client"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { McpServerManager } from "../server-manager.ts"
 import {
@@ -210,7 +210,6 @@ async function callTool(toolName: string, args: Record<string, unknown>) {
     try {
       const result = await connection.client.callTool(
         { name: toolName, arguments: args },
-        undefined,
         manager.getRequestOptions(SERVER_NAME),
       )
       if (result.isError) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,6 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type Client } from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
@@ -482,9 +481,9 @@ export function createDirectToolExecutor(
           name: spec.originalName,
           arguments: params ?? {},
           _meta: uiSession?.requestMeta,
-        }, undefined, requestOptions), ownedSignal),
+        }, requestOptions), ownedSignal),
       );
-      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
+      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -1,16 +1,15 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/client";
 import {
-  ElicitRequestSchema,
-  ErrorCode,
-  McpError,
+  ProtocolError,
+  ProtocolErrorCode,
   type ElicitRequest,
   type ElicitRequestFormParams,
   type ElicitRequestURLParams,
   type ElicitResult,
-} from "@modelcontextprotocol/sdk/types.js";
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
-import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation/types.js";
+} from "@modelcontextprotocol/client";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
+import type { JsonSchemaType } from "@modelcontextprotocol/client";
 import open from "open";
 
 export type ElicitationValue = string | number | boolean | string[] | undefined;
@@ -28,7 +27,7 @@ export interface ElicitationHandlerOptions {
 export type ServerElicitationConfig = Omit<ElicitationHandlerOptions, "serverName" | "onUrlAccepted">;
 
 export function registerElicitationHandler(client: Client, options: ElicitationHandlerOptions): void {
-  client.setRequestHandler(ElicitRequestSchema, request =>
+  client.setRequestHandler("elicitation/create", request =>
     handleElicitationRequest(options, request));
 }
 
@@ -305,16 +304,16 @@ export async function handleUrlElicitation(
   options: ElicitationHandlerOptions,
   params: ElicitRequestURLParams,
 ): Promise<ElicitResult> {
-  if (!options.allowUrl) throw new McpError(ErrorCode.InvalidParams, "URL elicitation is not supported");
+  if (!options.allowUrl) throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation is not supported");
 
   let parsed: URL;
   try {
     parsed = new URL(params.url);
   } catch {
-    throw new McpError(ErrorCode.InvalidParams, "URL elicitation supplied an invalid URL");
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation supplied an invalid URL");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new McpError(ErrorCode.InvalidParams, "URL elicitation only supports HTTP and HTTPS URLs");
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, "URL elicitation only supports HTTP and HTTPS URLs");
   }
 
   const decision = await options.ui.select([

--- a/json-schema-validator.ts
+++ b/json-schema-validator.ts
@@ -1,12 +1,12 @@
 import { Ajv } from "ajv";
 import Ajv2020Import from "ajv/dist/2020.js";
 import addFormatsImport from "ajv-formats";
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
 import type {
   JsonSchemaType,
   JsonSchemaValidator,
   jsonSchemaValidator as JsonSchemaValidatorProvider,
-} from "@modelcontextprotocol/sdk/validation/types.js";
+} from "@modelcontextprotocol/client";
 
 // ajv-formats types target its bundled ajv; the runtime accepts both instances.
 const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -7,9 +7,9 @@
 import {
   auth as runSdkAuth,
   extractWWWAuthenticateParams,
+  LATEST_PROTOCOL_VERSION,
   UnauthorizedError,
-} from "@modelcontextprotocol/sdk/client/auth.js"
-import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
+} from "@modelcontextprotocol/client"
 import open from "open"
 import { McpOAuthProvider, type McpOAuthConfig } from "./mcp-oauth-provider.ts"
 import {

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -22,8 +22,8 @@ import {
   type McpOAuthConfig,
 } from "./mcp-oauth-provider.ts"
 import { getAuthForUrl, saveAuthEntry } from "./mcp-auth.ts"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
-import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
+import { UnauthorizedError } from "@modelcontextprotocol/client"
+import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/client"
 
 describe("McpOAuthProvider", () => {
   const serverName = "test-server"

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -10,12 +10,12 @@ import {
   type AddClientAuthentication,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
-} from "@modelcontextprotocol/sdk/client/auth.js"
+} from "@modelcontextprotocol/client"
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
   OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js"
+} from "@modelcontextprotocol/client"
 import {
   getAuthForUrl,
   updateTokens,
@@ -288,7 +288,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
         updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
       }
       // Return all registration metadata and the local issuer extension.
-      // This keeps the SDK v1 view and the stored issuer binding consistent.
+      // This keeps the SDK OAuth view and the stored issuer binding consistent.
       return {
         client_id: clientInfo.clientId,
         client_secret: clientInfo.clientSecret,

--- a/mcp-trace.ts
+++ b/mcp-trace.ts
@@ -1,8 +1,8 @@
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { Buffer } from "node:buffer";
 import { dirname, isAbsolute, resolve } from "node:path";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js";
+import type { Transport } from "@modelcontextprotocol/client";
+import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/client";
 
 export const MCP_TRACE_SCHEMA_VERSION = 1;
 export const DEFAULT_MCP_TRACE_MAX_BYTES = 256 * 1024;
@@ -228,9 +228,10 @@ export function isMcpTraceEnabled(
 }
 
 /**
- * Compose the SDK's transport callbacks instead of replacing them. Protocol
- * assigns `onmessage` during connect, so the setter must keep the observer in
- * front of whichever callback the SDK installs.
+ * Compose the SDK's transport callbacks in place instead of replacing the
+ * transport object. SDK v2 detects its base stdio transport before connect so
+ * it can run `server/discover` on a disposable sibling process; returning a
+ * wrapper hides that identity and makes tracing change negotiation behavior.
  */
 export function wrapTransportWithMcpTrace(
   transport: Transport,
@@ -238,7 +239,9 @@ export function wrapTransportWithMcpTrace(
   transportKind: McpTraceTransport,
   observer: McpTraceObserver,
 ): Transport {
-  let messageHandler: Transport["onmessage"];
+  let messageHandler = transport.onmessage;
+  let tracedMessageHandler: Transport["onmessage"];
+  const originalSend = transport.send;
   const record = (event: McpTraceEvent): void => {
     try {
       observer.record(event);
@@ -246,60 +249,51 @@ export function wrapTransportWithMcpTrace(
       // An observer failure must never alter SDK transport behavior.
     }
   };
-  const traced = {
-    start: () => transport.start(),
-    send: async (message: JSONRPCMessage, options?: Parameters<Transport["send"]>[1]) => {
-      const started = performance.now();
-      const messages = Array.isArray(message) ? message : [message];
-      try {
-        await transport.send(message, options);
-        for (const item of messages) {
-          record(createMcpTraceEvent("outbound", server, transportKind, item, "sent", {
-            durationMs: performance.now() - started,
-          }));
-        }
-      } catch (error) {
-        for (const item of messages) {
-          record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
-            durationMs: performance.now() - started,
-          }));
-        }
-        throw error;
+
+  try {
+    Object.defineProperty(transport, "onmessage", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return tracedMessageHandler;
+      },
+      set(handler: Transport["onmessage"]) {
+        messageHandler = handler;
+        tracedMessageHandler = handler
+          ? ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
+              record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
+              handler(message, extra);
+            })
+          : undefined;
+      },
+    });
+    transport.onmessage = messageHandler;
+  } catch {
+    // Some future transport may make onmessage non-configurable. Keep tracing
+    // best-effort rather than changing connection behavior.
+  }
+
+  transport.send = async (message: JSONRPCMessage, options?: Parameters<Transport["send"]>[1]) => {
+    const started = performance.now();
+    const messages = Array.isArray(message) ? message : [message];
+    try {
+      await originalSend.call(transport, message, options);
+      for (const item of messages) {
+        record(createMcpTraceEvent("outbound", server, transportKind, item, "sent", {
+          durationMs: performance.now() - started,
+        }));
       }
-    },
-    close: () => transport.close(),
-    get onclose() {
-      return transport.onclose;
-    },
-    set onclose(handler: Transport["onclose"]) {
-      Reflect.set(transport, "onclose", handler);
-    },
-    get onerror() {
-      return transport.onerror;
-    },
-    set onerror(handler: Transport["onerror"]) {
-      Reflect.set(transport, "onerror", handler);
-    },
-    get onmessage() {
-      return messageHandler;
-    },
-    set onmessage(handler: Transport["onmessage"]) {
-      messageHandler = handler;
-      Reflect.set(transport, "onmessage", handler
-        ? ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
-            record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
-            handler(message, extra);
-          })
-        : undefined);
-    },
-    get sessionId() {
-      return transport.sessionId;
-    },
-    setProtocolVersion: transport.setProtocolVersion
-      ? (version: string) => transport.setProtocolVersion?.(version)
-      : undefined,
+    } catch (error) {
+      for (const item of messages) {
+        record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
+          durationMs: performance.now() - started,
+        }));
+      }
+      throw error;
+    }
   };
-  return traced as Transport;
+
+  return transport;
 }
 
 export function traceTransportKind(definition: { command?: string; url?: string; socket?: string }, transport: Transport): McpTraceTransport {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -91,6 +91,7 @@ export function computeServerHash(definition: ServerEntry): string {
     url: resolveServerUrl(definition),
     headers: interpolateEnvRecord(definition.headers),
     auth: definition.auth,
+    protocolVersion: definition.protocolVersion,
     bearerToken: resolveBearerToken(definition),
     bearerTokenEnv: definition.bearerTokenEnv,
     exposeResources: definition.exposeResources,

--- a/oauth-handler.ts
+++ b/oauth-handler.ts
@@ -1,5 +1,5 @@
 // oauth-handler.ts - OAuth token compatibility helpers for MCP servers
-import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthTokens } from "@modelcontextprotocol/client";
 import { getAuthEntry } from "./mcp-auth.ts";
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "2.19.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
         "@modelcontextprotocol/ext-apps": "^1.2.2",
-        "@modelcontextprotocol/sdk": "^1.30.0",
         "@napi-rs/keyring": "^1.3.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -990,7 +991,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1113,9 +1114,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1133,9 +1131,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,9 +1148,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1173,9 +1165,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,9 +1182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2954,6 +2940,24 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/conformance": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.1.16.tgz",
@@ -2973,6 +2977,18 @@
       },
       "bin": {
         "conformance": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
@@ -3142,9 +3158,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3160,9 +3173,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3180,9 +3190,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3199,9 +3206,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3217,9 +3221,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3639,9 +3640,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3656,9 +3654,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3673,9 +3668,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3690,9 +3682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3707,9 +3696,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3724,9 +3710,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3741,9 +3724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3758,9 +3738,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3775,9 +3752,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3792,9 +3766,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3809,9 +3780,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3826,9 +3794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3843,9 +3808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -123,8 +123,9 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/core": "2.0.0",
     "@modelcontextprotocol/ext-apps": "^1.2.2",
-    "@modelcontextprotocol/sdk": "^1.30.0",
     "@napi-rs/keyring": "^1.3.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/prompts.ts
+++ b/prompts.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import type {
   GetPromptResult,
   PromptMessage,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpConfig, type PromptMetadata } from "./types.ts";
 import { formatPromptCommandName } from "./types.ts";

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,6 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type Client } from "@modelcontextprotocol/client";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
@@ -1132,11 +1131,11 @@ export async function executeCall(
         name: toolMeta.originalName,
         arguments: args ?? {},
         _meta: uiSession?.requestMeta,
-      }, undefined, requestOptions), ownedSignal),
+      }, requestOptions), ownedSignal),
     );
 
     if (toolMeta.uiResourceUri) {
-      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult);
+      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -2,15 +2,14 @@ import { complete, type Api, type AssistantMessage, type Message, type Model, ty
 import { truncateAtWord } from "./utils.ts";
 import { throwIfAborted } from "./abort.ts";
 import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/client";
 import {
-  CreateMessageRequestSchema,
   type CreateMessageRequest,
   type CreateMessageResult,
   type ModelPreferences,
   type SamplingMessage,
   type SamplingMessageContentBlock,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
 
 export interface SamplingHandlerOptions {
   serverName: string;
@@ -24,7 +23,7 @@ export interface SamplingHandlerOptions {
 export type ServerSamplingConfig = Omit<SamplingHandlerOptions, "serverName">;
 
 export function registerSamplingHandler(client: Client, options: SamplingHandlerOptions): void {
-  client.setRequestHandler(CreateMessageRequestSchema, request => {
+  client.setRequestHandler("sampling/createMessage", request => {
     return handleSamplingRequest(options, request);
   });
 }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,18 +1,16 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
+  Client,
+  SdkHttpError,
+  SSEClientTransport,
   StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import {
-  ElicitationCompleteNotificationSchema,
+  UnauthorizedError,
   type GetPromptResult,
   type ReadResourceResult,
+  type RequestOptions,
   type UrlElicitationRequiredError,
-} from "@modelcontextprotocol/sdk/types.js";
+  type VersionNegotiationOptions,
+} from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { UnixSocketClientTransport } from "./unix-socket-transport.ts";
 import { probeMcpEndpoint } from "./mcp-probe.ts";
 import {
@@ -24,6 +22,7 @@ import {
   type ServerStreamResultPatchNotification,
   type Transport,
   type McpTraceSettings,
+  SERVER_STREAM_RESULT_PATCH_METHOD,
   serverStreamResultPatchNotificationSchema,
 } from "./types.ts";
 import { resolveNpxBinary } from "./npx-resolver.ts";
@@ -67,13 +66,26 @@ type HttpAuthProviderState =
   | { status: "implicit-challenged"; provider: McpOAuthProvider };
 
 function isUnauthorizedHttpError(error: unknown): boolean {
-  return error instanceof UnauthorizedError || (error instanceof StreamableHTTPError && error.code === 401);
+  return error instanceof UnauthorizedError || (error instanceof SdkHttpError && error.status === 401);
 }
 
-function asSdkTransport(transport: StreamableHTTPClientTransport): Transport {
-  // SDK 1.30 declares its class field as `sessionId?: string` in a way that is
-  // structurally incompatible with its own Transport interface under exact optional types.
-  return transport as Transport;
+function shouldFallbackToSse(error: unknown, definition: ServerDefinition): boolean {
+  if (definition.protocolVersion === "2026-07-28") return false;
+  return error instanceof SdkHttpError && [404, 405, 406, 415].includes(error.status);
+}
+
+function resolveVersionNegotiation(definition: ServerDefinition): VersionNegotiationOptions | undefined {
+  switch (definition.protocolVersion) {
+    case undefined:
+    case "legacy":
+      return undefined;
+    case "auto":
+      return { mode: "auto" };
+    case "2026-07-28":
+      return { mode: { pin: "2026-07-28" } };
+    default:
+      throw new Error(`Invalid MCP protocolVersion: ${String(definition.protocolVersion)}`);
+  }
 }
 
 function boundedStderrChunk(chunk: Buffer | string): Buffer {
@@ -313,7 +325,6 @@ export class McpServerManager {
     requestSignal?: AbortSignal,
   ): Promise<ServerConnection> {
     throwIfAborted(signal);
-    const client = this.createClient(name);
 
     const tracingEnabled = isMcpTraceEnabled(definition, this.traceSettings);
     const traceWriter = tracingEnabled
@@ -323,7 +334,10 @@ export class McpServerManager {
       ? { record: event => traceWriter.write(event) }
       : undefined;
 
+    let client: Client;
     let transport: Transport;
+    let clientConnected = false;
+    let transportAlreadyTraced = false;
     let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
     const configuredTransports = [definition.command, definition.url, definition.socket]
       .filter(value => typeof value === "string" && value.length > 0);
@@ -331,7 +345,10 @@ export class McpServerManager {
       throw new Error(`Server ${name} must configure exactly one of command, url, or socket`);
     }
 
+    const requestOptions = this.buildRequestOptions(definition, requestSignal);
+
     if (definition.command) {
+      client = this.createClient(name, definition);
       let command = definition.command;
       let args = definition.args ?? [];
 
@@ -362,22 +379,45 @@ export class McpServerManager {
       }
       transport = stdioTransport;
     } else if (definition.url) {
-      // HTTP transport with fallback
-      transport = await this.createHttpTransport(definition, name, signal, requestSignal, traceObserver);
+      const httpConnection = await this.connectHttpClient(
+        definition,
+        name,
+        requestOptions,
+        signal,
+        traceObserver,
+      );
+      client = httpConnection.client;
+      transport = httpConnection.transport;
+      if (httpConnection.status === "needs-auth") {
+        return {
+          client,
+          transport,
+          definition,
+          tools: [],
+          resources: [],
+          prompts: [],
+          lastUsedAt: Date.now(),
+          inFlight: 0,
+          status: "needs-auth",
+        };
+      }
+      clientConnected = true;
+      transportAlreadyTraced = traceObserver !== undefined;
     } else {
+      client = this.createClient(name, definition);
       transport = new UnixSocketClientTransport(resolveConfigPath(definition.socket!)!);
     }
 
-    if (traceObserver) {
+    if (traceObserver && !transportAlreadyTraced) {
       const traceTransportKindValue = traceTransportKind(definition, transport);
       transport = wrapTransportWithMcpTrace(transport, name, traceTransportKindValue, traceObserver);
     }
 
-    throwIfAborted(signal);
-    const requestOptions = this.buildRequestOptions(definition, requestSignal);
-
     try {
-      await this.connectClientWithAbort(client, transport, requestOptions, signal);
+      throwIfAborted(signal);
+      if (!clientConnected) {
+        await this.connectClientWithAbort(client, transport, requestOptions, signal);
+      }
       this.attachAdapterNotificationHandlers(name, client);
 
       const instructions = client.getInstructions?.();
@@ -395,15 +435,8 @@ export class McpServerManager {
       };
 
       // Reflect the SDK's own close signal in connection status, guarded by
-      // identity so a stale connection's late close (e.g. the old
-      // connection from before a session-recovery reconnect) can never
-      // clobber a fresh connection that has since taken its place in
-      // `this.connections`. This intentionally uses `client.onclose`
-      // (Protocol's public hook), not `transport.onclose` — the SDK's
-      // Protocol takes ownership of that one internally for pending-request
-      // rejection, and overwriting it would break that. `client.onerror` is
-      // avoided too: it can fire on benign events (e.g. the optional GET
-      // SSE stream failing) that don't mean the connection is closed.
+      // identity so a stale connection's late close can never clobber a fresh
+      // connection. The SDK client owns the transport callbacks.
       client.onclose = () => {
         if (this.connections.get(name) === connection) {
           connection.status = "closed";
@@ -425,8 +458,7 @@ export class McpServerManager {
       return connection;
     } catch (error) {
       // If connectClientWithAbort closed the transport, await that exact close.
-      // Otherwise the SDK client owns its transport, so client.close() is the
-      // single cleanup operation rather than closing the transport twice.
+      // Otherwise the SDK client owns its transport and performs cleanup once.
       const abortCleanup = abortCleanupPromises.get(transport);
       const abortCleanupFailed = error instanceof AggregateError && error.message === "MCP connection abort cleanup failed";
       const cleanupResults = abortCleanupFailed
@@ -440,8 +472,8 @@ export class McpServerManager {
         reportedError = new AggregateError([error, ...cleanupFailures], "MCP connection setup failed");
       }
 
-      // Check for UnauthorizedError - server requires OAuth. A cleanup failure
-      // remains a setup failure rather than being hidden behind needs-auth.
+      // A cleanup failure remains a setup failure rather than being hidden
+      // behind needs-auth.
       if (isUnauthorizedHttpError(error) && supportsOAuth(definition) && cleanupFailures.length === 0) {
         return {
           client,
@@ -523,13 +555,15 @@ export class McpServerManager {
     };
   }
 
-  private createClient(serverName: string): Client {
+  private createClient(serverName: string, definition: ServerDefinition): Client {
     const capabilities = this.buildClientCapabilities();
+    const versionNegotiation = resolveVersionNegotiation(definition);
     let client: Client;
     client = new Client(
       { name: `pi-mcp-${serverName}`, version: "1.0.0" },
       {
         jsonSchemaValidator: createJsonSchemaValidator(),
+        ...(versionNegotiation ? { versionNegotiation } : {}),
         ...(Object.keys(capabilities).length > 0 ? { capabilities } : {}),
         listChanged: {
           tools: {
@@ -560,7 +594,7 @@ export class McpServerManager {
         onUrlAccepted: elicitationId => this.rememberUrlElicitation(serverName, elicitationId),
       });
       if (this.elicitationConfig.allowUrl) {
-        client.setNotificationHandler(ElicitationCompleteNotificationSchema, notification => {
+        client.setNotificationHandler("notifications/elicitation/complete", notification => {
           if (this.runtimeSignal?.aborted) return;
           const accepted = this.acceptedUrlElicitations.get(serverName);
           if (!accepted?.delete(notification.params.elicitationId)) return;
@@ -652,18 +686,19 @@ export class McpServerManager {
     accepted.add(elicitationId);
   }
 
-  private async createHttpTransport(
+  private async connectHttpClient(
     definition: ServerDefinition,
     serverName: string,
+    requestOptions: RequestOptions | undefined,
     signal?: AbortSignal,
-    requestSignal?: AbortSignal,
     traceObserver?: McpTraceObserver,
-  ): Promise<Transport> {
+  ): Promise<{ client: Client; transport: Transport; status: "connected" | "needs-auth" }> {
     throwIfAborted(signal);
     const serverUrl = resolveServerUrl(definition)!;
     const url = new URL(serverUrl);
 
-    // Resolve secret commands only for this connection attempt, without mutating config.
+    // Resolve secret commands only for this connection attempt, without
+    // mutating the persisted configuration.
     const hasCommandHeader = Object.values(definition.headers ?? {})
       .some(value => value.startsWith("!") && !value.startsWith("!!"));
     const headers = resolveCommandSecretsRecord(
@@ -671,7 +706,8 @@ export class McpServerManager {
       key => `MCP server "${serverName}" HTTP header "${key}"`,
     ) ?? {};
 
-    // For bearer auth, add the token to headers BEFORE creating requestInit
+    // Resolve bearer auth before creating requestInit so every attempted
+    // transport receives the same headers.
     const commandBearer = definition.bearerToken?.startsWith("!") && !definition.bearerToken.startsWith("!!")
       ? definition.bearerToken
       : undefined;
@@ -690,104 +726,88 @@ export class McpServerManager {
       }
     }
 
-    // Create request init with headers (Authorization now included for bearer auth)
     const requestInit = Object.keys(headers).length > 0 ? { headers } : undefined;
     const createAuthProvider = (): McpOAuthProvider => new McpOAuthProvider(
       serverName,
       serverUrl,
       extractOAuthConfig(definition),
-      {
-        onRedirect: async (_authUrl) => {
-          // URL is captured by startAuth, no need to log
-        },
-      },
+      { onRedirect: async () => {} },
       this.authStorageOptions,
       this.oauthRuntime?.signal,
     );
 
-    // Explicit OAuth must check the secure credential store before connecting.
+    // Explicit OAuth checks secure storage immediately. Implicit OAuth defers
+    // provider construction until the server proves authentication is needed.
     let authState: HttpAuthProviderState = supportsOAuth(definition)
       ? definition.auth === undefined
         ? { status: "implicit-deferred" }
         : { status: "explicit", provider: createAuthProvider() }
       : { status: "disabled" };
 
-    // Try StreamableHTTP first (modern MCP servers). For implicit OAuth, defer
-    // creating the provider until the server proves that authentication is needed.
-    for (;;) {
+    const attempt = async (
+      kind: "streamable-http" | "sse",
+    ): Promise<
+      | { status: "connected"; client: Client; transport: Transport }
+      | { status: "failed"; client: Client; transport: Transport; error: unknown }
+    > => {
       const authProvider = "provider" in authState ? authState.provider : undefined;
-      const streamableTransport = asSdkTransport(new StreamableHTTPClientTransport(url, {
+      const transportOptions = {
         ...(requestInit !== undefined ? { requestInit } : {}),
         ...(authProvider !== undefined ? { authProvider } : {}),
-      }));
-      const probeTransport = traceObserver
-        ? wrapTransportWithMcpTrace(streamableTransport, serverName, "streamable-http", traceObserver)
-        : streamableTransport;
-      const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" });
-      let probeCleanupAttempted = false;
+      };
+      const baseTransport: Transport = kind === "streamable-http"
+        ? new StreamableHTTPClientTransport(url, transportOptions)
+        : new SSEClientTransport(url, transportOptions);
+      const transport = traceObserver
+        ? wrapTransportWithMcpTrace(baseTransport, serverName, kind, traceObserver)
+        : baseTransport;
+      const client = this.createClient(serverName, definition);
+
       try {
-        await this.connectClientWithAbort(
-          testClient,
-          probeTransport,
-          this.buildRequestOptions(definition, requestSignal),
-          signal,
-        );
-        probeCleanupAttempted = true;
-        try {
-          await testClient.close();
-        } catch (cleanupError) {
-          throw new AggregateError([cleanupError], "MCP HTTP probe cleanup failed");
-        }
-
-        // StreamableHTTP works - create fresh transport for actual use
-        return asSdkTransport(new StreamableHTTPClientTransport(url, {
-          ...(requestInit !== undefined ? { requestInit } : {}),
-          ...(authProvider !== undefined ? { authProvider } : {}),
-        }));
+        await this.connectClientWithAbort(client, transport, requestOptions, signal);
+        return { status: "connected", client, transport };
       } catch (error) {
-        if (error instanceof AggregateError && (
-          error.message === "MCP connection abort cleanup failed" ||
-          error.message === "MCP HTTP probe cleanup failed"
-        )) {
-          throw error;
-        }
-
-        // StreamableHTTP failed, close through the SDK client and try SSE fallback.
-        // If connectClientWithAbort already owned the close, await that operation
-        // instead of closing the same transport twice.
-        if (!probeCleanupAttempted) {
-          probeCleanupAttempted = true;
+        const abortCleanupFailed = error instanceof AggregateError
+          && error.message === "MCP connection abort cleanup failed";
+        if (!abortCleanupFailed) {
           try {
-            await (abortCleanupPromises.get(probeTransport) ?? testClient.close());
+            await (abortCleanupPromises.get(transport) ?? client.close());
           } catch (cleanupError) {
-            throw new AggregateError([error, cleanupError], "MCP HTTP probe cleanup failed");
+            throw new AggregateError([error, cleanupError], "MCP HTTP connection cleanup failed");
           }
         }
-
-        // Host cancellation is not transport capability evidence; do not fall
-        // through to SSE when the caller is trying to cancel the connect.
-        if (signal?.aborted) {
-          throwIfAborted(signal);
-        }
-
-        // An implicit URL-only server gets a provider only after a real auth
-        // challenge. This keeps unauthenticated servers independent of storage.
-        if (authState.status === "implicit-deferred" && isUnauthorizedHttpError(error)) {
-          authState = { status: "implicit-challenged", provider: createAuthProvider() };
-          continue;
-        }
-
-        // If this was an UnauthorizedError, don't try SSE - the server needs auth
-        if (isUnauthorizedHttpError(error)) {
-          throw error;
-        }
-
-        // SSE is the legacy transport
-        return new SSEClientTransport(url, {
-          ...(requestInit !== undefined ? { requestInit } : {}),
-          ...(authProvider !== undefined ? { authProvider } : {}),
-        });
+        return { status: "failed", client, transport, error };
       }
+    };
+
+    // Connect the real client once. Retry Streamable HTTP only for an implicit
+    // OAuth challenge; use SSE only for definitive endpoint incompatibility.
+    let kind: "streamable-http" | "sse" = "streamable-http";
+    for (;;) {
+      const result = await attempt(kind);
+      if (result.status === "connected") return result;
+      if (result.error instanceof AggregateError
+        && result.error.message === "MCP connection abort cleanup failed") {
+        throw result.error;
+      }
+      if (signal?.aborted) throwIfAborted(signal);
+
+      if (authState.status === "implicit-deferred" && isUnauthorizedHttpError(result.error)) {
+        authState = { status: "implicit-challenged", provider: createAuthProvider() };
+        continue;
+      }
+      if (isUnauthorizedHttpError(result.error)) {
+        if (supportsOAuth(definition)) {
+          return { client: result.client, transport: result.transport, status: "needs-auth" };
+        }
+        throw result.error;
+      }
+
+      if (kind === "streamable-http" && shouldFallbackToSse(result.error, definition)) {
+        kind = "sse";
+        continue;
+      }
+      throw result.error;
     }
   }
 
@@ -853,11 +873,15 @@ export class McpServerManager {
   }
 
   private attachAdapterNotificationHandlers(serverName: string, client: Client): void {
-    client.setNotificationHandler(serverStreamResultPatchNotificationSchema, notification => {
-      const listener = this.uiStreamListeners.get(notification.params.streamToken);
-      if (!listener) return;
-      listener(serverName, notification.params);
-    });
+    client.setNotificationHandler(
+      SERVER_STREAM_RESULT_PATCH_METHOD,
+      { params: serverStreamResultPatchNotificationSchema.shape.params },
+      params => {
+        const listener = this.uiStreamListeners.get(params.streamToken);
+        if (!listener) return;
+        listener(serverName, params);
+      },
+    );
   }
 
   registerUiStreamListener(streamToken: string, listener: UiStreamListener): void {

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -20,8 +20,7 @@
 //     many things other than "your session is gone"
 //   - treat generic -32000/ConnectionClosed errors as session expiry
 //   - treat AbortError/cancellation as a session failure
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { ProtocolError, SdkHttpError } from "@modelcontextprotocol/client";
 import { logger } from "./logger.ts";
 import { throwIfAborted } from "./abort.ts";
 import { isServerDisabled, type McpConfig } from "./types.ts";
@@ -34,25 +33,25 @@ import type { McpServerManager, ServerConnection } from "./server-manager.ts";
  * gate response some servers emit before dispatching to a handler.
  *
  * `hadSessionId` must reflect the transport's session id from *before* the
- * call that produced `err` was made. The installed SDK (1.30.0) does not
- * clear `transport.sessionId` on a 404 response, so callers must capture it
- * before the call rather than rely on catch-time transport state.
+ * call that produced `err` was made. Callers must capture it before the call
+ * rather than rely on catch-time transport state.
  */
+const CONNECTION_CLOSED_PROTOCOL_CODE = -32000;
 const SERVER_NOT_INITIALIZED_MCP_MESSAGES = new Set([
-  `MCP error ${ErrorCode.ConnectionClosed}: Server not initialized`,
-  `MCP error ${ErrorCode.ConnectionClosed}: Bad Request: Server not initialized`,
+  "Server not initialized",
+  "Bad Request: Server not initialized",
 ]);
 
 export function isTerminatedSession(err: unknown, hadSessionId: boolean): boolean {
   if (!hadSessionId) return false;
-  if (err instanceof StreamableHTTPError) {
-    return err.code === 404
-      || (err.code === 400
+  if (err instanceof SdkHttpError) {
+    return err.status === 404
+      || (err.status === 400
         && /"code"\s*:\s*-32000/.test(err.message)
         && /"message"\s*:\s*"Bad Request: Server not initialized"/.test(err.message));
   }
-  return err instanceof McpError
-    && err.code === ErrorCode.ConnectionClosed
+  return err instanceof ProtocolError
+    && err.code === CONNECTION_CLOSED_PROTOCOL_CODE
     && SERVER_NOT_INITIALIZED_MCP_MESSAGES.has(err.message);
 }
 

--- a/types.ts
+++ b/types.ts
@@ -1,11 +1,11 @@
 // types.ts - Core type definitions
-import type { Transport as McpTransport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type {
   ContentBlock as McpContentBlock,
   ListPromptsResult,
   ListResourcesResult,
   ListToolsResult,
-} from "@modelcontextprotocol/sdk/types.js";
+  Transport as McpTransport,
+} from "@modelcontextprotocol/client";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
 import type { UiStreamMode } from "./ui-stream-types.ts";
 import type { UiToolVisibility } from "./ui-tool-visibility.ts";
@@ -397,6 +397,14 @@ export interface ServerEntry {
   debug?: boolean;  // Show server stderr (default: false)
   /** Enable metadata-only JSONL protocol tracing for this server. */
   trace?: boolean;
+  /**
+   * MCP protocol era negotiation for this server. Defaults to `"legacy"`
+   * (byte-equivalent to pre-2026 behavior — no `versionNegotiation` is sent).
+   * `"auto"` offers the SDK's default 2026-07-28+ modern versions with
+   * legacy fallback; `"2026-07-28"` pins the connection to that revision
+   * with no fallback. `auto` and `2026-07-28` must be set explicitly.
+   */
+  protocolVersion?: "legacy" | "auto" | "2026-07-28";
   // Keep configuration visible without allowing connections or execution.
   disabled?: boolean;
 }

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -1,5 +1,5 @@
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/client";
 import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge";
 import {
-  ContentBlockSchema,
   type CallToolRequest,
   type CallToolResult,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/client";
+import { ContentBlockSchema } from "@modelcontextprotocol/core";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
 import { formatAuthRequiredMessage } from "./utils.ts";
@@ -457,9 +457,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
                   ...(options.onNeedsAuth ? { onNeedsAuth: options.onNeedsAuth } : {}),
                 },
                 options.serverName,
-                (conn) => conn.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName)),
+                (conn) => conn.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName)),
               )
-            : await connection.client.callTool(callArgs, undefined, options.manager.getRequestOptions?.(options.serverName));
+            : await connection.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName));
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import net from "node:net";
-import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { UrlElicitationRequiredError, type CallToolResult } from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import {
   createUiModelContextUpdate,
@@ -99,8 +99,10 @@ function withStreamEnvelope(
     return result;
   }
 
-  const structuredContent = result.structuredContent && typeof result.structuredContent === "object" && !Array.isArray(result.structuredContent)
-    ? { ...result.structuredContent }
+  const structuredContent: Record<string, unknown> = result.structuredContent
+    && typeof result.structuredContent === "object"
+    && !Array.isArray(result.structuredContent)
+    ? { ...(result.structuredContent as Record<string, unknown>) }
     : {};
 
   const rawEnvelope = structuredContent[UI_STREAM_STRUCTURED_CONTENT_KEY];

--- a/unix-socket-transport.ts
+++ b/unix-socket-transport.ts
@@ -1,7 +1,7 @@
 import { createConnection, type Socket } from "node:net";
-import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/client";
+import type { Transport } from "@modelcontextprotocol/client";
+import type { JSONRPCMessage } from "@modelcontextprotocol/client";
 
 /** MCP JSONL transport for an explicitly configured Unix-domain socket. */
 export class UnixSocketClientTransport implements Transport {


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #272, rebuilt on current `main` after #273, #275, and #276 landed. It preserves the contribution while resolving the current-base conflicts and the traced stdio negotiation regression found during fresh review.

- migrate the adapter from the monolithic SDK v1 package to stable modular `@modelcontextprotocol/client@2.0.0` and `@modelcontextprotocol/core@2.0.0`
- add per-server `protocolVersion: "legacy" | "auto" | "2026-07-28"`, with legacy remaining the default
- remove the throwaway Streamable HTTP initialize probe and only fall back to SSE for definitive transport incompatibility
- keep traced stdio auto negotiation on the SDK v2 disposable sibling probe path
- update README, OAuth docs, conformance baseline, and tests for the new protocol negotiation behavior

Supersedes #272.

Credit: thanks @mjfaga for PR #272 and the original SDK v2/protocol-negotiation implementation.

## Validation

- `npm run typecheck`
- `git diff --check`
- `npx vitest run __tests__/mcp-trace.test.ts __tests__/server-manager-legacy-handshake.test.ts`
- focused changed-path Vitest suite: 17 files / 266 tests
- `npm test` after building `examples/interactive-visualizer`: 90 files / 907 tests
- `npm run test:oauth`: 113 tests
- `npm run test:conformance`
- `npm pack --dry-run`
- fresh read-only review found the tracing/docs issues; targeted follow-up verified the tracing fix; parent verified the final OAuth import snippet resolves from the package root
