### PR TITLE
fix: add OAuth issuer validation escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `resolveServerFromToolName` so permission brokers can map prefixed MCP tool names back to their owning server. Thanks @jagaliano for PR #295.
+- Added per-server `oauth.skipIssuerMetadataValidation` for known-misconfigured OAuth servers. Thanks @embik for issue #297.
 
 ### Fixed
 - Stopped `/mcp` from inspecting host-specific config files when host config discovery is disabled. Thanks @rtfmkiesel for issue #292.

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -80,6 +80,7 @@ You can optionally provide a pre-registered client:
 - `oauth.redirectUri` - Exact browser callback URI to advertise and bind, such as `http://localhost:3118/callback` (optional)
 - `oauth.clientName` - Client display name used for dynamic registration (optional, defaults to `Pi Coding Agent`)
 - `oauth.clientUri` - Client homepage URI used for dynamic registration (optional)
+- `oauth.skipIssuerMetadataValidation` - Set `true` only for a known-misconfigured authorization server whose metadata issuer cannot be fixed immediately. This weakens OAuth issuer validation.
 
 Dynamic clients normally omit `oauth.redirectUri`; the adapter starts the callback server lazily on the default loopback host (`localhost`) and asks the OS for an available local port when auth begins. Use `oauth.redirectUri` when the provider requires a pre-registered callback, such as Slack MCP's Claude-compatible `http://localhost:3118/callback`. The URI must use `http://` with `localhost`, `127.0.0.1`, or `[::1]`, include an explicit port, and its host/path become the bound callback endpoint.
 
@@ -245,6 +246,12 @@ All OAuth flows use PKCE with the S256 method, preventing authorization code int
 ### State Parameter
 
 A cryptographically secure random state parameter is generated for each flow and validated on callback.
+
+### Issuer Metadata Validation
+
+OAuth authorization-server metadata normally must echo the expected issuer. This protects against authorization-server mix-up. The adapter keeps this check on by default.
+
+For private servers with known-broken metadata, `oauth.skipIssuerMetadataValidation: true` forwards the SDK's issuer-validation opt-out for that server only. Use it only as a temporary workaround while the server metadata is fixed. Do not use it for public or untrusted servers.
 
 ### OS Credential Store
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `oauth.redirectUri` | Exact localhost redirect URI for browser OAuth, including port and path, for providers that pre-register callbacks |
 | `oauth.clientName` | Client display name advertised during dynamic registration |
 | `oauth.clientUri` | Client homepage URI advertised during dynamic registration |
+| `oauth.skipIssuerMetadataValidation` | `true` disables the OAuth authorization-server metadata issuer check for this server. This weakens OAuth mix-up protection and should only be used for known-misconfigured internal servers while their metadata is being fixed. |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation. A leading `!` in `bearerToken` runs a command when the HTTP server connects; use `!!` for a literal leading `!`. |
 | `lifecycle` | `"lazy"` (default), `"eager"`, `"keep-alive"`, or `"lazy-keep-alive"` |
 | `idleTimeout` | Minutes before idle disconnect (overrides global) |
@@ -212,6 +213,8 @@ Use `"2026-07-28"` to pin that revision. Pinning has no legacy or SSE fallback a
 The stable SDK handles era-specific request envelopes, result decoding, list-changed subscriptions, cancellation, and multi-round-trip sampling/elicitation. The adapter keeps strict OAuth issuer validation in every mode. Adapter-level roots support, standard MCP logging presentation, and configuration/UI for protocol cache hints are not yet implemented.
 
 For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
+
+If an internal authorization server publishes mismatched OAuth metadata and cannot be fixed immediately, set `oauth.skipIssuerMetadataValidation: true` on that server only. This is security-weakening. It disables the RFC 8414 issuer echo check and should not be used for public or untrusted servers.
 
 Secret values in `headers`, `bearerToken`, `oauth.clientSecret`, and stdio `env` may use a leading `!command` to obtain their value at connection or authentication time. The command runs with stdin and stderr suppressed, stdout is limited to 1 MiB and trimmed, and it must finish within 10 seconds with non-empty output; failures stop the connection or authentication flow. Commands are not run during OAuth discovery or while reading, merging, previewing, hashing, or rendering configuration. Use `!!` to escape a literal leading `!`; ordinary and escaped values retain environment interpolation.
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1059,7 +1059,7 @@ describe("config discovery", () => {
           type: "remote",
           url: "https://global.test/mcp",
           headers: { "X-Global": "global", "X-Shared": "global" },
-          oauth: { clientId: "global-client", scope: "global-scope" },
+          oauth: { clientId: "global-client", scope: "global-scope", skipIssuerMetadataValidation: false },
         },
         globalOnly: { type: "local", command: ["global"] },
       },
