### PR TITLE
fix: harden local config and OAuth state parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reported MCP servers still connecting after a zero-result tool search, so agents retry instead of treating the result as definitive. Thanks @Leon69924 for issue #316.
+- Rejected malformed MCP config server entries and persisted OAuth credential records at their trust boundaries, so invalid local state fails before it reaches runtime connection or token code.
 - Sized OAuth credential chunks below the Windows Credential Manager per-value limit, so oversized OAuth records persist on Windows instead of failing at every payload size. The previous 1800-character chunk size exceeded the 1280-character ceiling, which left the chunking added in #246 ineffective on Windows. Thanks @CrazyCoder for PR #318.
 
 ## [2.21.1] - 2026-08-08

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -13,14 +13,14 @@ The Pi MCP Adapter uses the official MCP SDK's built-in OAuth implementation, wh
 
 ## Features
 
-- ✅ **PKCE (S256)** - Mandatory code challenge method for OAuth 2.1
-- ✅ **Automatic Callback Server** - Local browser redirects automatically when available
-- ✅ **Manual Remote Flow** - Copy auth URLs and pasted redirect URLs/codes for headless SSH sessions
-- ✅ **Dynamic Client Registration fallback** - Registers when no pre-registered `clientId` is configured and the server supports registration
-- ✅ **Auto-Discovery** - Discovers OAuth endpoints from server metadata
-- ✅ **Automatic Token Refresh** - SDK handles expired tokens automatically
-- ✅ **State Parameter Validation** - CSRF protection
-- ✅ **Secure Token Storage** - Persistent OAuth entries are stored in the operating system credential store
+- **PKCE (S256)** - Mandatory code challenge method for OAuth 2.1
+- **Automatic Callback Server** - Local browser redirects automatically when available
+- **Manual Remote Flow** - Copy auth URLs and pasted redirect URLs/codes for headless SSH sessions
+- **Dynamic Client Registration fallback** - Registers when no pre-registered `clientId` is configured and the server supports registration
+- **Auto-Discovery** - Discovers OAuth endpoints from server metadata
+- **Automatic Token Refresh** - SDK handles expired tokens automatically
+- **State Parameter Validation** - CSRF protection
+- **Secure Token Storage** - Persistent OAuth entries are stored in the operating system credential store
 
 ## Configuration
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -21,6 +21,26 @@ describe("config discovery", () => {
     process.chdir(originalCwd);
   });
 
