### PR TITLE
feat(oauth): advertise a client logo during dynamic registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `oauth.logoUri` for OAuth Dynamic Client Registration, with validation that requires an absolute HTTP(S) URL. Thanks @grinich for PR #321.
+
 ### Fixed
 - Named OAuth callback pages and dynamic client registrations after rebranded Pi hosts, while preserving stock Pi defaults and avoiding guessed client homepages. Thanks @grinich for PR #320.
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `oauth.redirectUri` | Exact localhost redirect URI for browser OAuth, including port and path, for providers that pre-register callbacks |
 | `oauth.clientName` | Client display name advertised during Dynamic Client Registration fallback |
 | `oauth.clientUri` | Client homepage URI advertised during Dynamic Client Registration fallback. Defaults to `piConfig.clientUri` from the host's manifest when set, and is omitted rather than guessed under a rebranded host |
+| `oauth.logoUri` | Client logo URL advertised during Dynamic Client Registration fallback (RFC 7591 `logo_uri`). Must be an absolute `http(s)` URL — consent screens fetch it server-side, so local paths render nothing. Omitted from the registration request when unset |
 | `oauth.skipIssuerMetadataValidation` | `true` disables the OAuth authorization-server metadata issuer check for this server. This weakens OAuth mix-up protection and should only be used for known-misconfigured internal servers while their metadata is being fixed. |
 | `bearerToken` / `bearerTokenEnv` | Token or env var name; `bearerToken` supports `${VAR}` and `$env:VAR` interpolation. A leading `!` in `bearerToken` runs a command when the HTTP server connects; use `!!` for a literal leading `!`. |
 | `lifecycle` | `"lazy"` (default), `"eager"`, `"keep-alive"`, or `"lazy-keep-alive"` |

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -297,6 +297,38 @@ describe("mcp-auth-flow", () => {
       )
     })
 
