### PR TITLE
refactor: tighten MCP handler TypeScript contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Refined MCP elicitation and sampling handler TypeScript contracts without changing runtime behavior.
+
 ### Fixed
 - Restored MCP sampling builds with current Pi AI releases by using its compatibility entry point. Thanks @eric-kansas for issue #308.
 - Simplified empty MCP form elicitation to one confirmation dialog. Thanks @shardulbee for issue #309.

--- a/__tests__/elicitation-handler.test.ts
+++ b/__tests__/elicitation-handler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElicitRequest } from "@modelcontextprotocol/client";
+import type { ElicitationUIContext } from "../elicitation-handler.ts";
 
 const mocks = vi.hoisted(() => ({
   open: vi.fn(async () => undefined),
@@ -11,6 +12,21 @@ function request(params: ElicitRequest["params"]): ElicitRequest {
   return { method: "elicitation/create", params } as ElicitRequest;
 }
 
+type TestElicitationUI = ElicitationUIContext & {
+  select: ReturnType<typeof vi.fn>;
+  input: ReturnType<typeof vi.fn>;
+  notify: ReturnType<typeof vi.fn>;
+};
+
+function createUi(overrides: Partial<TestElicitationUI> = {}): TestElicitationUI {
+  return {
+    select: vi.fn(),
+    input: vi.fn(),
+    notify: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe("MCP elicitation", () => {
   beforeEach(() => {
     mocks.open.mockReset();
@@ -19,17 +35,17 @@ describe("MCP elicitation", () => {
 
   it("collects a form with stock Pi dialogs and lets the user review it before sending", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = {
+    const ui = createUi({
       select: vi.fn()
         .mockResolvedValueOnce("Continue")
         .mockResolvedValueOnce("Enter value")
         .mockResolvedValueOnce("Submit"),
       input: vi.fn().mockResolvedValueOnce("octocat"),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "github", ui: ui as any, allowUrl: true },
+      { serverName: "github", ui, allowUrl: true },
       request({
         mode: "form",
         message: "Please provide your GitHub username",
@@ -54,7 +70,7 @@ describe("MCP elicitation", () => {
 
   it("lets the user edit a value from the review screen", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = {
+    const ui = createUi({
       select: vi.fn()
         .mockResolvedValueOnce("Continue")
         .mockResolvedValueOnce("Enter value")
@@ -64,10 +80,10 @@ describe("MCP elicitation", () => {
         .mockResolvedValueOnce("Submit"),
       input: vi.fn().mockResolvedValueOnce("Old").mockResolvedValueOnce("New"),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: true },
+      { serverName: "demo", ui, allowUrl: true },
       request({
         mode: "form",
         message: "Choose a name",
@@ -84,7 +100,7 @@ describe("MCP elicitation", () => {
 
   it("validates form values and lets the user correct invalid input", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = {
+    const ui = createUi({
       select: vi.fn()
         .mockResolvedValueOnce("Continue")
         .mockResolvedValueOnce("Enter value")
@@ -94,10 +110,10 @@ describe("MCP elicitation", () => {
         .mockResolvedValueOnce("not-an-email")
         .mockResolvedValueOnce("octocat@example.com"),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: true },
+      { serverName: "demo", ui, allowUrl: true },
       request({
         mode: "form",
         message: "Contact details",
@@ -122,7 +138,7 @@ describe("MCP elicitation", () => {
     ["integer", true],
   ] as const)("rejects blank %s input and reprompts when required=%s", async (type, required) => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = {
+    const ui = createUi({
       select: vi.fn()
         .mockResolvedValueOnce("Continue")
         .mockResolvedValueOnce("Enter value")
@@ -130,10 +146,10 @@ describe("MCP elicitation", () => {
         .mockResolvedValueOnce("Submit"),
       input: vi.fn().mockResolvedValueOnce("   ").mockResolvedValueOnce("7"),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: false },
+      { serverName: "demo", ui, allowUrl: false },
       request({
         mode: "form",
         message: "Choose a quantity",
@@ -166,7 +182,7 @@ describe("MCP elicitation", () => {
       const select = vi.fn().mockResolvedValue(selection);
       await expect(handleElicitationRequest({
         serverName: "demo",
-        ui: { select } as any,
+        ui: createUi({ select }),
         allowUrl: true,
       }, params)).resolves.toEqual(expected);
       expect(select).toHaveBeenCalledOnce();
@@ -188,12 +204,12 @@ describe("MCP elicitation", () => {
 
     await expect(handleElicitationRequest({
       serverName: "demo",
-      ui: { select: vi.fn().mockResolvedValue("Decline") } as any,
+      ui: createUi({ select: vi.fn().mockResolvedValue("Decline") }),
       allowUrl: true,
     }, params)).resolves.toEqual({ action: "decline" });
     await expect(handleElicitationRequest({
       serverName: "demo",
-      ui: { select: vi.fn().mockResolvedValue(undefined) } as any,
+      ui: createUi({ select: vi.fn().mockResolvedValue(undefined) }),
       allowUrl: true,
     }, params)).resolves.toEqual({ action: "cancel" });
     expect(mocks.open).not.toHaveBeenCalled();
@@ -202,15 +218,15 @@ describe("MCP elicitation", () => {
   it("shows the server, host, and full URL before opening an accepted URL elicitation", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
     const onUrlAccepted = vi.fn();
-    const ui = {
+    const ui = createUi({
       select: vi.fn().mockResolvedValueOnce("Open"),
       input: vi.fn(),
       notify: vi.fn(),
-    };
+    });
     const url = "https://checkout.example.com/authorize?state=a%2Fb";
 
     const result = await handleElicitationRequest(
-      { serverName: "payments", ui: ui as any, allowUrl: true, onUrlAccepted },
+      { serverName: "payments", ui, allowUrl: true, onUrlAccepted },
       request({
         mode: "url",
         message: "Authorize the payment provider",
@@ -237,10 +253,10 @@ describe("MCP elicitation", () => {
 
   it("rejects URL mode when the client advertised form-only support", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = { select: vi.fn(), input: vi.fn(), notify: vi.fn() };
+    const ui = createUi();
 
     await expect(handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: false },
+      { serverName: "demo", ui, allowUrl: false },
       request({
         mode: "url",
         message: "Authorize",
@@ -253,10 +269,10 @@ describe("MCP elicitation", () => {
 
   it("rejects URL schemes that cannot be opened safely in a browser", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = { select: vi.fn(), input: vi.fn(), notify: vi.fn() };
+    const ui = createUi();
 
     await expect(handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: true },
+      { serverName: "demo", ui, allowUrl: true },
       request({
         mode: "url",
         message: "Open a file",
@@ -271,14 +287,14 @@ describe("MCP elicitation", () => {
   it("cancels URL elicitation when the browser cannot be opened", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
     mocks.open.mockRejectedValueOnce(new Error("no browser"));
-    const ui = {
+    const ui = createUi({
       select: vi.fn().mockResolvedValueOnce("Open"),
       input: vi.fn(),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: true },
+      { serverName: "demo", ui, allowUrl: true },
       request({
         mode: "url",
         message: "Authorize",
@@ -293,7 +309,7 @@ describe("MCP elicitation", () => {
 
   it("supports every primitive form field, defaults, and omission", async () => {
     const { handleElicitationRequest } = await import("../elicitation-handler.ts");
-    const ui = {
+    const ui = createUi({
       select: vi.fn()
         .mockResolvedValueOnce("Continue")
         .mockResolvedValueOnce("Use default")
@@ -307,10 +323,10 @@ describe("MCP elicitation", () => {
         .mockResolvedValueOnce("Submit"),
       input: vi.fn().mockResolvedValueOnce("42"),
       notify: vi.fn(),
-    };
+    });
 
     const result = await handleElicitationRequest(
-      { serverName: "demo", ui: ui as any, allowUrl: true },
+      { serverName: "demo", ui, allowUrl: true },
       request({
         mode: "form",
         message: "Configure the operation",

--- a/__tests__/sampling-handler.test.ts
+++ b/__tests__/sampling-handler.test.ts
@@ -54,12 +54,8 @@ const geminiFlash = {
   baseUrl: "https://generativelanguage.googleapis.com",
 } satisfies Model<"google-generative-ai">;
 
-type SamplingTestOptions = Omit<SamplingHandlerOptions, "modelRegistry"> & {
-  modelRegistry: Pick<SamplingHandlerOptions["modelRegistry"], "getAvailable" | "getApiKeyAndHeaders">;
-};
-
-function createOptions(overrides: Partial<SamplingTestOptions> = {}): SamplingHandlerOptions {
-  const options = {
+function createOptions(overrides: Partial<SamplingHandlerOptions> = {}): SamplingHandlerOptions {
+  return {
     serverName: "i18n",
     autoApprove: true,
     modelRegistry: {
@@ -69,12 +65,11 @@ function createOptions(overrides: Partial<SamplingTestOptions> = {}): SamplingHa
     getCurrentModel: vi.fn(() => undefined),
     getSignal: vi.fn(() => undefined),
     ...overrides,
-  } satisfies SamplingTestOptions;
-  return options as SamplingHandlerOptions;
+  };
 }
 
 async function runBasicSampling(
-  overrides: Partial<SamplingTestOptions>,
+  overrides: Partial<SamplingHandlerOptions>,
   modelPreferences?: ModelPreferences,
 ): Promise<void> {
   const { handleSamplingRequest } = await import("../sampling-handler.ts");

--- a/elicitation-handler.ts
+++ b/elicitation-handler.ts
@@ -14,8 +14,9 @@ import open from "open";
 
 export type ElicitationValue = string | number | boolean | string[] | undefined;
 type FormProperty = ElicitRequestFormParams["requestedSchema"]["properties"][string];
+type FieldCollectionResult = { status: "cancelled" } | { status: "collected"; value: ElicitationValue };
 
-export type ElicitationUIContext = ExtensionUIContext;
+export type ElicitationUIContext = Pick<ExtensionUIContext, "select" | "input" | "notify">;
 
 export interface ElicitationHandlerOptions {
   serverName: string;
@@ -56,7 +57,7 @@ export async function handleFormElicitation(
   const values: Record<string, ElicitationValue> = {};
   for (const [name, schema] of properties) {
     const value = await collectValidField(options.ui, params, name, schema);
-    if (!("value" in value)) return { action: "cancel" };
+    if (value.status === "cancelled") return { action: "cancel" };
     values[name] = value.value;
   }
 
@@ -64,7 +65,7 @@ export async function handleFormElicitation(
     const content = coerceAndValidateFormValues(params, values);
     const action = await options.ui.select(
       formatReview(options.serverName, properties, content),
-      properties.length > 0 ? ["Submit", "Edit", "Decline"] : ["Submit", "Decline"],
+      ["Submit", "Edit", "Decline"],
     );
     if (action === undefined) return { action: "cancel" };
     if (action === "Decline") return { action: "decline" };
@@ -77,7 +78,7 @@ export async function handleFormElicitation(
     if (!property) continue;
     const [name, schema] = property;
     const value = await collectValidField(options.ui, params, name, schema, values[name]);
-    if (!("value" in value)) return { action: "cancel" };
+    if (value.status === "cancelled") return { action: "cancel" };
     values[name] = value.value;
   }
 }
@@ -88,11 +89,11 @@ async function collectValidField(
   name: string,
   schema: FormProperty,
   current?: ElicitationValue,
-): Promise<{ cancelled: true } | { cancelled: false; value: ElicitationValue }> {
+): Promise<FieldCollectionResult> {
   const required = params.requestedSchema.required?.includes(name) === true;
   while (true) {
     const result = await collectField(ui, params, name, schema, current);
-    if (!("value" in result)) return result;
+    if (result.status === "cancelled") return result;
     try {
       coerceAndValidateFormValues({
         ...params,
@@ -116,7 +117,7 @@ async function collectField(
   name: string,
   schema: FormProperty,
   current?: ElicitationValue,
-): Promise<{ cancelled: true } | { cancelled: false; value: ElicitationValue }> {
+): Promise<FieldCollectionResult> {
   const required = params.requestedSchema.required?.includes(name) === true;
   const title = [schema.title ?? humanizeName(name), required ? "(required)" : "", schema.description]
     .filter(Boolean)
@@ -136,10 +137,10 @@ async function collectField(
     const omit = required ? undefined : uniqueAction("Omit", actions);
     if (omit) actions.push(omit);
     const action = await ui.select(title, actions);
-    if (action === undefined) return { cancelled: true };
-    if (action === useDefault) return { cancelled: false, value: schema.default };
-    if (action === omit) return { cancelled: false, value: undefined };
-    return { cancelled: false, value: choices[displays.indexOf(action)]?.value };
+    if (action === undefined) return { status: "cancelled" };
+    if (action === useDefault) return { status: "collected", value: schema.default };
+    if (action === omit) return { status: "collected", value: undefined };
+    return { status: "collected", value: choices[displays.indexOf(action)]?.value };
   }
 
   if (schema.type === "boolean") {
@@ -147,10 +148,10 @@ async function collectField(
     if (schema.default !== undefined) actions.push("Use default");
     if (!required) actions.push("Omit");
     const action = await ui.select(title, actions);
-    if (action === undefined) return { cancelled: true };
-    if (action === "Use default") return { cancelled: false, value: schema.default };
-    if (action === "Omit") return { cancelled: false, value: undefined };
-    return { cancelled: false, value: action === "Yes" };
+    if (action === undefined) return { status: "cancelled" };
+    if (action === "Use default") return { status: "collected", value: schema.default };
+    if (action === "Omit") return { status: "collected", value: undefined };
+    return { status: "collected", value: action === "Yes" };
   }
 
   if (schema.type === "array") {
@@ -158,9 +159,9 @@ async function collectField(
     if (schema.default !== undefined) actions.push("Use default");
     if (!required) actions.push("Omit");
     const action = await ui.select(title, actions);
-    if (action === undefined) return { cancelled: true };
-    if (action === "Use default") return { cancelled: false, value: schema.default };
-    if (action === "Omit") return { cancelled: false, value: undefined };
+    if (action === undefined) return { status: "cancelled" };
+    if (action === "Use default") return { status: "collected", value: schema.default };
+    if (action === "Omit") return { status: "collected", value: undefined };
 
     const choices = extractMultiSelectOptions(schema);
     const selected = new Set(Array.isArray(current) ? current : []);
@@ -168,8 +169,8 @@ async function collectField(
       const displays = uniqueLabels(choices.map(choice => selected.has(choice.value) ? `✓ ${choice.display}` : choice.display));
       const done = uniqueAction("Done", displays);
       const picked = await ui.select(title, [...displays, done]);
-      if (picked === undefined) return { cancelled: true };
-      if (picked === done) return { cancelled: false, value: [...selected] };
+      if (picked === undefined) return { status: "cancelled" };
+      if (picked === done) return { status: "collected", value: [...selected] };
       const choice = choices[displays.indexOf(picked)];
       if (!choice) continue;
       if (selected.has(choice.value)) selected.delete(choice.value);
@@ -181,11 +182,11 @@ async function collectField(
   if (schema.default !== undefined) actions.push("Use default");
   if (!required) actions.push("Omit");
   const action = await ui.select(title, actions);
-  if (action === undefined) return { cancelled: true };
-  if (action === "Use default") return { cancelled: false, value: schema.default };
-  if (action === "Omit") return { cancelled: false, value: undefined };
+  if (action === undefined) return { status: "cancelled" };
+  if (action === "Use default") return { status: "collected", value: schema.default };
+  if (action === "Omit") return { status: "collected", value: undefined };
   const entered = await ui.input(title, current === undefined ? undefined : String(current));
-  return entered === undefined ? { cancelled: true } : { cancelled: false, value: entered };
+  return entered === undefined ? { status: "cancelled" } : { status: "collected", value: entered };
 }
 
 export function coerceAndValidateFormValues(

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -12,11 +12,14 @@ import {
   type SamplingMessageContentBlock,
 } from "@modelcontextprotocol/client";
 
+export type SamplingUIContext = Pick<ExtensionUIContext, "confirm">;
+export type SamplingModelRegistry = Pick<ModelRegistry, "getAvailable" | "getApiKeyAndHeaders">;
+
 export interface SamplingHandlerOptions {
   serverName: string;
   autoApprove: boolean;
-  ui?: ExtensionUIContext;
-  modelRegistry: ModelRegistry;
+  ui?: SamplingUIContext;
+  modelRegistry: SamplingModelRegistry;
   getCurrentModel: () => Model<Api> | undefined;
   getSignal: () => AbortSignal | undefined;
 }


### PR DESCRIPTION
## Summary

This tightens the TypeScript shape of the MCP elicitation and sampling handlers without changing runtime behavior.

It narrows handler contracts to the UI and model-registry methods they use, makes field collection results an explicit discriminated union, removes an unreachable empty-form review branch, and replaces repeated test casts with typed helpers.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/elicitation-handler.test.ts __tests__/sampling-handler.test.ts`
- `git diff --check`

Fresh read-only review found no issues before publication. The changelog entry was added after review.
