### PR TITLE
fix: size OAuth credential chunks below the Windows store limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reported MCP servers still connecting after a zero-result tool search, so agents retry instead of treating the result as definitive. Thanks @Leon69924 for issue #316.
-- Sized OAuth credential chunks below the Windows Credential Manager per-value limit, so oversized OAuth records persist on Windows instead of failing at every payload size. The previous 1800-character chunk size exceeded the 1280-character ceiling, which left the chunking added in #246 ineffective on Windows.
+- Sized OAuth credential chunks below the Windows Credential Manager per-value limit, so oversized OAuth records persist on Windows instead of failing at every payload size. The previous 1800-character chunk size exceeded the 1280-character ceiling, which left the chunking added in #246 ineffective on Windows. Thanks @CrazyCoder for PR #318.
 
 ## [2.21.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reported MCP servers still connecting after a zero-result tool search, so agents retry instead of treating the result as definitive. Thanks @Leon69924 for issue #316.
+- Sized OAuth credential chunks below the Windows Credential Manager per-value limit, so oversized OAuth records persist on Windows instead of failing at every payload size. The previous 1800-character chunk size exceeded the 1280-character ceiling, which left the chunking added in #246 ineffective on Windows.
 
 ## [2.21.1] - 2026-08-08
 

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -16,6 +16,12 @@ import {
   saveAuthEntry,
 } from "../mcp-auth.ts";
 
