### PR TITLE
Keep OAuth authorization links accessible before callback input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.
+
 ## [2.23.0] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The adapter owns only its client socket and closes that connection when the Pi r
 
 ### Remote/headless OAuth
 
-If Pi is running on a remote server, `/mcp-auth <server>` prints the authorization URL and opens a callback input. Open the URL in your local browser. After approval, the browser may fail to load the localhost callback page because localhost refers to your workstation; copy the full URL from its address bar and paste it into Pi. The input closes automatically instead when the browser can reach Pi's callback directly.
+If Pi is running on a remote server, `/mcp-auth <server>` shows a clickable authorization URL first. Open it in your local browser and approve access, then select **Yes** in Pi to open the callback input. The browser may fail to load the localhost callback page because localhost refers to your workstation; copy the full URL from its address bar and paste it into Pi. The authorization screen closes automatically instead when the browser can reach Pi's callback directly.
 
 The same flow is available through the proxy tool for non-interactive clients. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable.
 

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -135,7 +135,12 @@ describe("authenticateServer", () => {
       expect(input).toBe(callbackUrl);
       return "authenticated";
     });
-    const ui = { notify: vi.fn(), setStatus: vi.fn(), input: vi.fn(async () => callbackUrl) };
+    const ui = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      confirm: vi.fn(async () => true),
+      input: vi.fn(async () => callbackUrl),
+    };
     const { authenticateServer } = await import("../commands.ts");
 
     const result = await authenticateServer("sentry", {
@@ -158,10 +163,16 @@ describe("authenticateServer", () => {
       expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
       "info",
     );
-    expect(ui.input).toHaveBeenCalledWith(
-      "Complete sentry OAuth",
-      "Paste the full callback URL, or wait for automatic completion",
+    expect(ui.confirm).toHaveBeenCalledWith(
+      "Authorize sentry",
+      expect.stringContaining(authorizationUrl),
       { signal: inputController.signal },
     );
+    expect(ui.input).toHaveBeenCalledWith(
+      "Complete sentry OAuth",
+      "Paste the full callback URL",
+      { signal: inputController.signal },
+    );
+    expect(ui.confirm.mock.invocationCallOrder[0]).toBeLessThan(ui.input.mock.invocationCallOrder[0]);
   });
 });

--- a/commands.ts
+++ b/commands.ts
@@ -283,11 +283,20 @@ export async function authenticateServer(
           "info"
         );
       },
-      onAuthorizationInput: (_authorizationUrl, inputSignal) => ui.input(
-        `Complete ${serverName} OAuth`,
-        "Paste the full callback URL, or wait for automatic completion",
-        { signal: inputSignal },
-      ),
+      onAuthorizationInput: async (authorizationUrl, inputSignal) => {
+        const readyToPaste = await ui.confirm(
+          `Authorize ${serverName}`,
+          `Open this link in your browser:\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
+          "After approving access, select Yes to paste the callback URL.",
+          { signal: inputSignal },
+        );
+        if (!readyToPaste || inputSignal.aborted) return undefined;
+        return ui.input(
+          `Complete ${serverName} OAuth`,
+          "Paste the full callback URL",
+          { signal: inputSignal },
+        );
+      },
       ...(signal ? { signal } : {}),
       ...(runtime ? { runtime } : {}),
     });


### PR DESCRIPTION
## Summary

- show the OAuth authorization URL inside a clickable confirmation screen before opening callback input
- open callback-paste input only after the user confirms they approved access
- retain automatic localhost completion and dismiss the authorization screen when it wins

## Motivation

The callback input opened immediately and blocked interaction with the authorization link behind it. Closing that input correctly cancelled authentication, leaving remote users unable to progress through the intended flow.

## Verification

- `npm run typecheck`
- `npx vitest run __tests__/commands-auth.test.ts`
- `npm test` (93 files, 991 tests)
