### PR TITLE
fix: report connecting servers in tool search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Reported MCP servers still connecting after a zero-result tool search, so agents retry instead of treating the result as definitive. Thanks @Leon69924 for issue #316.
+
 ## [2.21.1] - 2026-08-08
 
 ### Changed

--- a/__tests__/disabled-server.test.ts
+++ b/__tests__/disabled-server.test.ts
@@ -43,6 +43,7 @@ function disabledState() {
     manager: {
       getConnection: vi.fn((name: string) => name === "disabled" ? connection : undefined),
       getAllConnections: vi.fn(() => new Map([["disabled", connection]])),
+      isConnecting: vi.fn(() => false),
       connect: vi.fn(),
       close: vi.fn(),
     },

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -29,6 +29,7 @@ function createState(): McpExtensionState {
     ]),
     manager: {
       getConnection: () => undefined,
+      isConnecting: () => false,
     },
     failureTracker: new Map(),
   } as unknown as McpExtensionState;
@@ -40,6 +41,36 @@ describe("proxy discovery", () => {
 
     expect(result.content[0].text).toBe('No tools matching "read"');
     expect(result.details).toMatchObject({ count: 0, matches: [] });
+  });
+
+  it("reports only the filtered server that is still connecting after a zero-result search", () => {
+    const state = createState();
+    state.config.mcpServers.other = { command: "npx", args: ["other"] };
+    state.manager.isConnecting = () => true;
+
+    const result = executeSearch(state, "read", false, "demo");
+
+    expect(result.content[0].text).toBe(
+      'No tools matching "read" in "demo" Server "demo" is still connecting; retry in a moment.',
+    );
+    expect(result.details).toMatchObject({ count: 0, matches: [], connectingServers: ["demo"] });
+  });
+
+  it("reports all enabled servers that are still connecting after an unfiltered zero-result search", () => {
+    const state = createState();
+    state.config.mcpServers = {
+      zeta: { command: "npx", args: ["zeta"] },
+      disabled: { command: "npx", args: ["disabled"], disabled: true },
+      alpha: { command: "npx", args: ["alpha"] },
+    };
+    state.manager.isConnecting = name => name !== "disabled";
+
+    const result = executeSearch(state, "read");
+
+    expect(result.content[0].text).toBe(
+      'No tools matching "read" Servers "alpha", "zeta" are still connecting; retry in a moment.',
+    );
+    expect(result.details).toMatchObject({ count: 0, matches: [], connectingServers: ["alpha", "zeta"] });
   });
 
   it("rejects regex queries longer than the safety cap", () => {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -525,10 +525,28 @@ export function executeSearch(
 
   const page = paginate(matches, offset, limit);
   if (page.total === 0) {
+    const connectingServers = server
+      ? state.config.mcpServers[server] && state.manager.isConnecting(server) ? [server] : []
+      : Object.keys(state.config.mcpServers)
+        .filter(name => !isServerDisabled(state.config.mcpServers[name]) && state.manager.isConnecting(name))
+        .sort((a, b) => a.localeCompare(b));
     const msg = server ? `No tools matching "${query}" in "${server}"` : `No tools matching "${query}"`;
+    const connectingMessage = connectingServers.length === 1
+      ? ` Server "${connectingServers[0]}" is still connecting; retry in a moment.`
+      : connectingServers.length > 1
+        ? ` Servers ${connectingServers.map(name => `"${name}"`).join(", ")} are still connecting; retry in a moment.`
+        : "";
     return {
-      content: [{ type: "text" as const, text: msg }],
-      details: { mode: "search", matches: [], count: 0, hasMore: false, nextOffset: null, query },
+      content: [{ type: "text" as const, text: `${msg}${connectingMessage}` }],
+      details: {
+        mode: "search",
+        matches: [],
+        count: 0,
+        hasMore: false,
+        nextOffset: null,
+        query,
+        ...(connectingServers.length > 0 ? { connectingServers } : {}),
+      },
     };
   }
 

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1030,6 +1030,10 @@ export class McpServerManager {
     return false;
   }
 
+  isConnecting(name: string): boolean {
+    return this.connectPromises.has(name);
+  }
+
   getConnection(name: string): ServerConnection | undefined {
     return this.connections.get(name);
   }


### PR DESCRIPTION
Closes #316.

This reports configured MCP servers that are still connecting when a tool search has no matches. Filtered searches name only the selected server. Unfiltered searches list all relevant enabled servers in stable order. Normal no-match results remain unchanged.

The manager exposes only a read-only connection-state query. Search details include `connectingServers` so callers can inspect the condition.

Validation:
- focused discovery and disabled-server tests: 24 passed
- TypeScript typecheck passed
- candidate full suite: 970 tests passed; the two visualizer artifact tests passed after the CI-required example build
- exact-base diff and merge checks passed

Thanks @Leon69924 for the report.
