### PR TITLE
fix: rename MCP scripting tool to mcpScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated the MCP client from the monolithic SDK v1 package to the stable modular `@modelcontextprotocol/client` and `@modelcontextprotocol/core` v2 packages. The stable release restores conservative legacy discovery fallback and declared JSON Schema dialect support while retaining strict OAuth issuer validation.
 
 ### Fixed
+- Renamed the MCP scripting tool to camel-case `mcpScript` because Anthropic rejects the previous underscore-form name. Thanks @ritvij14 for issue #278 and @wierdbytes for confirmation and the workaround.
 - Pinned the Chrome DevTools setup preset and README examples to `chrome-devtools-mcp@1.6.0` instead of `@latest`, so reviewed scaffolded commands stay stable. Thanks @fitchmultz for issue #274.
 - Removed the adapter's throwaway Streamable HTTP initialize probe. HTTP connections now initialize once on the real client and use narrowly classified SSE fallback, avoiding duplicate sessions and preventing authentication, cancellation, timeout, negotiation, and server failures from being misclassified as transport incompatibility.
 - Stopped tokenless discovery requests, sandboxed MCP app documents, unrelated child windows, and app-opened popups from gaining session authority; discovery now serves a non-sensitive landing page, app HTML loads with a separate resource-only token, host messages accept only the app frame as their source, and the app response enforces sandboxing even when opened as a top-level page.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |
 | `directTools` | Global default for all servers (default: false). Per-server overrides this. |
 | `freezeDirectTools` | Keep direct-tool registration stable after the initial sync so automatic reconnects and list-change notifications do not rebuild the system prompt. Use `mcp({ connect: "server" })` or `/mcp reconnect <server>` to refresh deliberately. Default: false. |
-| `scriptMode` | Register the MCP-only `mcp_script` plain-JavaScript tool (default: true). Set to `false` to hide it. |
+| `scriptMode` | Register the MCP-only `mcpScript` plain-JavaScript tool (default: true). Set to `false` to hide it. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
 | `sampling` | Allow MCP servers to sample through Pi models, honoring `modelPreferences.hints` before current/default fallback (default: true when UI approval is available). |
@@ -350,7 +350,7 @@ Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — t
 
 ### MCP Scripting
 
-For multi-call MCP work, write ordinary JavaScript: discover, inspect, call, loop, filter, chain, or fan out, then return one result. Run that code with the default-on `mcp_script` tool. For a single MCP call, search, describe, status check, or auth action, use `mcp` instead. Set `settings.scriptMode` to `false` to hide the scripting tool.
+For multi-call MCP work, write ordinary JavaScript: discover, inspect, call, loop, filter, chain, or fan out, then return one result. Run that code with the default-on `mcpScript` tool. For a single MCP call, search, describe, status check, or auth action, use `mcp` instead. Set `settings.scriptMode` to `false` to hide the scripting tool.
 
 The bundled `mcp-scripting` skill is a separate Pi package resource. To hide that skill while keeping the adapter extension installed, replace the package entry in Pi settings with the object form and disable package skills:
 
@@ -364,7 +364,7 @@ The bundled `mcp-scripting` skill is a separate Pi package resource. To hide tha
 
 Preserve any version pin in `source` if your existing package entry has one. You can also disable package resources through `pi config`.
 
