### PR TITLE
fix: suppress app-only tool call intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Rendered closed JSON Schema object shapes that use `additionalProperties: false`. Thanks @giuseppecrj for PR #313.
+- Stopped app-only MCP tool calls from triggering model turns or persisting as UI intents. Thanks @VikashLoomba for issue #314.
 - Restored MCP sampling builds with current Pi AI releases by using its compatibility entry point. Thanks @eric-kansas for issue #308.
 - Simplified empty MCP form elicitation to one confirmation dialog. Thanks @shardulbee for issue #309.
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -84,6 +84,14 @@ describe("buildHostHtmlTemplate", () => {
       expect(html).toContain("closeOrShowDone");
       expect(html).toContain("visibilitychange");
     });
+
+    it("sends generated tool-call intents through a host-only endpoint", () => {
+      const html = buildHostHtmlTemplate(createMinimalInput());
+
+      expect(html).toContain('await post("/proxy/ui/generated-tool-call-intent", {');
+      expect(html).toContain("tool: params.name");
+      expect(html).not.toContain("_piGeneratedToolCallIntent");
+    });
   });
 
   describe("data injection", () => {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -631,6 +631,68 @@ describe("UiServer", () => {
       }, requestOptions);
     });
 
+    it("executes app-only tools without recording their synthetic call intent", async () => {
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "app result" }] });
+      const onMessage = vi.fn();
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{ name: "app_only", _meta: { ui: { visibility: ["app"] } } }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager, onMessage }));
+
+      const call = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "app_only", arguments: { value: 1 } },
+        },
+      });
+      const message = await request(`http://localhost:${handle.port}/proxy/ui/generated-tool-call-intent`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { tool: "app_only", arguments: { value: 1 }, isError: false },
+        },
+      });
+
+      expect(call.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "app result" }] } });
+      expect(callTool).toHaveBeenCalledWith({ name: "app_only", arguments: { value: 1 } }, undefined);
+      expect(message.body).toEqual({ ok: true, result: {} });
+      expect(handle.getSessionMessages().intents).toEqual([]);
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("keeps app-authored call_tool intents for app-only tools", async () => {
+      const onMessage = vi.fn();
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool: vi.fn() },
+          tools: [{ name: "app_only", _meta: { ui: { visibility: ["app"] } } }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager, onMessage }));
+      const params = {
+        type: "intent",
+        intent: "call_tool",
+        _piGeneratedToolCallIntent: true,
+        params: { tool: "app_only", reason: "user-requested" },
+      };
+
+      await request(`http://localhost:${handle.port}/proxy/ui/message`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params },
+      });
+
+      expect(handle.getSessionMessages().intents).toEqual([
+        { intent: "call_tool", params: { tool: "app_only", reason: "user-requested" } },
+      ]);
+      expect(onMessage).toHaveBeenCalledWith(params);
+    });
+
     it("returns a gated iframe call as an approval_denied tool result", async () => {
       const mockClient = { callTool: vi.fn() };
       const manager = createMockManager({
@@ -925,19 +987,39 @@ describe("UiServer", () => {
       expect(onMessage).toHaveBeenCalled();
     });
 
-    it("tracks intent messages", async () => {
-      handle = await startUiServer(createServerOptions());
+    it("tracks and forwards call_tool intents that do not name an app-only tool", async () => {
+      const onMessage = vi.fn();
+      handle = await startUiServer(createServerOptions({ onMessage }));
+      const params = { type: "intent", intent: "call_tool", params: { tool: "business_action" } };
 
       await request(`http://localhost:${handle.port}/proxy/ui/message`, {
         method: "POST",
-        body: {
-          token: handle.sessionToken,
-          params: { type: "intent", intent: "navigate", params: { to: "/home" } },
-        },
+        body: { token: handle.sessionToken, params },
       });
 
-      const messages = handle.getSessionMessages();
-      expect(messages.intents).toEqual([{ intent: "navigate", params: { to: "/home" } }]);
+      expect(handle.getSessionMessages().intents).toEqual([{ intent: "call_tool", params: { tool: "business_action" } }]);
+      expect(onMessage).toHaveBeenCalledWith(params);
+    });
+
+    it("tracks and forwards generated call intents for tools visible to both app and model", async () => {
+      const onMessage = vi.fn();
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool: vi.fn() },
+          tools: [{ name: "both", _meta: { ui: { visibility: ["model", "app"] } } }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager, onMessage }));
+      const expected = { type: "intent", intent: "call_tool", params: { tool: "both", isError: false } };
+
+      await request(`http://localhost:${handle.port}/proxy/ui/generated-tool-call-intent`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: { tool: "both", isError: false } },
+      });
+
+      expect(handle.getSessionMessages().intents).toEqual([{ intent: "call_tool", params: { tool: "both", isError: false } }]);
+      expect(onMessage).toHaveBeenCalledWith(expected);
     });
 
     it("tracks notification messages", async () => {

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -226,10 +226,10 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
       }
       const result = await post("/proxy/tools/call", params);
       // Notify agent about the tool call
-      await post("/proxy/ui/message", {
-        type: "intent",
-        intent: "call_tool",
-        params: { tool: params.name, arguments: params.arguments, isError: result.isError }
+      await post("/proxy/ui/generated-tool-call-intent", {
+        tool: params.name,
+        arguments: params.arguments,
+        isError: result.isError
       }).catch(() => {});
       return result;
     };

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -17,7 +17,7 @@ import type { McpServerManager } from "./server-manager.ts";
 import type { McpExtensionState } from "./state.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
-import { extractUiToolVisibility, isUiToolCallableByApp } from "./ui-tool-visibility.ts";
+import { extractUiToolVisibility, isUiToolCallableByApp, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import {
   createUiModelContextUpdate,
   extractUiPromptText,
@@ -144,6 +144,41 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       };
     }
   }
+
+  const isAppOnlyTool = (toolName: string): boolean => {
+    const toolDefinition = options.manager.getConnection(options.serverName)?.tools?.find((tool) => tool.name === toolName);
+    if (!toolDefinition) return false;
+    const visibility = extractUiToolVisibility(toolDefinition._meta);
+    return isUiToolCallableByApp(visibility) && !isUiToolVisibleToModel(visibility);
+  };
+
+  const recordUiMessage = async (msgParams: UiMessageParams): Promise<void> => {
+    const promptText = extractUiPromptText(msgParams);
+
+    // Track messages by type (order: prompt → intent → notify)
+    // Must match the order in index.ts onMessage handler
+    if (promptText) {
+      sessionMessages.prompts.push(promptText);
+      log.debug("UI prompt received", { prompt: promptText.slice(0, 100) });
+    } else if (msgParams.type === "intent" || msgParams.intent) {
+      const intentName = msgParams.intent ?? "";
+      if (intentName) {
+        sessionMessages.intents.push({
+          intent: intentName,
+          ...(msgParams.params !== undefined ? { params: msgParams.params } : {}),
+        });
+        log.debug("UI intent received", { intent: intentName });
+      }
+    } else if (msgParams.type === "notify" || msgParams.message) {
+      const notifyText = msgParams.message ?? "";
+      if (notifyText) {
+        sessionMessages.notifications.push(notifyText);
+        log.debug("UI notification", { message: notifyText.slice(0, 100) });
+      }
+    }
+
+    await options.onMessage?.(msgParams);
+  };
 
   const touchHeartbeat = () => {
     lastHeartbeatAt = Date.now();
@@ -476,33 +511,27 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         return;
       }
 
-      if (url.pathname === "/proxy/ui/message") {
-        const msgParams = params as UiMessageParams;
-        const promptText = extractUiPromptText(msgParams);
-        
-        // Track messages by type (order: prompt → intent → notify)
-        // Must match the order in index.ts onMessage handler
-        if (promptText) {
-          sessionMessages.prompts.push(promptText);
-          log.debug("UI prompt received", { prompt: promptText.slice(0, 100) });
-        } else if (msgParams.type === "intent" || msgParams.intent) {
-          const intentName = msgParams.intent ?? "";
-          if (intentName) {
-            sessionMessages.intents.push({
-              intent: intentName,
-              ...(msgParams.params !== undefined ? { params: msgParams.params } : {}),
-            });
-            log.debug("UI intent received", { intent: intentName });
-          }
-        } else if (msgParams.type === "notify" || msgParams.message) {
-          const notifyText = msgParams.message ?? "";
-          if (notifyText) {
-            sessionMessages.notifications.push(notifyText);
-            log.debug("UI notification", { message: notifyText.slice(0, 100) });
-          }
+      if (url.pathname === "/proxy/ui/generated-tool-call-intent") {
+        const tool = typeof params.tool === "string" ? params.tool : undefined;
+        if (tool && isAppOnlyTool(tool)) {
+          log.debug("Ignored generated app-only tool call intent", { tool });
+        } else {
+          await recordUiMessage({
+            type: "intent",
+            intent: "call_tool",
+            params: {
+              ...(tool !== undefined ? { tool } : {}),
+              ...(params.arguments !== undefined ? { arguments: params.arguments } : {}),
+              ...(params.isError !== undefined ? { isError: params.isError } : {}),
+            },
+          });
         }
-        
-        await options.onMessage?.(msgParams);
+        sendJson(res, 200, { ok: true, result: {} });
+        return;
+      }
+
+      if (url.pathname === "/proxy/ui/message") {
+        await recordUiMessage(params as UiMessageParams);
         sendJson(res, 200, { ok: true, result: {} });
         return;
       }


### PR DESCRIPTION
## Summary

This stops app-only MCP tool calls from waking the agent or persisting into completed UI session summaries.

The app call still executes and returns to the app. The suppression only applies to the generated `call_tool` intent when `params.tool` resolves to a current tool that is app-callable and not model-visible. Model-visible tools, omitted visibility, prompts, app-authored intents, notifications, and model-context updates keep their existing behavior.

Closes #314.

## Validation

- `npm run typecheck`
- `npx vitest run __tests__/ui-server.test.ts __tests__/ui-viewer-none.test.ts`
- `git diff --check origin/main..HEAD`

Fresh read-only review found no issues on the rebased exact head.
