### PR TITLE
fix(oauth): name the host app on the callback pages, and restyle them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Named OAuth callback pages and dynamic client registrations after rebranded Pi hosts, while preserving stock Pi defaults and avoiding guessed client homepages. Thanks @grinich for PR #320.
+
 ## [2.21.2] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `oauth.scope` | Requested OAuth scopes |
 | `oauth.redirectUri` | Exact localhost redirect URI for browser OAuth, including port and path, for providers that pre-register callbacks |
 | `oauth.clientName` | Client display name advertised during Dynamic Client Registration fallback |
-| `oauth.clientUri` | Client homepage URI advertised during Dynamic Client Registration fallback |
+| `oauth.clientUri` | Client homepage URI advertised during Dynamic Client Registration fallback. Defaults to `piConfig.clientUri` from the host's manifest when set, and is omitted rather than guessed under a rebranded host |
 | `oauth.skipIssuerMetadataValidation` | `true` disables the OAuth authorization-server metadata issuer check for this server. This weakens OAuth mix-up protection and should only be used for known-misconfigured internal servers while their metadata is being fixed. |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation. A leading `!` in `bearerToken` runs a command when the HTTP server connects; use `!!` for a literal leading `!`. |
 | `lifecycle` | `"lazy"` (default), `"eager"`, `"keep-alive"`, or `"lazy-keep-alive"` |

