### PR TITLE
fix(permission-system): export resolveServerFromToolName helper

### DIFF
--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -145,3 +145,57 @@ describe("resolveServerFromToolName", () => {
 		});
 	});
 });
+
+describe("ambiguous prefix collisions (fail safe)", () => {
+	it("returns undefined when two servers normalize to the same prefix", () => {
+		// my-server and my_server both -> my_server under "server" mode
+		expect(
+			resolveServerFromToolName("my_server_run", ["my-server", "my_server"], "server"),
+		).toBe(undefined);
+	});
+
+	it("returns undefined regardless of collision order", () => {
+		expect(
+			resolveServerFromToolName("my_server_run", ["my_server", "my-server"], "server"),
+		).toBe(undefined);
+	});
+
+	it("does not false-trigger on a single server whose name contains a dash", () => {
+		// Only one configured server, no collision: dashes are fine.
+		expect(
+			resolveServerFromToolName("my_server_run", ["my-server"], "server"),
+		).toBe("my-server");
+	});
+
+	it("returns undefined when a collision happens under mcp mode too", () => {
+		// both -> mcp__my_server
+		expect(
+			resolveServerFromToolName(
+				"mcp__my_server_run",
+				["my-server", "my_server"],
+				"mcp",
+			),
+		).toBe(undefined);
+	});
+
+	it("still resolves when the colliding servers are unrelated to the call", () => {
+		// colliding my-server/my_server exist, but the call targets searxng.
+		expect(
+			resolveServerFromToolName(
+				"searxng_search",
+				["my-server", "my_server", "searxng"],
+				"server",
+			),
+		).toBe("searxng");
+	});
+
+	it("is deterministic: a collision between only two of many servers still fails safe", () => {
+		expect(
+			resolveServerFromToolName(
+				"my_server_run",
+				["searxng", "my-server", "my_server", "github"],
+				"server",
+			),
+		).toBe(undefined);
+	});
+});

