### PR TITLE
fix: avoid early MCP active-tool startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stopped load-time MCP initialization from printing a TUI startup error when Pi action methods are not bound yet. Thanks @21307369 for issue #327.
+
 ## [2.22.0] - 2026-08-11
 
 ### Added

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -822,6 +822,36 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.executeStatus).toHaveBeenCalledWith(state);
   });
 
+  it("does not fail load-time tool sync before Pi action methods are bound", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { url: "http://localhost:3999/mcp", lifecycle: "eager" },
+      },
+    });
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { default: mcpAdapter } = await import("../index.ts");
+      const { api } = createPi();
+      api.getActiveTools.mockImplementation(() => {
+        throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
+      });
+      mcpAdapter(api);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mocks.initializeMcp).toHaveBeenCalledTimes(1);
+      expect(mocks.updateStatusBar).toHaveBeenCalledWith(state);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("does not initialize at load when startup servers are absent or disabled", async () => {
     mocks.loadMcpConfig.mockReturnValue({
       mcpServers: {

--- a/index.ts
+++ b/index.ts
@@ -169,13 +169,23 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     return resolveDirectTools(config, cache, prefix, envDirectToolOverride);
   }
 
+  function getActiveToolsIfReady(): string[] | undefined {
+    try {
+      return pi.getActiveTools?.();
+    } catch (error) {
+      if (error instanceof Error
+        && error.message.includes("Action methods cannot be called during extension loading")) return undefined;
+      throw error;
+    }
+  }
+
   function deactivateTools(toolNames: string[]): string[] {
     if (toolNames.length === 0) return [];
     const unregisterTool = (pi as ExtensionAPI & { unregisterTool?: (name: string) => boolean }).unregisterTool;
     const unregistered = toolNames.filter((toolName) => unregisterTool?.(toolName) === true);
     const fallbackNames = toolNames.filter((toolName) => !unregistered.includes(toolName));
     const remove = new Set(toolNames);
-    const activeTools = pi.getActiveTools?.();
+    const activeTools = getActiveToolsIfReady();
     if (!activeTools || activeTools.length === 0) {
       for (const toolName of fallbackNames) fallbackDeactivatedTools.add(toolName);
       return unregistered;
@@ -207,7 +217,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         registerDirectTool(spec);
         registeredDirectTools.set(spec.prefixedName, fingerprint);
         if (fallbackDeactivatedTools.delete(spec.prefixedName)) {
-          const activeTools = pi.getActiveTools?.();
+          const activeTools = getActiveToolsIfReady();
           if (activeTools && !activeTools.includes(spec.prefixedName)) {
             pi.setActiveTools([...activeTools, spec.prefixedName]);
           }
@@ -849,7 +859,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         registerProxyTool(description);
         return;
       }
-      const activeTools = pi.getActiveTools?.();
+      const activeTools = getActiveToolsIfReady();
       if (activeTools && !activeTools.includes("mcp")) {
         pi.setActiveTools([...activeTools, "mcp"]);
       }


### PR DESCRIPTION
Closes #327.

This keeps load-time MCP initialization from treating Pi's temporary action-method binding error as a fatal initialization failure while the TUI is still starting. Unexpected active-tool errors still throw.

Validation:
- npm test -- __tests__/index-lifecycle.test.ts
- npm run typecheck
- git diff --check

Fresh review:
- /Users/nicobailon/Documents/docs/pi-mcp-adapter-issue-327-fresh-review.md