@@ -1068,7 +1068,7 @@ describe("config discovery", () => {
       mcp: {
         shared: {
           headers: { "X-Project": "project", "X-Shared": "project" },
-          oauth: { scope: "project-scope", clientSecret: "project-secret" },
+          oauth: { scope: "project-scope", clientSecret: "project-secret", skipIssuerMetadataValidation: true },
         },
         projectOnly: { type: "local", command: ["project"] },
         oauthFalse: { type: "remote", url: "https://false.test/mcp", oauth: false },
@@ -1086,7 +1086,12 @@ describe("config discovery", () => {
         url: "https://global.test/mcp",
         headers: { "X-Global": "global", "X-Shared": "project", "X-Project": "project" },
         auth: "oauth",
-        oauth: { clientId: "global-client", scope: "project-scope", clientSecret: "project-secret" },
+        oauth: {
+          clientId: "global-client",
+          scope: "project-scope",
+          clientSecret: "project-secret",
+          skipIssuerMetadataValidation: true,
+        },
       },
       globalOnly: { command: "global", args: [] },
       projectOnly: { command: "project", args: [] },

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -107,6 +107,23 @@ describe("mcp-auth-flow explicit auth", () => {
     )).toThrow("state mismatch");
   });
 
+  it("passes the issuer metadata validation opt-out to SDK auth", async () => {
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("issuer-skip", "https://api.example.com/mcp", {
+      auth: "oauth",
+      oauth: { skipIssuerMetadataValidation: true },
+    });
+
+    expect(mocks.sdkAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        serverUrl: "https://api.example.com/mcp",
+        skipIssuerMetadataValidation: true,
+      }),
+    );
+  });
+
   it("keeps a pending flow when an advertised RFC 9207 issuer is missing", async () => {
     let oauthState = "";
     mocks.sdkAuth.mockImplementation(async (provider, options) => {
@@ -347,6 +364,35 @@ describe("mcp-auth-flow explicit auth", () => {
 
     expect(token?.accessToken).toBe("new-access");
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the issuer metadata validation opt-out during token refresh", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.saveTokens({
+        access_token: "new-access",
+        token_type: "Bearer",
+        refresh_token: "new-refresh",
+        expires_in: 3600,
+      });
+      return "AUTHORIZED";
+    });
+    const { getValidToken } = await import("../mcp-auth-flow.ts");
+    const { updateClientInfo, updateTokens } = await import("../mcp-auth.ts");
+
+    updateClientInfo("refresh-skip-issuer", { clientId: "client", redirectUris: ["http://localhost:19876/callback"] }, "https://api.example.com/mcp");
+    updateTokens("refresh-skip-issuer", {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() / 1000 - 60,
+    }, "https://api.example.com/mcp");
+
+    await expect(getValidToken("refresh-skip-issuer", "https://api.example.com/mcp", {
+      skipIssuerMetadataValidation: true,
+    })).resolves.toMatchObject({ accessToken: "new-access" });
+    expect(mocks.sdkAuth).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skipIssuerMetadataValidation: true }),
+    );
   });
 
   it("re-registers dynamic OAuth clients when only stale client info is stored", async () => {

--- a/__tests__/opencode-interpolation.test.ts
+++ b/__tests__/opencode-interpolation.test.ts
@@ -38,11 +38,13 @@ describe("OpenCode environment interpolation", () => {
         clientId: "{env:MCP_TEST_VALUE}-client",
         clientSecret: "{env:MCP_TEST_VALUE}-secret",
         scope: "scope-{env:MCP_TEST_VALUE}",
+        skipIssuerMetadataValidation: true,
       },
     })).toEqual({
       clientId: "interpolated-client",
       clientSecret: "interpolated-secret",
       scope: "scope-interpolated",
+      skipIssuerMetadataValidation: true,
     });
   });
 