+/**
+ * Windows Credential Manager stores at most CRED_MAX_CREDENTIAL_BLOB_SIZE
+ * (2560 bytes) as UTF-16, so a single value cannot exceed 1280 characters.
+ */
+const AUTH_SECRET_VALUE_LIMIT = 1280;
+
 describe("OAuth credential-store diagnostics", () => {
   it("recognizes a revoked Linux keyring through the error cause chain", () => {
     const nativeError = new Error("Couldn't access platform storage: KeyRevoked", {
@@ -156,7 +162,50 @@ describe("mcp-auth storage paths", () => {
     const manifest = JSON.parse(manifestEntry![1]) as { __piMcpAdapterOAuthChunked?: number; chunkCount?: number };
     expect(manifest.__piMcpAdapterOAuthChunked).toBe(1);
     expect(chunkEntries).toHaveLength(manifest.chunkCount);
-    expect(chunkEntries.every(([, payload]) => payload.length <= 1800)).toBe(true);
+    expect(chunkEntries.every(([, payload]) => payload.length <= AUTH_SECRET_VALUE_LIMIT)).toBe(true);
+  });
+
+  it("persists records that exceed the strictest per-value store limit", () => {
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "sizelimited";
+    const accessToken = "x".repeat(5000);
+
+    saveAuthEntry("size-limited-large", { tokens: { accessToken } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("size-limited-large")?.tokens?.accessToken).toBe(accessToken);
+    expect(getTestAuthSecretStoreEntries().every(([, payload]) => payload.length <= AUTH_SECRET_VALUE_LIMIT)).toBe(true);
+  });
+
+  it("persists records just above the per-value limit that are too small for a naive chunk threshold", () => {
+    // Regression: a threshold above the store limit skipped chunking entirely,
+    // so records in this band failed to persist on Windows at any payload size.
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "sizelimited";
+    const accessToken = "x".repeat(AUTH_SECRET_VALUE_LIMIT + 200);
+
+    saveAuthEntry("size-limited-boundary", { tokens: { accessToken } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("size-limited-boundary")?.tokens?.accessToken).toBe(accessToken);
+    expect(getTestAuthSecretStoreEntries().every(([, payload]) => payload.length <= AUTH_SECRET_VALUE_LIMIT)).toBe(true);
+  });
+
+  it("keeps small records in a single entry on a size-limited store", () => {
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "sizelimited";
+
+    saveAuthEntry("size-limited-small", { tokens: { accessToken: "small" } }, "https://example.com/mcp");
+
+    expect(getAuthEntry("size-limited-small")?.tokens?.accessToken).toBe("small");
+    const entries = getTestAuthSecretStoreEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0][0]).not.toContain(".chunk.");
+  });
+
+  it("clears chunked records written to a size-limited store", () => {
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "sizelimited";
+    saveAuthEntry("size-limited-remove", { tokens: { accessToken: "x".repeat(5000) } }, "https://example.com/mcp");
+    expect(getTestAuthSecretStoreEntries().some(([account]) => account.includes(".chunk."))).toBe(true);
+
+    clearAllCredentials("size-limited-remove");
+
+    expect(getTestAuthSecretStoreEntries()).toHaveLength(0);
   });
 
   it("returns unavailable status when a stored chunk cannot be read", () => {

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -22,7 +22,16 @@ import { resolveConfiguredOAuthDir } from './config.ts';
 const require = createRequire(import.meta.url);
 const AUTH_SECRET_SERVICE = 'pi-mcp-adapter.oauth';
 const TEST_AUTH_STORE_ENV = 'PI_MCP_ADAPTER_TEST_AUTH_STORE';
-const AUTH_SECRET_CHUNK_SIZE = 1800;
+/**
+ * Windows Credential Manager caps one value at CRED_MAX_CREDENTIAL_BLOB_SIZE
+ * (2560 bytes) and stores it as UTF-16, so the real ceiling is
+ * AUTH_SECRET_VALUE_LIMIT characters. Chunks must stay below that, and so must
+ * the threshold that decides whether to chunk at all, or oversized records still
+ * fail to persist on Windows.
+ */
+const AUTH_SECRET_CHUNK_SIZE = 1000;
+/** Largest single value the strictest supported credential store accepts. */
+const AUTH_SECRET_VALUE_LIMIT = 1280;
 const KEYRING_RECOVERY_DISABLED_ENV = 'PI_MCP_ADAPTER_DISABLE_KEYRING_RECOVERY';
 const KEYRING_RECOVERY_KEYCTL_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL';
 const KEYRING_RECOVERY_NODE_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE';
@@ -163,6 +172,22 @@ const keyringAuthSecretStore: AuthSecretStore = {
   },
 };
 
+/** Mimics the Windows Credential Manager per-value ceiling for tests. */
+const sizeLimitedAuthSecretStore: AuthSecretStore = {
+  read(account) {
+    return memoryAuthEntries.get(account);
+  },
+  write(account, payload) {
+    if (payload.length > AUTH_SECRET_VALUE_LIMIT) {
+      throw new Error(`Value of 'password encoded as UTF-16' is longer than the platform limit of ${AUTH_SECRET_VALUE_LIMIT * 2} chars`);
+    }
+    memoryAuthEntries.set(account, payload);
+  },
+  remove(account) {
+    memoryAuthEntries.delete(account);
+  },
+};
+
 const unavailableAuthSecretStore: AuthSecretStore = {
   read() {
     throw new Error('simulated secure credential store unavailable');
@@ -205,6 +230,7 @@ export function removeTestAuthSecretStoreEntry(account: string): void {
 
 function getAuthSecretStore(): AuthSecretStore {
   if (process.env[TEST_AUTH_STORE_ENV] === 'memory') return memoryAuthSecretStore;
+  if (process.env[TEST_AUTH_STORE_ENV] === 'sizelimited') return sizeLimitedAuthSecretStore;
   if (process.env[TEST_AUTH_STORE_ENV] === 'unavailable') return unavailableAuthSecretStore;
   if (process.env[TEST_AUTH_STORE_ENV] === 'keyrevoked') return keyRevokedAuthSecretStore;
   return keyringAuthSecretStore;


### PR DESCRIPTION
## Summary

`AUTH_SECRET_CHUNK_SIZE` is 1800, which is above the Windows Credential Manager per-value limit, so OAuth records that need chunking never persist on Windows.

Windows Credential Manager caps one credential blob at `CRED_MAX_CREDENTIAL_BLOB_SIZE` (2560 bytes) and stores the value as UTF-16. The real ceiling is 1280 characters. The 1800 constant is used in two places, and both are above that ceiling:

- `writeSecureAuthEntryToStore` chunks only when the payload is longer than 1800 characters.
- Each chunk it then writes is up to 1800 characters.

The chunking added in #246 is therefore ineffective on Windows at every payload size:

| Payload | Behavior | Result |
|---|---|---|
| 1280 characters or less | single write | works |
| 1281 to 1800 characters | no chunking at all | the single write fails |
| more than 1800 characters | chunking runs | every chunk is still above 1280, so it fails |

Both failing bands report:

```text
Failed to write OAuth credentials for <server> to the OS secure credential store
```

OAuth completes with the authorization server and then cannot persist. This is the failure reported in #223, which is still reachable on Windows after the change that closed it.

Measured with `@napi-rs/keyring` 1.3.0 on Windows 11 x64, build 26200:

```text
write 1000 -> OK (readback 1000)
write 1800 -> FAIL: Value of 'password encoded as UTF-16' is longer than the platform limit of 2560 chars
max ASCII chars that fit = 1280
```

## Change

`AUTH_SECRET_CHUNK_SIZE` goes from 1800 to 1000. A new constant `AUTH_SECRET_VALUE_LIMIT` (1280) names the platform ceiling, so the relation between the chunk size and the limit is explicit in the source.

There is no storage-format change. The manifest and the chunk-account layout are the same. Existing single-entry credentials still read. Existing chunked records are rewritten under a new digest on the next save, and the stale chunks are removed.

## Why the current tests do not catch this

The memory test store accepts a value of any size, and the chunk assertion compares payload lengths against the same 1800 constant the production code uses. The test passes whether or not the value is writable on a real Windows store.

This PR adds a `sizelimited` test store. It enforces the 1280-character ceiling and throws the message the native store throws. Four tests run against it:

1. A 5000-character record persists, and every stored value stays within the limit.
2. A record of 1480 characters persists. The old threshold skipped chunking for this band.
3. A small record stays in one entry, with no chunks.
4. `clearAllCredentials` removes a chunked record completely.

All four fail against 1800 and pass against 1000.

## Verification

`npm run typecheck` passes. `npx vitest run __tests__/mcp-auth-storage.test.ts` gives 15 passed and 2 failed.

The 2 failures are the Linux `keyctl` recovery harness. It is a bash script and cannot spawn on Windows. The same 2 tests fail on unmodified `main` in this checkout, and CI runs `ubuntu-latest`.

The full `vitest` run and `npm run test:oauth` fail the same tests before and after this change. I compared the failing test names against a stashed baseline of `main`.

I also verified the fix live. An MCP OAuth flow over `streamable-http` that failed at the credential write now completes, and the record round-trips through Windows Credential Manager.