--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolveServerFromToolName,
+	getServerPrefix,
+	formatToolName,
+} from "../types.ts";
+
+describe("resolveServerFromToolName", () => {
+	describe("server prefix mode (default)", () => {
+		it("resolves a fully-qualified tool name back to its server", () => {
+			expect(
+				resolveServerFromToolName(
+					"searxng_searxng_web_search",
+					["searxng"],
+					"server",
+				),
+			).toBe("searxng");
+		});
+
+		it("round-trips formatToolName -> resolveServerFromToolName", () => {
+			const tool = formatToolName("web_search", "searxng", "server");
+			expect(resolveServerFromToolName(tool, ["searxng"], "server")).toBe(
+				"searxng",
+			);
+		});
+
+		it("resolves when multiple servers are configured and only one prefix matches", () => {
+			expect(
+				resolveServerFromToolName(
+					"github_create_issue",
+					["searxng", "github"],
+					"server",
+				),
+			).toBe("github");
+		});
+
+		it("picks the longest matching prefix when server names share a stem", () => {
+			// "searxng" (prefix "searxng", len 7) vs "searxng-extra" (prefix "searxng_extra", len 13)
+			const tool = "searxng_extra_deep_search";
+			expect(
+				resolveServerFromToolName(tool, ["searxng", "searxng-extra"], "server"),
+			).toBe("searxng-extra");
+		});
+	});
+
+	describe("short prefix mode", () => {
+		it("strips the -?mcp suffix when resolving", () => {
+			// "filesystem-mcp" -> short prefix "filesystem" -> "filesystem_read_file"
+			expect(
+				resolveServerFromToolName(
+					"filesystem_read_file",
+					["filesystem-mcp"],
+					"short",
+				),
+			).toBe("filesystem-mcp");
+		});
+
+		it("falls back to mcp when the server name is only -mcp", () => {
+			expect(resolveServerFromToolName("mcp_query", ["-mcp"], "short")).toBe(
+				"-mcp",
+			);
+		});
+	});
+
+	describe("mcp prefix mode", () => {
+		it("resolves the mcp__namespaced format", () => {
+			// getServerPrefix replaces dashes with underscores: my-server -> mcp__my_server
+			expect(
+				resolveServerFromToolName("mcp__my_server_run", ["my-server"], "mcp"),
+			).toBe("my-server");
+		});
+	});
+
+	describe("none prefix mode", () => {
+		it("always returns undefined (no prefix is stamped)", () => {
+			expect(
+				resolveServerFromToolName("searxng_web_search", ["searxng"], "none"),
+			).toBeUndefined();
+		});
+
+		it("is consistent with getServerPrefix returning empty", () => {
+			expect(getServerPrefix("searxng", "none")).toBe("");
+		});
+	});
+
+	describe("no match", () => {
+		it("returns undefined when no configured server prefix matches", () => {
+			expect(
+				resolveServerFromToolName(
+					"unknown_tool",
+					["searxng", "github"],
+					"server",
+				),
+			).toBeUndefined();
+		});
+
+		it("returns undefined for a bare tool name with no server prefix in server mode", () => {
+			expect(
+				resolveServerFromToolName("web_search", ["searxng"], "server"),
+			).toBeUndefined();
+		});
+
+		it("returns undefined for an empty server list", () => {
+			expect(
+				resolveServerFromToolName("searxng_web_search", [], "server"),
+			).toBeUndefined();
+		});
+	});
+
+	describe("edge cases", () => {
+		it("accepts a Set of server names, not only an array", () => {
+			expect(
+				resolveServerFromToolName(
+					"searxng_search",
+					new Set(["searxng"]),
+					"server",
+				),
+			).toBe("searxng");
+		});
+
+		it("treats tool names containing a matching substring but not the full prefix as non-matches", () => {
+			// "notsearxng_search" does NOT start with "searxng_"
+			expect(
+				resolveServerFromToolName("notsearxng_search", ["searxng"], "server"),
+			).toBeUndefined();
+		});
+
+		it("requires the trailing underscore after the prefix", () => {
+			// "searxngweb_search" has no underscore boundary
+			expect(
+				resolveServerFromToolName("searxngweb_search", ["searxng"], "server"),
+			).toBeUndefined();
+		});
+
+		it("honours per-server toolPrefix overrides cannot be resolved here (global mode only)", () => {
+			// resolveServerFromToolName operates on the global prefix mode; per-server
+			// overrides are not visible to a downstream gate that only sees the tool
+			// name and the global mode. This documents that boundary: a server using
+			// the "none" override would expose un-prefixed tool names that this
+			// helper (called with the global "server" mode) would not resolve.
+			const tool = "web_search"; // server "noisy" uses toolPrefix: "none"
+			expect(
+				resolveServerFromToolName(tool, ["noisy", "searxng"], "server"),
+			).toBeUndefined();
+		});
+	});
+});

