### PR TITLE
fix: avoid peer-dependent app bridge load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stopped server-side MCP app helper imports from requiring the legacy `@modelcontextprotocol/sdk` peer at extension load time, fixing peerless Pi installs of 2.20.0. Thanks @aryzing for issue #285 and @DevDominic and @Shinkicast for confirmations.
+
 ## [2.20.0] - 2026-08-04
 
 ### Added

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -47,6 +47,19 @@ describe("package.json files", () => {
     expect(runtimeModules.length).toBeGreaterThan(0);
     expect(runtimeModules.filter((entry) => !publishedFiles.has(entry))).toEqual([]);
   });
+
+  it("does not import the peer-dependent MCP app bridge from runtime modules", () => {
+    const runtimeModules = readdirSync(repoRoot)
+      .filter((entry) => entry.endsWith(".ts"))
+      .filter((entry) => !entry.endsWith(".test.ts"))
+      .filter((entry) => entry !== "vitest.config.ts");
+
+    const offenders = runtimeModules.filter((entry) =>
+      readFileSync(join(repoRoot, entry), "utf-8").includes("@modelcontextprotocol/ext-apps/app-bridge")
+    );
+
+    expect(offenders).toEqual([]);
+  });
 });
 
 describe("package.json dependency policy", () => {

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "
 import { dirname } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
 import { createHash } from "node:crypto";
-import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { getToolUiResourceUri } from "./ui-app-bridge-helpers.ts";
 import type {
   CachedPrompt,
   CachedResource,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "types.ts",
     "ui-stream-types.ts",
     "ui-tool-visibility.ts",
+    "ui-app-bridge-helpers.ts",
     "config.ts",
     "server-manager.ts",
     "unix-socket-transport.ts",

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,4 +1,4 @@
-import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { getToolUiResourceUri } from "./ui-app-bridge-helpers.ts";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from "./types.ts";
 import { formatToolName, isToolAllowed, resolveToolPrefix } from "./types.ts";

--- a/ui-app-bridge-helpers.ts
+++ b/ui-app-bridge-helpers.ts
@@ -1,0 +1,40 @@
+import type { UiResourcePermissions } from "./types.ts";
+
+export const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+const RESOURCE_URI_META_KEY = "ui/resourceUri";
+
+export function getToolUiResourceUri(tool: { _meta?: Record<string, unknown> | undefined }): string | undefined {
+  const meta = tool._meta;
+  let resourceUri = getNestedResourceUri(meta);
+  if (resourceUri === undefined) {
+    resourceUri = meta?.[RESOURCE_URI_META_KEY];
+  }
+
+  if (typeof resourceUri === "string" && resourceUri.startsWith("ui://")) {
+    return resourceUri;
+  }
+
+  if (resourceUri !== undefined) {
+    throw new Error(`Invalid UI resource URI: ${JSON.stringify(resourceUri)}`);
+  }
+
+  return undefined;
+}
+
+export function buildAllowAttribute(permissions: UiResourcePermissions | undefined): string {
+  if (!permissions) return "";
+
+  const allowed: string[] = [];
+  if (permissions.camera) allowed.push("camera");
+  if (permissions.microphone) allowed.push("microphone");
+  if (permissions.geolocation) allowed.push("geolocation");
+  if (permissions.clipboardWrite) allowed.push("clipboard-write");
+  return allowed.join("; ");
+}
+
+function getNestedResourceUri(meta: Record<string, unknown> | undefined): unknown {
+  const ui = meta?.ui;
+  if (!ui || typeof ui !== "object") return undefined;
+  return (ui as Record<string, unknown>).resourceUri;
+}

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -1,4 +1,4 @@
-import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { RESOURCE_MIME_TYPE } from "./ui-app-bridge-helpers.ts";
 import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/client";
 import { ResourceFetchError, ResourceParseError } from "./errors.ts";
 import { logger } from "./logger.ts";

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -2,7 +2,7 @@ import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { buildAllowAttribute } from "./ui-app-bridge-helpers.ts";
 import {
   type CallToolRequest,
   type CallToolResult,


### PR DESCRIPTION
Fixes #285.\n\nThis removes server-side runtime imports of the MCP app bridge package entry that pulls in the legacy `@modelcontextprotocol/sdk` peer. The adapter now keeps the three small helper behaviors locally, so peerless Pi installs can load the extension without evaluating `@modelcontextprotocol/ext-apps/app-bridge`.\n\nValidation:\n- `npm run typecheck`\n- `npm test -- --run __tests__/package-manifest.test.ts __tests__/ui-resource-handler.test.ts __tests__/host-html-template.test.ts`\n- packed install smoke with `@modelcontextprotocol/sdk` absent\n\nCredit: thanks @aryzing for the report in #285, and @DevDominic and @Shinkicast for confirming the failure.