### PR TITLE
fix: harden Agent Plugin loader translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `settings.agentPluginPaths` to load MCP servers from Agent Plugins 1.0 packages.
 
 ### Fixed
+- Rejected Agent Plugin command paths that escape the plugin directory and skipped normalized server-name collisions instead of overwriting servers.
 - Stopped `/mcp` from inspecting host-specific config files when host config discovery is disabled. Thanks @rtfmkiesel for issue #292.
 - Stopped optional numeric `mcp` and `mcpScript` tool parameters from leaking TypeBox internal markers into serialized schemas. Thanks @RainbowXie for issue #289 and PR #290.
 - Forwarded RFC 9207 OAuth callback issuers to the MCP SDK during manual authorization completion. Thanks @tkoenig for issue #293 and PR #294, and @ugur-murat-alt for independent live verification.

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -106,6 +106,7 @@ describe("config discovery", () => {
       $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
       mcpServers: {
         unsafeCommand: { type: "stdio", command: "../bin/server" },
+        escapedCommand: { type: "stdio", command: "./../bin/server" },
         reservedEnv: { type: "stdio", command: "node", env: { PLUGIN_ROOT: "override" } },
         insecureRemote: { type: "streamable-http", url: "http://example.test/mcp" },
         duplicateHeader: { type: "streamable-http", url: "https://example.test/mcp", headers: { "X-Test": "one", "x-test": "two" } },
@@ -121,6 +122,37 @@ describe("config discovery", () => {
     const { loadMcpConfig } = await import("../config.ts");
     expect(Object.keys(loadMcpConfig().mcpServers).sort()).toEqual(["bad-plugin__valid", "native"]);
     expect(warning).toHaveBeenCalled();
+    warning.mockRestore();
+  });
+
+  it("does not let Agent Plugin normalized server-name collisions overwrite servers", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-collision-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-collision-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const plugin = join(project, "plugins", "collision-plugin");
+    writeJson(join(plugin, "plugin.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "collision-plugin",
+    });
+    writeJson(join(plugin, "mcp.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: {
+        "tools.db": { type: "stdio", command: "node", args: ["first.js"] },
+        tools_db: { type: "stdio", command: "node", args: ["second.js"] },
+      },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      settings: { agentPluginPaths: [plugin] },
+      mcpServers: {},
+    });
+
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers["collision-plugin__tools_db"].args).toEqual(["first.js"]);
+    expect(Object.keys(loadMcpConfig().mcpServers)).toEqual(["collision-plugin__tools_db"]);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("normalized server name collision-plugin__tools_db already exists"));
     warning.mockRestore();
   });
 

--- a/agent-plugin-loader.ts
+++ b/agent-plugin-loader.ts
@@ -33,16 +33,19 @@ export interface AgentPluginSummary {
 }
 
 export function loadAgentPluginConfigs(paths: unknown, cwd = process.cwd()): McpConfig {
-  let config: McpConfig = { mcpServers: {} };
+  const mcpServers: Record<string, ServerEntry> = {};
   for (const pluginPath of getPluginPaths(paths)) {
     const loaded = loadAgentPluginMcpConfig(pluginPath, cwd);
-    if (loaded) {
-      config = {
-        mcpServers: { ...config.mcpServers, ...loaded.mcpServers },
-      };
+    if (!loaded) continue;
+    for (const [serverName, server] of Object.entries(loaded.mcpServers)) {
+      if (mcpServers[serverName]) {
+        console.warn(`Agent Plugin at ${resolvePluginPath(pluginPath, cwd)} skips duplicate normalized MCP server ${serverName}`);
+        continue;
+      }
+      mcpServers[serverName] = server;
     }
   }
-  return config;
+  return { mcpServers };
 }
 
 export function getAgentPluginSummaries(paths: unknown, cwd = process.cwd()): AgentPluginSummary[] {
@@ -154,7 +157,14 @@ function translateAgentPluginMcpConfig(raw: unknown, manifest: AgentPluginManife
   const mcpServers: Record<string, ServerEntry> = {};
   for (const [serverName, entry] of Object.entries(mcpConfig.mcpServers)) {
     const translated = translateAgentPluginServer(manifest, pluginRoot, serverName, entry);
-    if (translated) mcpServers[formatAgentPluginServerName(manifest.name, serverName)] = translated;
+    if (!translated) continue;
+
+    const normalizedName = formatAgentPluginServerName(manifest.name, serverName);
+    if (mcpServers[normalizedName]) {
+      console.warn(`Agent Plugin ${manifest.name} skips invalid MCP server ${serverName}: normalized server name ${normalizedName} already exists`);
+      continue;
+    }
+    mcpServers[normalizedName] = translated;
   }
   return { mcpServers };
 }
@@ -195,12 +205,15 @@ function translateStdioServer(
   const env = translateEnv(raw.env, manifest, serverName);
   if (env === null) return null;
 
+  const command = raw.command.startsWith("./") ? resolveContainedPath(pluginRoot, raw.command, pluginRoot) : raw.command;
+  if (command === null) return skipServer(manifest, serverName, "command must stay inside the plugin directory");
+
   const pluginDataDir = getAgentPath("agent-plugin-data", manifest.name);
   const cwd = resolvePluginCwd(raw.cwd, pluginRoot, pluginDataDir);
   if (cwd === null) return skipServer(manifest, serverName, "cwd must be plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted");
 
   return {
-    command: raw.command.startsWith("./") ? resolveContainedPath(pluginRoot, raw.command, pluginRoot) ?? raw.command : raw.command,
+    command,
     args: args.map(value => expandPluginPlaceholders(value, pluginRoot, pluginDataDir)),
     env: {
       ...Object.fromEntries(Object.entries(env).map(([key, value]) => [key, expandPluginPlaceholders(value, pluginRoot, pluginDataDir)])),


### PR DESCRIPTION
Fixes the two post-merge Agent Plugin loader findings from Greptile on #304.

Changes:
- reject plugin-relative stdio commands that resolve outside the plugin root,
- skip normalized server-name collisions instead of overwriting earlier servers,
- apply the same first-wins collision rule across configured plugin paths,
- add focused regression coverage.

Validation:
- `npx vitest run __tests__/config.test.ts __tests__/server-manager-streamable-http.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review found no issues.