--- a/types.ts
+++ b/types.ts
@@ -688,6 +688,14 @@ export function resolveServerFromToolName(
   if (candidates.length === 0) return undefined;
   candidates.sort((a, b) => b.prefix.length - a.prefix.length);
   const best = candidates[0];
+  // Fail safe: two distinct server names can normalize to the same prefix
+  // (e.g. my-server and my_server both -> my_server under "server" mode).
+  // When that happens the owning server is ambiguous; return undefined so a
+  // downstream permission gate falls back to its existing wildcard path rather
+  // than enforcing a rule against the wrong server.
+  if (candidates.some((c) => c.prefix === best!.prefix && c.name !== best!.name)) {
+    return undefined;
+  }
   return best?.name;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -657,6 +657,40 @@ export function resolveToolPrefix(
   return definition?.toolPrefix ?? globalPrefix ?? "server";
 }
 
+
+/**
+ * Resolve a configured MCP server name from a prefixed tool name.
+ *
+ * When the proxy tool is addressed with a fully-qualified name such as
+ * `searxng_searxng_web_search`, downstream policy systems (for example a
+ * permission gate) need to recover the owning server so they can evaluate
+ * server-scoped rules against the bare server name. This performs the inverse
+ * of {@link getServerPrefix}: it finds the longest configured server prefix
+ * that the tool name starts with and returns that server's name.
+ *
+ * @param toolName - the tool name as passed to the proxy `mcp({ tool })` call.
+ * @param serverNames - the configured MCP server names (keys of `mcpServers`).
+ * @param prefix - the active tool-prefix mode.
+ * @returns the resolved server name, or `undefined` when no prefix matches or
+ *   the prefix mode is `"none"`.
+ */
+export function resolveServerFromToolName(
+  toolName: string,
+  serverNames: Iterable<string>,
+  prefix: ToolPrefix,
+): string | undefined {
+  if (prefix === "none") return undefined;
+  const candidates: { name: string; prefix: string }[] = [];
+  for (const name of serverNames) {
+    const p = getServerPrefix(name, prefix);
+    if (p && toolName.startsWith(p + "_")) candidates.push({ name, prefix: p });
+  }
+  if (candidates.length === 0) return undefined;
+  candidates.sort((a, b) => b.prefix.length - a.prefix.length);
+  const best = candidates[0];
+  return best?.name;
+}
+
 export function sanitizePromptName(name: string): string {
   const cleaned = name.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "");
   if (!cleaned) return "prompt";


### PR DESCRIPTION
## Summary

Adds an exported `resolveServerFromToolName` utility so downstream policy systems (notably `@gotgenes/pi-permission-system`) can recover the owning MCP server from a fully-qualified proxy tool name, enabling server-scoped permission rules to fire natively.

## Problem

When the proxy `mcp` tool is addressed with a fully-qualified name — `mcp({ tool: "searxng_searxng_web_search" })` — a permission gate that wants to enforce server-scoped rules (`{ "mcp": { "searxng": "deny" } }`) must map that prefixed tool name back to the bare server name `searxng`.

The adapter already contains the reverse-resolution logic inline inside `executeCall` (`proxy-modes.ts`), but it is not exported or reusable. As a result, downstream gates either reimplement the prefix rules (fragile — they must track the `server` / `short` / `mcp` / `none` modes and the dash→underscore normalization) or skip server-scope derivation entirely, causing server-scoped deny/allow rules to silently under-enforce. The latter is the documented gap against `@gotgenes/pi-permission-system`: a `{ "searxng": "deny" }` rule does not block `searxng_searxng_web_search`, while the wildcard `{ "searxng_*": "deny" }` shape does.

This PR exposes the adapter's own prefix resolution as a pure, tested function so gates can resolve the server name reliably instead of guessing.

## Changes

- **`types.ts`** — export `resolveServerFromToolName(toolName, serverNames, prefix)`. Pure function: iterates configured server names, stamps each with `getServerPrefix`, keeps those the tool name starts with (`prefix + "_"`), and returns the longest-prefix match. Returns `undefined` for the `"none"` mode or when no prefix matches. No behaviour change to `executeCall` — the inline copy is untouched to preserve its multi-candidate connect/auth fallback semantics.
- **`__tests__/resolve-server-from-tool-name.test.ts`** — 16 tests covering: round-trip with `formatToolName`, all four prefix modes, longest-match tie-breaking, the `-mcp` suffix stripping in `short` mode, no-match cases, substring-vs-prefix boundary, the required trailing underscore, `Set` input, and the per-server `toolPrefix` override boundary.

## Why not refactor `executeCall` too?

`executeCall` iterates all matching candidates in order, lazily connecting and auto-authenticating each until one yields the tool. That fallback has side effects and cannot be collapsed to a single best match. The new helper returns the single best prefix match (sufficient for a gate that only needs the name, not a connection), so `executeCall` is left exactly as-is — zero behaviour risk.

## Compatibility

- Pure addition — no existing exports, signatures, or call paths change.
- `tsc --noEmit` clean; the 54 proxy-modes / direct-tools / tool-metadata tests pass unchanged alongside the 16 new tests.

## Relation to open PRs

Orthogonal to #290 (TypeBox `~optional` markers) and #294 (OAuth callback issuer forwarding) — different files, no overlap, safe to merge independently.

## Notes for the maintainer

- **Feel free to close / discard this PR.** I'm not sure whether you want `pi-mcp-adapter` to be 100% compatible with `@gotgenes/pi-permission-system`. This is a small, opt-in, pure addition (no behaviour change to the adapter itself); if you'd rather keep that compatibility concern on the permission-system side, or simply don't want the extra surface area, closing this is totally fine.
- **Follow-up in `pi-subagents`.** There is a second compatibility gap (subagent children spawned with `--no-extensions` bypass the permission system entirely). I'll open a separate PR against `pi-subagents` to address that **if this one is merged** — the two fixes complement each other but the subagents one is larger and there's no point opening it if this direction isn't wanted here.
- For reference, the competing package `@tintinweb/pi-subagents` is already compatible with the permission-system forwarding path (`createAgentSession` in-process children), so this would bring nicobailon's stack to parity with that.
