### PR TITLE
feat: broker MCP tool approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added an MCP tool approval broker event so permission extensions can allow, deny, or abstain on proxy, direct, `mcpScript`, resource, and iframe-originated MCP calls before the built-in `approveTools` prompt runs. Thanks @geshido for issue #279.
 - Added opt-in per-server MCP protocol selection with `protocolVersion: "legacy" | "auto" | "2026-07-28"`. Legacy remains the default; auto negotiates the modern era with conservative legacy fallback, while the pinned mode fails instead of falling back. Thanks @mjfaga for PR #272.
 - Added a strict TypeScript typecheck command and CI gate.
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,23 @@ Use `approveTools` when a tool should stay visible but not run without confirmat
 
 When a matching tool is called from the proxy tool, a direct MCP tool, a resource call, or an MCP UI iframe, Pi asks: **Allow once**, **Allow for session**, or **Deny**. Session approvals are kept in memory only. In headless sessions, matching calls fail closed with an `approval_required` result instead of running. `excludeTools` still removes tools entirely; `approveTools` only gates visible tools at call time.
 
+Permission extensions can broker these decisions by listening on `pi-mcp-adapter:tool-approval-request` and claiming the request synchronously:
+
+```ts
+import {
+  MCP_TOOL_APPROVAL_REQUEST_EVENT,
+  type McpToolApprovalRequest,
+} from "pi-mcp-adapter";
+
+pi.events.on(MCP_TOOL_APPROVAL_REQUEST_EVENT, (request: McpToolApprovalRequest) => {
+  request.claim(async () => {
+    return "allow_once"; // "allow_for_session" | "deny" | "abstain"
+  });
+});
+```
+
+The request includes `serverName`, `originalToolName`, `prefixedToolName`, `args`, `origin`, and optional `signal`. The first synchronous claim wins. `allow_for_session` updates the same in-memory approval cache as the built-in dialog; `deny` blocks the MCP call; `abstain` or no claim preserves the fallback behavior above. Brokered approval runs for every uncached MCP call regardless of `approveTools` configuration, across proxy, direct, `mcpScript`, resource, and iframe origins.
+
 ### Output Guard
 
 Oversized MCP tool/resource results are guarded by default so a single huge response can't blow up the model context window or the session file:

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -4,6 +4,7 @@ import { createMcpAdapter } from "../index.ts";
 import { runMcpScript } from "../mcp-code.ts";
 import { McpServerManager } from "../server-manager.ts";
 import type { McpExtensionState } from "../state.ts";
+import { MCP_TOOL_APPROVAL_REQUEST_EVENT, type McpToolApprovalRequest } from "../types.ts";
 
 const fixture = fileURLToPath(new URL("./fixtures/mcp-code-server.mjs", import.meta.url));
 const definition = { command: process.execPath, args: [fixture] };
