### PR TITLE
fix: simplify empty MCP elicitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Restored MCP sampling builds with current Pi AI releases by using its compatibility entry point. Thanks @eric-kansas for issue #308.
+- Simplified empty MCP form elicitation to one confirmation dialog. Thanks @shardulbee for issue #309.
 
 ## [2.21.0] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Prompt results are flattened into one user message, preserving `[user]` and `[as
 
 ### MCP Elicitation
 
-When Pi exposes dialog-capable UI, the adapter advertises form elicitation support. Forms use Pi's stock `select()` and `input()` dialogs, validate the response, and provide a review/edit step before submission. Explicit refusal maps to MCP `decline`; dismissing a dialog maps to `cancel`.
+When Pi exposes dialog-capable UI, the adapter advertises form elicitation support. Forms use Pi's stock `select()` and `input()` dialogs, validate the response, and provide a review/edit step before submission. Empty forms use one confirmation dialog. Explicit refusal maps to MCP `decline`; dismissing a dialog maps to `cancel`.
 
 URL mode is advertised only in TUI mode. The adapter displays the requesting server, target host, and full URL, and always requires consent before opening the browser. It also handles URL-required tool errors (`-32042`) and completion notifications; after completing the browser interaction, retry the original tool call.
 

--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -150,24 +150,31 @@ describe("MCP elicitation", () => {
     expect(result).toEqual({ action: "accept", content: { quantity: 7 } });
   });
 
-  it("maps explicit refusal and dialog dismissal to decline and cancel", async () => {
+  it("uses one confirmation dialog for an empty form", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
     const params = request({
       mode: "form",
-      message: "Provide a value",
+      message: "Confirm the operation",
       requestedSchema: { type: "object", properties: {} },
     });
 
-    await expect(handleElicitationRequest({
-      serverName: "demo",
-      ui: { select: vi.fn().mockResolvedValue("Decline") } as any,
-      allowUrl: true,
-    }, params)).resolves.toEqual({ action: "decline" });
-    await expect(handleElicitationRequest({
-      serverName: "demo",
-      ui: { select: vi.fn().mockResolvedValue(undefined) } as any,
-      allowUrl: true,
-    }, params)).resolves.toEqual({ action: "cancel" });
+    for (const [selection, expected] of [
+      ["Continue", { action: "accept", content: {} }],
+      ["Decline", { action: "decline" }],
+      [undefined, { action: "cancel" }],
+    ]) {
+      const select = vi.fn().mockResolvedValue(selection);
+      await expect(handleElicitationRequest({
+        serverName: "demo",
+        ui: { select } as any,
+        allowUrl: true,
+      }, params)).resolves.toEqual(expected);
+      expect(select).toHaveBeenCalledOnce();
+      expect(select).toHaveBeenCalledWith(
+        "MCP Input Request\nServer: demo\n\nConfirm the operation",
+        ["Continue", "Decline"],
+      );
+    }
   });
 
   it("does not open URL elicitations that are declined or dismissed", async () => {

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -44,15 +44,16 @@ export async function handleFormElicitation(
   options: ElicitationHandlerOptions,
   params: ElicitRequestFormParams,
 ): Promise<ElicitResult> {
+  const properties = Object.entries(params.requestedSchema.properties);
   const decision = await options.ui.select(
     `MCP Input Request\nServer: ${options.serverName}\n\n${params.message}`,
     ["Continue", "Decline"],
   );
   if (decision === undefined) return { action: "cancel" };
   if (decision === "Decline") return { action: "decline" };
+  if (properties.length === 0) return { action: "accept", content: {} };
 
   const values: Record<string, ElicitationValue> = {};
-  const properties = Object.entries(params.requestedSchema.properties);
   for (const [name, schema] of properties) {
     const value = await collectValidField(options.ui, params, name, schema);
     if (!("value" in value)) return { action: "cancel" };


### PR DESCRIPTION
## Summary

This simplifies empty MCP form elicitation so empty object schemas use one confirmation dialog instead of a confirm plus an empty review step.

`Continue` accepts with empty content, `Decline` declines, and dialog dismissal cancels. Non-empty forms keep their existing field collection and review/edit flow.

Closes #309.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/elicitation-handler.test.ts`
- `git diff --check origin/main..HEAD`

Fresh read-only review found no issues after rebasing onto current `main`.
