### PR TITLE
fix: avoid host config scans in MCP panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `resolveServerFromToolName` so permission brokers can map prefixed MCP tool names back to their owning server. Thanks @jagaliano for PR #295.
 
 ### Fixed
+- Stopped `/mcp` from inspecting host-specific config files when host config discovery is disabled. Thanks @rtfmkiesel for issue #292.
 - Stopped optional numeric `mcp` and `mcpScript` tool parameters from leaking TypeBox internal markers into serialized schemas. Thanks @RainbowXie for issue #289 and PR #290.
 - Forwarded RFC 9207 OAuth callback issuers to the MCP SDK during manual authorization completion. Thanks @tkoenig for issue #293 and PR #294, and @ugur-murat-alt for independent live verification.
 - Kept `mcpScript` `tools.describe()` from omitting parameter information when TypeScript shape rendering falls back. Thanks @sheurich for issue #288.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pi also reads Pi-owned override files for settings and host-specific compatibili
 - `<Pi agent dir>/mcp.json` — Pi global override (`~/.pi/agent/mcp.json` by default)
 - `.pi/mcp.json` — Pi project override
 
-Host-specific configs are detected and shown by `/mcp setup` and `pi-mcp-adapter init`, but they are not loaded automatically. To explicitly opt in to host-config fallback discovery, set `settings.hostConfigDiscovery` to `"on"` or run `pi-mcp-adapter init --discover-host-configs`. The default is `"off"`; `"prompt"` is available for integrations that want detection without activation. Host configs are lower precedence than every shared and Pi-owned source, and `/mcp setup` continues to offer explicit import adoption. Discovery reports source paths, provenance, and same-name conflicts; it never writes to external host files or silently launches commands from them.
+Host-specific configs are detected and shown by `/mcp setup` and `pi-mcp-adapter init`, but they are not loaded automatically. The normal `/mcp` panel does not scan host-specific files when `settings.hostConfigDiscovery` is `"off"`. To explicitly opt in to host-config fallback discovery, set `settings.hostConfigDiscovery` to `"on"` or run `pi-mcp-adapter init --discover-host-configs`. The default is `"off"`; `"prompt"` is available for integrations that want detection without activation. Host configs are lower precedence than every shared and Pi-owned source, and `/mcp setup` continues to offer explicit import adoption. Discovery reports source paths, provenance, and same-name conflicts; it never writes to external host files or silently launches commands from them.
 
 Precedence is:
 

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -102,6 +102,63 @@ describe("commands onboarding", () => {
     expect(loadOnboardingState().sharedConfigHintShown).toBe(true);
   });
 
