### PR TITLE
feat: add public OAuth token API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added the `pi-mcp-adapter/oauth` subpath for URL-bound OAuth token reuse by cooperating Pi extensions. Thanks @ThePhoenixCoding for issue #323.
 - Added `oauth.logoUri` for OAuth Dynamic Client Registration, with validation that requires an absolute HTTP(S) URL. Thanks @grinich for PR #321.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ A supplied `config` is a complete, isolated snapshot. It is not merged with file
 
 With `configPath` and no `config`, the adapter keeps normal file merge behavior, and that path takes precedence over argv and `--mcp-config`. The default export keeps the normal file-based behavior. OAuth credentials are stored in the operating system credential store and keyed by the configured server name; URL binding prevents credentials from being accepted for a different server URL. `settings.oauthDir` and `MCP_OAUTH_DIR` are used only as legacy plaintext import locations for older `tokens.json` files, not as credential namespaces. CSRF state and PKCE verifiers are flow-local, so concurrent authorization flows do not share transient secrets.
 
+Cooperating Pi extensions can use `pi-mcp-adapter/oauth` to reuse URL-bound OAuth tokens without deep-importing private files:
+
+```ts
+import { getMcpOAuthTokensForUrl, updateMcpOAuthTokensForUrl } from "pi-mcp-adapter/oauth";
+
+const tokens = await getMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp");
+updateMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp", { accessToken: "..." });
+```
+
+The public subpath exposes only token read/update helpers plus a status helper. The async read path uses the adapter's refresh logic before it returns tokens. The helpers keep secure-store storage, URL binding, refresh persistence, chunk handling, legacy import, and fail-closed credential-store errors. They do not expose client registration secrets, PKCE verifiers, or OAuth state.
+
 ### Runtime status snapshots
 
 Extensions can subscribe to the adapter's versioned shared event-bus channel instead of parsing `/mcp` or `mcp({})` output:

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -31,6 +31,7 @@ import {
   getOAuthState,
   clearOAuthState,
   getAuthBaseDir,
+  OAuthCredentialStoreError,
   type AuthStorageOptions,
   type StoredTokens,
 } from "./mcp-auth.ts"
@@ -820,7 +821,7 @@ export async function getValidToken(
         authProvider.deactivate()
       }
     } catch (error) {
-      if (isAbortError(error, signal)) throw error
+      if (isAbortError(error, signal) || error instanceof OAuthCredentialStoreError) throw error
       console.error(`MCP Auth: Token refresh failed for ${serverName}`, { error })
       return null
     }

--- a/oauth-public-api.test.ts
+++ b/oauth-public-api.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the public OAuth token reuse API.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "memory";
+
+const {
+  getMcpOAuthTokensForUrl,
+  inspectMcpOAuthTokensForUrl,
+  updateMcpOAuthTokensForUrl,
+} = await import("pi-mcp-adapter/oauth");
+const {
+  getAuthForUrl,
+  resetTestAuthSecretStore,
+  saveAuthEntry,
+} = await import("./mcp-auth.ts");
+
+describe("public OAuth token API", () => {
+  beforeEach(() => {
+    resetTestAuthSecretStore();
+  });
+
+  it("reads and updates URL-bound tokens through the package export", async () => {
+    const expiresAt = Date.now() / 1000 + 3600;
+    updateMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp", {
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      expiresAt,
+      scope: "read write",
+    });
+
+    assert.deepStrictEqual(await getMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp"), {
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      expiresAt,
+      scope: "read write",
+    });
+    assert.deepStrictEqual(inspectMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp"), {
+      status: "present",
+      tokens: {
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        expiresAt,
+        scope: "read write",
+      },
+    });
+  });
+
+  it("does not return tokens for a different URL", async () => {
+    updateMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp", { accessToken: "access-1" });
+
+    assert.strictEqual(await getMcpOAuthTokensForUrl("jira", "https://other.example.com/mcp"), undefined);
+    assert.deepStrictEqual(inspectMcpOAuthTokensForUrl("jira", "https://other.example.com/mcp"), {
+      status: "absent",
+    });
+  });
+
+  it("does not expose client info or OAuth flow secrets", () => {
+    saveAuthEntry("jira", {
+      tokens: { accessToken: "access-1" },
+      clientInfo: { clientId: "client-1", clientSecret: "secret-1" },
+      codeVerifier: "verifier-1",
+      oauthState: "state-1",
+      serverUrl: "https://jira.example.com/mcp",
+    }, "https://jira.example.com/mcp");
+
+    const status = inspectMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp");
+    assert.deepStrictEqual(status, { status: "present", tokens: { accessToken: "access-1" } });
+    assert(!("entry" in status));
+  });
+
+  it("does not return refreshable expired tokens as valid when refresh cannot complete", async () => {
+    const expiresAt = Date.now() / 1000 - 3600;
+    saveAuthEntry("jira", {
+      tokens: {
+        accessToken: "expired-token",
+        refreshToken: "refresh-token",
+        expiresAt,
+      },
+      clientInfo: { clientId: "config-client", configPreRegistered: true },
+      serverUrl: "https://jira.example.com/mcp",
+    }, "https://jira.example.com/mcp");
+
+    assert.strictEqual(await getMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp"), undefined);
+    assert.deepStrictEqual(inspectMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp"), {
+      status: "present",
+      tokens: {
+        accessToken: "expired-token",
+        refreshToken: "refresh-token",
+        expiresAt,
+      },
+    });
+  });
+
+  it("fails closed when the secure credential store is unavailable", async () => {
+    const previous = process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+    resetTestAuthSecretStore();
+    try {
+      await assert.rejects(
+        () => getMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp"),
+        /Failed to read OAuth credentials.*OS secure credential store/,
+      );
+      const status = inspectMcpOAuthTokensForUrl("jira", "https://jira.example.com/mcp");
+      assert.strictEqual(status.status, "unavailable");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+      } else {
+        process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = previous;
+      }
+      resetTestAuthSecretStore();
+    }
+  });
+
+  it("clears stale URL-bound state when tokens move to another URL", async () => {
+    saveAuthEntry("jira", {
+      tokens: { accessToken: "old-token" },
+      clientInfo: { clientId: "old-client" },
+      codeVerifier: "old-verifier",
+      oauthState: "old-state",
+      serverUrl: "https://old.example.com/mcp",
+    }, "https://old.example.com/mcp");
+
+    updateMcpOAuthTokensForUrl("jira", "https://new.example.com/mcp", { accessToken: "new-token" });
+
+    assert.strictEqual(await getMcpOAuthTokensForUrl("jira", "https://old.example.com/mcp"), undefined);
+    assert.deepStrictEqual(await getMcpOAuthTokensForUrl("jira", "https://new.example.com/mcp"), {
+      accessToken: "new-token",
+    });
+    const privateEntry = getAuthForUrl("jira", "https://new.example.com/mcp");
+    assert.strictEqual(privateEntry?.clientInfo, undefined);
+    assert.strictEqual(privateEntry?.codeVerifier, undefined);
+    assert.strictEqual(privateEntry?.oauthState, undefined);
+  });
+});