-For example, this is the JavaScript passed as the `code` argument to `mcp_script`:
+For example, this is the JavaScript passed as the `code` argument to `mcpScript`:
 
 ```js
 const { items } = await tools.search({ query: "search issues", server: "github" });
@@ -382,9 +382,9 @@ return result.data;
 
 See the bundled `mcp-scripting` skill for the complete workflow guide. The API is `await tools.search({ query, server?, limit?, offset? })`, `await tools.describe({ path })`, `tools.call(path, args)`, direct flat calls, `emit(value)`, and a captured `console`. Use ordinary JavaScript loops and Promise utilities for composition; fluent helpers such as `tools.find(...).one()`, `tools.parallel(...)`, and `tools.retry(...)` are not provided. MCP calls return `{ ok: true, data }` or `{ ok: false, error: { code, message } }`, so a failed call does not stop the rest of the script. Result details include a concise `calls` trace with each operation, its path or query, outcome, and duration. Emitted values and console output appear before the script's final return value, and the combined result uses the normal MCP output guard. The default timeout is 30 seconds; each script runs in a worker thread that is terminated at the deadline, including for infinite loops.
 
-For a tool-restricted subagent, launch the child Pi with its tool allowlist set to `["mcp_script"]`. Have the parent discover MCP tool names with `mcp({ search: "..." })` and include the relevant prefixed names in the child's task; the child can then loop, filter, and chain those MCP calls without filesystem, shell, or edit tools. The adapter's ordinary lazy connection, authentication, output guard, abort handling, and approval gates still apply to every call.
+For a tool-restricted subagent, launch the child Pi with its tool allowlist set to `["mcpScript"]`. Have the parent discover MCP tool names with `mcp({ search: "..." })` and include the relevant prefixed names in the child's task; the child can then loop, filter, and chain those MCP calls without filesystem, shell, or edit tools. The adapter's ordinary lazy connection, authentication, output guard, abort handling, and approval gates still apply to every call.
 
-`mcp_script` is a trusted agent-authored MCP scripting layer, not an isolation boundary. If you need isolation, run Pi in an isolated environment. It is distinct from Pi's code-mode skill: Pi's skill batches general Pi tools, while `mcp_script` exposes MCP calls only and can be the child's sole tool.
+`mcpScript` is a trusted agent-authored MCP scripting layer, not an isolation boundary. If you need isolation, run Pi in an isolated environment. It is distinct from Pi's code-mode skill: Pi's skill batches general Pi tools, while `mcpScript` exposes MCP calls only and can be the child's sole tool.
 
 ### MCP Prompts
 

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -75,7 +75,7 @@ describe("buildProxyDescription", () => {
     expect(description).toContain('mcp({ action: "ui-messages" })');
     expect(description).toContain("Retrieve accumulated messages from completed UI sessions");
     expect(description).toContain("server status, tool search/describe, auth, and single MCP tool calls");
-    expect(description).toContain("When one request needs several MCP calls with logic between them, use mcp_script.");
+    expect(description).toContain("When one request needs several MCP calls with logic between them, use mcpScript.");
     expect(description).toContain("Search MCP tools by name/description");
     expect(description).toContain("Non-MCP Pi tools should be called directly, not through mcp.");
     expect(description).not.toContain("MCP + pi");

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -17,7 +17,7 @@ function textBlocks(result: Awaited<ReturnType<typeof runMcpScript>>): string[] 
 }
 
 describe("runMcpScript", () => {
-  it("registers mcp_script by default", () => {
+  it("registers mcpScript by default", () => {
     const registerTool = vi.fn();
     createMcpAdapter({ config: { settings: {}, mcpServers: {} } })({
       registerTool,
@@ -28,13 +28,14 @@ describe("runMcpScript", () => {
     } as any);
 
     expect(registerTool).toHaveBeenCalledWith(expect.objectContaining({
-      name: "mcp_script",
+      name: "mcpScript",
       description: expect.stringContaining("multiple MCP tool calls in one request"),
       promptSnippet: "Batch multiple MCP tool calls in one JavaScript request (loop, filter, chain)",
     }));
+    expect(registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp_script" }));
   });
 
-  it("skips mcp_script when scriptMode is false", () => {
+  it("skips mcpScript when scriptMode is false", () => {
     const registerTool = vi.fn();
     createMcpAdapter({ config: { settings: { scriptMode: false }, mcpServers: {} } })({
       registerTool,
@@ -45,7 +46,7 @@ describe("runMcpScript", () => {
     } as any);
 
     expect(registerTool).toHaveBeenCalled();
-    expect(registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp_script" }));
+    expect(registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcpScript" }));
   });
 
   beforeAll(async () => {
@@ -78,7 +79,7 @@ describe("runMcpScript", () => {
       ok: false,
       error: {
         code: "tool_not_found",
-        message: expect.stringContaining('Use await tools.search({ query: "..." }) inside mcp_script.'),
+        message: expect.stringContaining('Use await tools.search({ query: "..." }) inside mcpScript.'),
       },
     });
     expect(payload.error.message).not.toContain("mcp({ search:");
@@ -281,7 +282,7 @@ describe("runMcpScript", () => {
 
     expect(textBlocks(result)[0]).toBe("before timeout");
     expect(result.details).toMatchObject({ error: "timeout", timeoutMs: 250 });
-    expect(textBlocks(result).at(-1)).toBe("mcp_script timed out after 250ms");
+    expect(textBlocks(result).at(-1)).toBe("mcpScript timed out after 250ms");
   });
 
   it("orders emitted and captured console blocks before the return value", async () => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -212,7 +212,7 @@ export function buildProxyDescription(
   directSpecs: DirectToolSpec[],
 ): string {
   const prefix = config.settings?.toolPrefix ?? "server";
-  let desc = `MCP gateway — server status, tool search/describe, auth, and single MCP tool calls. When one request needs several MCP calls with logic between them, use mcp_script. Non-MCP Pi tools should be called directly, not through mcp.\n`;
+  let desc = `MCP gateway — server status, tool search/describe, auth, and single MCP tool calls. When one request needs several MCP calls with logic between them, use mcpScript. Non-MCP Pi tools should be called directly, not through mcp.\n`;
 
   const directByServer = new Map<string, number>();
   for (const spec of directSpecs) {

--- a/index.ts
+++ b/index.ts
@@ -616,7 +616,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   if (earlyConfig.settings?.scriptMode !== false) {
     (pi.registerTool as (tool: unknown) => unknown)({
-      name: "mcp_script",
+      name: "mcpScript",
       label: "MCP Script",
       description: "Run trusted JavaScript that makes multiple MCP tool calls in one request — loop, filter, chain, or fan out between calls. For a single MCP call, search, describe, status check, or auth action, use the mcp tool instead. Discover with await tools.search({ query }) — resolves to { items: [{ path, name, server, description? }], total, hasMore, nextOffset }, not an { ok, data } envelope. Inspect with await tools.describe({ path }) — resolves to the tool descriptor with inputTypeScript, or { path, error: { code, message, suggestions } }. Then call tools.call(path, args) — resolves to { ok: true, data } or { ok: false, error: { code, message } } — or use direct flat calls when the name is already known; use emit(value) for user-visible output. Load the mcp-scripting skill for the full workflow guide.",
       promptSnippet: "Batch multiple MCP tool calls in one JavaScript request (loop, filter, chain)",

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -14,7 +14,7 @@ export const DEFAULT_MCP_SCRIPT_TIMEOUT_MS = 30_000;
 
 class McpScriptTimeoutError extends Error {
   constructor(timeoutMs: number) {
-    super(`mcp_script timed out after ${timeoutMs}ms`);
+    super(`mcpScript timed out after ${timeoutMs}ms`);
     this.name = "McpScriptTimeoutError";
   }
 }
@@ -147,7 +147,7 @@ export async function runMcpScript(
         ? details.suggestions.filter((suggestion): suggestion is string => typeof suggestion === "string")
         : [];
       const message = errorCode === "tool_not_found"
-        ? `Tool "${path}" not found. Use await tools.search({ query: "..." }) inside mcp_script.${suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : ""}`
+        ? `Tool "${path}" not found. Use await tools.search({ query: "..." }) inside mcpScript.${suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : ""}`
         : typeof details.message === "string"
           ? details.message
           : textFromContent(result.content);
@@ -285,7 +285,7 @@ export async function runMcpScript(
       });
       activeWorker.once("error", reject);
       activeWorker.once("exit", (code) => {
-        if (!completed && code !== 0) reject(new Error(`mcp_script worker exited with code ${code}`));
+        if (!completed && code !== 0) reject(new Error(`mcpScript worker exited with code ${code}`));
       });
     });
     const timeoutError = new McpScriptTimeoutError(resolvedTimeoutMs);
@@ -313,7 +313,7 @@ export async function runMcpScript(
   } catch (error) {
     if (error instanceof McpScriptTimeoutError) {
       errorCode = "timeout";
-      errorMessage = `mcp_script timed out after ${resolvedTimeoutMs}ms`;
+      errorMessage = `mcpScript timed out after ${resolvedTimeoutMs}ms`;
     } else if (externalSignal?.aborted) {
       errorCode = "aborted";
       errorMessage = error instanceof Error ? error.message : String(error);
@@ -330,7 +330,7 @@ export async function runMcpScript(
     callsSnapshot ??= snapshotCalls();
     // A script may finish without awaiting every call; abort leftovers so
     // parent-side dispatches do not outlive the script.
-    timeoutController.abort(new Error("mcp_script finished"));
+    timeoutController.abort(new Error("mcpScript finished"));
     await worker?.terminate();
   }
 

--- a/mcp-script-worker.mjs
+++ b/mcp-script-worker.mjs
@@ -113,9 +113,9 @@ try {
     console: capturedConsole,
   }), {
     codeGeneration: { strings: false, wasm: false },
-    name: "mcp_script",
+    name: "mcpScript",
   });
-  const script = new vm.Script(`(async () => {\n${workerData.code}\n})()`, { filename: "mcp_script.js" });
+  const script = new vm.Script(`(async () => {\n${workerData.code}\n})()`, { filename: "mcpScript.js" });
   const returnValue = await Promise.resolve(script.runInContext(context));
   parentPort.postMessage(returnValue === undefined
     ? { type: "done" }

--- a/skills/mcp-scripting/SKILL.md
+++ b/skills/mcp-scripting/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: mcp-scripting
-description: Write mcp_script JavaScript for discovering, inspecting, and calling MCP tools.
+description: Write mcpScript JavaScript for discovering, inspecting, and calling MCP tools.
 ---
 
 # MCP scripting
 
-For multi-call MCP work, write ordinary JavaScript with loops, filtering, chaining, fan-out, or other logic between calls. Run that source with `mcp_script`; it is the primary MCP orchestration surface. For a single MCP search, describe, status check, auth action, or tool call, use `mcp` instead.
+For multi-call MCP work, write ordinary JavaScript with loops, filtering, chaining, fan-out, or other logic between calls. Run that source with `mcpScript`; it is the primary MCP orchestration surface. For a single MCP search, describe, status check, auth action, or tool call, use `mcp` instead.
 
-Write the source naturally, then pass it as `mcp_script`'s `code` argument:
+Write the source naturally, then pass it as `mcpScript`'s `code` argument:
 
 ```js
 const { items } = await tools.search({ query: "search issues", server: "github" });


### PR DESCRIPTION
## Summary

Fixes #278 by hard-renaming the registered MCP scripting tool from `mcp_script` to `mcpScript`.

The legacy underscore alias is intentionally not registered, because the issue is triggered by merely sending a tool definition named `mcp_script`.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/mcp-code.test.ts __tests__/direct-tools.test.ts`
- `rg -n 'mcp_script' --glob '!node_modules' --glob '!package-lock.json' .` audit: only historical released changelog entries and the explicit negative test assertion remain
- `git diff --check`
- fresh read-only reviewer: no issues found

Thanks @ritvij14 for issue #278 and @wierdbytes for confirming the failure and workaround.
