### PR TITLE
feat: load MCP servers from Agent Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `resolveServerFromToolName` so permission brokers can map prefixed MCP tool names back to their owning server. Thanks @jagaliano for PR #295.
 - Added per-server `oauth.skipIssuerMetadataValidation` for known-misconfigured OAuth servers. Thanks @embik for issue #297.
 - Added a configurable `mcp.panel.save` keybinding for the MCP panel Save action. Thanks @tim-hilde for issue #299.
+- Added `settings.agentPluginPaths` to load MCP servers from Agent Plugins 1.0 packages.
 
 ### Fixed
 - Stopped `/mcp` from inspecting host-specific config files when host config discovery is disabled. Thanks @rtfmkiesel for issue #292.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ Use the shared MCP files when you want one setup to work across hosts, and Pi-ow
 
 Pi-specific files are the write targets for imported or shared global servers when Pi needs to persist adapter-only settings such as `directTools`.
 
+### Agent Plugins
+
+The adapter can load MCP servers from [Agent Plugins](https://agent-plugins.org/) packages when you list plugin directories in `settings.agentPluginPaths`:
+
+```json
+{
+  "settings": {
+    "agentPluginPaths": ["./plugins/acme-tools"]
+  },
+  "mcpServers": {}
+}
+```
+
+Each directory must contain a valid Agent Plugins 1.0 `plugin.json`. If it also has a root `mcp.json`, the adapter loads its `mcpServers` entries and prefixes them as `<plugin>__<server>`. The loader uses the Agent Plugins transport declared by each server `type` and skips invalid entries without blocking other servers. For stdio plugin servers, `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` are expanded only in `args`, `env`, and `cwd`; the adapter sets both variables for the child process and stores plugin data under the Pi agent directory.
+
+Agent Plugins is a portable package format. Native Pi MCP config remains `.mcp.json`, `~/.config/mcp/mcp.json`, and Pi-owned overrides.
+
 ### SDK configuration
 
 Use `createMcpAdapter` when an SDK or server integration already owns its MCP configuration:
@@ -297,6 +314,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
 | `mcpFooterStatus` | MCP footer verbosity: `"full"` (default), `"compact"` for `MCP connected/enabled`, or `"off"` to clear the persistent footer status. `/mcp status` remains available. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
+| `agentPluginPaths` | Agent Plugins package directories to load MCP servers from. Relative paths resolve from the active project cwd. |
 | `approveTools` | `true` to require approval before every MCP tool call, or an array of glob patterns such as `["github_delete_*", "notion_update_*"]`. Per-server `approveTools` overrides this. |
 | `oauthDir` | Legacy OAuth `tokens.json` import directory for this MCP config. Relative paths resolve from the active project cwd. `MCP_OAUTH_DIR` still wins when set. Persistent OAuth credentials are stored in the OS credential store, not this directory. |
 | `mcpServers.<name>.oauth.authorizationParams` | Extra authorization URL parameters for provider-specific OAuth extensions. Flow-owned parameters such as `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge`, `response_type`, and `resource` cannot be overridden. |

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -21,6 +21,109 @@ describe("config discovery", () => {
     process.chdir(originalCwd);
   });
 
+  it("loads Agent Plugin MCP servers from configured plugin paths", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const plugin = join(project, "plugins", "acme-tools");
+    writeJson(join(plugin, "plugin.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "acme.tools",
+    });
+    writeJson(join(plugin, "mcp.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: {
+        local: {
+          type: "stdio",
+          command: "./bin/server",
+          args: ["--config", "${PLUGIN_ROOT}/config.json", "--data", "${PLUGIN_DATA}/local"],
+          env: { CACHE: "${PLUGIN_DATA}/cache", LITERAL_HOME: "${HOME}", LITERAL_COMMAND: "!echo pwned" },
+        },
+        remote: {
+          type: "streamable-http",
+          url: "https://example.test/mcp",
+          headers: { "X-Tenant": "public" },
+        },
+        legacy: {
+          type: "sse",
+          url: "http://localhost:3845/sse",
+        },
+      },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      settings: { agentPluginPaths: ["./plugins/acme-tools"] },
+      mcpServers: {},
+    });
+
+    const { loadMcpConfig, getMcpDiscoverySummary } = await import("../config.ts");
+    const config = loadMcpConfig();
+    const realPlugin = realpathSync(plugin);
+    const pluginDataDir = join(home, ".pi", "agent", "agent-plugin-data", "acme.tools");
+    expect(config.mcpServers).toMatchObject({
+      acme_tools__local: {
+        command: join(realPlugin, "bin", "server"),
+        args: ["--config", join(realPlugin, "config.json"), "--data", join(pluginDataDir, "local")],
+        env: {
+          CACHE: join(pluginDataDir, "cache"),
+          LITERAL_HOME: "${HOME}",
+          LITERAL_COMMAND: "!echo pwned",
+          PLUGIN_ROOT: realPlugin,
+          PLUGIN_DATA: pluginDataDir,
+        },
+        cwd: realPlugin,
+        pluginDataDir,
+        literalEnv: true,
+      },
+      acme_tools__remote: {
+        url: "https://example.test/mcp",
+        headers: { "X-Tenant": "public" },
+        httpTransport: "streamable-http",
+      },
+      acme_tools__legacy: {
+        url: "http://localhost:3845/sse",
+        httpTransport: "sse",
+      },
+    });
+    expect(getMcpDiscoverySummary().agentPlugins).toEqual([
+      { path: realPlugin, name: "acme.tools", serverCount: 3 },
+    ]);
+  });
+
+  it("skips invalid Agent Plugin MCP server entries without loading credentials or unsafe paths", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-invalid-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-invalid-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const plugin = join(project, "plugins", "bad-plugin");
+    writeJson(join(plugin, "plugin.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "bad-plugin",
+    });
+    writeJson(join(plugin, "mcp.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: {
+        unsafeCommand: { type: "stdio", command: "../bin/server" },
+        reservedEnv: { type: "stdio", command: "node", env: { PLUGIN_ROOT: "override" } },
+        insecureRemote: { type: "streamable-http", url: "http://example.test/mcp" },
+        duplicateHeader: { type: "streamable-http", url: "https://example.test/mcp", headers: { "X-Test": "one", "x-test": "two" } },
+        valid: { type: "stdio", command: "node" },
+      },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      settings: { agentPluginPaths: [plugin] },
+      mcpServers: { native: { command: "native" } },
+    });
+
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(Object.keys(loadMcpConfig().mcpServers).sort()).toEqual(["bad-plugin__valid", "native"]);
+    expect(warning).toHaveBeenCalled();
+    warning.mockRestore();
+  });
+
   it("loads standard MCP files first, then Pi overrides", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-config-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-config-project-"));

--- a/__tests__/server-manager-streamable-http.test.ts
+++ b/__tests__/server-manager-streamable-http.test.ts
@@ -110,6 +110,27 @@ describe("McpServerManager StreamableHTTP transport", () => {
     });
   });
 