+    it("should accept an absolute http(s) OAuth logoUri", () => {
+      const config = extractOAuthConfig({
+        url: "https://api.example.com/mcp",
+        auth: "oauth",
+        oauth: { logoUri: "https://example.com/logo.png" },
+      })
+      assert.strictEqual(config.logoUri, "https://example.com/logo.png")
+    })
+
+    it("should reject an OAuth logoUri that is not an absolute http(s) URL", () => {
+      // Consent screens fetch the logo server-side, so a local path renders
+      // nothing at all — failing here is the only place it can be explained.
+      for (const logoUri of ["./logo.png", "/Users/me/logo.png", "file:///tmp/logo.png"]) {
+        assert.throws(
+          () => extractOAuthConfig({
+            url: "https://api.example.com/mcp",
+            auth: "oauth",
+            oauth: { logoUri },
+          }),
+          /logoUri must be an absolute http\(s\) URL/
+        )
+      }
+      assert.throws(
+        () => extractOAuthConfig({
+          url: "https://api.example.com/mcp",
+          auth: "oauth",
+          oauth: { logoUri: 123 as unknown as string },
+        }),
+        /logoUri must be a string/
+      )
+    })
+
     it("should reject malformed OAuth authorizationParams", () => {
       assert.throws(
         () => extractOAuthConfig({

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -211,6 +211,27 @@ export function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
     }
     config.clientUri = clientUri
   }
+  if (definition.oauth?.logoUri !== undefined) {
+    if (typeof definition.oauth.logoUri !== "string") {
+      throw new Error("OAuth logoUri must be a string")
+    }
+    const logoUri = interpolateEnvVars(definition.oauth.logoUri).trim()
+    if (!logoUri) {
+      throw new Error("OAuth logoUri must not be empty")
+    }
+    // Consent screens fetch this server-side, so a local path silently renders
+    // nothing. Fail here instead, where the message can say why.
+    let parsed: URL
+    try {
+      parsed = new URL(logoUri)
+    } catch {
+      throw new Error("OAuth logoUri must be an absolute http(s) URL")
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      throw new Error("OAuth logoUri must be an absolute http(s) URL")
+    }
+    config.logoUri = logoUri
+  }
   if (definition.oauth?.skipIssuerMetadataValidation !== undefined) {
     if (typeof definition.oauth.skipIssuerMetadataValidation !== "boolean") {
       throw new Error("OAuth skipIssuerMetadataValidation must be a boolean")

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -176,6 +176,16 @@ describe("McpOAuthProvider", () => {
       }
     })
 
+    it("should omit logo_uri when unset", () => {
+      const provider = createProvider()
+      assert.ok(!("logo_uri" in provider.clientMetadata))
+    })
+
+    it("should advertise logo_uri when configured", () => {
+      const provider = createProvider({ logoUri: "https://example.com/logo.png" })
+      assert.strictEqual(provider.clientMetadata.logo_uri, "https://example.com/logo.png")
+    })
+
     it("should return correct metadata for confidential client", () => {
       const provider = createProvider({ clientSecret: "secret" })
       const metadata = provider.clientMetadata

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -117,6 +117,7 @@ export interface McpOAuthConfig {
   redirectUri?: string
   clientName?: string
   clientUri?: string
+  logoUri?: string
   skipIssuerMetadataValidation?: boolean
 }
 
@@ -234,6 +235,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       return {
         client_name: this.config.clientName ?? defaultClientName(),
         ...(this.clientUri !== undefined ? { client_uri: this.clientUri } : {}),
+        ...(this.config.logoUri !== undefined ? { logo_uri: this.config.logoUri } : {}),
         redirect_uris: [],
         grant_types: ["client_credentials"],
         token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
@@ -249,6 +251,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       redirect_uris: [redirectUrl],
       client_name: this.config.clientName ?? defaultClientName(),
       ...(this.clientUri !== undefined ? { client_uri: this.clientUri } : {}),
+      ...(this.config.logoUri !== undefined ? { logo_uri: this.config.logoUri } : {}),
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",

--- a/types.ts
+++ b/types.ts
@@ -350,6 +350,8 @@ export interface OAuthConfig {
   clientName?: string;
   /** Client homepage URI for dynamic registration */
   clientUri?: string;
+  /** Client logo URL for dynamic registration; shown on consent screens */
+  logoUri?: string;
   /** Security-weakening escape hatch for known-misconfigured authorization servers. */
   skipIssuerMetadataValidation?: boolean;
 }


### PR DESCRIPTION
## Why

RFC 7591 defines `logo_uri`, and authorization servers render it on the consent screen beside `client_name`. The adapter already lets a server config set `clientName` and `clientUri`, but never sends a logo — so a pi-registered client shows up as a text row where every other client has a mark.

WorkOS (and others) pick this up straight from the Dynamic Client Registration payload, so it is the only thing standing between the current blank consent screen and a branded one.

## Changes

- `oauth.logoUri` on a server entry, following the existing `clientName` / `clientUri` shape — same validation style, same env-var interpolation.
- Included in **both** metadata branches (`client_credentials` and `authorization_code`).
- **Omitted entirely when unset**, so registration payloads are byte-identical for anyone who does not set it.

```jsonc
{
  "mcpServers": {
    "alto": {
      "url": "https://mcp.workos.site/mcp",
      "oauth": {
        "clientName": "arc",
        "logoUri": "https://example.com/logo.png"
      }
    }
  }
}
```

### One validation decision

`logoUri` must be an absolute `http(s)` URL, and anything else throws at config-read time:

```
OAuth logoUri must be an absolute http(s) URL
```

That is stricter than the neighbouring fields, deliberately. Consent screens fetch the logo **server-side**, so a relative path or a `file://` URL produces no image and no error anywhere in the stack — the user sees a blank consent screen and has nothing to debug. Failing where the config is read is the only place that can say why.

## Testing

`npm run typecheck` clean. `npm run test:oauth`: **121 pass, 0 fail** (119 existing + 4 new):

- `clientMetadata` omits `logo_uri` when unset
- `clientMetadata` advertises `logo_uri` when configured
- `extractOAuthConfig` accepts an absolute `http(s)` logo URL
- `extractOAuthConfig` rejects `./logo.png`, `/abs/path.png`, `file://…`, and non-strings

README config table updated.
