### PR TITLE
Support pasted OAuth callbacks on remote machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added interactive callback URL pasting to `/mcp-auth` for OAuth flows running on remote or headless machines. Thanks @trevorleibert-mixpanel for PR #330.
+
 ### Fixed
 - Stopped load-time MCP initialization from printing a TUI startup error when Pi action methods are not bound yet. Thanks @21307369 for issue #327.
 - Kept interactive OAuth authorization URLs clickable as a single terminal hyperlink. Thanks @rfccg for PR #329.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ The adapter owns only its client socket and closes that connection when the Pi r
 
 ### Remote/headless OAuth
 
-If Pi is running on a remote server and cannot open a local browser, start OAuth through the proxy tool. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable.
+If Pi is running on a remote server, `/mcp-auth <server>` prints the authorization URL and opens a callback input. Open the URL in your local browser. After approval, the browser may fail to load the localhost callback page because localhost refers to your workstation; copy the full URL from its address bar and paste it into Pi. The input closes automatically instead when the browser can reach Pi's callback directly.
+
+The same flow is available through the proxy tool for non-interactive clients. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable.
 
 On Linux, if credential access fails because Pi inherited a revoked session keyring, the adapter uses a best-effort recovery path through `keyctl session - node <packaged helper>` so explicit re-authentication can write fresh credentials without killing a long-lived tmux server. This path requires `keyctl` and `node` on `PATH`; missing, locked, or otherwise unavailable credential stores still fail closed.
 

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -51,7 +51,10 @@ describe("authenticateServer", () => {
         "sentry",
         "https://mcp.sentry.dev/mcp",
         definition,
-        { onAuthorizationUrl: expect.any(Function) },
+        {
+          onAuthorizationUrl: expect.any(Function),
+          onAuthorizationInput: expect.any(Function),
+        },
       );
     } finally {
       if (originalUrl === undefined) delete process.env.MCP_AUTH_URL;
@@ -122,13 +125,17 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the exact OAuth URL as one terminal hyperlink", async () => {
+  it("surfaces the OAuth URL as one terminal hyperlink and accepts a pasted remote callback", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
+    const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
+    const inputController = new AbortController();
     mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
       await options.onAuthorizationUrl(authorizationUrl);
+      const input = await options.onAuthorizationInput(authorizationUrl, inputController.signal);
+      expect(input).toBe(callbackUrl);
       return "authenticated";
     });
-    const ui = { notify: vi.fn(), setStatus: vi.fn() };
+    const ui = { notify: vi.fn(), setStatus: vi.fn(), input: vi.fn(async () => callbackUrl) };
     const { authenticateServer } = await import("../commands.ts");
 
     const result = await authenticateServer("sentry", {
@@ -142,11 +149,19 @@ describe("authenticateServer", () => {
       "sentry",
       "https://mcp.sentry.dev/mcp",
       { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
-      { onAuthorizationUrl: expect.any(Function) },
+      {
+        onAuthorizationUrl: expect.any(Function),
+        onAuthorizationInput: expect.any(Function),
+      },
     );
     expect(ui.notify).toHaveBeenCalledWith(
       expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
       "info",
+    );
+    expect(ui.input).toHaveBeenCalledWith(
+      "Complete sentry OAuth",
+      "Paste the full callback URL, or wait for automatic completion",
+      { signal: inputController.signal },
     );
   });
 });

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -695,6 +695,43 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(getOAuthState("browser-fail")).toBeUndefined();
   });
 
+  it("completes from a pasted callback URL and clears the localhost waiter", async () => {
+    let oauthState = "";
+    mocks.sdkAuth
+      .mockImplementationOnce(async (provider) => {
+        oauthState = await provider.state();
+        await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+        return "REDIRECT";
+      })
+      .mockImplementationOnce(async (_provider, options) => {
+        expect(options).toEqual({
+          serverUrl: "https://api.example.com/mcp",
+          authorizationCode: "pasted-code",
+        });
+        return "AUTHORIZED";
+      });
+    mocks.waitForCallback.mockReturnValueOnce(new Promise(() => {}));
+    mocks.open.mockResolvedValueOnce(undefined);
+    const onAuthorizationInput = vi.fn(async () => (
+      `http://localhost:19876/callback?code=pasted-code&state=${encodeURIComponent(oauthState)}`
+    ));
+    const { authenticate, hasPendingAuth } = await import("../mcp-auth-flow.ts");
+    const { getOAuthState } = await import("../mcp-auth.ts");
+
+    await expect(authenticate("remote-manual", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+    }, { onAuthorizationInput })).resolves.toBe("authenticated");
+
+    expect(onAuthorizationInput).toHaveBeenCalledWith(
+      "https://auth.example.com/authorize",
+      expect.any(AbortSignal),
+    );
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(oauthState);
+    expect(hasPendingAuth("remote-manual")).toBe(false);
+    expect(getOAuthState("remote-manual")).toBeUndefined();
+  });
+
   it("clears a pending manual flow when cancellation happens after callback registration", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));