+  it("does not recover through legacy fallback when a server declares Streamable HTTP", async () => {
+    const server = http.createServer((req, res) => {
+      if (req.method === "POST") {
+        res.writeHead(404).end("Not Found");
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/event-stream" }).end("event: endpoint\ndata: /messages\n\n");
+    });
+    servers.push(server);
+
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port");
+
+    const manager = new McpServerManager();
+    await expect(manager.connect("agent-plugin-http", {
+      url: `http://127.0.0.1:${address.port}/mcp`,
+      httpTransport: "streamable-http",
+    })).rejects.toThrow();
+  });
+
   it("resolves command-backed HTTP secrets without falling back to SSE on GET 405", async () => {
     const requests: string[] = [];
     const server = http.createServer(async (req, res) => {

--- a/agent-plugin-loader.ts
+++ b/agent-plugin-loader.ts
@@ -1,0 +1,364 @@
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { getAgentPath } from "./agent-dir.ts";
+import type { McpConfig, ServerEntry } from "./types.ts";
+
+const PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const PLUGIN_MANIFEST_FIELDS = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions",
+]);
+const MCP_CONFIG_FIELDS = new Set(["$schema", "mcpServers"]);
+const STDIO_FIELDS = new Set(["type", "command", "args", "env", "cwd"]);
+const HTTP_FIELDS = new Set(["type", "url", "headers"]);
+
+interface AgentPluginManifest {
+  name: string;
+}
+
+export interface AgentPluginSummary {
+  path: string;
+  name?: string;
+  serverCount: number;
+}
+
+export function loadAgentPluginConfigs(paths: unknown, cwd = process.cwd()): McpConfig {
+  let config: McpConfig = { mcpServers: {} };
+  for (const pluginPath of getPluginPaths(paths)) {
+    const loaded = loadAgentPluginMcpConfig(pluginPath, cwd);
+    if (loaded) {
+      config = {
+        mcpServers: { ...config.mcpServers, ...loaded.mcpServers },
+      };
+    }
+  }
+  return config;
+}
+
+export function getAgentPluginSummaries(paths: unknown, cwd = process.cwd()): AgentPluginSummary[] {
+  return getPluginPaths(paths).map(path => {
+    const pluginRoot = resolvePluginPath(path, cwd);
+    const loaded = loadAgentPluginMcpConfig(path, cwd);
+    const manifest = loaded ? readPluginManifest(pluginRoot, false) : null;
+    return {
+      path: pluginRoot,
+      ...(manifest?.name ? { name: manifest.name } : {}),
+      serverCount: loaded ? Object.keys(loaded.mcpServers).length : 0,
+    };
+  });
+}
+
+function getPluginPaths(paths: unknown): string[] {
+  return Array.isArray(paths) ? paths.filter((path): path is string => typeof path === "string") : [];
+}
+
+function loadAgentPluginMcpConfig(path: string, cwd: string): McpConfig | null {
+  const pluginRoot = resolvePluginPath(path, cwd);
+  const manifest = readPluginManifest(pluginRoot, true);
+  if (!manifest) return null;
+
+  const mcpPath = resolve(pluginRoot, "mcp.json");
+  if (!existsSync(mcpPath)) return { mcpServers: {} };
+  if (!statSync(mcpPath).isFile()) {
+    console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: mcp.json is not a regular file`);
+    return { mcpServers: {} };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(mcpPath, "utf8"));
+  } catch (error) {
+    console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: failed to parse mcp.json`, error);
+    return { mcpServers: {} };
+  }
+
+  return translateAgentPluginMcpConfig(raw, manifest, pluginRoot);
+}
+
+function readPluginManifest(pluginRoot: string, report: boolean): AgentPluginManifest | null {
+  const manifestPath = resolve(pluginRoot, "plugin.json");
+  if (!existsSync(manifestPath)) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: missing plugin.json`);
+    return null;
+  }
+  if (!statSync(manifestPath).isFile()) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: plugin.json is not a regular file`);
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: failed to parse plugin.json`, error);
+    return null;
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: plugin.json must be an object`);
+    return null;
+  }
+
+  const manifest = raw as Record<string, unknown>;
+  for (const key of Object.keys(manifest)) {
+    if (!PLUGIN_MANIFEST_FIELDS.has(key) && report) {
+      console.warn(`Agent Plugin at ${pluginRoot} ignores unknown plugin.json field: ${key}`);
+    }
+  }
+  if (manifest.$schema !== PLUGIN_SCHEMA) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: unsupported plugin.json $schema`);
+    return null;
+  }
+  if (typeof manifest.name !== "string" || manifest.name.length < 1 || manifest.name.length > 64 || !PLUGIN_NAME_PATTERN.test(manifest.name)) {
+    if (report) console.warn(`Agent Plugin at ${pluginRoot} is invalid: plugin.json name is invalid`);
+    return null;
+  }
+  if (manifest.extensions !== undefined && (!manifest.extensions || typeof manifest.extensions !== "object" || Array.isArray(manifest.extensions))) {
+    if (report) console.warn(`Agent Plugin ${manifest.name} ignores non-object plugin.json extensions`);
+  }
+
+  return { name: manifest.name };
+}
+
+function translateAgentPluginMcpConfig(raw: unknown, manifest: AgentPluginManifest, pluginRoot: string): McpConfig {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: mcp.json must be an object`);
+    return { mcpServers: {} };
+  }
+
+  const mcpConfig = raw as Record<string, unknown>;
+  for (const key of Object.keys(mcpConfig)) {
+    if (!MCP_CONFIG_FIELDS.has(key)) {
+      console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: unknown top-level field ${key}`);
+      return { mcpServers: {} };
+    }
+  }
+  if (mcpConfig.$schema !== MCP_SCHEMA) {
+    console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: unsupported mcp.json $schema`);
+    return { mcpServers: {} };
+  }
+  if (!mcpConfig.mcpServers || typeof mcpConfig.mcpServers !== "object" || Array.isArray(mcpConfig.mcpServers)) {
+    console.warn(`Agent Plugin ${manifest.name} has invalid MCP config: mcpServers must be an object`);
+    return { mcpServers: {} };
+  }
+
+  const mcpServers: Record<string, ServerEntry> = {};
+  for (const [serverName, entry] of Object.entries(mcpConfig.mcpServers)) {
+    const translated = translateAgentPluginServer(manifest, pluginRoot, serverName, entry);
+    if (translated) mcpServers[formatAgentPluginServerName(manifest.name, serverName)] = translated;
+  }
+  return { mcpServers };
+}
+
+function translateAgentPluginServer(
+  manifest: AgentPluginManifest,
+  pluginRoot: string,
+  serverName: string,
+  entry: unknown,
+): ServerEntry | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: entry must be an object`);
+    return null;
+  }
+
+  const raw = entry as Record<string, unknown>;
+  if (raw.type === "stdio") return translateStdioServer(manifest, pluginRoot, serverName, raw);
+  if (raw.type === "streamable-http" || raw.type === "sse") return translateHttpServer(manifest, serverName, raw, raw.type);
+
+  console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: unsupported type`);
+  return null;
+}
+
+function translateStdioServer(
+  manifest: AgentPluginManifest,
+  pluginRoot: string,
+  serverName: string,
+  raw: Record<string, unknown>,
+): ServerEntry | null {
+  for (const key of Object.keys(raw)) {
+    if (!STDIO_FIELDS.has(key)) return skipServer(manifest, serverName, `unknown field ${key}`);
+  }
+  if (typeof raw.command !== "string" || raw.command.length === 0) return skipServer(manifest, serverName, "command must be a non-empty string");
+  if (!isBareCommand(raw.command) && !raw.command.startsWith("./")) return skipServer(manifest, serverName, "command must be bare or plugin-relative");
+
+  const args = translateStringArray(raw.args, manifest, serverName, "args");
+  if (args === null) return null;
+  const env = translateEnv(raw.env, manifest, serverName);
+  if (env === null) return null;
+
+  const pluginDataDir = getAgentPath("agent-plugin-data", manifest.name);
+  const cwd = resolvePluginCwd(raw.cwd, pluginRoot, pluginDataDir);
+  if (cwd === null) return skipServer(manifest, serverName, "cwd must be plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted");
+
+  return {
+    command: raw.command.startsWith("./") ? resolveContainedPath(pluginRoot, raw.command, pluginRoot) ?? raw.command : raw.command,
+    args: args.map(value => expandPluginPlaceholders(value, pluginRoot, pluginDataDir)),
+    env: {
+      ...Object.fromEntries(Object.entries(env).map(([key, value]) => [key, expandPluginPlaceholders(value, pluginRoot, pluginDataDir)])),
+      PLUGIN_ROOT: pluginRoot,
+      PLUGIN_DATA: pluginDataDir,
+    },
+    cwd,
+    pluginDataDir,
+    literalEnv: true,
+  };
+}
+
+function translateHttpServer(
+  manifest: AgentPluginManifest,
+  serverName: string,
+  raw: Record<string, unknown>,
+  type: "streamable-http" | "sse",
+): ServerEntry | null {
+  for (const key of Object.keys(raw)) {
+    if (!HTTP_FIELDS.has(key)) return skipServer(manifest, serverName, `unknown field ${key}`);
+  }
+  if (typeof raw.url !== "string" || raw.url.length === 0) return skipServer(manifest, serverName, "url must be a non-empty string");
+  if (!isValidAgentPluginUrl(raw.url)) return skipServer(manifest, serverName, "url must be an allowed absolute HTTP(S) URL");
+  const headers = translateHeaders(raw.headers, manifest, serverName);
+  if (headers === null) return null;
+
+  return {
+    url: raw.url,
+    httpTransport: type,
+    ...(headers ? { headers } : {}),
+  };
+}
+
+function formatAgentPluginServerName(pluginName: string, serverName: string): string {
+  const pluginPart = pluginName.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || "plugin";
+  const serverPart = serverName.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || "server";
+  return `${pluginPart}__${serverPart}`;
+}
+
+function skipServer(manifest: AgentPluginManifest, serverName: string, reason: string): null {
+  console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: ${reason}`);
+  return null;
+}
+
+function translateStringArray(value: unknown, manifest: AgentPluginManifest, serverName: string, field: string): string[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some(item => typeof item !== "string")) {
+    console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: ${field} must be an array of strings`);
+    return null;
+  }
+  return value;
+}
+
+function translateEnv(value: unknown, manifest: AgentPluginManifest, serverName: string): Record<string, string> | null {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: env must be an object of strings`);
+    return null;
+  }
+  const env: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "PLUGIN_ROOT" || key === "PLUGIN_DATA") {
+      console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: env must not define ${key}`);
+      return null;
+    }
+    if (typeof entry !== "string") {
+      console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: env values must be strings`);
+      return null;
+    }
+    env[key] = entry;
+  }
+  return env;
+}
+
+function translateHeaders(value: unknown, manifest: AgentPluginManifest, serverName: string): Record<string, string> | undefined | null {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: headers must be an object of strings`);
+    return null;
+  }
+  const headers: Record<string, string> = {};
+  const seen = new Set<string>();
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: header values must be strings`);
+      return null;
+    }
+    const normalized = key.toLowerCase();
+    if (seen.has(normalized)) {
+      console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: duplicate header ${key}`);
+      return null;
+    }
+    seen.add(normalized);
+    headers[key] = entry;
+  }
+  try {
+    new Headers(headers);
+  } catch {
+    console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: headers are not valid HTTP fields`);
+    return null;
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function resolvePluginPath(path: string, cwd: string): string {
+  if (path === "~") return resolve(process.env.HOME ?? "", ".");
+  if (path.startsWith("~/")) return resolve(process.env.HOME ?? "", path.slice(2));
+  return isAbsolute(path) ? resolve(path) : resolve(cwd, path);
+}
+
+function isBareCommand(command: string): boolean {
+  return !command.includes("/") && !command.includes("\\") && !command.includes("${PLUGIN_ROOT}") && !command.includes("${PLUGIN_DATA}");
+}
+
+function resolvePluginCwd(value: unknown, pluginRoot: string, pluginDataDir: string): string | null {
+  if (value === undefined) return pluginRoot;
+  if (typeof value !== "string") return null;
+  if (value.startsWith("./")) return resolveContainedPath(pluginRoot, value, pluginRoot);
+  if (value === "${PLUGIN_ROOT}" || value.startsWith("${PLUGIN_ROOT}/")) {
+    return resolveContainedPath(pluginRoot, value.replace("${PLUGIN_ROOT}", "."), pluginRoot);
+  }
+  if (value === "${PLUGIN_DATA}" || value.startsWith("${PLUGIN_DATA}/")) {
+    return resolveContainedPath(pluginDataDir, value.replace("${PLUGIN_DATA}", "."), pluginDataDir);
+  }
+  return null;
+}
+
+function resolveContainedPath(root: string, value: string, containmentRoot: string): string | null {
+  const resolved = resolve(root, value);
+  const rel = relative(containmentRoot, resolved);
+  if (rel === "" || (!rel.startsWith("..") && !rel.startsWith(sep) && !isAbsolute(rel))) return resolved;
+  return null;
+}
+
+function expandPluginPlaceholders(value: string, pluginRoot: string, pluginDataDir: string): string {
+  return value
+    .replaceAll("${PLUGIN_ROOT}", pluginRoot)
+    .replaceAll("${PLUGIN_DATA}", pluginDataDir);
+}
+
+function isValidAgentPluginUrl(value: string): boolean {
+  if (value.includes("${") || value.includes("$env:") || value.includes("{env:")) return false;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  if (url.username || url.password || url.hash) return false;
+  if (url.protocol === "https:") return true;
+  return isLoopbackHost(url.hostname);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return true;
+  if (/^127(?:\.\d{1,3}){3}$/.test(host)) return true;
+  return false;
+}

--- a/config.ts
+++ b/config.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { parse as parseToml } from "smol-toml";
 import stripJsonComments from "strip-json-comments";
 import { getAgentPath } from "./agent-dir.ts";
+import { getAgentPluginSummaries, loadAgentPluginConfigs, type AgentPluginSummary } from "./agent-plugin-loader.ts";
 import { isServerDisabled, type HostConfigDiscovery, type McpConfig, type ServerEntry, type McpSettings, type ImportKind, type ServerProvenance } from "./types.ts";
 import { toStringRecord } from "./utils.ts";
 
@@ -137,6 +138,7 @@ export interface McpDiscoverySummary {
   imports: ImportConfigSummary[];
   hostConfigs: HostConfigSummary[];
   hostConfigDiscovery: HostConfigDiscovery;
+  agentPlugins: AgentPluginSummary[];
   conflicts: McpConfigConflict[];
   hasAnyConfig: boolean;
   hasAnyDetectedPaths: boolean;
@@ -247,10 +249,12 @@ export function getMcpDiscoverySummary(
     : [];
   const hostConfigDiscovery = getConfiguredHostConfigDiscovery(overridePath, cwd);
   const hostConfigs = imports.map((entry) => ({ ...entry, active: hostConfigDiscovery === "on" }));
-  const totalServerCount = sources.reduce((sum, source) => sum + source.serverCount, 0);
-  const hasSharedServers = sources.some((source) => source.kind === "shared" && source.serverCount > 0);
+  const settings = getMergedSettings(overridePath, cwd);
+  const agentPlugins = getAgentPluginSummaries(settings?.agentPluginPaths, cwd);
+  const totalServerCount = sources.reduce((sum, source) => sum + source.serverCount, 0) + agentPlugins.reduce((sum, plugin) => sum + plugin.serverCount, 0);
+  const hasSharedServers = sources.some((source) => source.kind === "shared" && source.serverCount > 0) || agentPlugins.some(plugin => plugin.serverCount > 0);
   const hasPiOwnedServers = sources.some((source) => source.kind === "pi" && source.serverCount > 0);
-  const hasAnyDetectedPaths = sources.some((source) => source.exists) || imports.length > 0;
+  const hasAnyDetectedPaths = sources.some((source) => source.exists) || imports.length > 0 || agentPlugins.length > 0;
   const hasAnyConfig = totalServerCount > 0 || imports.some((entry) => entry.serverCount > 0) || hasAnyDetectedPaths;
 
   const summaryWithoutRepoPrompt = {
@@ -258,6 +262,7 @@ export function getMcpDiscoverySummary(
     imports,
     hostConfigs,
     hostConfigDiscovery,
+    agentPlugins,
     conflicts: getConfigConflicts(sourceSpecs, imports, cwd),
     hasAnyConfig,
     hasAnyDetectedPaths,
@@ -269,6 +274,7 @@ export function getMcpDiscoverySummary(
   const fingerprint = JSON.stringify({
     sources: sources.map((source) => [source.id, source.exists, source.serverCount]),
     imports: imports.map((entry) => [entry.kind, entry.path, entry.serverCount]),
+    agentPlugins: agentPlugins.map((entry) => [entry.path, entry.name, entry.serverCount]),
     hostConfigDiscovery,
     conflicts: summaryWithoutRepoPrompt.conflicts,
   });
@@ -300,16 +306,24 @@ export function loadMcpConfig(overridePath?: string, cwd = process.cwd()): McpCo
     config = mergeConfigs(config, expandImports(loaded, cwd));
   }
 
-  return config;
+  const pluginConfig = loadAgentPluginConfigs(config.settings?.agentPluginPaths, cwd);
+  return mergeConfigs(pluginConfig, config);
+}
+
+function getMergedSettings(overridePath?: string, cwd = process.cwd()): McpSettings | undefined {
+  let settings: McpSettings | undefined;
+  for (const source of getConfigSources(overridePath, cwd)) {
+    const loaded = readValidatedConfig(source.readPath, `MCP config from ${source.readPath}`);
+    if (loaded?.settings) settings = { ...settings, ...loaded.settings };
+  }
+  return settings;
 }
 
 function getConfiguredHostConfigDiscovery(overridePath?: string, cwd = process.cwd()): HostConfigDiscovery {
   let configured: HostConfigDiscovery = "off";
-  for (const source of getConfigSources(overridePath, cwd)) {
-    const loaded = readValidatedConfig(source.readPath, `MCP config from ${source.readPath}`);
-    const value = loaded?.settings?.hostConfigDiscovery;
-    if (value === "off" || value === "prompt" || value === "on") configured = value;
-  }
+  const settings = getMergedSettings(overridePath, cwd);
+  const value = settings?.hostConfigDiscovery;
+  if (value === "off" || value === "prompt" || value === "on") configured = value;
   return configured;
 }
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "mcp-code.ts",
     "mcp-script-worker.mjs",
     "mcp-probe.ts",
+    "agent-plugin-loader.ts",
     "resource-tools.ts",
     "lifecycle.ts",
     "mcp-status.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import {
   Client,
   SdkHttpError,
@@ -362,11 +363,12 @@ export class McpServerManager {
       }
       throwIfAborted(signal);
 
+      if (definition.pluginDataDir) mkdirSync(definition.pluginDataDir, { recursive: true });
       const cwd = resolveConfigPath(definition.cwd) ?? this.defaultCwd;
       const stdioTransport = new StdioClientTransport({
         command,
         args,
-        env: resolveEnv(definition.env, name),
+        env: resolveEnv(definition.env, name, definition.literalEnv === true),
         ...(cwd !== undefined ? { cwd } : {}),
         stderr: definition.debug ? "inherit" : "pipe",
       });
@@ -787,7 +789,8 @@ export class McpServerManager {
 
     // Connect the real client once. Retry Streamable HTTP only for an implicit
     // OAuth challenge; use SSE only for definitive endpoint incompatibility.
-    let kind: "streamable-http" | "sse" = "streamable-http";
+    // Agent Plugins set httpTransport, and their declared transport is used without fallback.
+    let kind: "streamable-http" | "sse" = definition.httpTransport ?? "streamable-http";
     for (;;) {
       const result = await attempt(kind);
       if (result.status === "connected") return result;
@@ -808,7 +811,7 @@ export class McpServerManager {
         throw result.error;
       }
 
-      if (kind === "streamable-http" && shouldFallbackToSse(result.error, definition)) {
+      if (definition.httpTransport === undefined && kind === "streamable-http" && shouldFallbackToSse(result.error, definition)) {
         kind = "sse";
         continue;
       }
@@ -1067,11 +1070,13 @@ export class McpServerManager {
 /**
  * Resolve environment variables with interpolation.
  */
-function resolveEnv(env: Record<string, string> | undefined, serverName: string): Record<string, string> {
+function resolveEnv(env: Record<string, string> | undefined, serverName: string, literalEnv = false): Record<string, string> {
   const resolved: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) resolved[key] = value;
   }
+  if (literalEnv) return env ? { ...resolved, ...env } : resolved;
+
   const overrides = resolveCommandSecretsRecord(
     env,
     key => `MCP server "${serverName}" stdio env "${key}"`,

--- a/types.ts
+++ b/types.ts
@@ -399,6 +399,12 @@ export interface ServerEntry {
   debug?: boolean;  // Show server stderr (default: false)
   /** Enable metadata-only JSONL protocol tracing for this server. */
   trace?: boolean;
+  /** Force a specific HTTP MCP transport. Used by Agent Plugins, whose `type` declares the transport and forbids client fallback. */
+  httpTransport?: "streamable-http" | "sse";
+  /** Client-managed persistent data directory for Agent Plugin stdio servers. */
+  pluginDataDir?: string;
+  /** Treat env values as already resolved literals. Used for Agent Plugin env rules. */
+  literalEnv?: boolean;
   /**
    * MCP protocol era negotiation for this server. Defaults to `"legacy"`
    * (byte-equivalent to pre-2026 behavior — no `versionNegotiation` is sent).
@@ -467,6 +473,8 @@ export interface McpSettings {
   mcpFooterStatus?: McpFooterStatus;
   /** Discover detected host-specific MCP configs only when explicitly enabled. */
   hostConfigDiscovery?: HostConfigDiscovery;
+  /** Agent Plugin package directories to load MCP servers from. */
+  agentPluginPaths?: string[];
   idleTimeout?: number; // minutes, default 10, 0 to disable
   requestTimeoutMs?: number; // milliseconds, overrides the SDK request timeout when > 0
   directTools?: boolean;


### PR DESCRIPTION
Adds explicit Agent Plugins 1.0 loading behind `settings.agentPluginPaths`.

The loader reads plugin package directories, validates `plugin.json`, translates root `mcp.json` servers into native MCP entries, and prefixes server names as `<plugin>__<server>`. It supports stdio, Streamable HTTP, and SSE server types. Stdio plugins get `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` expansion only, with env values kept literal after plugin expansion.

Native Pi MCP config semantics stay unchanged.

Validation:
- `npx vitest run __tests__/config.test.ts __tests__/server-manager-streamable-http.test.ts`
- `npm run typecheck`
- `git diff --check`

Review:
- Fresh Agent Plugins loader review found one env interpolation issue.
- Targeted follow-up review after the fix found no issues.