@@ -64,11 +66,15 @@ describe("OpenCode environment interpolation", () => {
       .toThrow(/^Failed to resolve test secret: command returned empty output$/);
   });
 
-  it("rejects non-string OAuth fields before interpolation", () => {
+  it("rejects invalid OAuth fields before interpolation", () => {
     expect(() => extractOAuthConfig({
       url: "https://example.test/mcp",
       oauth: { clientId: 42 } as any,
     })).toThrow("OAuth clientId must be a string");
+    expect(() => extractOAuthConfig({
+      url: "https://example.test/mcp",
+      oauth: { skipIssuerMetadataValidation: "true" } as any,
+    })).toThrow("OAuth skipIssuerMetadataValidation must be a boolean");
   });
 
   it("fails closed before URL resolution when a brace variable is missing", () => {

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -17,6 +17,7 @@ type TransportOptions = {
     headers?: Record<string, string>;
   };
   authProvider?: OAuthProviderLike;
+  skipIssuerMetadataValidation?: boolean;
 };
 
 type HttpTransportMock = {
@@ -209,7 +210,7 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
   });
 
-  it("preserves OAuth redirect URI and client metadata for HTTP transports", async () => {
+  it("preserves OAuth redirect URI, client metadata, and issuer opt-out for HTTP transports", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
 
     const manager = new McpServerManager();
@@ -220,6 +221,7 @@ describe("McpServerManager HTTP bearer auth", () => {
         redirectUri: "http://127.0.0.1:3118/callback",
         clientName: "Custom MCP",
         clientUri: "https://example.com/custom-mcp",
+        skipIssuerMetadataValidation: true,
       },
     });
 
@@ -228,6 +230,7 @@ describe("McpServerManager HTTP bearer auth", () => {
     expect(authProvider?.clientMetadata?.redirect_uris).toEqual(["http://127.0.0.1:3118/callback"]);
     expect(authProvider?.clientMetadata?.client_name).toBe("Custom MCP");
     expect(authProvider?.clientMetadata?.client_uri).toBe("https://example.com/custom-mcp");
+    expect(mocks.httpTransports.at(-1)!.options.skipIssuerMetadataValidation).toBe(true);
   });
 
   it("closes the HTTP transport when cancellation lands as connect resolves", async () => {

--- a/config.ts
+++ b/config.ts
@@ -763,6 +763,9 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
             ...(typeof oauth.clientId === "string" ? { clientId: oauth.clientId } : {}),
             ...(typeof oauth.clientSecret === "string" ? { clientSecret: oauth.clientSecret } : {}),
             ...(typeof oauth.scope === "string" ? { scope: oauth.scope } : {}),
+            ...(typeof oauth.skipIssuerMetadataValidation === "boolean"
+              ? { skipIssuerMetadataValidation: oauth.skipIssuerMetadataValidation }
+              : {}),
           };
         }
         mappedServers[name] = mapped;

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -9,6 +9,7 @@ import {
   extractWWWAuthenticateParams,
   LATEST_PROTOCOL_VERSION,
   UnauthorizedError,
+  type AuthOptions,
 } from "@modelcontextprotocol/client"
 import open from "open"
 import { McpOAuthProvider, type McpOAuthConfig } from "./mcp-oauth-provider.ts"
@@ -50,15 +51,17 @@ export interface AuthenticateOptions {
   authStorageOptions?: AuthStorageOptions
   signal?: AbortSignal
   runtime?: McpOAuthRuntime
+  skipIssuerMetadataValidation?: boolean
 }
 
-type AuthDiscovery = {
-  resourceMetadataUrl?: URL
-  scope?: string
-}
+type AuthDiscovery = Pick<AuthOptions, "resourceMetadataUrl" | "scope" | "skipIssuerMetadataValidation">
 
-function applyConfiguredScope(discovery: AuthDiscovery, config: McpOAuthConfig): AuthDiscovery {
-  return config.scope !== undefined ? { ...discovery, scope: config.scope } : discovery
+function applyOAuthConfig(discovery: AuthDiscovery, config: McpOAuthConfig): AuthDiscovery {
+  return {
+    ...discovery,
+    ...(config.scope !== undefined ? { scope: config.scope } : {}),
+    ...(config.skipIssuerMetadataValidation === true ? { skipIssuerMetadataValidation: true } : {}),
+  }
 }
 
 type PendingAuth = {
@@ -208,6 +211,12 @@ export function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     }
     config.clientUri = clientUri
   }
+  if (definition.oauth?.skipIssuerMetadataValidation !== undefined) {
+    if (typeof definition.oauth.skipIssuerMetadataValidation !== "boolean") {
+      throw new Error("OAuth skipIssuerMetadataValidation must be a boolean")
+    }
+    config.skipIssuerMetadataValidation = definition.oauth.skipIssuerMetadataValidation
+  }
   return config
 }
 
@@ -320,7 +329,7 @@ export async function startAuth(
       },
     }, authStorageOptions, runtime.signal)
     try {
-      const discovery = applyConfiguredScope(await probeAuthDiscovery(serverUrl, definition, signal), config)
+      const discovery = applyOAuthConfig(await probeAuthDiscovery(serverUrl, definition, signal), config)
       throwIfAborted(signal)
       const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
       throwIfAborted(signal)
@@ -386,7 +395,7 @@ export async function startAuth(
 
     throwIfAborted(signal)
 
-    const discovery = applyConfiguredScope(await probeAuthDiscovery(serverUrl, definition, signal), config)
+    const discovery = applyOAuthConfig(await probeAuthDiscovery(serverUrl, definition, signal), config)
     throwIfAborted(signal)
     const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
     throwIfAborted(signal)
@@ -782,7 +791,11 @@ export async function getValidToken(
 
         const discovery = await probeAuthDiscovery(serverUrl, undefined, signal)
         throwIfAborted(signal)
-        const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+        const result = await abortable(runSdkAuth(authProvider, {
+          serverUrl,
+          ...discovery,
+          ...(options.skipIssuerMetadataValidation === true ? { skipIssuerMetadataValidation: true } : {}),
+        }), signal)
         throwIfAborted(signal)
         if (result !== "AUTHORIZED") {
           return null

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -86,6 +86,7 @@ export interface McpOAuthConfig {
   redirectUri?: string
   clientName?: string
   clientUri?: string
+  skipIssuerMetadataValidation?: boolean
 }
 
 const reservedAuthorizationParams = new Set([

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -754,6 +754,11 @@ export class McpServerManager {
       const transportOptions = {
         ...(requestInit !== undefined ? { requestInit } : {}),
         ...(authProvider !== undefined ? { authProvider } : {}),
+        ...(authProvider !== undefined
+          && definition.oauth !== false
+          && definition.oauth?.skipIssuerMetadataValidation === true
+          ? { skipIssuerMetadataValidation: true }
+          : {}),
       };
       const baseTransport: Transport = kind === "streamable-http"
         ? new StreamableHTTPClientTransport(url, transportOptions)

--- a/types.ts
+++ b/types.ts
@@ -350,6 +350,8 @@ export interface OAuthConfig {
   clientName?: string;
   /** Client homepage URI for dynamic registration */
   clientUri?: string;
+  /** Security-weakening escape hatch for known-misconfigured authorization servers. */
+  skipIssuerMetadataValidation?: boolean;
 }
 
 // Server configuration


### PR DESCRIPTION
Adds a per-server `oauth.skipIssuerMetadataValidation` option for known-misconfigured OAuth authorization servers. Strict issuer validation remains the default. The option is documented as security-weakening and intended only as a temporary workaround for private servers while their metadata is fixed.

Fixes #297.

Validation:
- `npx vitest run __tests__/mcp-auth-flow-client-credentials.test.ts __tests__/server-manager-http-auth.test.ts __tests__/opencode-interpolation.test.ts`
- `npm run typecheck`
- fresh-context security review found a refresh-path gap; fixed
- targeted follow-up review found no issues

Thanks @embik for the report.