+  it("does not inspect host-specific configs when opening the MCP panel", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-commands-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-commands-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    writeJson(join(home, ".config", "mcp", "mcp.json"), {
+      mcpServers: { sharedServer: { command: "shared" } },
+    });
+    writeFileSync(join(home, ".claude.json"), "{ malformed", "utf-8");
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(join(home, ".config", "opencode", "opencode.json"), "{ malformed", "utf-8");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ui = createUi();
+    const { loadMcpConfig } = await import("../config.ts");
+    const { openMcpPanel } = await import("../commands.ts");
+
+    await openMcpPanel({
+      config: loadMcpConfig(),
+      manager: { getConnection: () => null },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+
+    expect(mocks.createMcpPanel).toHaveBeenCalled();
+    expect(warning).not.toHaveBeenCalled();
+    warning.mockRestore();
+  });
+
+  it("does not inspect host-specific configs when /mcp opens empty setup", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-commands-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-commands-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    writeFileSync(join(home, ".claude.json"), "{ malformed", "utf-8");
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(join(home, ".config", "opencode", "opencode.json"), "{ malformed", "utf-8");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ui = createUi();
+    const { openMcpPanel } = await import("../commands.ts");
+
+    await openMcpPanel({
+      config: { mcpServers: {} },
+      manager: { getConnection: () => null },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+
+    expect(mocks.createMcpSetupPanel).toHaveBeenCalled();
+    const discovery = mocks.createMcpSetupPanel.mock.calls[0]?.[0];
+    expect(discovery.imports).toEqual([]);
+    expect(discovery.hostConfigs).toEqual([]);
+    expect(warning).not.toHaveBeenCalled();
+    warning.mockRestore();
+  });
+
   it("clears OAuth credentials, cancels pending auth, and closes the server on logout", async () => {
     process.env.MCP_OAUTH_DIR = mkdtempSync(join(tmpdir(), "pi-mcp-commands-logout-"));
     const ui = createUi();

--- a/commands.ts
+++ b/commands.ts
@@ -4,6 +4,7 @@ import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCall
 import {
   ensureCompatibilityImports,
   getMcpDiscoverySummary,
+  getMcpStandardConfigSummary,
   getProjectConfigPath,
   type KnownServerPreset,
   getServerProvenance,
@@ -354,7 +355,7 @@ export interface PanelFlowResult {
 }
 
 function buildSharedConfigNoticeLines(configOverridePath: string | undefined, cwd: string): { lines: string[]; fingerprint: string | null } {
-  const discovery = getMcpDiscoverySummary(configOverridePath, cwd);
+  const discovery = getMcpStandardConfigSummary(configOverridePath, cwd);
   const onboardingState = loadOnboardingState();
   if (!discovery.hasSharedServers || onboardingState.sharedConfigHintShown) {
     return { lines: [], fingerprint: null };
@@ -377,6 +378,7 @@ export async function openMcpSetup(
   ctx: ExtensionContext,
   configOverridePath?: string,
   mode: "empty" | "setup" = "setup",
+  options: { includeHostConfigs?: boolean } = {},
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
   if (state.programmaticConfig) {
@@ -384,7 +386,7 @@ export async function openMcpSetup(
     return { configChanged: false };
   }
 
-  const discovery = getMcpDiscoverySummary(configOverridePath, ctx.cwd);
+  const discovery = getMcpDiscoverySummary(configOverridePath, ctx.cwd, options);
   const onboardingState = loadOnboardingState();
   const { createMcpSetupPanel } = await import("./mcp-setup-panel.ts");
   let configChanged = false;
@@ -393,7 +395,7 @@ export async function openMcpSetup(
     previewImports: (imports: ImportKind[]) => previewCompatibilityImports(imports, configOverridePath),
     previewStarterProject: () => previewStarterProjectConfig(ctx.cwd),
     previewRepoPrompt: () => {
-      const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd).repoPrompt;
+      const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd, options).repoPrompt;
       if (!repoPrompt.entry || !repoPrompt.targetPath || !repoPrompt.serverName) return null;
       return previewSharedServerEntry(repoPrompt.targetPath, repoPrompt.serverName, repoPrompt.entry);
     },
@@ -409,7 +411,7 @@ export async function openMcpSetup(
       return { path };
     },
     addRepoPrompt: async () => {
-      const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd).repoPrompt;
+      const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd, options).repoPrompt;
       if (!repoPrompt.entry || !repoPrompt.targetPath || !repoPrompt.serverName) {
         throw new Error("RepoPrompt is not available to add from this setup screen.");
       }
@@ -514,7 +516,7 @@ export async function openMcpPanel(
     return { configChanged: false };
   }
   if (Object.keys(state.config.mcpServers).length === 0) {
-    return openMcpSetup(state, pi, ctx, configOverridePath, "empty");
+    return openMcpSetup(state, pi, ctx, configOverridePath, "empty", { includeHostConfigs: false });
   }
 
   const config = state.config;

--- a/config.ts
+++ b/config.ts
@@ -147,6 +147,12 @@ export interface McpDiscoverySummary {
   repoPrompt: RepoPromptDiscovery;
 }
 
+export interface McpStandardConfigSummary {
+  sources: ConfigDiscoverySource[];
+  hasSharedServers: boolean;
+  fingerprint: string;
+}
+
 export interface ConfigWritePreview {
   path: string;
   existed: boolean;
@@ -193,9 +199,8 @@ export function findAvailableImportConfigs(cwd = process.cwd()): DiscoveredImpor
   return discovered;
 }
 
-export function getMcpDiscoverySummary(overridePath?: string, cwd = process.cwd()): McpDiscoverySummary {
-  const sourceSpecs = getConfigSources(overridePath, cwd);
-  const sources = sourceSpecs.map((source) => {
+function getConfigSourceSummaries(sourceSpecs: ConfigSourceSpec[]): ConfigDiscoverySource[] {
+  return sourceSpecs.map((source) => {
     const loaded = readValidatedConfig(source.readPath, `MCP config from ${source.readPath}`);
     return {
       id: source.id,
@@ -207,18 +212,39 @@ export function getMcpDiscoverySummary(overridePath?: string, cwd = process.cwd(
       serverCount: loaded ? Object.keys(loaded.mcpServers).length : 0,
     } satisfies ConfigDiscoverySource;
   });
+}
 
-  const imports = (Object.keys(IMPORT_PATHS) as ImportKind[])
-    .map((kind) => {
-      const imported = loadImportedConfig(kind, cwd, `Failed to inspect imported MCP config from ${kind}:`);
-      if (!imported) return null;
-      return {
-        kind,
-        path: imported.path,
-        serverCount: Object.keys(extractServers(imported.value, kind)).length,
-      } satisfies ImportConfigSummary;
-    })
-    .filter((value): value is ImportConfigSummary => value !== null);
+export function getMcpStandardConfigSummary(overridePath?: string, cwd = process.cwd()): McpStandardConfigSummary {
+  const sources = getConfigSourceSummaries(getConfigSources(overridePath, cwd));
+  return {
+    sources,
+    hasSharedServers: sources.some((source) => source.kind === "shared" && source.serverCount > 0),
+    fingerprint: JSON.stringify({ sources: sources.map((source) => [source.id, source.exists, source.serverCount]) }),
+  };
+}
+
+export function getMcpDiscoverySummary(
+  overridePath?: string,
+  cwd = process.cwd(),
+  options: { includeHostConfigs?: boolean } = {},
+): McpDiscoverySummary {
+  const sourceSpecs = getConfigSources(overridePath, cwd);
+  const sources = getConfigSourceSummaries(sourceSpecs);
+  const includeHostConfigs = options.includeHostConfigs !== false;
+
+  const imports = includeHostConfigs
+    ? (Object.keys(IMPORT_PATHS) as ImportKind[])
+      .map((kind) => {
+        const imported = loadImportedConfig(kind, cwd, `Failed to inspect imported MCP config from ${kind}:`);
+        if (!imported) return null;
+        return {
+          kind,
+          path: imported.path,
+          serverCount: Object.keys(extractServers(imported.value, kind)).length,
+        } satisfies ImportConfigSummary;
+      })
+      .filter((value): value is ImportConfigSummary => value !== null)
+    : [];
   const hostConfigDiscovery = getConfiguredHostConfigDiscovery(overridePath, cwd);
   const hostConfigs = imports.map((entry) => ({ ...entry, active: hostConfigDiscovery === "on" }));
   const totalServerCount = sources.reduce((sum, source) => sum + source.serverCount, 0);


### PR DESCRIPTION
Normal `/mcp` no longer inspects host-specific MCP config files when host discovery is disabled. The explicit `/mcp setup` flow still performs full host discovery for users who choose setup/imports.\n\nFixes #292.\n\nValidation:\n- `npx vitest run __tests__/commands-onboarding.test.ts __tests__/config.test.ts`\n- `npm run typecheck`\n- fresh-context review: no issues found