--- a/commands.ts
+++ b/commands.ts
@@ -278,10 +278,16 @@ export async function authenticateServer(
       onAuthorizationUrl: (authorizationUrl) => {
         ui.notify(
           `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving, return to Pi; the local callback will complete automatically.",
+          "After approving, Pi will complete automatically if the browser can reach its localhost callback. " +
+          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi."
           "info"
         );
       },
+      onAuthorizationInput: (_authorizationUrl, inputSignal) => ui.input(
+        `Complete ${serverName} OAuth`,
+        "Paste the full callback URL, or wait for automatic completion",
+        { signal: inputSignal },
+      ),
       ...(signal ? { signal } : {}),
       ...(runtime ? { runtime } : {}),
     });

--- a/commands.ts
+++ b/commands.ts
@@ -279,7 +279,7 @@ export async function authenticateServer(
         ui.notify(
           `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
           "After approving, Pi will complete automatically if the browser can reach its localhost callback. " +
-          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi."
+          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi.",
           "info"
         );
       },

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -24,6 +24,7 @@ import {
   extractOAuthConfig,
   initializeOAuth,
   shutdownOAuth,
+  waitForAuthorizationResponse,
   type AuthStatus,
 } from "./mcp-auth-flow.ts"
 import { isCallbackServerRunning } from "./mcp-callback-server.ts"
@@ -190,6 +191,115 @@ describe("mcp-auth-flow", () => {
       await initializeOAuth()
       await shutdownOAuth()
       assert.strictEqual(isCallbackServerRunning(), false)
+    })
+  })
+
+  describe("waitForAuthorizationResponse", () => {
+    it("should accept a pasted callback URL and validate its state", async () => {
+      let promptSignal: AbortSignal | undefined
+      const result = await waitForAuthorizationResponse(
+        new Promise(() => {}),
+        "https://auth.example.com/authorize",
+        "expected-state",
+        async (_authorizationUrl, signal) => {
+          promptSignal = signal
+          return "http://localhost:3118/callback?code=manual-code&state=expected-state"
+        },
+      )
+
+      assert.deepStrictEqual(result, {
+        input: { code: "manual-code" },
+        source: "manual",
+      })
+      assert.strictEqual(promptSignal?.aborted, true)
+    })
+
+    it("should dismiss manual input when the localhost callback wins", async () => {
+      let promptSignal: AbortSignal | undefined
+      const result = await waitForAuthorizationResponse(
+        Promise.resolve({ code: "callback-code" }),
+        "https://auth.example.com/authorize",
+        "expected-state",
+        async (_authorizationUrl, signal) => {
+          promptSignal = signal
+          await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }))
+          return undefined
+        },
+      )
+
+      assert.deepStrictEqual(result, {
+        input: { code: "callback-code" },
+        source: "callback",
+      })
+      assert.strictEqual(promptSignal?.aborted, true)
+    })
+
+    it("should reject a pasted callback URL with the wrong state", async () => {
+      await assert.rejects(
+        waitForAuthorizationResponse(
+          new Promise(() => {}),
+          "https://auth.example.com/authorize",
+          "expected-state",
+          async () => "http://localhost:3118/callback?code=manual-code&state=wrong-state",
+        ),
+        /OAuth state mismatch/,
+      )
+    })
+
+    it("should reject a pasted callback URL without state", async () => {
+      await assert.rejects(
+        waitForAuthorizationResponse(
+          new Promise(() => {}),
+          "https://auth.example.com/authorize",
+          "expected-state",
+          async () => "http://localhost:3118/callback?code=manual-code",
+        ),
+        /OAuth state missing/,
+      )
+    })
+
+    it("should reject a raw authorization code from manual input", async () => {
+      await assert.rejects(
+        waitForAuthorizationResponse(
+          new Promise(() => {}),
+          "https://auth.example.com/authorize",
+          "expected-state",
+          async () => "manual-code",
+        ),
+        /Paste the full OAuth callback URL/,
+      )
+    })
+
+    it("should abort manual input when the OAuth operation is cancelled", async () => {
+      const controller = new AbortController()
+      const reason = new Error("request cancelled")
+      let promptSignal: AbortSignal | undefined
+      const response = waitForAuthorizationResponse(
+        new Promise(() => {}),
+        "https://auth.example.com/authorize",
+        "expected-state",
+        async (_authorizationUrl, signal) => {
+          promptSignal = signal
+          return new Promise(() => {})
+        },
+        controller.signal,
+      )
+
+      controller.abort(reason)
+      await assert.rejects(response, (error) => error === reason)
+      assert.strictEqual(promptSignal?.aborted, true)
+    })
+
+    it("should treat dismissing manual input as cancellation", async () => {
+      await assert.rejects(
+        waitForAuthorizationResponse(
+          new Promise(() => {}),
+          "https://auth.example.com/authorize",
+          "expected-state",
+          async () => undefined,
+        ),
+        /OAuth authentication cancelled/,
+      )
     })
   })
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -49,6 +49,10 @@ export interface McpOAuthRuntime {
 
 export interface AuthenticateOptions {
   onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
+  onAuthorizationInput?: (
+    authorizationUrl: string,
+    signal: AbortSignal,
+  ) => Promise<string | undefined>
   authStorageOptions?: AuthStorageOptions
   signal?: AbortSignal
   runtime?: McpOAuthRuntime
@@ -568,6 +572,53 @@ export function parseAuthorizationCodeInput(input: string, expectedState?: strin
   return parseAuthorizationRedirectInput(input, expectedState).code
 }
 
+type AuthorizationResponse = {
+  input: AuthorizationCodeInput
+  source: "callback" | "manual"
+}
+
+/**
+ * Wait for either the localhost callback or a manually pasted redirect URL.
+ * The manual input prompt is dismissed as soon as either path finishes.
+ */
+export async function waitForAuthorizationResponse(
+  callbackPromise: Promise<AuthorizationCodeInput>,
+  authorizationUrl: string,
+  expectedState: string,
+  onAuthorizationInput?: AuthenticateOptions["onAuthorizationInput"],
+  signal?: AbortSignal,
+): Promise<AuthorizationResponse> {
+  if (!onAuthorizationInput) {
+    return {
+      input: await abortable(callbackPromise, signal),
+      source: "callback",
+    }
+  }
+
+  const inputController = new AbortController()
+  try {
+    const response = await abortable(Promise.race([
+      callbackPromise.then((input) => ({ input, source: "callback" as const })),
+      onAuthorizationInput(authorizationUrl, inputController.signal).then((input) => ({
+        input,
+        source: "manual" as const,
+      })),
+    ]), signal)
+
+    if (response.source === "callback") return response
+    if (!response.input?.trim()) throw new Error("OAuth authentication cancelled")
+    if (!getSearchParamsFromInput(response.input.trim())) {
+      throw new Error("Paste the full OAuth callback URL, including its code and state parameters")
+    }
+    return {
+      input: parseAuthorizationRedirectInput(response.input, expectedState),
+      source: "manual",
+    }
+  } finally {
+    inputController.abort()
+  }
+}
+
 /**
  * Complete OAuth authentication from manual user input.
  */
@@ -728,12 +779,22 @@ export async function authenticate(
         console.warn(`MCP Auth: Failed to open browser for ${serverName}; waiting for manual callback`, { error })
       }
 
-      const callbackResult = await abortable(callbackPromise, signal)
+      const authorizationResponse = await waitForAuthorizationResponse(
+        callbackPromise,
+        authorizationUrl,
+        oauthState,
+        options.onAuthorizationInput,
+        signal,
+      )
+      if (authorizationResponse.source === "manual") {
+        cancelPendingCallback(oauthState)
+      }
 
-      // The callback server accepted only the flow-local reserved state.
+      // The callback server accepted only the flow-local reserved state. Manual
+      // input is checked against the same state before token exchange.
       throwIfAborted(signal)
 
-      return await completeAuth(serverName, callbackResult, {
+      return await completeAuth(serverName, authorizationResponse.input, {
         ...options,
         ...(signal ? { signal } : {}),
         runtime,


### PR DESCRIPTION
## Summary

- print the OAuth authorization URL and offer a callback URL input during `/mcp-auth`
- race pasted callback input with the existing localhost callback so local flows still complete automatically
- validate manually pasted callbacks against the pending OAuth state and require the full callback URL
- dismiss stale input when the local callback wins or authentication is cancelled
- document the remote/headless workflow

## Motivation

When Pi runs on a remote devbox, the user's local browser redirects to its own `localhost`, not the devbox callback listener. The existing flow then waits indefinitely unless the user invokes the lower-level proxy auth actions. This makes the normal `/mcp-auth` flow support the same copy/paste callback procedure directly.

## Verification

- `npm run typecheck`
- `npm test` (93 files, 991 tests)
- `npm run test:oauth` (137 tests)