--- a/oauth.ts
+++ b/oauth.ts
@@ -1,0 +1,48 @@
+import { getValidToken } from "./mcp-auth-flow.ts";
+import {
+  inspectAuthForUrl,
+  updateTokens,
+  type AuthStorageOptions,
+  type StoredTokens,
+} from "./mcp-auth.ts";
+
+export type McpOAuthTokens = StoredTokens;
+export type McpOAuthStorageOptions = AuthStorageOptions;
+export interface McpOAuthTokenOptions {
+  authStorageOptions?: McpOAuthStorageOptions;
+  signal?: AbortSignal;
+  skipIssuerMetadataValidation?: boolean;
+}
+export type McpOAuthTokenStatus =
+  | { status: "present"; tokens: McpOAuthTokens }
+  | { status: "absent" }
+  | { status: "unavailable"; message: string };
+
+export async function getMcpOAuthTokensForUrl(
+  serverName: string,
+  serverUrl: string,
+  options: McpOAuthTokenOptions = {},
+): Promise<McpOAuthTokens | undefined> {
+  return (await getValidToken(serverName, serverUrl, options)) ?? undefined;
+}
+
+export function inspectMcpOAuthTokensForUrl(
+  serverName: string,
+  serverUrl: string,
+  options?: McpOAuthStorageOptions,
+): McpOAuthTokenStatus {
+  const status = inspectAuthForUrl(serverName, serverUrl, options);
+  if (status.status !== "present") return status;
+  return status.entry.tokens
+    ? { status: "present", tokens: status.entry.tokens }
+    : { status: "absent" };
+}
+
+export function updateMcpOAuthTokensForUrl(
+  serverName: string,
+  serverUrl: string,
+  tokens: McpOAuthTokens,
+  options?: McpOAuthStorageOptions,
+): void {
+  updateTokens(serverName, tokens, serverUrl, options);
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
       "types": "./types.ts",
       "import": "./types.ts",
       "default": "./types.ts"
+    },
+    "./oauth": {
+      "types": "./oauth.ts",
+      "import": "./oauth.ts",
+      "default": "./oauth.ts"
     }
   },
   "license": "MIT",
@@ -29,7 +34,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test --test-concurrency=1 mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts",
+    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test --test-concurrency=1 oauth-public-api.test.ts mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts",
     "test:oauth-provider": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test mcp-oauth-provider.test.ts",
     "test:conformance": "bash conformance/run.sh"
   },
@@ -107,6 +112,7 @@
     "glimpse-ui.ts",
     "npx-resolver.ts",
     "oauth-handler.ts",
+    "oauth.ts",
     "mcp-auth.ts",
     "mcp-keyring-helper.cjs",
     "mcp-oauth-provider.ts",


### PR DESCRIPTION
## Summary

Adds a supported `pi-mcp-adapter/oauth` subpath for cooperating Pi extensions that need URL-bound OAuth token reuse.

The public API is intentionally token-only:

- `getMcpOAuthTokensForUrl`
- `inspectMcpOAuthTokensForUrl`
- `updateMcpOAuthTokensForUrl`

It keeps private auth internals out of the supported surface.

## Validation

- `npm run test:oauth`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `npm pack --dry-run --json`
- runtime import check confirmed `./oauth.ts` exports only the three token helpers

Fresh follow-up review on `045da93dd45e9fe9536b171221827a1a9ebb64e0`: no findings.

Closes #323.
