### PR TITLE
fix: forward OAuth callback issuer to SDK

### DIFF
--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -141,6 +141,13 @@ describe("mcp-auth-flow explicit auth", () => {
       `code=auth-code&state=${oauthState}&iss=${encodeURIComponent("https://auth.example.com")}`,
     )).resolves.toBe("authenticated");
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(2);
+    expect(mocks.sdkAuth).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        authorizationCode: "auth-code",
+        iss: "https://auth.example.com",
+      }),
+    );
     expect(hasPendingAuth("rfc9207-missing")).toBe(false);
   });
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -606,6 +606,7 @@ export async function completeAuth(
     const result = await abortable(runSdkAuth(pendingAuth.authProvider, {
       serverUrl: pendingAuth.serverUrl,
       authorizationCode: code,
+      ...(iss !== undefined ? { iss } : {}),
       ...pendingAuth.discovery,
     }), signal)
     throwIfAborted(signal)


### PR DESCRIPTION
## Summary

Restores forwarding of the RFC 9207 callback `iss` parameter to the SDK during manual OAuth completion.

PR #210 included the handoff. It was removed during the SDK v2 → v1 compatibility rollback in #242, while the v1 SDK still validates the authorization-response issuer.

Closes #293.

## Verification

- `npx vitest run __tests__/mcp-auth-flow-client-credentials.test.ts`
- `npm run typecheck`
- `npm run test:oauth`
