### PR TITLE
fix: stop leaking TypeBox ~optional markers into tool schemas

### DIFF
--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -224,6 +224,42 @@ describe("mcpAdapter session lifecycle", () => {
     }));
   });
 
+  it("does not leak TypeBox internal markers into registered tool parameter schemas", async () => {
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    const collectTildeKeys = (value: unknown, path = "$", keys: string[] = []): string[] => {
+      if (value === null || typeof value !== "object") return keys;
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => collectTildeKeys(item, `${path}[${index}]`, keys));
+        return keys;
+      }
+      for (const [key, child] of Object.entries(value)) {
+        if (key.startsWith("~")) keys.push(`${path}.${key}`);
+        collectTildeKeys(child, `${path}.${key}`, keys);
+      }
+      return keys;
+    };
+
+    for (const toolName of ["mcpScript", "mcp"]) {
+      const tool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === toolName)?.[0];
+      expect(tool, `expected ${toolName} to be registered`).toBeDefined();
+
+      const serialized = JSON.parse(JSON.stringify(tool.parameters));
+      expect(
+        collectTildeKeys(serialized),
+        `${toolName} parameters must not leak TypeBox internal markers (~optional etc.)`,
+      ).toEqual([]);
+
+      // Optional numeric fields must still be present with their options and not required.
+      for (const key of toolName === "mcpScript" ? ["timeoutMs"] : ["limit", "offset"]) {
+        expect(serialized.properties[key]).toMatchObject({ type: "number", description: expect.any(String) });
+        expect(serialized.required ?? []).not.toContain(key);
+      }
+    }
+  });
+
   it("registers direct MCP tools when the host TypeBox shim omits Unsafe", async () => {
     vi.doMock("typebox", () => ({
       Type: {

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata } from "./types.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
+import type { TSchema } from "typebox";
 import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
@@ -49,6 +50,18 @@ async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Prom
   } finally {
     clearTimeout(timer);
   }
+}
+
+// TypeBox 1.x annotates raw objects passed to Type.Optional with an enumerable
+// "~optional" key that survives serialization into provider tool schemas (Gemini
+// rejects it with 400 INVALID_ARGUMENT). Prefer a real Type.Number schema; fall
+// back to a plain raw schema for host TypeBox shims that omit Type.Number, since
+// a property left out of `required` is optional by default.
+function optionalNumber(options: { minimum?: number; description: string }): TSchema {
+  const number = (Type as { Number?: (opts: typeof options) => TSchema }).Number;
+  return typeof number === "function"
+    ? Type.Optional(number(options))
+    : ({ type: "number", ...options } as unknown as TSchema);
 }
 
 function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
@@ -627,8 +640,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       promptSnippet: "Batch multiple MCP tool calls in one JavaScript request (loop, filter, chain)",
       parameters: Type.Object({
         code: Type.String({ description: "Trusted JavaScript MCP script. Use tools.<prefixedToolName>(args) and emit(value)." }),
-        // Raw JSON schema: host TypeBox shims may omit Type.Number (see index-lifecycle shim test).
-        timeoutMs: Type.Optional({ type: "number", minimum: 1, description: "Execution timeout in milliseconds (default: 30000)" } as any),
+        timeoutMs: optionalNumber({ minimum: 1, description: "Execution timeout in milliseconds (default: 30000)" }),
       }),
       renderResult: renderMcpToolResult,
       async execute(_toolCallId: string, params: { code: string; timeoutMs?: number }, signal: AbortSignal | undefined) {
@@ -687,9 +699,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
         regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
-        // Raw JSON schema: host TypeBox shims may omit Type.Number (see index-lifecycle shim test).
-        limit: Type.Optional({ type: "number", minimum: 1, description: "Maximum search results to return (default: 12)" } as any),
-        offset: Type.Optional({ type: "number", minimum: 0, description: "Search result offset (default: 0)" } as any),
+        limit: optionalNumber({ minimum: 1, description: "Maximum search results to return (default: 12)" }),
+        offset: optionalNumber({ minimum: 0, description: "Search result offset (default: 0)" }),
         server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
         action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
       }),


### PR DESCRIPTION
Fixes nicobailon/pi-mcp-adapter#289

## Summary

`Type.Optional(<raw JSON schema object>)` makes TypeBox 1.x stamp an enumerable `"~optional": true` key onto the schema. Since these parameter schemas are passed to the host and serialized into provider tool definitions, the marker reaches the model — Gemini rejects it with `400 INVALID_ARGUMENT`, failing every request that includes the `mcpScript` / `mcp` tools.

This PR builds the three optional numeric fields (`mcpScript.timeoutMs`, `mcp.limit`, `mcp.offset`) with a real `Type.Number()` schema via a small `optionalNumber` helper:

- Prefers `Type.Optional(Type.Number({ ... }))` when the host TypeBox has `Type.Number` (no `~optional` leak, proper `required` handling).
- Falls back to a plain raw schema (no `Type.Optional` wrapper) for host TypeBox shims that omit `Type.Number`, preserving the compat intent of the original raw-object form. A property left out of `required` is optional by default, and no marker keys are emitted in either path.

## Verification

- Regression test `does not leak TypeBox internal markers into registered tool parameter schemas` added to `__tests__/index-lifecycle.test.ts`. It fails against the old raw-object code (serialized `properties.timeoutMs.~optional` detected) and passes with the fix.
- `npx tsc --noEmit` — clean.
- `npx vitest run __tests__/index-lifecycle.test.ts` — 40/40 pass.
- Full suite: 924/926 pass; the only 2 failures are pre-existing `interactive-visualizer-server` tests that require a built `examples/interactive-visualizer/dist/server.js` (same failures on clean `main`).

Serialization before vs. after:

```jsonc
// before (leaked to provider)
"timeoutMs": { "type": "number", "minimum": 1, "description": "...", "~optional": true }

// after
"timeoutMs": { "type": "number", "minimum": 1, "description": "..." }   // absent from "required"
```
