### PR TITLE
fix: make MCP panel save key configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `resolveServerFromToolName` so permission brokers can map prefixed MCP tool names back to their owning server. Thanks @jagaliano for PR #295.
 - Added per-server `oauth.skipIssuerMetadataValidation` for known-misconfigured OAuth servers. Thanks @embik for issue #297.
+- Added a configurable `mcp.panel.save` keybinding for the MCP panel Save action. Thanks @tim-hilde for issue #299.
 
 ### Fixed
 - Stopped `/mcp` from inspecting host-specific config files when host config discovery is disabled. Thanks @rtfmkiesel for issue #292.

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ If prompt-cache stability matters more than automatic direct-tool hot-loading, s
 
 When you change direct-tool toggles in `/mcp`, the extension updates direct tool registration in the current session. Broader setup writes from `/mcp setup` still use Pi's normal reload flow because they can add or restructure MCP config files.
 
-**Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers and toggle tools between direct and proxy from the same overlay. For OAuth, press Enter on a server that needs auth or `ctrl+a` on any OAuth server.
+**Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers and toggle tools between direct and proxy from the same overlay. For OAuth, press Enter on a server that needs auth or `ctrl+a` on any OAuth server. The Save action defaults to `ctrl+s` and can be remapped with the `mcp.panel.save` keybinding.
 
 **Guided first-run setup:** Run `/mcp setup` to inspect detected shared MCP files, adopt compatibility imports from other hosts, open discovered config paths, preview exact before/after file diffs for writes, scaffold a minimal project `.mcp.json`, add a curated known server (DeepWiki, Context7, Notion, GitHub, or Chrome DevTools), or quick-add RepoPrompt into a standard/shared MCP file.
 

--- a/__tests__/mcp-panel-keybindings.test.ts
+++ b/__tests__/mcp-panel-keybindings.test.ts
@@ -8,14 +8,31 @@ import type { McpConfig, McpPanelCallbacks } from "../types.ts";
 
 const CTRL_P = "\x10";
 const CTRL_N = "\x0e";
+const CTRL_S = "\x13";
 const UP = "\x1b[A";
 const DOWN = "\x1b[B";
 const ENTER = "\r";
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
 
 function createEmacsKeybindings(): KeybindingsManager {
   return new KeybindingsManager(TUI_KEYBINDINGS, {
     "tui.select.up": ["up", "ctrl+p"],
     "tui.select.down": ["down", "ctrl+n"],
+  });
+}
+
+function createSaveKeybindings(): KeybindingsManager {
+  return new KeybindingsManager(TUI_KEYBINDINGS, {
+    "mcp.panel.save": "ctrl+p",
+  });
+}
+
+function createUnboundSaveKeybindings(): KeybindingsManager {
+  return new KeybindingsManager(TUI_KEYBINDINGS, {
+    "mcp.panel.save": [],
   });
 }
 
@@ -81,6 +98,20 @@ describe("panel-keys", () => {
     expect(keys.selectConfirm(ENTER)).toBe(true);
   });
 
