### PR TITLE
fix hyperlink rendering. Old behaviors breaks links on line break.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Stopped load-time MCP initialization from printing a TUI startup error when Pi action methods are not bound yet. Thanks @21307369 for issue #327.
+- Kept interactive OAuth authorization URLs clickable as a single terminal hyperlink. Thanks @rfccg for PR #329.
 
 ## [2.22.0] - 2026-08-11
 

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -122,7 +122,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the exact OAuth URL through UI notification", async () => {
+  it("surfaces the exact OAuth URL as one terminal hyperlink", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
       await options.onAuthorizationUrl(authorizationUrl);
@@ -145,7 +145,7 @@ describe("authenticateServer", () => {
       { onAuthorizationUrl: expect.any(Function) },
     );
     expect(ui.notify).toHaveBeenCalledWith(
-      expect.stringContaining(authorizationUrl),
+      expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
       "info",
     );
   });

--- a/commands.ts
+++ b/commands.ts
@@ -24,6 +24,7 @@ import { getAuthStorageOptions, inspectAuthForUrl } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
 import { isAbortError } from "./runtime-owner.ts";
+import { hyperlink } from "@earendil-works/pi-tui";
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -273,7 +274,7 @@ export async function authenticateServer(
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
       onAuthorizationUrl: (authorizationUrl) => {
         ui.notify(
-          `Open this URL to authenticate ${serverName}:\n\n${authorizationUrl}\n\n` +
+          `Open this URL to authenticate ${serverName}:\n\n${hyperlink(authorizationUrl, authorizationUrl)}\n\n` +
           "After approving, return to Pi; the local callback will complete automatically.",
           "info"
         );

--- a/commands.ts
+++ b/commands.ts
@@ -24,7 +24,10 @@ import { getAuthStorageOptions, inspectAuthForUrl } from "./mcp-auth.ts";
 import { loadOnboardingState, markSetupCompleted as persistSetupCompleted, markSharedConfigHintShown } from "./onboarding-state.ts";
 import { openPath, resolveServerUrl, sanitizeTerminalText } from "./utils.ts";
 import { isAbortError } from "./runtime-owner.ts";
-import { hyperlink } from "@earendil-works/pi-tui";
+
+function terminalHyperlink(label: string, url: string): string {
+  return `\u001B]8;;${sanitizeTerminalText(url)}\u001B\\${sanitizeTerminalText(label)}\u001B]8;;\u001B\\`;
+}
 
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
@@ -274,7 +277,7 @@ export async function authenticateServer(
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
       onAuthorizationUrl: (authorizationUrl) => {
         ui.notify(
-          `Open this URL to authenticate ${serverName}:\n\n${hyperlink(authorizationUrl, authorizationUrl)}\n\n` +
+          `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
           "After approving, return to Pi; the local callback will complete automatically.",
           "info"
         );


### PR DESCRIPTION
This simple change fixes the rendering of the URL printed to proceed with authentication. This is a usability fix allowing to click on it to directly open the browser.
Currently the hyperlink breaks depending on rendering on first line break, and clicking on it opens a cropped link. The current workaround is to copy and full link and copy on the browser.

