### PR TITLE
fix: close MCP describe and render backlog items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `resolveServerFromToolName` so permission brokers can map prefixed MCP tool names back to their owning server. Thanks @jagaliano for PR #295.
+
+### Fixed
+- Stopped optional numeric `mcp` and `mcpScript` tool parameters from leaking TypeBox internal markers into serialized schemas. Thanks @RainbowXie for issue #289 and PR #290.
+- Forwarded RFC 9207 OAuth callback issuers to the MCP SDK during manual authorization completion. Thanks @tkoenig for issue #293 and PR #294, and @ugur-murat-alt for independent live verification.
+- Kept `mcpScript` `tools.describe()` from omitting parameter information when TypeScript shape rendering falls back. Thanks @sheurich for issue #288.
+- Reduced repeated collapsed MCP result rendering allocation after large or truncated tool outputs. Thanks @cp-yu for issue #291.
+
 ## [2.20.1] - 2026-08-04
 
 ### Fixed

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -57,8 +57,26 @@ describe("runMcpScript", () => {
       config: { settings: {}, mcpServers: { fixture: definition } },
       toolMetadata: new Map([
         ["fixture", [
-          { name: "fixture_echo", originalName: "echo", description: "Echo a value" },
-          { name: "fixture_fail", originalName: "fail", description: "Return an MCP tool error" },
+          {
+            name: "fixture_echo",
+            originalName: "echo",
+            description: "Echo a value",
+            inputSchema: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              required: ["value"],
+            },
+          },
+          {
+            name: "fixture_fail",
+            originalName: "fail",
+            description: "Return an MCP tool error",
+            inputSchema: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              additionalProperties: false,
+            },
+          },
           { name: "fixture_hang", originalName: "hang", description: "Never resolves" },
         ]],
       ]),
@@ -109,18 +127,26 @@ describe("runMcpScript", () => {
     });
   });
 
-  it("describes exact script-visible paths and suggests corrections without throwing", async () => {
+  it("describes script-visible schemas and suggests corrections without throwing", async () => {
     const result = await runMcpScript(
       state,
-      'return { found: await tools.describe({ path: "fixture_echo" }), missing: await tools.describe({ path: "fixture_ech" }) };',
+      'return { supported: await tools.describe({ path: "fixture_echo" }), unsupported: await tools.describe({ path: "fixture_fail" }), missing: await tools.describe({ path: "fixture_ech" }) };',
     );
 
     expect(JSON.parse(textBlocks(result).at(-1)!)).toEqual({
-      found: {
+      supported: {
         path: "fixture_echo",
         name: "echo",
         server: "fixture",
         description: "Echo a value",
+        inputTypeScript: "{ value: string; }",
+      },
+      unsupported: {
+        path: "fixture_fail",
+        name: "fail",
+        server: "fixture",
+        description: "Return an MCP tool error",
+        inputTypeScript: "  value (string)",
       },
       missing: {
         path: "fixture_ech",

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -173,6 +173,20 @@ describe("MCP tool result renderer", () => {
     expect(output).not.toContain("tail-marker");
   });
 
+  it("reuses truncated collapsed lines at the same width", () => {
+    const renderer = renderMcpToolResult(
+      result([{ type: "text", text: "one\ntwo\nthree\nfour" }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false },
+    );
+
+    const first = renderer.render(80);
+    const second = renderer.render(80);
+    expect(second).toBe(first);
+    expect(second.join("\n")).toContain("Ctrl+O to expand");
+  });
+
   it("shows proxy call result identity without hiding the third content line", () => {
     const output = renderMcpToolResult(
       result([{ type: "text", text: "one\ntwo\nthree\nfour" }], { mode: "call", server: "figma", tool: "get_nodes" }),

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -6,7 +6,7 @@ import { executeCall } from "./proxy-modes.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts";
 import type { McpExtensionState } from "./state.ts";
-import { findToolByName } from "./tool-metadata.ts";
+import { findToolByName, formatSchema } from "./tool-metadata.ts";
 import { renderTsShape } from "./ts-shape.ts";
 import type { ContentBlock } from "./types.ts";
 
@@ -204,7 +204,9 @@ export async function runMcpScript(
       for (const [server, metadata] of state.toolMetadata) {
         const tool = findToolByName(metadata, path);
         if (!tool) continue;
-        const inputTypeScript = tool.inputSchema ? renderTsShape(tool.inputSchema) : null;
+        const inputTypeScript = tool.inputSchema
+          ? renderTsShape(tool.inputSchema) ?? formatSchema(tool.inputSchema)
+          : null;
         return {
           path: tool.name,
           name: tool.originalName,

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -41,6 +41,7 @@ class CollapsibleText implements Component {
   private readonly fullText: Text;
   private readonly footerText: Text;
   private collapsedText: { charBudget: number; fullyIncluded: boolean; text: Text } | null = null;
+  private collapsedRender: { width: number; charBudget: number; lines: string[] } | null = null;
 
   constructor(
     private readonly text: string,
@@ -70,18 +71,29 @@ class CollapsibleText implements Component {
         fullyIncluded: prefix === this.text,
         text: new Text(prefix, 0, 0),
       };
+      this.collapsedRender = null;
     }
 
     const lines = this.collapsedText.text.render(width);
     if (!this.preTruncated && this.collapsedText.fullyIncluded && lines.length <= this.maxCollapsedLines) return lines;
+    if (this.collapsedRender?.width === width && this.collapsedRender.charBudget === charBudget) {
+      return this.collapsedRender.lines;
+    }
 
-    return [
+    const rendered = [
       ...lines.slice(0, this.maxCollapsedLines),
       ...this.footerText.render(width),
     ];
+    this.collapsedRender = { width, charBudget, lines: rendered };
+    return rendered;
   }
 
-  invalidate(): void {}
+  invalidate(): void {
+    this.fullText.invalidate();
+    this.footerText.invalidate();
+    this.collapsedText?.text.invalidate();
+    this.collapsedRender = null;
+  }
 }
 
 function truncateText(value: string, maxChars: number): string {


### PR DESCRIPTION
## Summary

Closes the remaining implementable backlog items from the current queue:

- fixes `mcpScript` `tools.describe()` so unsupported schemas fall back to formatted parameter text instead of silently omitting parameters;
- caches repeated same-width collapsed MCP result renders after truncated output;
- updates the Unreleased changelog with contributor and reporter credit for the accepted queue items.

Fixes #288.
Fixes #291.

## Validation

- `npx vitest run __tests__/mcp-code.test.ts __tests__/ts-shape.test.ts __tests__/tool-result-renderer.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh read-only review found no issues.