@@ -189,6 +190,39 @@ describe("runMcpScript", () => {
     expect(result.details).toMatchObject({
       calls: [{ path: "fixture_echo", ok: false, error: "approval_required" }],
     });
+  });
+
+  it("lets approval brokers handle internal script calls", async () => {
+    const broker = vi.fn((request: McpToolApprovalRequest) => {
+      expect(request).toMatchObject({
+        serverName: "fixture",
+        originalToolName: "echo",
+        prefixedToolName: "fixture_echo",
+        args: { value: "brokered" },
+        origin: "script",
+      });
+      expect(request.claim(() => "allow_once")).toBe(true);
+    });
+    const brokeredState = {
+      ...state,
+      config: { settings: { approveTools: ["echo"] }, mcpServers: { fixture: definition } },
+      approvedToolCalls: new Map(),
+      approvalEvents: { emit: vi.fn((channel: string, data: unknown) => {
+        expect(channel).toBe(MCP_TOOL_APPROVAL_REQUEST_EVENT);
+        broker(data as McpToolApprovalRequest);
+      }) },
+    } as unknown as McpExtensionState;
+
+    const result = await runMcpScript(
+      brokeredState,
+      'return await tools.fixture_echo({ value: "brokered" });',
+    );
+
+    expect(JSON.parse(textBlocks(result).at(-1)!)).toMatchObject({
+      ok: true,
+      data: { structuredContent: { echoed: "brokered" } },
+    });
+    expect(broker).toHaveBeenCalledOnce();
   });
 
   it("calls a prefixed MCP tool through the flat tools proxy", async () => {

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -3,7 +3,12 @@ import { createDirectToolExecutor } from "../direct-tools.ts";
 import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "../tool-approval.ts";
-import type { McpConfig, ToolMetadata } from "../types.ts";
+import {
+  MCP_TOOL_APPROVAL_REQUEST_EVENT,
+  type McpConfig,
+  type McpToolApprovalRequest,
+  type ToolMetadata,
+} from "../types.ts";
 
 const tool: ToolMetadata = {
   name: "demo_search-records",
@@ -15,6 +20,7 @@ function createState(options: {
   approveTools?: boolean | string[];
   decision?: "Allow once" | "Allow for session" | "Deny";
   interactive?: boolean;
+  broker?: (request: McpToolApprovalRequest) => void;
 } = {}) {
   const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
   const select = vi.fn().mockResolvedValue(options.decision ?? "Allow once");
@@ -40,6 +46,12 @@ function createState(options: {
     promptMetadataLive: new Set(),
     serverInstructions: new Map(),
     approvedToolCalls: new Map<string, true>(),
+    ...(options.broker
+      ? { approvalEvents: { emit: vi.fn((channel: string, data: unknown) => {
+          expect(channel).toBe(MCP_TOOL_APPROVAL_REQUEST_EVENT);
+          options.broker?.(data as McpToolApprovalRequest);
+        }) } }
+      : {}),
     manager: {
       getConnection: () => connection,
       getRequestOptions: () => undefined,
@@ -123,6 +135,138 @@ describe("tool approval", () => {
     await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
     expect(once.select).toHaveBeenCalledTimes(2);
     expect(once.state.approvedToolCalls.size).toBe(0);
+  });
+
+  it("lets a broker allow a gated call without showing the built-in prompt", async () => {
+    const { state, callTool, select } = createState({
+      approveTools: true,
+      interactive: false,
+      broker: (request) => {
+        expect(request).toMatchObject({
+          serverName: "demo",
+          originalToolName: "search-records",
+          prefixedToolName: "demo_search-records",
+          args: { query: "private" },
+          origin: "proxy",
+        });
+        expect(request.claim(() => "allow_once")).toBe(true);
+      },
+    });
+
+    const result = await executeCall(state, tool.name, { query: "private" });
+
+    expect(result.details).not.toHaveProperty("error");
+    expect(callTool).toHaveBeenCalledOnce();
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("lets a broker deny even when approveTools does not match", async () => {
+    const { state, callTool } = createState({
+      broker: (request) => {
+        expect(request.claim(() => "deny")).toBe(true);
+      },
+    });
+
+    await expect(executeCall(state, tool.name, {})).resolves.toMatchObject({
+      details: { error: "approval_denied", server: "demo", tool: "search-records" },
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("marks direct MCP tool calls with the direct origin", async () => {
+    const { state, callTool } = createState({
+      approveTools: true,
+      interactive: false,
+      broker: (request) => {
+        expect(request.origin).toBe("direct");
+        expect(request.claim(() => "allow_once")).toBe(true);
+      },
+    });
+    const execute = createDirectToolExecutor(() => state, () => null, {
+      serverName: "demo",
+      originalName: "search-records",
+      prefixedName: "demo_search-records",
+      description: "Search records",
+    });
+
+    await execute("call-1", {}, undefined, undefined, {} as never);
+
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the built-in prompt when a broker abstains", async () => {
+    const { state, select } = createState({
+      approveTools: true,
+      decision: "Allow once",
+      broker: (request) => {
+        expect(request.claim(() => "abstain")).toBe(true);
+      },
+    });
+
+    await ensureToolCallApproved(state, "demo", tool, {}, undefined);
+    expect(select).toHaveBeenCalledOnce();
+  });
+
+  it("uses broker allow_for_session decisions for the existing session cache", async () => {
+    const broker = vi.fn((request: McpToolApprovalRequest) => {
+      expect(request.claim(() => "allow_for_session")).toBe(true);
+    });
+    const { state } = createState({ approveTools: true, broker });
+
+    await ensureToolCallApproved(state, "demo", tool, {}, undefined);
+    await ensureToolCallApproved(state, "demo", tool, {}, undefined);
+
+    expect(broker).toHaveBeenCalledOnce();
+    expect(state.approvedToolCalls.has("demo\u0000search-records")).toBe(true);
+  });
+
+  it("requires brokers to claim synchronously", async () => {
+    const { state } = createState({ approveTools: true, interactive: false, broker: (request) => {
+      queueMicrotask(() => request.claim(() => "allow_once"));
+    } });
+
+    await expect(ensureToolCallApproved(state, "demo", tool, {}, undefined)).resolves.toEqual({
+      ok: false,
+      reason: "approval_required_headless",
+    });
+  });
+
+  it("fails closed when a claimed broker returns an invalid decision", async () => {
+    const { state, callTool } = createState({ broker: (request) => {
+      request.claim(() => undefined as never);
+    } });
+
+    await expect(executeCall(state, tool.name, {})).resolves.toMatchObject({
+      details: { error: "approval_denied", server: "demo", tool: "search-records" },
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a claimed broker throws", async () => {
+    const { state } = createState({ broker: (request) => {
+      request.claim(() => {
+        throw new Error("broker failed");
+      });
+    } });
+
+    await expect(ensureToolCallApproved(state, "demo", tool, {}, undefined)).resolves.toEqual({
+      ok: false,
+      reason: "denied",
+    });
+  });
+
+  it("propagates aborts while a claimed broker is pending", async () => {
+    const { state } = createState({ broker: (request) => {
+      request.claim(() => new Promise(() => {}));
+    } });
+    const controller = new AbortController();
+    const reason = new Error("broker stopped");
+    reason.name = "AbortError";
+
+    const pending = ensureToolCallApproved(state, "demo", tool, {}, controller.signal);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
   });
 
   it("propagates aborts while the approval dialog is open", async () => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -386,7 +386,7 @@ export function createDirectToolExecutor(
       ...(spec.resourceUri !== undefined ? { resourceUri: spec.resourceUri } : {}),
       ...(spec.uiResourceUri !== undefined ? { uiResourceUri: spec.uiResourceUri } : {}),
       ...(spec.uiStreamMode !== undefined ? { uiStreamMode: spec.uiStreamMode } : {}),
-    }, params, ownedSignal);
+    }, params, ownedSignal, spec.resourceUri ? "resource" : "direct");
     if (approval.ok === false) {
       const denied = approval.reason === "denied";
       const message = denied

--- a/index.ts
+++ b/index.ts
@@ -23,9 +23,14 @@ export type { McpAdapterOptions } from "./types.ts";
 export {
   MCP_STATUS_EVENT,
   MCP_STATUS_SNAPSHOT_VERSION,
+  MCP_TOOL_APPROVAL_REQUEST_EVENT,
   type McpServerRuntimeStatus,
   type McpServerStatusSnapshot,
   type McpStatusSnapshot,
+  type McpToolApprovalDecision,
+  type McpToolApprovalHandler,
+  type McpToolApprovalOrigin,
+  type McpToolApprovalRequest,
 } from "./types.ts";
 
 const INIT_WAIT_TIMEOUT_MS = 30_000;

--- a/init.ts
+++ b/init.ts
@@ -166,6 +166,7 @@ export async function initializeMcp(
     failureTracker,
     failureMessages,
     approvedToolCalls,
+    approvalEvents: pi.events,
     uiResourceHandler,
     consentManager,
     uiServer: null,

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -139,7 +139,7 @@ export async function runMcpScript(
     // Record before dispatch so calls still in flight at timeout/abort appear in the trace.
     const startedAt = Date.now();
     const index = calls.push({ operation: "call", path, ok: false, error: "incomplete", durationMs: 0, startedAt }) - 1;
-    const result = await executeCall(state, path, args, undefined, getPiTools, callSignal);
+    const result = await executeCall(state, path, args, undefined, getPiTools, callSignal, "script");
     const details = result.details;
     if (details.error !== undefined) {
       const errorCode = String(details.error);

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -749,6 +749,7 @@ export async function executeCall(
   serverOverride?: string,
   getPiTools?: () => ToolInfo[],
   signal?: AbortSignal,
+  origin?: "proxy" | "script",
 ): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
@@ -1034,7 +1035,14 @@ export async function executeCall(
     return disabledCallResult(serverName, toolMeta);
   }
 
-  const approval = await ensureToolCallApproved(state, serverName, toolMeta, args, ownedSignal);
+  const approval = await ensureToolCallApproved(
+    state,
+    serverName,
+    toolMeta,
+    args,
+    ownedSignal,
+    origin ?? (toolMeta.resourceUri ? "resource" : "proxy"),
+  );
   if (approval.ok === false) {
     const denied = approval.reason === "denied";
     const message = denied

--- a/state.ts
+++ b/state.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ConsentManager } from "./consent-manager.ts";
 import type { McpLifecycleManager } from "./lifecycle.ts";
 import type { McpServerManager } from "./server-manager.ts";
@@ -48,6 +48,8 @@ export interface McpExtensionState {
   failureMessages: Map<string, string>;
   /** Session-only approvals keyed by server and original tool name. */
   approvedToolCalls: Map<string, true>;
+  /** Shared event bus used by permission extensions to broker MCP approvals. */
+  approvalEvents?: ExtensionAPI["events"];
   uiResourceHandler: UiResourceHandler;
   consentManager: ConsentManager;
   uiServer: UiServerHandle | null;

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { abortable } from "./abort.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import type { McpExtensionState } from "./state.ts";
@@ -5,7 +6,12 @@ import {
   getToolNameCandidates,
   matchesToolPattern,
   resolveToolPrefix,
+  MCP_TOOL_APPROVAL_REQUEST_EVENT,
   type McpConfig,
+  type McpToolApprovalDecision,
+  type McpToolApprovalHandler,
+  type McpToolApprovalOrigin,
+  type McpToolApprovalRequest,
   type ToolMetadata,
 } from "./types.ts";
 import { sanitizeTerminalText } from "./utils.ts";
@@ -34,19 +40,76 @@ export function isToolCallApprovalRequired(
   );
 }
 
+function isMcpToolApprovalDecision(value: unknown): value is McpToolApprovalDecision {
+  return value === "allow_once"
+    || value === "allow_for_session"
+    || value === "deny"
+    || value === "abstain";
+}
+
+async function requestBrokerApproval(
+  state: McpExtensionState,
+  serverName: string,
+  toolMeta: ToolMetadata,
+  args: Record<string, unknown> | undefined,
+  origin: McpToolApprovalOrigin,
+  signal?: AbortSignal,
+): Promise<McpToolApprovalDecision> {
+  if (!state.approvalEvents) return "abstain";
+
+  let acceptingClaim = true;
+  let handler: McpToolApprovalHandler | undefined;
+  const request: McpToolApprovalRequest = {
+    requestId: randomUUID(),
+    serverName,
+    originalToolName: toolMeta.originalName,
+    prefixedToolName: toolMeta.name,
+    args: args ?? {},
+    origin,
+    ...(signal !== undefined ? { signal } : {}),
+    claim(candidate: McpToolApprovalHandler) {
+      if (!acceptingClaim || handler) return false;
+      handler = candidate;
+      return true;
+    },
+  };
+
+  state.approvalEvents.emit(MCP_TOOL_APPROVAL_REQUEST_EVENT, request);
+  acceptingClaim = false;
+  if (!handler) return "abstain";
+
+  try {
+    const decision = await abortable(Promise.resolve().then(handler), signal);
+    return isMcpToolApprovalDecision(decision) ? decision : "deny";
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    return "deny";
+  }
+}
+
 export async function ensureToolCallApproved(
   state: McpExtensionState,
   serverName: string,
   toolMeta: ToolMetadata,
   args: Record<string, unknown> | undefined,
   signal?: AbortSignal,
+  origin: McpToolApprovalOrigin = toolMeta.resourceUri ? "resource" : "proxy",
 ): Promise<ToolCallApprovalResult> {
-  if (!isToolCallApprovalRequired(state.config, serverName, toolMeta)) {
+  const cacheKey = `${serverName}\u0000${toolMeta.originalName}`;
+  const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
+  if (approvedToolCalls.has(cacheKey)) {
     return { ok: true };
   }
 
-  const cacheKey = `${serverName}\u0000${toolMeta.originalName}`;
-  if (state.approvedToolCalls.has(cacheKey)) {
+  const brokerDecision = await requestBrokerApproval(state, serverName, toolMeta, args, origin, signal);
+  if (brokerDecision === "allow_once") return { ok: true };
+  if (brokerDecision === "allow_for_session") {
+    approvedToolCalls.set(cacheKey, true);
+    return { ok: true };
+  }
+  if (brokerDecision === "deny") return { ok: false, reason: "denied" };
+
+  if (!isToolCallApprovalRequired(state.config, serverName, toolMeta)) {
     return { ok: true };
   }
 
@@ -71,7 +134,7 @@ export async function ensureToolCallApproved(
     return { ok: true };
   }
   if (decision === "Allow for session") {
-    state.approvedToolCalls.set(cacheKey, true);
+    approvedToolCalls.set(cacheKey, true);
     return { ok: true };
   }
   return { ok: false, reason: "denied" };

--- a/types.ts
+++ b/types.ts
@@ -440,6 +440,23 @@ export interface McpTraceSettings {
   maxEvents?: number;
 }
 
+export const MCP_TOOL_APPROVAL_REQUEST_EVENT = "pi-mcp-adapter:tool-approval-request" as const;
+
+export type McpToolApprovalOrigin = "proxy" | "direct" | "script" | "resource" | "iframe";
+export type McpToolApprovalDecision = "allow_once" | "allow_for_session" | "deny" | "abstain";
+export type McpToolApprovalHandler = () => McpToolApprovalDecision | Promise<McpToolApprovalDecision>;
+
+export interface McpToolApprovalRequest {
+  requestId: string;
+  serverName: string;
+  originalToolName: string;
+  prefixedToolName: string;
+  args: Record<string, unknown>;
+  origin: McpToolApprovalOrigin;
+  signal?: AbortSignal;
+  claim(handler: McpToolApprovalHandler): boolean;
+}
+
 export interface McpSettings {
   toolPrefix?: ToolPrefix;
   /** Show the plug prefix in MCP status and connection text (default: true). Set to false to disable it. */

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -423,6 +423,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               toolMeta,
               callArgs.arguments,
               options.state.owner?.signal,
+              "iframe",
             )
           : options.config && isToolCallApprovalRequired(options.config, options.serverName, toolMeta)
             ? { ok: false as const, reason: "approval_required_headless" as const }


### PR DESCRIPTION
## Summary

Fixes #279 by adding an adapter-level MCP tool approval broker event:

```ts
MCP_TOOL_APPROVAL_REQUEST_EVENT === "pi-mcp-adapter:tool-approval-request"
```

Permission extensions can synchronously claim a request, then asynchronously return `allow_once`, `allow_for_session`, `deny`, or `abstain`. If nobody claims or a claimed broker explicitly abstains, the existing `approveTools` prompt/fail-closed fallback remains unchanged.

The broker runs for proxy, direct, `mcpScript`, resource, and iframe-originated MCP calls. `allow_for_session` updates the existing in-memory approval cache. Invalid decisions and broker failures deny/fail closed; aborts still propagate.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/tool-approval.test.ts __tests__/mcp-code.test.ts __tests__/ui-server.test.ts __tests__/direct-tools.test.ts`
- `npm run test:oauth`
- `npm run test:conformance`
- `npm pack --dry-run`
- import smoke for `MCP_TOOL_APPROVAL_REQUEST_EVENT`
- `git diff --check`
- fresh review found and fixed invalid-decision fail-open
- targeted follow-up found and fixed broker abort propagation

Thanks @geshido for issue #279.
