### PR TITLE
fix: render closed JSON schema shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined MCP elicitation and sampling handler TypeScript contracts without changing runtime behavior.
 
 ### Fixed
+- Rendered closed JSON Schema object shapes that use `additionalProperties: false`. Thanks @giuseppecrj for PR #313.
 - Restored MCP sampling builds with current Pi AI releases by using its compatibility entry point. Thanks @eric-kansas for issue #308.
 - Simplified empty MCP form elicitation to one confirmation dialog. Thanks @shardulbee for issue #309.
 

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -146,7 +146,7 @@ describe("runMcpScript", () => {
         name: "fail",
         server: "fixture",
         description: "Return an MCP tool error",
-        inputTypeScript: "  value (string)",
+        inputTypeScript: "{ value?: string; }",
       },
       missing: {
         path: "fixture_ech",

--- a/__tests__/ts-shape.test.ts
+++ b/__tests__/ts-shape.test.ts
@@ -54,6 +54,43 @@ describe("renderTsShape", () => {
     })).toBe("{ query: string; }");
   });
 
+  it("renders closed objects with referenced union variants", () => {
+    expect(renderTsShape({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        blocks: { type: "array", items: { $ref: "#/$defs/block" } },
+      },
+      required: ["blocks"],
+      $defs: {
+        text: {
+          type: "object",
+          additionalProperties: false,
+          properties: { type: { const: "text" }, text: { type: "string" } },
+          required: ["type", "text"],
+        },
+        qr: {
+          type: "object",
+          additionalProperties: false,
+          properties: { type: { const: "qr" }, data: { type: "string" } },
+          required: ["type", "data"],
+        },
+        block: {
+          oneOf: [
+            { $ref: "#/$defs/text" },
+            { $ref: "#/$defs/qr" },
+          ],
+        },
+      },
+    })).toBe([
+      'type block = text | qr;',
+      'type text = { type: "text"; text: string; };',
+      'type qr = { type: "qr"; data: string; };',
+      "",
+      "{ blocks: block[]; }",
+    ].join("\n"));
+  });
+
   it("returns null for exotic schemas", () => {
     expect(renderTsShape({ if: { type: "string" }, then: { type: "number" } })).toBeNull();
     expect(renderTsShape({ $ref: "https://example.com/schema" })).toBeNull();

--- a/ts-shape.ts
+++ b/ts-shape.ts
@@ -113,8 +113,7 @@ function isSchema(value: unknown): value is Schema {
 function hasUnsupportedKeyword(schema: Schema): boolean {
   return UNSUPPORTED_KEYWORDS.some(keyword => {
     if (!Object.hasOwn(schema, keyword)) return false;
-    // `additionalProperties: false` is a closed-object constraint, not a
-    // shape that this renderer needs to understand.
+    // `additionalProperties: false` is a closed-object constraint, not a shape that this renderer needs to understand.
     return keyword !== "additionalProperties" || schema.additionalProperties !== false;
   });
 }

--- a/ts-shape.ts
+++ b/ts-shape.ts
@@ -111,7 +111,12 @@ function isSchema(value: unknown): value is Schema {
 }
 
 function hasUnsupportedKeyword(schema: Schema): boolean {
-  return UNSUPPORTED_KEYWORDS.some(keyword => Object.hasOwn(schema, keyword));
+  return UNSUPPORTED_KEYWORDS.some(keyword => {
+    if (!Object.hasOwn(schema, keyword)) return false;
+    // `additionalProperties: false` is a closed-object constraint, not a
+    // shape that this renderer needs to understand.
+    return keyword !== "additionalProperties" || schema.additionalProperties !== false;
+  });
 }
 
 function decodePointerToken(token: string): string {


### PR DESCRIPTION
## Summary

Treat `additionalProperties: false` as a supported closed-object constraint in the TypeScript schema renderer. This preserves validation semantics while allowing referenced `oneOf`/`$defs` variants to render in `mcp describe`.

For schemas such as Paperbridge's receipt input, `mcp describe` can now show the block union and its named definitions instead of falling back to a shallow `items` entry.

## Tests

- `bun test __tests__/ts-shape.test.ts`
- `bun run typecheck`

The full test suite was also attempted, but has unrelated environment-sensitive failures in callback port binding, OAuth/keyring storage, and child-process fixtures.