+  it("honors the MCP panel save keybinding", () => {
+    const keys = createPanelKeys(createSaveKeybindings());
+    expect(keys.save(CTRL_P)).toBe(true);
+    expect(keys.save(CTRL_S)).toBe(false);
+    expect(keys.saveLabel()).toBe("ctrl+p");
+  });
+
+  it("lets users unbind the MCP panel save keybinding", () => {
+    const keys = createPanelKeys(createUnboundSaveKeybindings());
+    expect(keys.save(CTRL_P)).toBe(false);
+    expect(keys.save(CTRL_S)).toBe(false);
+    expect(keys.saveLabel()).toBeNull();
+  });
+
   it("falls back to hardcoded defaults without a manager", () => {
     const keys = createPanelKeys();
     expect(keys.selectUp(UP)).toBe(true);
@@ -88,6 +119,9 @@ describe("panel-keys", () => {
     expect(keys.selectDown(DOWN)).toBe(true);
     expect(keys.selectDown(CTRL_N)).toBe(false);
     expect(keys.selectConfirm(ENTER)).toBe(true);
+    expect(keys.save(CTRL_S)).toBe(true);
+    expect(keys.save(CTRL_P)).toBe(false);
+    expect(keys.saveLabel()).toBe("ctrl+s");
   });
 
   it("respects rebinding that removes a default key", () => {
@@ -161,6 +195,47 @@ describe("mcp-panel custom keybindings", () => {
     await Promise.resolve();
     // Cursor did not move: still authenticates the first server.
     expect(callbacks.authenticate).toHaveBeenLastCalledWith("alpha");
+    panel.dispose();
+  });
+
+  it("uses the configured save key and hint", () => {
+    const done = vi.fn();
+    const panel = createMcpPanel(
+      createTwoServerConfig(),
+      null,
+      new Map(),
+      createAuthCallbacks(),
+      { requestRender: () => {} },
+      done,
+      { keybindings: createSaveKeybindings() },
+    );
+
+    expect(stripAnsi(panel.render(100).join("\n"))).toContain("ctrl+p save");
+    panel.handleInput(CTRL_S);
+    expect(done).not.toHaveBeenCalled();
+    panel.handleInput(CTRL_P);
+    expect(done).toHaveBeenCalledWith({ changes: new Map(), cancelled: false });
+    panel.dispose();
+  });
+
+  it("hides the save hint when the save keybinding is unbound", () => {
+    const done = vi.fn();
+    const panel = createMcpPanel(
+      createTwoServerConfig(),
+      null,
+      new Map(),
+      createAuthCallbacks(),
+      { requestRender: () => {} },
+      done,
+      { keybindings: createUnboundSaveKeybindings() },
+    );
+
+    const output = stripAnsi(panel.render(100).join("\n"));
+    expect(output).not.toContain("ctrl+s save");
+    expect(output).not.toContain("ctrl+p save");
+    panel.handleInput(CTRL_S);
+    panel.handleInput(CTRL_P);
+    expect(done).not.toHaveBeenCalled();
     panel.dispose();
   });
 });

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -358,7 +358,7 @@ class McpPanel {
       return;
     }
 
-    if (matchesKey(data, "ctrl+s")) {
+    if (this.keys.save(data)) {
       this.cleanup();
       this.done(this.buildResult());
       return;
@@ -802,6 +802,7 @@ class McpPanel {
     }
 
     lines.push(emptyRow());
+    const saveLabel = this.keys.saveLabel();
     const hints = this.authOnly
       ? [
           italic("↑↓") + " navigate",
@@ -818,7 +819,7 @@ class McpPanel {
           italic("ctrl+r") + " reconnect",
           ...(this.selectedServerHasFailureMessage() ? [italic("ctrl+y") + " copy error"] : []),
           italic("?") + " desc search",
-          italic("ctrl+s") + " save",
+          ...(saveLabel ? [italic(saveLabel) + " save"] : []),
           italic("esc") + " clear/close",
           italic("ctrl+c") + " quit",
         ];

--- a/panel-keys.ts
+++ b/panel-keys.ts
@@ -1,6 +1,6 @@
-import { matchesKey } from "@earendil-works/pi-tui";
+import { matchesKey, type KeyId } from "@earendil-works/pi-tui";
 
-/** The `tui.select.*` keybinding ids the adapter panels resolve. */
+/** The panel keybinding ids the adapter panels resolve through pi-tui. */
 export type PanelSelectKeybinding =
   | "tui.select.up"
   | "tui.select.down"
@@ -9,29 +9,45 @@ export type PanelSelectKeybinding =
 /** Structural subset of pi-tui's `KeybindingsManager` (which satisfies it). */
 export interface PanelKeybindings {
   matches(data: string, keybinding: PanelSelectKeybinding): boolean;
+  getUserBindings?(): Record<string, KeyId | KeyId[] | undefined>;
 }
 
 /**
- * Key matchers for list navigation: user's `tui.select.*` bindings when a
- * manager is provided, otherwise the previous hardcoded defaults.
+ * Key matchers for panel actions: user bindings when a manager is provided,
+ * otherwise the previous hardcoded defaults.
  */
 export interface PanelKeys {
   selectUp(data: string): boolean;
   selectDown(data: string): boolean;
   selectConfirm(data: string): boolean;
+  save(data: string): boolean;
+  saveLabel(): string | null;
+}
+
+function configuredSaveKeys(keybindings?: PanelKeybindings): { keys: KeyId[]; configured: boolean } {
+  const explicit = keybindings?.getUserBindings?.()["mcp.panel.save"];
+  if (explicit !== undefined) return { keys: Array.isArray(explicit) ? explicit : [explicit], configured: true };
+  return { keys: [], configured: false };
 }
 
 export function createPanelKeys(keybindings?: PanelKeybindings): PanelKeys {
+  const saveBinding = configuredSaveKeys(keybindings);
   if (keybindings) {
     return {
       selectUp: (data) => keybindings.matches(data, "tui.select.up"),
       selectDown: (data) => keybindings.matches(data, "tui.select.down"),
       selectConfirm: (data) => keybindings.matches(data, "tui.select.confirm"),
+      save: (data) => saveBinding.keys.length > 0
+        ? saveBinding.keys.some((key) => matchesKey(data, key))
+        : !saveBinding.configured && matchesKey(data, "ctrl+s"),
+      saveLabel: () => saveBinding.keys[0] ?? (saveBinding.configured ? null : "ctrl+s"),
     };
   }
   return {
     selectUp: (data) => matchesKey(data, "up"),
     selectDown: (data) => matchesKey(data, "down"),
     selectConfirm: (data) => matchesKey(data, "return"),
+    save: (data) => matchesKey(data, "ctrl+s"),
+    saveLabel: () => "ctrl+s",
   };
 }


### PR DESCRIPTION
Makes the MCP panel Save shortcut configurable with `mcp.panel.save` while keeping `ctrl+s` as the default. The footer now shows the configured save binding and hides the hint when the action is explicitly unbound.

Fixes #299.

Validation:
- `npx vitest run __tests__/mcp-panel-keybindings.test.ts`
- `npm run typecheck`
- fresh-context review: initial empty-binding hint finding fixed; follow-up review found no issues

Thanks @tim-hilde for the report and proposed direction.