### PR TITLE
Materialize binary MCP resources as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `oauth.logoUri` for OAuth Dynamic Client Registration, with validation that requires an absolute HTTP(S) URL. Thanks @grinich for PR #321.
 
 ### Fixed
+- Materialized binary MCP resources as private temporary files before model-facing output, with bounded per-session cleanup. Thanks @zenworr and @shaworr for PR #324.
 - Named OAuth callback pages and dynamic client registrations after rebranded Pi hosts, while preserving stock Pi defaults and avoiding guessed client homepages. Thanks @grinich for PR #320.
 
 ## [2.21.2] - 2026-08-09

--- a/README.md
+++ b/README.md
@@ -373,9 +373,10 @@ Oversized MCP tool/resource results are guarded by default so a single huge resp
 
 - Inline text output is capped at **50 KiB / 2,000 lines** (matching Pi's built-in `bash` guard). Larger output is truncated to a head preview and the full text is saved to a temp file whose path is included in the result, so the agent can `read`/`grep` it.
 - **Image content blocks pass through unchanged** — only text output is guarded. Images are delivered to the provider as native image content.
+- Binary resource blobs up to **10 MiB** are decoded to private temp files and replaced with file references. Each session is limited to **100 MiB** and **10,000 files**. The files are removed at session teardown.
 - In proxy mode, `details.mcpResult` is kept raw when its JSON is **≤ 16 KiB**; larger results are replaced with a compact summary (block counts, sizes, key previews) and the raw JSON is saved to a temp file. Direct tools keep their lean details and never carry `mcpResult`.
 
-Tune the limits with the object form:
+Tune the text and details limits with the object form:
 
 ```json
 {
@@ -385,7 +386,7 @@ Tune the limits with the object form:
 }
 ```
 
-Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — to disable the guard and restore raw output behavior. Saved temp files are created with mode `0600` under the system temp directory and are not cleaned up automatically; note that spilled MCP output may contain sensitive data.
+Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — to disable text and details guarding. Binary resource materialization and its safety limits remain active. Output-guard spill files are created with mode `0600` under the system temp directory and are not cleaned up automatically; note that spilled MCP output may contain sensitive data.
 
 ### MCP Scripting
 

--- a/__tests__/resource-tool-materialization.test.ts
+++ b/__tests__/resource-tool-materialization.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { executeCall } from "../proxy-modes.ts";
+import { cleanupMaterializedBinaryResources } from "../tool-registrar.ts";
+import type { DirectToolSpec, ToolMetadata } from "../types.ts";
+
+const initMocks = vi.hoisted(() => ({
+  lazyConnect: vi.fn(async () => true),
+  getFailureAgeSeconds: vi.fn(() => null),
+}));
+
+vi.mock("../init.ts", () => ({
+  lazyConnect: initMocks.lazyConnect,
+  getFailureAgeSeconds: initMocks.getFailureAgeSeconds,
+  updateServerMetadata: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  updateStatusBar: vi.fn(),
+  clearFailure: vi.fn(),
+  recordFailure: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
+  notifyToolMetadataUpdated: vi.fn(),
+}));
+
+const resourceUri = "file://binary-resource";
+const blob = Buffer.from("binary resource content").toString("base64");
+
+function createState() {
+  const metadata: ToolMetadata = {
+    name: "demo_read_binary_resource",
+    originalName: "read_binary_resource",
+    description: "Read binary resource",
+    resourceUri,
+  };
+  const readResource = vi.fn(async () => ({
+    contents: [{ uri: resourceUri, mimeType: "application/octet-stream", blob }],
+  }));
+  const connection = {
+    status: "connected",
+    client: { readResource, callTool: vi.fn() },
+  };
+
+  return {
+    metadata,
+    readResource,
+    state: {
+      config: { settings: {}, mcpServers: { demo: { command: "demo" } } },
+      toolMetadata: new Map([["demo", [metadata]]]),
+      manager: {
+        getConnection: vi.fn(() => connection),
+        getRequestOptions: vi.fn(() => undefined),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      ui: undefined,
+      completedUiSessions: [],
+    } as any,
+  };
+}
+
+function materializedPath(text: string): string {
+  const path = text.match(/Binary content saved to (.+)/)?.[1];
+  expect(path).toBeDefined();
+  return path!;
+}
+
+afterEach(() => {
+  cleanupMaterializedBinaryResources();
+  vi.clearAllMocks();
+});
+
+describe("resource tool binary materialization", () => {
+  it("materializes binary proxy resource results", async () => {
+    const { state, metadata, readResource } = createState();
+
+    const result = await executeCall(state, metadata.name, {}, "demo");
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    const path = materializedPath(text);
+
+    expect(text).toContain("[Resource: file://binary-resource]");
+    expect(text).not.toContain(blob);
+    expect(readFileSync(path, "utf8")).toBe("binary resource content");
+    expect(readResource).toHaveBeenCalledWith({ uri: resourceUri }, undefined);
+  });
+
+  it("materializes binary direct resource results", async () => {
+    const { state, metadata, readResource } = createState();
+    const execute = createDirectToolExecutor(
+      () => state,
+      () => null,
+      { serverName: "demo", prefixedName: metadata.name, description: metadata.description, originalName: metadata.originalName, resourceUri } satisfies DirectToolSpec,
+    );
+
+    const result = await execute("call-1", {}, undefined as any, undefined, undefined as any);
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    const path = materializedPath(text);
+
+    expect(text).toContain("[Resource: file://binary-resource]");
+    expect(text).not.toContain(blob);
+    expect(readFileSync(path, "utf8")).toBe("binary resource content");
+    expect(readResource).toHaveBeenCalledWith({ uri: resourceUri }, undefined);
+  });
+});

--- a/__tests__/tool-registrar-structured-content.test.ts
+++ b/__tests__/tool-registrar-structured-content.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { resolveMcpResultContent } from "../tool-registrar.ts";
+import fs, { existsSync, readFileSync, statSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { dirname } from "node:path";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import {
+  cleanupMaterializedBinaryResources,
+  resolveMcpResultContent,
+} from "../tool-registrar.ts";
 
 describe("resolveMcpResultContent", () => {
+  afterEach(() => cleanupMaterializedBinaryResources());
+
   it("returns transformed content blocks when content is present", () => {
     const blocks = resolveMcpResultContent({
       content: [{ type: "text", text: "hello" }],
@@ -9,6 +17,282 @@ describe("resolveMcpResultContent", () => {
     });
 
     expect(blocks).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("materializes binary resources without retaining base64", () => {
+    const data = Buffer.from("binary content");
+    const blob = data.toString("base64");
+    const result = {
+      content: [{
+        type: "resource",
+        resource: {
+          uri: "test://resource",
+          mimeType: "application/octet-stream",
+          blob,
+        },
+      }],
+    };
+    const blocks = resolveMcpResultContent(result);
+
+    const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+    const path = text.match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+    expect(text).not.toContain(blob);
+    expect(result.content[0]?.resource).toEqual({
+      uri: "test://resource",
+      mimeType: "application/octet-stream",
+      text,
+    });
+
+    expect(readFileSync(path!)).toEqual(data);
+    expect(statSync(path!).mode & 0o777).toBe(0o600);
+    expect(statSync(dirname(path!)).mode & 0o777).toBe(0o700);
+
+    cleanupMaterializedBinaryResources();
+    expect(existsSync(dirname(path!))).toBe(false);
+  });
+
+  it("cleans only the requested materialization scope", () => {
+    const scopeA = {};
+    const scopeB = {};
+
+    const first = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://scope-a", blob: "YQ==" } }],
+    }, scopeA);
+    const second = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://scope-b", blob: "Yg==" } }],
+    }, scopeB);
+
+    const pathA = (first[0]?.type === "text" ? first[0].text : "").match(/Binary content saved to (.+)/)?.[1];
+    const pathB = (second[0]?.type === "text" ? second[0].text : "").match(/Binary content saved to (.+)/)?.[1];
+    expect(pathA).toBeDefined();
+    expect(pathB).toBeDefined();
+
+    cleanupMaterializedBinaryResources(scopeB);
+    expect(existsSync(dirname(pathA!))).toBe(true);
+    expect(existsSync(dirname(pathB!))).toBe(false);
+
+    cleanupMaterializedBinaryResources(scopeA);
+    expect(existsSync(dirname(pathA!))).toBe(false);
+  });
+
+  it("does not recreate an aborted materialization scope", () => {
+    const controller = new AbortController();
+    const first = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://aborted-scope", blob: "YQ==" } }],
+    }, controller.signal);
+    const path = (first[0]?.type === "text" ? first[0].text : "").match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+
+    controller.abort();
+    cleanupMaterializedBinaryResources(controller.signal);
+    expect(existsSync(dirname(path!))).toBe(false);
+
+    const late = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://late", blob: "Yg==" } }],
+    }, controller.signal);
+    const text = late[0]?.type === "text" ? late[0].text : "";
+    expect(text).toContain("Binary content omitted: runtime stopped");
+    expect(text).not.toContain("Binary content saved to");
+  });
+
+  it("omits binary resources larger than 10 MiB", () => {
+    const byteLength = vi.spyOn(Buffer, "byteLength").mockReturnValueOnce(10 * 1024 * 1024 + 1);
+    const result = {
+      content: [{
+        type: "resource",
+        resource: { uri: "test://large", blob: "base64" },
+      }],
+    };
+
+    try {
+      const blocks = resolveMcpResultContent(result);
+      const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+      expect(text).toContain("Binary content omitted: decoded size exceeds 10 MiB");
+      expect(result.content[0]?.resource).toEqual({ uri: "test://large", text });
+    } finally {
+      byteLength.mockRestore();
+    }
+  });
+
+  it("restores quota when a failed write leaves no file", () => {
+    const byteLength = vi.spyOn(Buffer, "byteLength").mockReturnValue(10 * 1024 * 1024);
+    const originalWriteFileSync = fs.writeFileSync;
+
+    try {
+      fs.writeFileSync = (() => { throw new Error("disk full"); }) as typeof fs.writeFileSync;
+      syncBuiltinESMExports();
+      const failed = resolveMcpResultContent({
+        content: [{ type: "resource", resource: { uri: "test://failure", blob: "YQ==" } }],
+      });
+      expect(failed[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("Binary content omitted: could not be saved"),
+      });
+
+      fs.writeFileSync = originalWriteFileSync;
+      syncBuiltinESMExports();
+      for (let i = 0; i < 10; i++) {
+        const result = resolveMcpResultContent({
+          content: [{ type: "resource", resource: { uri: `test://retry-${i}`, blob: "YQ==" } }],
+        });
+        expect(result[0]).toMatchObject({
+          type: "text",
+          text: expect.stringContaining("Binary content saved to"),
+        });
+      }
+    } finally {
+      fs.writeFileSync = originalWriteFileSync;
+      syncBuiltinESMExports();
+      byteLength.mockRestore();
+    }
+  });
+
+  it("retries failed session cleanup", () => {
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://cleanup", blob: "YQ==" } }],
+    });
+    const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+    const path = text.match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+
+    const originalRmSync = fs.rmSync;
+    try {
+      fs.rmSync = (() => { throw new Error("file busy"); }) as typeof fs.rmSync;
+      syncBuiltinESMExports();
+      expect(() => cleanupMaterializedBinaryResources()).toThrow("Failed to clean materialized MCP resources");
+    } finally {
+      fs.rmSync = originalRmSync;
+      syncBuiltinESMExports();
+    }
+
+    expect(existsSync(dirname(path!))).toBe(true);
+    cleanupMaterializedBinaryResources();
+    expect(existsSync(dirname(path!))).toBe(false);
+  });
+
+  it("retries failed scoped cleanup from later cleanup calls", () => {
+    const scope = {};
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://scoped-cleanup", blob: "YQ==" } }],
+    }, scope);
+    const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+    const path = text.match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+
+    const originalRmSync = fs.rmSync;
+    try {
+      fs.rmSync = (() => { throw new Error("file busy"); }) as typeof fs.rmSync;
+      syncBuiltinESMExports();
+      expect(() => cleanupMaterializedBinaryResources(scope)).toThrow("Failed to clean materialized MCP resources");
+    } finally {
+      fs.rmSync = originalRmSync;
+      syncBuiltinESMExports();
+    }
+
+    expect(existsSync(dirname(path!))).toBe(true);
+    cleanupMaterializedBinaryResources({});
+    expect(existsSync(dirname(path!))).toBe(false);
+  });
+
+  it("schedules a retry without deleting active default-scope resources", () => {
+    vi.useFakeTimers();
+    const scope = {};
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://scheduled-cleanup", blob: "YQ==" } }],
+    }, scope);
+    const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+    const path = text.match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+
+    const originalRmSync = fs.rmSync;
+    try {
+      fs.rmSync = (() => { throw new Error("file busy"); }) as typeof fs.rmSync;
+      syncBuiltinESMExports();
+      expect(() => cleanupMaterializedBinaryResources(scope)).toThrow("Failed to clean materialized MCP resources");
+      expect(existsSync(dirname(path!))).toBe(true);
+
+      fs.rmSync = originalRmSync;
+      syncBuiltinESMExports();
+      const active = resolveMcpResultContent({
+        content: [{ type: "resource", resource: { uri: "test://default-active", blob: "Yg==" } }],
+      });
+      const activePath = (active[0]?.type === "text" ? active[0].text : "").match(/Binary content saved to (.+)/)?.[1];
+      expect(activePath).toBeDefined();
+
+      vi.runOnlyPendingTimers();
+      expect(existsSync(dirname(path!))).toBe(false);
+      expect(existsSync(dirname(activePath!))).toBe(true);
+      cleanupMaterializedBinaryResources();
+      expect(existsSync(dirname(activePath!))).toBe(false);
+    } finally {
+      fs.rmSync = originalRmSync;
+      syncBuiltinESMExports();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops automatic cleanup retries after repeated failures", () => {
+    vi.useFakeTimers();
+    const blocks = resolveMcpResultContent({
+      content: [{ type: "resource", resource: { uri: "test://permanent-cleanup-failure", blob: "YQ==" } }],
+    });
+    const text = blocks[0]?.type === "text" ? blocks[0].text : "";
+    const path = text.match(/Binary content saved to (.+)/)?.[1];
+    expect(path).toBeDefined();
+
+    const originalRmSync = fs.rmSync;
+    try {
+      fs.rmSync = (() => { throw new Error("file busy"); }) as typeof fs.rmSync;
+      syncBuiltinESMExports();
+      expect(() => cleanupMaterializedBinaryResources()).toThrow("Failed to clean materialized MCP resources");
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.runOnlyPendingTimers();
+      expect(vi.getTimerCount()).toBe(1);
+      vi.runOnlyPendingTimers();
+      expect(vi.getTimerCount()).toBe(1);
+      vi.runOnlyPendingTimers();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(existsSync(dirname(path!))).toBe(true);
+    } finally {
+      fs.rmSync = originalRmSync;
+      syncBuiltinESMExports();
+      cleanupMaterializedBinaryResources();
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps materialized binary resources per session", () => {
+    const byteLength = vi.spyOn(Buffer, "byteLength").mockReturnValue(10 * 1024 * 1024);
+
+    try {
+      for (let i = 0; i < 10; i++) {
+        const blocks = resolveMcpResultContent({
+          content: [{ type: "resource", resource: { uri: `test://${i}`, blob: "YQ==" } }],
+        });
+        expect(blocks[0]).toMatchObject({ type: "text", text: expect.stringContaining("Binary content saved to") });
+      }
+
+      const blocks = resolveMcpResultContent({
+        content: [{ type: "resource", resource: { uri: "test://limit", blob: "YQ==" } }],
+      });
+      expect(blocks[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("Binary content omitted: session resource limit reached"),
+      });
+
+      cleanupMaterializedBinaryResources();
+      const nextSession = resolveMcpResultContent({
+        content: [{ type: "resource", resource: { uri: "test://next-session", blob: "YQ==" } }],
+      });
+      expect(nextSession[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("Binary content saved to"),
+      });
+    } finally {
+      byteLength.mockRestore();
+    }
   });
 
   it("falls back to structuredContent when content is empty", () => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -8,7 +8,7 @@ import { abortable, throwIfAborted } from "./abort.ts";
 import { isServerCacheValid, parseDirectToolSelectors } from "./metadata-cache.ts";
 export { getMissingConfiguredDirectToolServers } from "./metadata-cache.ts";
 import { formatSchema } from "./tool-metadata.ts";
-import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
+import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
 import { formatToolName, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
@@ -20,6 +20,7 @@ import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
 
 type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
+type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 const INSTRUCTIONS_SNIPPET_LENGTH = 150;
@@ -435,7 +436,7 @@ export function createDirectToolExecutor(
       state.manager.incrementInFlight(spec.serverName);
 
       if (spec.resourceUri) {
-        const result = await withSessionRecovery(
+        const result = await withSessionRecovery<ClientReadResourceResult>(
           {
             manager: state.manager,
             config: state.config,
@@ -445,10 +446,7 @@ export function createDirectToolExecutor(
           spec.serverName,
           (conn) => conn.client.readResource({ uri: spec.resourceUri! }, requestOptions),
         );
-        const content = (result.contents ?? []).map(c => ({
-          type: "text" as const,
-          text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
-        }));
+        const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
         const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
         return {
           content: guarded.content,
@@ -487,7 +485,7 @@ export function createDirectToolExecutor(
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];
-        const content = transformMcpContent(mcpContent);
+        const content = transformMcpContent(mcpContent, state.owner?.signal);
         const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
         const schemaText = spec.inputSchema ? `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}` : "";
         const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed" });
@@ -497,7 +495,7 @@ export function createDirectToolExecutor(
         };
       }
 
-      const content = resolveMcpResultContent(result as Record<string, unknown>);
+      const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
       const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
       if (hasUi) {
         const uiSummary = summarizeUiSessionResult(uiSession);

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import { toolErrorOverride } from "./error-signal.ts";
 import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
 import { runMcpScript } from "./mcp-code.ts";
+import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export {
@@ -275,6 +276,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   });
 
   function startInitialization(ctx: ExtensionContext, owner: McpRuntimeOwner, oauthRuntime: McpOAuthRuntime, generation: number, staleReason: string): Promise<void> {
+    owner.addCleanup(() => cleanupMaterializedBinaryResources(owner.signal));
     const promise = initializeMcp(pi, ctx, owner, {
       ...(programmaticConfig || options.configPath !== undefined
         ? {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -10,7 +10,7 @@ import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { renderTsShape } from "./ts-shape.ts";
 import { reconstructPromptMetadata } from "./metadata-cache.ts";
-import { resolveMcpResultContent, transformMcpContent } from "./tool-registrar.ts";
+import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateAtWord } from "./utils.ts";
@@ -21,6 +21,7 @@ import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-appro
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
+type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
 
 const require = createRequire(import.meta.url);
 const MAX_REGEX_SEARCH_QUERY_LENGTH = 256;
@@ -1112,7 +1113,7 @@ export async function executeCall(
     state.manager.incrementInFlight(serverName);
 
     if (toolMeta.resourceUri) {
-      const result = await withSessionRecovery(
+      const result = await withSessionRecovery<ClientReadResourceResult>(
         {
           manager: state.manager,
           config: state.config,
@@ -1122,10 +1123,7 @@ export async function executeCall(
         serverName,
         (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
       );
-      const content = (result.contents ?? []).map(c => ({
-        type: "text" as const,
-        text: "text" in c ? c.text : ("blob" in c ? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]` : JSON.stringify(c)),
-      }));
+      const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
       const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
       return {
         content: guarded.content,
@@ -1165,7 +1163,7 @@ export async function executeCall(
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];
-        const content = transformMcpContent(mcpContent);
+        const content = transformMcpContent(mcpContent, state.owner?.signal);
         const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
         const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
         const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
@@ -1175,7 +1173,7 @@ export async function executeCall(
         };
       }
 
-      const content = resolveMcpResultContent(result as Record<string, unknown>);
+      const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
       const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
       const uiSummary = summarizeUiSessionResult(uiSession);
       const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiSummary.message}`, rawMcpResult: result });
@@ -1194,7 +1192,7 @@ export async function executeCall(
 
     if (result.isError) {
       const mcpContent = (result.content ?? []) as McpContent[];
-      const content = transformMcpContent(mcpContent);
+      const content = transformMcpContent(mcpContent, state.owner?.signal);
       const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
       const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
       const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
@@ -1204,7 +1202,7 @@ export async function executeCall(
       };
     }
 
-    const content = resolveMcpResultContent(result as Record<string, unknown>);
+    const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
     const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
     const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
     return {

--- a/tool-registrar.ts
+++ b/tool-registrar.ts
@@ -2,12 +2,189 @@
 // NOTE: Tools are NOT registered with Pi - only the unified `mcp` proxy tool is registered.
 // This keeps the LLM context small (1 tool instead of 100s).
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { McpContent, ContentBlock } from "./types.ts";
+
+const MAX_BINARY_RESOURCE_BYTES = 10 * 1024 * 1024;
+const MAX_SESSION_RESOURCE_BYTES = 100 * 1024 * 1024;
+const MAX_SESSION_RESOURCE_FILES = 10_000; // Bounds metadata from empty or tiny resources.
+const CLEANUP_RETRY_DELAY_MS = 30_000;
+const MAX_CLEANUP_RETRY_ATTEMPTS = 3;
+type MaterializedResourceSession = {
+  directory: string | undefined;
+  bytes: number;
+  files: number;
+  sequence: number;
+};
+
+function createMaterializedResourceSession(): MaterializedResourceSession {
+  return {
+    directory: undefined,
+    bytes: 0,
+    files: 0,
+    sequence: 0,
+  };
+}
+
+const defaultMaterializedResourceSession = createMaterializedResourceSession();
+const scopedMaterializedResourceSessions = new WeakMap<object, MaterializedResourceSession>();
+const pendingCleanupDirectories = new Set<string>();
+const cleanupRetryAttempts = new Map<string, number>();
+let pendingCleanupRetry: ReturnType<typeof setTimeout> | undefined;
+
+function isAbortedScope(scope: object | undefined): boolean {
+  return !!scope && "aborted" in scope && (scope as { aborted?: unknown }).aborted === true;
+}
+
+function getMaterializedResourceSession(scope?: object): MaterializedResourceSession | undefined {
+  if (isAbortedScope(scope)) return undefined;
+  if (!scope) return defaultMaterializedResourceSession;
+  let session = scopedMaterializedResourceSessions.get(scope);
+  if (!session) {
+    session = createMaterializedResourceSession();
+    scopedMaterializedResourceSessions.set(scope, session);
+  }
+  return session;
+}
+
+type BinaryResource = { uri?: string | undefined; text?: string | undefined; mimeType?: string | undefined; blob: string };
+type McpResourceContent = {
+  uri: string;
+  text?: string | undefined;
+  blob?: string | undefined;
+  mimeType?: string | undefined;
+  [key: string]: unknown;
+};
+
+function hasRetryableCleanupDirectory(): boolean {
+  for (const directory of pendingCleanupDirectories) {
+    if ((cleanupRetryAttempts.get(directory) ?? 0) < MAX_CLEANUP_RETRY_ATTEMPTS) return true;
+  }
+  return false;
+}
+
+function schedulePendingCleanupRetry(): void {
+  if (pendingCleanupRetry || !hasRetryableCleanupDirectory()) return;
+  for (const directory of pendingCleanupDirectories) {
+    const attempts = cleanupRetryAttempts.get(directory) ?? 0;
+    if (attempts < MAX_CLEANUP_RETRY_ATTEMPTS) cleanupRetryAttempts.set(directory, attempts + 1);
+  }
+  pendingCleanupRetry = setTimeout(() => {
+    pendingCleanupRetry = undefined;
+    try {
+      drainPendingCleanupDirectories();
+    } catch {
+      // drainPendingCleanupDirectories already retained the paths and rescheduled another retry.
+    }
+  }, CLEANUP_RETRY_DELAY_MS);
+}
+
+function drainPendingCleanupDirectories(): void {
+  const failures: unknown[] = [];
+  for (const directory of Array.from(pendingCleanupDirectories)) {
+    try {
+      rmSync(directory, { recursive: true, force: true });
+      pendingCleanupDirectories.delete(directory);
+      cleanupRetryAttempts.delete(directory);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (pendingCleanupDirectories.size === 0 && pendingCleanupRetry) {
+    clearTimeout(pendingCleanupRetry);
+    pendingCleanupRetry = undefined;
+  }
+  if (failures.length > 0) {
+    schedulePendingCleanupRetry();
+    throw new AggregateError(failures, "Failed to clean materialized MCP resources");
+  }
+}
+
+export function cleanupMaterializedBinaryResources(scope?: object): void {
+  const session = scope ? scopedMaterializedResourceSessions.get(scope) : defaultMaterializedResourceSession;
+  if (session?.directory) pendingCleanupDirectories.add(session.directory);
+  if (session) {
+    session.directory = undefined;
+    session.bytes = 0;
+    session.files = 0;
+    session.sequence = 0;
+    if (scope) scopedMaterializedResourceSessions.delete(scope);
+  }
+
+  drainPendingCleanupDirectories();
+}
+
+function replaceBlob(resource: BinaryResource, text: string): string {
+  delete (resource as Partial<BinaryResource>).blob;
+  resource.text = text;
+  return text;
+}
+
+function omitBinaryResource(resource: BinaryResource, reason: string): string {
+  return replaceBlob(resource, [
+    `[Resource: ${resource.uri ?? "(no URI)"}]`,
+    `Binary content omitted: ${reason}`,
+    `MIME type: ${resource.mimeType ?? "application/octet-stream"}`,
+  ].join("\n"));
+}
+
+function materializeBinaryResource(resource: BinaryResource, scope?: object): string {
+  const session = getMaterializedResourceSession(scope);
+  if (!session) return omitBinaryResource(resource, "runtime stopped");
+  const decodedBytes = Buffer.byteLength(resource.blob, "base64");
+  if (decodedBytes > MAX_BINARY_RESOURCE_BYTES) {
+    return omitBinaryResource(resource, "decoded size exceeds 10 MiB");
+  }
+  if (
+    session.bytes + decodedBytes > MAX_SESSION_RESOURCE_BYTES ||
+    session.files >= MAX_SESSION_RESOURCE_FILES
+  ) {
+    return omitBinaryResource(resource, "session resource limit reached");
+  }
+
+  try {
+    session.directory ??= mkdtempSync(join(tmpdir(), "pi-mcp-resource-"));
+  } catch {
+    return omitBinaryResource(resource, "could not be saved");
+  }
+
+  const filePath = join(session.directory, `resource-${++session.sequence}.bin`);
+  session.bytes += decodedBytes;
+  session.files += 1;
+  try {
+    writeFileSync(filePath, Buffer.from(resource.blob, "base64"), { flag: "wx", mode: 0o600 });
+  } catch {
+    try {
+      rmSync(filePath, { force: true });
+      session.bytes -= decodedBytes;
+      session.files -= 1;
+    } catch {
+      // Keep the reservation when a partial file cannot be removed.
+    }
+    return omitBinaryResource(resource, "could not be saved");
+  }
+
+  return replaceBlob(resource, [
+    `[Resource: ${resource.uri ?? "(no URI)"}]`,
+    `Binary content saved to ${filePath}`,
+    `MIME type: ${resource.mimeType ?? "application/octet-stream"}`,
+  ].join("\n"));
+}
 
 /**
  * Transform MCP content types to Pi content blocks.
  */
-export function transformMcpContent(content: McpContent[]): ContentBlock[] {
+export function transformMcpResourceContents(contents: McpResourceContent[], scope?: object): ContentBlock[] {
+  return contents.map(resource => {
+    if (typeof resource.text === "string") return { type: "text" as const, text: resource.text };
+    if (typeof resource.blob === "string") return { type: "text" as const, text: materializeBinaryResource(resource as BinaryResource, scope) };
+    return { type: "text" as const, text: JSON.stringify(resource) };
+  });
+}
+
+export function transformMcpContent(content: McpContent[], scope?: object): ContentBlock[] {
   return content.map(c => {
     if (c.type === "text") {
       return { type: "text" as const, text: c.text ?? "" };
@@ -21,6 +198,13 @@ export function transformMcpContent(content: McpContent[]): ContentBlock[] {
     }
     if (c.type === "resource") {
       const resourceUri = c.resource?.uri ?? "(no URI)";
+      if (c.resource && "blob" in c.resource && typeof c.resource.blob === "string") {
+        const binaryResource = c.resource as typeof c.resource & { mimeType?: string; blob: string };
+        return {
+          type: "text" as const,
+          text: materializeBinaryResource(binaryResource, scope),
+        };
+      }
       const resourceContent = c.resource?.text ?? (c.resource ? JSON.stringify(c.resource) : "(no content)");
       return {
         type: "text" as const,
@@ -49,8 +233,8 @@ export function transformMcpContent(content: McpContent[]): ContentBlock[] {
  * Resolve a tool result's content blocks, falling back to structuredContent
  * when content is empty.
  */
-export function resolveMcpResultContent(result: Record<string, unknown>): ContentBlock[] {
-  const blocks = transformMcpContent((Array.isArray(result.content) ? result.content : []) as McpContent[]);
+export function resolveMcpResultContent(result: Record<string, unknown>, scope?: object): ContentBlock[] {
+  const blocks = transformMcpContent((Array.isArray(result.content) ? result.content : []) as McpContent[], scope);
   if (blocks.length > 0) return blocks;
 
   if (result.structuredContent !== undefined && result.structuredContent !== null) {


### PR DESCRIPTION
MCP binary resources are serialized into tool results as base64. This can add large binary payloads to the model context.

Save each blob to a private temporary file and return its path instead.