### PR TITLE
fix: exec absolute-path $BROWSER directly on darwin instead of via open -a

### DIFF
--- a/__tests__/utils-exec-open.test.ts
+++ b/__tests__/utils-exec-open.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { platform } from "node:os";
+import { openUrl } from "../utils.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: vi.fn() };
+});
+
+function fakePi(): { pi: ExtensionAPI; exec: ReturnType<typeof vi.fn> } {
+  const exec = vi.fn().mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  return { pi: { exec } as unknown as ExtensionAPI, exec };
+}
+
+describe("openUrl on darwin", () => {
+  beforeEach(() => {
+    vi.mocked(platform).mockReturnValue("darwin");
+  });
+
+  it("execs an absolute-path browser override directly", async () => {
+    const { pi, exec } = fakePi();
+
+    await openUrl(pi, "https://example.com", "/usr/bin/open");
+
+    expect(exec).toHaveBeenCalledWith("/usr/bin/open", ["https://example.com"], {});
+  });
+
+  it("still uses `open -a <name>` for a non-path browser override", async () => {
+    const { pi, exec } = fakePi();
+
+    await openUrl(pi, "https://example.com", "Google Chrome");
+
+    expect(exec).toHaveBeenCalledWith("open", ["-a", "Google Chrome", "https://example.com"], {});
+  });
+
+  it("falls back to bare `open` with no browser override", async () => {
+    const { pi, exec } = fakePi();
+
+    await openUrl(pi, "https://example.com");
+
+    expect(exec).toHaveBeenCalledWith("open", ["https://example.com"], {});
+  });
+});

--- a/__tests__/utils-exec-open.test.ts
+++ b/__tests__/utils-exec-open.test.ts
@@ -41,4 +41,13 @@ describe("openUrl on darwin", () => {
 
     expect(exec).toHaveBeenCalledWith("open", ["https://example.com"], {});
   });
+
+  it("forwards an AbortSignal for an absolute-path browser override", async () => {
+    const { pi, exec } = fakePi();
+    const controller = new AbortController();
+
+    await openUrl(pi, "https://example.com", "/usr/bin/open", controller.signal);
+
+    expect(exec).toHaveBeenCalledWith("/usr/bin/open", ["https://example.com"], { signal: controller.signal });
+  });
 });

--- a/utils.ts
+++ b/utils.ts
@@ -1,16 +1,22 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { spawnSync } from "node:child_process";
 import { homedir, platform } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { McpConfig, ServerEntry } from "./types.ts";
 
 async function execOpen(pi: ExtensionAPI, target: string, browser?: string, signal?: AbortSignal) {
   const os = platform();
 
   if (os === "darwin") {
-    return browser
-      ? pi.exec("open", ["-a", browser, target], signal ? { signal } : {})
-      : pi.exec("open", [target], signal ? { signal } : {});
+    if (browser) {
+      // An absolute path (e.g. from $BROWSER) names a launcher binary, not an
+      // application: exec it directly instead of `open -a`, which expects an
+      // app name/bundle and mishandles a bare executable path.
+      return isAbsolute(browser)
+        ? pi.exec(browser, [target], signal ? { signal } : {})
+        : pi.exec("open", ["-a", browser, target], signal ? { signal } : {});
+    }
+    return pi.exec("open", [target], signal ? { signal } : {});
   }
   if (os === "win32") {
     return browser


### PR DESCRIPTION
## Summary

- On darwin, `execOpen` always shells out to the bare `open` command, even when a `browser` override is supplied — the override only ever gets passed as `open -a <browser>`, which expects an application name/bundle rather than an executable path.
- Sandboxing/launcher tools (e.g. [nono](https://github.com/nolabs-ai/nono)) that set `$BROWSER` to an absolute binary path (e.g. `/usr/bin/open`) have no way to make use of it on macOS, unlike the existing Linux/Windows code paths where the override already replaces the executable.
- This changes the darwin branch so that when `browser` is an absolute path, it's exec'd directly; a bare app name still goes through `open -a` as before.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (909/911 passing — the 2 pre-existing failures in `interactive-visualizer-server.test.ts` are unrelated, missing built example assets, and fail identically on `main`)
- [x] Added `__tests__/utils-exec-open.test.ts` covering: absolute-path browser exec's directly, non-path browser name still uses `open -a`, no browser falls back to bare `open`