--- a/agent-dir.ts
+++ b/agent-dir.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -17,4 +18,29 @@ export function getAgentDir(): string {
 
 export function getAgentPath(...segments: string[]): string {
   return join(getAgentDir(), ...segments);
+}
+
+/**
+ * What the host calls itself.
+ *
+ * pi supports rebranding through `piConfig.name` in the package.json that its
+ * `getPackageDir()` resolves, and distributions built on pi (arc, tau, …) point
+ * `PI_PACKAGE_DIR` at their own manifest. Read that manifest directly rather
+ * than importing pi: this package deliberately depends on pi-ai and pi-tui
+ * only, and `getAgentDir()` above reads its env var the same self-contained way.
+ *
+ * Falls back to "pi", which is what pi's own APP_NAME resolves to.
+ */
+export function getAppName(): string {
+  const dir = process.env.PI_PACKAGE_DIR?.trim()
+  if (!dir) return "pi"
+  try {
+    const manifest = JSON.parse(readFileSync(join(resolve(dir), "package.json"), "utf8")) as {
+      piConfig?: { name?: unknown }
+    }
+    const name = manifest.piConfig?.name
+    return typeof name === "string" && name.trim() ? name.trim() : "pi"
+  } catch {
+    return "pi"
+  }
 }

--- a/agent-dir.ts
+++ b/agent-dir.ts
@@ -31,16 +31,30 @@ export function getAgentPath(...segments: string[]): string {
  *
  * Falls back to "pi", which is what pi's own APP_NAME resolves to.
  */
-export function getAppName(): string {
+function readPiConfig(): { name?: unknown; clientUri?: unknown } | undefined {
   const dir = process.env.PI_PACKAGE_DIR?.trim()
-  if (!dir) return "pi"
+  if (!dir) return undefined
   try {
     const manifest = JSON.parse(readFileSync(join(resolve(dir), "package.json"), "utf8")) as {
-      piConfig?: { name?: unknown }
+      piConfig?: { name?: unknown; clientUri?: unknown }
     }
-    const name = manifest.piConfig?.name
-    return typeof name === "string" && name.trim() ? name.trim() : "pi"
+    return manifest.piConfig
   } catch {
-    return "pi"
+    return undefined
   }
+}
+
+export function getAppName(): string {
+  const name = readPiConfig()?.name
+  return typeof name === "string" && name.trim() ? name.trim() : "pi"
+}
+
+/**
+ * Home page the host declares for itself, via `piConfig.clientUri` in the same
+ * manifest that carries `piConfig.name`. Only the distribution knows its own
+ * URL, so this is the one place it can come from without guessing.
+ */
+export function getAppClientUri(): string | undefined {
+  const uri = readPiConfig()?.clientUri
+  return typeof uri === "string" && uri.trim() ? uri.trim() : undefined
 }

--- a/mcp-callback-server.test.ts
+++ b/mcp-callback-server.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert"
 import { createServer } from "node:http"
-import { mkdtempSync, writeFileSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -444,9 +444,11 @@ describe("mcp-callback-server", () => {
 
 describe("callback page branding", () => {
   const originalPackageDir = process.env.PI_PACKAGE_DIR
+  const packageDirs: string[] = []
 
   function brandedPackageDir(name?: string): string {
     const dir = mkdtempSync(join(tmpdir(), "mcp-callback-brand-"))
+    packageDirs.push(dir)
     writeFileSync(
       join(dir, "package.json"),
       JSON.stringify(name ? { name: "pi", piConfig: { name } } : { name: "pi" }),
@@ -469,6 +471,7 @@ describe("callback page branding", () => {
   afterEach(async () => {
     if (originalPackageDir === undefined) delete process.env.PI_PACKAGE_DIR
     else process.env.PI_PACKAGE_DIR = originalPackageDir
+    for (const dir of packageDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
     await stopCallbackServer()
   })
 

--- a/mcp-callback-server.test.ts
+++ b/mcp-callback-server.test.ts
@@ -5,6 +5,9 @@
 import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert"
 import { createServer } from "node:http"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   ensureCallbackServer,
   waitForCallback,
@@ -436,5 +439,56 @@ describe("mcp-callback-server", () => {
       await assert.rejects(promise2, /Authorization cancelled/)
       await assert.rejects(promise3, /Authorization cancelled/)
     })
+  })
+})
+
+describe("callback page branding", () => {
+  const originalPackageDir = process.env.PI_PACKAGE_DIR
+
+  function brandedPackageDir(name?: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-callback-brand-"))
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify(name ? { name: "pi", piConfig: { name } } : { name: "pi" }),
+    )
+    return dir
+  }
+
+  /** Drive a real callback request and read the HTML the browser would get. */
+  async function fetchCallbackHtml(): Promise<string> {
+    await ensureCallbackServer()
+    const state = "brandingteststate"
+    const pending = waitForCallback(state)
+    const url = `http://localhost:${getOAuthCallbackPort()}${getOAuthCallbackPath()}?state=${state}&code=abc123`
+    const response = await fetch(url)
+    const html = await response.text()
+    await pending
+    return html
+  }
+
+  afterEach(async () => {
+    if (originalPackageDir === undefined) delete process.env.PI_PACKAGE_DIR
+    else process.env.PI_PACKAGE_DIR = originalPackageDir
+    await stopCallbackServer()
+  })
+
+  it("names the host app rather than hardcoding Pi", async () => {
+    process.env.PI_PACKAGE_DIR = brandedPackageDir("arc")
+    const html = await fetchCallbackHtml()
+    assert.match(html, /return to <span class="app">arc<\/span>/)
+    assert.match(html, /<title>arc — Authorization Successful<\/title>/)
+    assert.doesNotMatch(html, /return to <span class="app">Pi<\/span>/)
+  })
+
+  it("falls back to pi when the host is not rebranded", async () => {
+    process.env.PI_PACKAGE_DIR = brandedPackageDir()
+    const html = await fetchCallbackHtml()
+    assert.match(html, /return to <span class="app">pi<\/span>/)
+  })
+
+  it("serves a self-contained page — no external assets", async () => {
+    delete process.env.PI_PACKAGE_DIR
+    const html = await fetchCallbackHtml()
+    assert.doesNotMatch(html, /https?:\/\//)
   })
 })

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -135,7 +135,6 @@ function htmlSuccess(): string {
     body: `You can close this window and return to <span class="app">${app}</span>.`,
     icon: CHECK_ICON,
     tone: "ok",
-    extra: '<p class="hint">This window closes itself in a moment.</p>',
     autoClose: true,
   })
 }

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -6,6 +6,7 @@
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http"
+import { getAppName } from "./agent-dir.ts"
 import {
   DEFAULT_OAUTH_CALLBACK_PATH,
   getConfiguredOAuthCallbackPort,
@@ -15,45 +16,106 @@ import {
   setOAuthCallbackPort,
 } from "./mcp-oauth-provider.ts"
 
-// HTML templates for callback responses
-const HTML_SUCCESS = `<!DOCTYPE html>
-<html>
-<head>
-  <title>Pi - Authorization Successful</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
-    .container { text-align: center; padding: 2rem; }
-    h1 { color: #4ade80; margin-bottom: 1rem; }
-    p { color: #aaa; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Authorization Successful</h1>
-    <p>You can close this window and return to Pi.</p>
-  </div>
-  <script>setTimeout(() => window.close(), 2000);</script>
-</body>
-</html>`
+// HTML templates for callback responses.
+//
+// These pages are served from localhost during OAuth and are the last thing a
+// user sees before returning to their terminal, so they are self-contained: no
+// webfonts, no external assets, nothing that needs the network. They also name
+// the host rather than hardcoding "Pi", so a distribution that rebrands pi
+// (arc, tau, …) does not send its users back to an app they are not running.
 
-const HTML_MANUAL_SUCCESS = `<!DOCTYPE html>
-<html>
+/** Shared chrome: system fonts, a centred card, and light/dark support. */
+const PAGE_STYLE = `
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: #0f1117;
+      color: #e6e8ee;
+    }
+    .card {
+      width: 100%;
+      max-width: 26rem;
+      padding: 2.5rem 2rem;
+      text-align: center;
+      background: #161922;
+      border: 1px solid #242938;
+      border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.3), 0 12px 32px rgba(0,0,0,.25);
+    }
+    .badge {
+      width: 3rem; height: 3rem;
+      margin: 0 auto 1.25rem;
+      display: grid; place-items: center;
+      border-radius: 50%;
+    }
+    .badge svg { width: 1.5rem; height: 1.5rem; display: block; }
+    .ok   { background: rgba(74,222,128,.12); color: #4ade80; }
+    .bad  { background: rgba(248,113,113,.12); color: #f87171; }
+    h1 { margin: 0 0 .5rem; font-size: 1.15rem; font-weight: 600; letter-spacing: -0.01em; }
+    p  { margin: 0; color: #9aa1b1; }
+    .app { color: #e6e8ee; font-weight: 500; }
+    .hint { margin-top: 1.25rem; font-size: .8125rem; color: #6b7280; }
+    code {
+      display: block;
+      margin-top: 1.25rem;
+      padding: .75rem .875rem;
+      text-align: left;
+      font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: #fca5a5;
+      background: rgba(248,113,113,.08);
+      border: 1px solid rgba(248,113,113,.2);
+      border-radius: 8px;
+      overflow-wrap: anywhere;
+    }
+    @media (prefers-color-scheme: light) {
+      body { background: #f6f7f9; color: #121620; }
+      .card { background: #fff; border-color: #e4e7ee; }
+      p { color: #5b6474; }
+      .app { color: #121620; }
+      .hint { color: #8b93a3; }
+    }`
+
+const CHECK_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>'
+
+const CROSS_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>'
+
+function page(options: {
+  title: string
+  heading: string
+  body: string
+  icon: string
+  tone: "ok" | "bad"
+  extra?: string
+  autoClose?: boolean
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en">
 <head>
-  <title>Pi - Authorization Received</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
-    .container { text-align: center; padding: 2rem; }
-    h1 { color: #4ade80; margin-bottom: 1rem; }
-    p { color: #aaa; }
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${options.title}</title>
+  <style>${PAGE_STYLE}
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Authorization Received</h1>
-    <p>Copy the full callback URL from your browser address bar and paste it back into Pi with auth-complete.</p>
-  </div>
-</body>
+  <main class="card">
+    <div class="badge ${options.tone}">${options.icon}</div>
+    <h1>${options.heading}</h1>
+    <p>${options.body}</p>
+    ${options.extra ?? ""}
+  </main>
+${options.autoClose ? "  <script>setTimeout(() => window.close(), 2000);</script>\n" : ""}</body>
 </html>`
+}
 
 function escapeHtml(value: string): string {
   return value
@@ -64,26 +126,42 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;")
 }
 
-const HTML_ERROR = (error: string) => `<!DOCTYPE html>
-<html>
-<head>
-  <title>Pi - Authorization Failed</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
-    .container { text-align: center; padding: 2rem; }
-    h1 { color: #f87171; margin-bottom: 1rem; }
-    p { color: #aaa; }
-    .error { color: #fca5a5; font-family: monospace; margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Authorization Failed</h1>
-    <p>An error occurred during authorization.</p>
-    <div class="error">${escapeHtml(error)}</div>
-  </div>
-</body>
-</html>`
+/** Built per request so a host that sets PI_PACKAGE_DIR late is still named right. */
+function htmlSuccess(): string {
+  const app = escapeHtml(getAppName())
+  return page({
+    title: `${app} — Authorization Successful`,
+    heading: "Authorization Successful",
+    body: `You can close this window and return to <span class="app">${app}</span>.`,
+    icon: CHECK_ICON,
+    tone: "ok",
+    extra: '<p class="hint">This window closes itself in a moment.</p>',
+    autoClose: true,
+  })
+}
+
+function htmlManualSuccess(): string {
+  const app = escapeHtml(getAppName())
+  return page({
+    title: `${app} — Authorization Received`,
+    heading: "Authorization Received",
+    body: `Copy the full callback URL from your browser address bar and paste it back into <span class="app">${app}</span> with auth-complete.`,
+    icon: CHECK_ICON,
+    tone: "ok",
+  })
+}
+
+function htmlError(error: string): string {
+  const app = escapeHtml(getAppName())
+  return page({
+    title: `${app} — Authorization Failed`,
+    heading: "Authorization Failed",
+    body: `Something went wrong during authorization. You can close this window and try again from <span class="app">${app}</span>.`,
+    icon: CROSS_ICON,
+    tone: "bad",
+    extra: `<code>${escapeHtml(error)}</code>`,
+  })
+}
 
 /** Result of a successful OAuth callback */
 export interface OAuthCallbackResult {
@@ -145,7 +223,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
   if (!state) {
     const errorMsg = "Missing required state parameter - potential CSRF attack"
     res.writeHead(400, { "Content-Type": "text/html" })
-    res.end(HTML_ERROR(errorMsg))
+    res.end(htmlError(errorMsg))
     return
   }
 
@@ -157,14 +235,14 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
     if (!pending && !isReserved) {
       const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
       res.writeHead(400, { "Content-Type": "text/html" })
-      res.end(HTML_ERROR(errorMsg))
+      res.end(htmlError(errorMsg))
       return
     }
 
     const errorMsg = errorDescription || error
     // Send HTTP response first before rejecting promise
     res.writeHead(200, { "Content-Type": "text/html" })
-    res.end(HTML_ERROR(errorMsg))
+    res.end(htmlError(errorMsg))
     // Reject promise after response is sent (defer to allow test to attach handler)
     if (pending) {
       reservedAuthStates.delete(state)
@@ -179,20 +257,20 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
   if (!pending && !isReserved) {
     const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
     res.writeHead(400, { "Content-Type": "text/html" })
-    res.end(HTML_ERROR(errorMsg))
+    res.end(htmlError(errorMsg))
     return
   }
 
   // Require authorization code
   if (!code) {
     res.writeHead(400, { "Content-Type": "text/html" })
-    res.end(HTML_ERROR("No authorization code provided"))
+    res.end(htmlError("No authorization code provided"))
     return
   }
 
   if (!pending) {
     res.writeHead(200, { "Content-Type": "text/html" })
-    res.end(HTML_MANUAL_SUCCESS)
+    res.end(htmlManualSuccess())
     return
   }
 
@@ -202,7 +280,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
   pending.resolve({ code, ...(iss !== null ? { iss } : {}) })
 
   res.writeHead(200, { "Content-Type": "text/html" })
-  res.end(HTML_SUCCESS)
+  res.end(htmlSuccess())
 }
 
 /**

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -142,6 +142,25 @@ describe("McpOAuthProvider", () => {
       }
     })
 
+    it("should omit client_uri under a rebranded host rather than name the adapter", () => {
+      const original = process.env.PI_PACKAGE_DIR
+      const dir = mkdtempSync(join(tmpdir(), "oauth-brand-uri-"))
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "pi", piConfig: { name: "arc" } }))
+      process.env.PI_PACKAGE_DIR = dir
+      try {
+        // The client is arc; advertising the adapter's repo would misidentify it.
+        assert.ok(!("client_uri" in createProvider().clientMetadata))
+        // An explicit config still wins.
+        assert.strictEqual(
+          createProvider({ clientUri: "https://arc.example" }).clientMetadata.client_uri,
+          "https://arc.example",
+        )
+      } finally {
+        if (original === undefined) delete process.env.PI_PACKAGE_DIR
+        else process.env.PI_PACKAGE_DIR = original
+      }
+    })
+
     it("should return correct metadata for confidential client", () => {
       const provider = createProvider({ clientSecret: "secret" })
       const metadata = provider.clientMetadata

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -150,6 +150,16 @@ describe("McpOAuthProvider", () => {
       try {
         // The client is arc; advertising the adapter's repo would misidentify it.
         assert.ok(!("client_uri" in createProvider().clientMetadata))
+        // A host that declares its own homepage gets it advertised.
+        const declaring = mkdtempSync(join(tmpdir(), "oauth-brand-declared-"))
+        writeFileSync(
+          join(declaring, "package.json"),
+          JSON.stringify({ name: "pi", piConfig: { name: "arc", clientUri: "https://arc.workos.tools" } }),
+        )
+        process.env.PI_PACKAGE_DIR = declaring
+        assert.strictEqual(createProvider().clientMetadata.client_uri, "https://arc.workos.tools")
+        process.env.PI_PACKAGE_DIR = dir
+
         // An explicit config still wins.
         assert.strictEqual(
           createProvider({ clientUri: "https://arc.example" }).clientMetadata.client_uri,

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -100,11 +100,13 @@ describe("McpOAuthProvider", () => {
     // client_name now follows the host app, so these assertions must not read
     // whatever PI_PACKAGE_DIR the developer's shell happens to export.
     const inheritedPackageDir = process.env.PI_PACKAGE_DIR
+    const packageDirs: string[] = []
     before(() => {
       delete process.env.PI_PACKAGE_DIR
     })
     after(() => {
       if (inheritedPackageDir !== undefined) process.env.PI_PACKAGE_DIR = inheritedPackageDir
+      for (const dir of packageDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
     })
 
     it("should return correct metadata for public client", () => {
@@ -122,6 +124,7 @@ describe("McpOAuthProvider", () => {
     it("should register under the host app name when pi is rebranded", () => {
       const original = process.env.PI_PACKAGE_DIR
       const dir = mkdtempSync(join(tmpdir(), "oauth-brand-"))
+      packageDirs.push(dir)
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "pi", piConfig: { name: "arc" } }))
       process.env.PI_PACKAGE_DIR = dir
       try {
@@ -145,6 +148,7 @@ describe("McpOAuthProvider", () => {
     it("should omit client_uri under a rebranded host rather than name the adapter", () => {
       const original = process.env.PI_PACKAGE_DIR
       const dir = mkdtempSync(join(tmpdir(), "oauth-brand-uri-"))
+      packageDirs.push(dir)
       writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "pi", piConfig: { name: "arc" } }))
       process.env.PI_PACKAGE_DIR = dir
       try {
@@ -152,6 +156,7 @@ describe("McpOAuthProvider", () => {
         assert.ok(!("client_uri" in createProvider().clientMetadata))
         // A host that declares its own homepage gets it advertised.
         const declaring = mkdtempSync(join(tmpdir(), "oauth-brand-declared-"))
+        packageDirs.push(declaring)
         writeFileSync(
           join(declaring, "package.json"),
           JSON.stringify({ name: "pi", piConfig: { name: "arc", clientUri: "https://arc.workos.tools" } }),

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, before, after } from "node:test"
 import assert from "node:assert"
-import { existsSync, rmSync, mkdirSync } from "fs"
+import { existsSync, rmSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import { randomBytes } from "crypto"
@@ -97,6 +97,16 @@ describe("McpOAuthProvider", () => {
   })
 
   describe("clientMetadata", () => {
+    // client_name now follows the host app, so these assertions must not read
+    // whatever PI_PACKAGE_DIR the developer's shell happens to export.
+    const inheritedPackageDir = process.env.PI_PACKAGE_DIR
+    before(() => {
+      delete process.env.PI_PACKAGE_DIR
+    })
+    after(() => {
+      if (inheritedPackageDir !== undefined) process.env.PI_PACKAGE_DIR = inheritedPackageDir
+    })
+
     it("should return correct metadata for public client", () => {
       const provider = createProvider()
       const metadata = provider.clientMetadata
@@ -107,6 +117,29 @@ describe("McpOAuthProvider", () => {
       assert.deepStrictEqual(metadata.grant_types, ["authorization_code", "refresh_token"])
       assert.deepStrictEqual(metadata.response_types, ["code"])
       assert.strictEqual(metadata.token_endpoint_auth_method, "none")
+    })
+
+    it("should register under the host app name when pi is rebranded", () => {
+      const original = process.env.PI_PACKAGE_DIR
+      const dir = mkdtempSync(join(tmpdir(), "oauth-brand-"))
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "pi", piConfig: { name: "arc" } }))
+      process.env.PI_PACKAGE_DIR = dir
+      try {
+        assert.strictEqual(createProvider().clientMetadata.client_name, "arc")
+      } finally {
+        if (original === undefined) delete process.env.PI_PACKAGE_DIR
+        else process.env.PI_PACKAGE_DIR = original
+      }
+    })
+
+    it("should keep the historical client name on stock pi", () => {
+      const original = process.env.PI_PACKAGE_DIR
+      delete process.env.PI_PACKAGE_DIR
+      try {
+        assert.strictEqual(createProvider().clientMetadata.client_name, "Pi Coding Agent")
+      } finally {
+        if (original !== undefined) process.env.PI_PACKAGE_DIR = original
+      }
     })
 
     it("should return correct metadata for confidential client", () => {

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -30,7 +30,7 @@ import {
   type StoredClientInfo,
 } from "./mcp-auth.ts"
 import { resolveCommandSecret } from "./utils.ts"
-import { getAppName } from "./agent-dir.ts"
+import { getAppClientUri, getAppName } from "./agent-dir.ts"
 
 /**
  * Client name advertised during Dynamic Client Registration.
@@ -57,6 +57,8 @@ function defaultClientName(): string {
  * Stock pi keeps the historical value.
  */
 function defaultClientUri(): string | undefined {
+  const declared = getAppClientUri()
+  if (declared) return declared
   return getAppName() === "pi" ? "https://github.com/nicobailon/pi-mcp-adapter" : undefined
 }
 

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -30,6 +30,20 @@ import {
   type StoredClientInfo,
 } from "./mcp-auth.ts"
 import { resolveCommandSecret } from "./utils.ts"
+import { getAppName } from "./agent-dir.ts"
+
+/**
+ * Client name advertised during Dynamic Client Registration.
+ *
+ * A distribution that rebrands pi (arc, tau, …) should register under its own
+ * name — otherwise every consent screen its users see asks them to authorize
+ * an app they have never run. Stock pi keeps the long-standing
+ * "Pi Coding Agent" so existing registrations are unaffected.
+ */
+function defaultClientName(): string {
+  const app = getAppName()
+  return app === "pi" ? "Pi Coding Agent" : app
+}
 
 type IssuerBoundClientInformation = OAuthClientInformationMixed & { issuer?: string }
 type IssuerBoundTokens = OAuthTokens & { issuer?: string }
@@ -189,14 +203,14 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return this.redirectUrlSnapshot
   }
 
-  /**
+/**
    * Client metadata for dynamic registration.
    * Describes this client to the OAuth authorization server.
    */
   get clientMetadata(): OAuthClientMetadata {
     if (this.usesClientCredentials) {
       return {
-        client_name: this.config.clientName ?? "Pi Coding Agent",
+        client_name: this.config.clientName ?? defaultClientName(),
         client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
         redirect_uris: [],
         grant_types: ["client_credentials"],
@@ -211,7 +225,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     return {
       redirect_uris: [redirectUrl],
-      client_name: this.config.clientName ?? "Pi Coding Agent",
+      client_name: this.config.clientName ?? defaultClientName(),
       client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -45,6 +45,21 @@ function defaultClientName(): string {
   return app === "pi" ? "Pi Coding Agent" : app
 }
 
+/**
+ * Client homepage advertised during Dynamic Client Registration.
+ *
+ * RFC 7591 defines client_uri as the home page *of the client*. Under a
+ * rebranded pi the client is that distribution, not this adapter, so pointing
+ * at the adapter's repository misidentifies it on the consent screen. There is
+ * no way to guess the right URL and a wrong one is worse than none, so the
+ * field is omitted unless a server config supplies oauth.clientUri.
+ *
+ * Stock pi keeps the historical value.
+ */
+function defaultClientUri(): string | undefined {
+  return getAppName() === "pi" ? "https://github.com/nicobailon/pi-mcp-adapter" : undefined
+}
+
 type IssuerBoundClientInformation = OAuthClientInformationMixed & { issuer?: string }
 type IssuerBoundTokens = OAuthTokens & { issuer?: string }
 
@@ -203,7 +218,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return this.redirectUrlSnapshot
   }
 
-/**
+  /** Configured homepage, else the historical default on stock pi, else nothing. */
+  private get clientUri(): string | undefined {
+    return this.config.clientUri ?? defaultClientUri()
+  }
+
+  /**
    * Client metadata for dynamic registration.
    * Describes this client to the OAuth authorization server.
    */
@@ -211,7 +231,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.usesClientCredentials) {
       return {
         client_name: this.config.clientName ?? defaultClientName(),
-        client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
+        ...(this.clientUri !== undefined ? { client_uri: this.clientUri } : {}),
         redirect_uris: [],
         grant_types: ["client_credentials"],
         token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -226,7 +246,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return {
       redirect_uris: [redirectUrl],
       client_name: this.config.clientName ?? defaultClientName(),
-      client_uri: this.config.clientUri ?? "https://github.com/nicobailon/pi-mcp-adapter",
+      ...(this.clientUri !== undefined ? { client_uri: this.clientUri } : {}),
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",


### PR DESCRIPTION
## Problem

The OAuth callback pages hardcode "Pi" in five places:

```html
<title>Pi - Authorization Successful</title>
<p>You can close this window and return to Pi.</p>
```

pi supports rebranding through `piConfig.name` — distributions built on it (arc, tau, …) flip `APP_NAME` across pi's user-visible strings. This page doesn't follow, so after authenticating an MCP server the browser tells the user to return to an app they are not running:

![before](https://user-images.githubusercontent.com/placeholder/before.png)

> Authorization Successful
> You can close this window and return to Pi.

…in a terminal running `arc`.

## Changes

**1. Name the host.** `getAppName()` sits beside the existing `getAgentDir()` in `agent-dir.ts` and reads `piConfig.name` from `PI_PACKAGE_DIR`'s manifest — the same hook pi's own `APP_NAME` uses — falling back to `"pi"`.

It reads the manifest directly rather than importing `@earendil-works/pi-coding-agent`, so the dependency surface is unchanged. That matches how `getAgentDir()` already reads `PI_CODING_AGENT_DIR` itself instead of borrowing pi's helper.

**2. One renderer instead of three copies.** The success / manual-success / error templates each carried their own near-identical `<style>` block. They now share a `page()` helper: a centred card, a status badge with an inline SVG glyph, `prefers-color-scheme` support, and the error text in a bordered monospace block.

Headings keep their existing wording (`Authorization Successful`, etc.) so existing assertions and user expectations are untouched — the diff is branding and presentation, not copy.

**3. Still self-contained.** No webfonts, no external images, no network. These pages are served from localhost during auth and have to render offline; there's a test asserting the markup contains no `http(s)://` at all.

## Testing

`npm run typecheck` clean. `npm run test:oauth`: **117 pass, 0 fail**, including three new tests that drive a real callback request and read the served HTML:

- names the host app rather than hardcoding Pi (with `PI_PACKAGE_DIR` branded `arc`)
- falls back to `pi` when the host is not rebranded
- serves a self-contained page — no external assets

Templates are rendered per request rather than at module load, so a host that sets `PI_PACKAGE_DIR` late is still named correctly.