+  it("drops malformed server entries at the config boundary", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-config-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-config-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(project, ".mcp.json"), {
+      mcpServers: {
+        valid: { command: "node" },
+        nullEntry: null,
+        listEntry: [],
+        stringEntry: "node",
+      },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+
+    expect(loadMcpConfig().mcpServers).toEqual({ valid: { command: "node" } });
+  });
+
   it("loads Agent Plugin MCP servers from configured plugin paths", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-agent-plugin-project-"));

--- a/config.ts
+++ b/config.ts
@@ -638,22 +638,32 @@ function readValidatedConfig(path: string, label: string): McpConfig | null {
 }
 
 function validateConfig(raw: unknown): McpConfig {
-  if (!raw || typeof raw !== "object") {
-    return { mcpServers: {} };
-  }
-
-  const obj = raw as Record<string, unknown>;
-  const servers = obj.mcpServers ?? obj["mcp-servers"] ?? {};
-
-  if (typeof servers !== "object" || servers === null || Array.isArray(servers)) {
+  if (!isRecord(raw)) {
     return { mcpServers: {} };
   }
 
   return {
-    mcpServers: servers as Record<string, ServerEntry>,
-    ...(Array.isArray(obj.imports) ? { imports: obj.imports as ImportKind[] } : {}),
-    ...(obj.settings !== undefined ? { settings: obj.settings as McpSettings } : {}),
+    mcpServers: toServerEntries(raw.mcpServers ?? raw["mcp-servers"]),
+    ...(Array.isArray(raw.imports) ? { imports: raw.imports as ImportKind[] } : {}),
+    ...(raw.settings !== undefined ? { settings: raw.settings as McpSettings } : {}),
   };
+}
+
+function toServerEntries(servers: unknown): Record<string, ServerEntry> {
+  if (!isRecord(servers)) return {};
+  const entries: Record<string, ServerEntry> = {};
+  for (const [name, entry] of Object.entries(servers)) {
+    if (isServerEntry(entry)) entries[name] = entry;
+  }
+  return entries;
+}
+
+function isServerEntry(value: unknown): value is ServerEntry {
+  return isRecord(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function mergeOpenCodeConfigs(base: Record<string, unknown>, next: Record<string, unknown>): Record<string, unknown> {
@@ -787,12 +797,13 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
       continue;
     }
 
-    if (kind !== "codex" || !entry || typeof entry !== "object" || Array.isArray(entry)) {
-      mappedServers[name] = entry as ServerEntry;
+    if (!isRecord(entry)) continue;
+    if (kind !== "codex") {
+      mappedServers[name] = entry;
       continue;
     }
 
-    const mapped = { ...(entry as Record<string, unknown>) };
+    const mapped = { ...entry };
     const bearerTokenEnv = mapped.bearer_token_env_var;
     const httpHeaders = mapped.http_headers;
     const envHttpHeaders = mapped.env_http_headers;

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -44,6 +44,7 @@ Current gaps:
 | --- | --- |
 | `auth/basic-cimd` | The adapter does not yet publish an HTTPS Client ID Metadata Document; omitted `oauth.clientId` falls back to Dynamic Client Registration when the server supports it. |
 | `auth/scope-step-up` | Pi's user-gated OAuth flow cannot yet resume the SDK's in-call 403 scope challenge with the widened scope. |
+| `auth/2025-03-26-oauth-metadata-backcompat` | The SDK rejects authorization metadata whose issuer differs from the identifier used to fetch it; the adapter keeps the strict RFC 8414 mix-up protection. |
 | `auth/client-credentials-jwt` | Private-key JWT client authentication is not configured by the adapter. |
 | `auth/cross-app-access-complete-flow` | The adapter does not implement SEP-990 token exchange and JWT bearer grants. |
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -667,14 +667,12 @@ export async function authenticate(
   }
 
   const operation = (async (): Promise<AuthStatus> => {
-    // Start auth flow
     const { authorizationUrl } = await startAuth(serverName, serverUrl, definition, {
       ...options,
       ...(signal ? { signal } : {}),
       runtime,
     })
 
-    // If no auth URL needed, already authenticated
     if (!authorizationUrl) {
       return "authenticated"
     }
@@ -708,13 +706,11 @@ export async function authenticate(
         console.warn(`MCP Auth: Failed to open browser for ${serverName}; waiting for manual callback`, { error })
       }
 
-      // Wait for callback
       const callbackResult = await abortable(callbackPromise, signal)
 
       // The callback server accepted only the flow-local reserved state.
       throwIfAborted(signal)
 
-      // Complete the auth
       return await completeAuth(serverName, callbackResult, {
         ...options,
         ...(signal ? { signal } : {}),
@@ -758,25 +754,21 @@ export async function getValidToken(
   const authStorageOptions = options.authStorageOptions ?? {}
   const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
-  // Check if we have valid tokens
   const entry = await getAuthForUrl(serverName, serverUrl, authStorageOptions)
   throwIfAborted(signal)
   if (!entry?.tokens) {
     return null
   }
 
-  // Check expiration
   const expired = await isTokenExpired(serverName, authStorageOptions)
   if (expired === false) {
     return entry.tokens
   }
 
   if (expired === true && entry.tokens.refreshToken) {
-    // Token is expired, try to refresh
     console.log(`MCP Auth: Token expired for ${serverName}, attempting refresh`)
 
     try {
-      // Create auth provider for token refresh
       const authProvider = new McpOAuthProvider(serverName, serverUrl, {}, {
         onRedirect: async () => {},
       }, authStorageOptions, runtime.signal)

--- a/mcp-auth.test.ts
+++ b/mcp-auth.test.ts
@@ -159,6 +159,20 @@ describe("mcp-auth", () => {
       assert.strictEqual(getAuthEntry("legacy-import")?.tokens?.accessToken, "legacy-token")
     })
 
+    it("should reject malformed legacy plaintext entries", () => {
+      const filePath = getAuthEntryFilePath("legacy-invalid")
+      mkdirSync(dirname(filePath), { recursive: true })
+      writeFileSync(filePath, JSON.stringify({
+        tokens: { refreshToken: "missing-access-token" },
+      }), "utf-8")
+
+      assert.throws(
+        () => getAuthEntry("legacy-invalid"),
+        /Failed to parse OAuth credentials.*invalid credential shape/,
+      )
+      assert.strictEqual(existsSync(filePath), true)
+    })
+
     it("should fail closed when the secure credential store is unavailable", () => {
       const previous = process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE
       process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable"

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -427,7 +427,99 @@ function parseJsonPayload(serverName: string, payload: string, source: string): 
 }
 
 function parseAuthEntryPayload(serverName: string, payload: string, source: string): AuthEntry {
-  return parseJsonPayload(serverName, payload, source) as AuthEntry;
+  const parsed = parseJsonPayload(serverName, payload, source);
+  const entry = toAuthEntry(parsed);
+  if (!entry) {
+    throw new Error(`Failed to parse OAuth credentials for ${serverName} from ${source}: invalid credential shape`);
+  }
+  return entry;
+}
+
+function toAuthEntry(value: unknown): AuthEntry | undefined {
+  const entry = toRecord(value);
+  if (!entry) return undefined;
+
+  const codeVerifier = optionalString(entry.codeVerifier);
+  const oauthState = optionalString(entry.oauthState);
+  const serverUrl = optionalString(entry.serverUrl);
+  if (codeVerifier === null || oauthState === null || serverUrl === null) return undefined;
+
+  const tokens = entry.tokens === undefined ? undefined : toStoredTokens(entry.tokens);
+  const clientInfo = entry.clientInfo === undefined ? undefined : toStoredClientInfo(entry.clientInfo);
+  if ((entry.tokens !== undefined && !tokens) || (entry.clientInfo !== undefined && !clientInfo)) return undefined;
+
+  const authEntry: AuthEntry = {};
+  if (tokens) authEntry.tokens = tokens;
+  if (clientInfo) authEntry.clientInfo = clientInfo;
+  if (codeVerifier !== undefined) authEntry.codeVerifier = codeVerifier;
+  if (oauthState !== undefined) authEntry.oauthState = oauthState;
+  if (serverUrl !== undefined) authEntry.serverUrl = serverUrl;
+  return authEntry;
+}
+
+function toStoredTokens(value: unknown): StoredTokens | undefined {
+  const tokens = toRecord(value);
+  if (!tokens || typeof tokens.accessToken !== 'string') return undefined;
+
+  const refreshToken = optionalString(tokens.refreshToken);
+  const scope = optionalString(tokens.scope);
+  const issuer = optionalString(tokens.issuer);
+  const expiresAt = optionalNumber(tokens.expiresAt);
+  if (refreshToken === null || scope === null || issuer === null || expiresAt === null) return undefined;
+
+  const storedTokens: StoredTokens = { accessToken: tokens.accessToken };
+  if (refreshToken !== undefined) storedTokens.refreshToken = refreshToken;
+  if (expiresAt !== undefined) storedTokens.expiresAt = expiresAt;
+  if (scope !== undefined) storedTokens.scope = scope;
+  if (issuer !== undefined) storedTokens.issuer = issuer;
+  return storedTokens;
+}
+
+function toStoredClientInfo(value: unknown): StoredClientInfo | undefined {
+  const clientInfo = toRecord(value);
+  if (!clientInfo || typeof clientInfo.clientId !== 'string') return undefined;
+
+  const clientSecret = optionalString(clientInfo.clientSecret);
+  const issuer = optionalString(clientInfo.issuer);
+  const clientIdIssuedAt = optionalNumber(clientInfo.clientIdIssuedAt);
+  const clientSecretExpiresAt = optionalNumber(clientInfo.clientSecretExpiresAt);
+  const configPreRegistered = optionalBoolean(clientInfo.configPreRegistered);
+  if (clientSecret === null || issuer === null || clientIdIssuedAt === null || clientSecretExpiresAt === null || configPreRegistered === null) return undefined;
+
+  const storedClient: StoredClientInfo = { clientId: clientInfo.clientId };
+  const redirectUris = stringArray(clientInfo.redirectUris);
+  if (clientSecret !== undefined) storedClient.clientSecret = clientSecret;
+  if (clientIdIssuedAt !== undefined) storedClient.clientIdIssuedAt = clientIdIssuedAt;
+  if (clientSecretExpiresAt !== undefined) storedClient.clientSecretExpiresAt = clientSecretExpiresAt;
+  if (redirectUris !== undefined) storedClient.redirectUris = redirectUris;
+  if (issuer !== undefined) storedClient.issuer = issuer;
+  if (configPreRegistered !== undefined) storedClient.configPreRegistered = configPreRegistered;
+  return storedClient;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function optionalString(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'string' ? value : null;
+}
+
+function optionalNumber(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? value : null;
+}
+
+function optionalBoolean(value: unknown): boolean | null | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'boolean' ? value : null;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every(uri => typeof uri === 'string') ? value : undefined;
 }
 
 function isAuthEntryChunkManifest(value: unknown): value is AuthEntryChunkManifest {

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -179,10 +179,10 @@ function extractUiMeta(meta: Record<string, unknown> | undefined): UiResourceMet
 
   const ui = isRecord(meta.ui) ? meta.ui : undefined;
   const out: UiResourceMeta = {};
-  const openAiCsp = hasOwnProperty(meta, "openai/widgetCSP")
+  const openAiCsp = Object.hasOwn(meta, "openai/widgetCSP")
     ? normalizeOpenAiWidgetCsp(meta["openai/widgetCSP"])
     : undefined;
-  const hasStandardCsp = !!ui && hasOwnProperty(ui, "csp");
+  const hasStandardCsp = !!ui && Object.hasOwn(ui, "csp");
   const standardCspValue = hasStandardCsp ? ui.csp : undefined;
 
   if (hasStandardCsp && !isRecord(standardCspValue)) {
@@ -196,7 +196,7 @@ function extractUiMeta(meta: Record<string, unknown> | undefined): UiResourceMet
       out.csp = { ...openAiCsp, ...standardCsp };
       if (isRecord(standardCspValue)) {
         for (const [, standardField] of OPENAI_CSP_FIELD_MAPPINGS) {
-          if (hasOwnProperty(standardCspValue, standardField) && !copyStringArray(standardCspValue[standardField])) {
+          if (Object.hasOwn(standardCspValue, standardField) && !copyStringArray(standardCspValue[standardField])) {
             delete out.csp[standardField];
           }
         }
@@ -243,10 +243,6 @@ function copyStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string")
     ? [...value]
     : undefined;
-}
-
-function hasOwnProperty(record: Record<string, unknown>, property: string): boolean {
-  return Object.prototype.hasOwnProperty.call(record, property);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- reject malformed MCP config server entries before they reach runtime code
- validate persisted OAuth credential records before returning `AuthEntry`, while preserving recovery from malformed redirect URI metadata
- remove local deslop noise in docs, comments, and a pass-through helper

## Validation
- `npm run typecheck`
- `npm test`
- `npm run test:oauth`
- `npm run test:conformance`
- `npm test -- __tests__/mcp-auth-flow-client-credentials.test.ts -t "re-registers dynamic OAuth clients when cached redirect URI metadata is malformed"`
- `git diff --check`
- fresh exact-diff review before publication: no release-blocking issues

## Static cleanup signals
- `npx fallow audit` was used during review. After the CI-failure fix, it still reports inherited dependency/dead-code leads and flags the OAuth sanitizer as a complexity lead. The runtime gates above cover the accepted behavior.
