### PR TITLE
Cache OAuth credentials in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.
+- Cached OAuth credentials in memory and refreshed them after OAuth-backed 401 responses. Thanks @daniel-sampliner for PR #335.
 
 ## [2.23.0] - 2026-08-11
 

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -233,6 +233,10 @@ The adapter fails closed when the OS credential store is unavailable. On headles
 
 On Linux, if credential access fails because Pi inherited a revoked session keyring, the adapter makes one best-effort retry through `keyctl session - node <packaged helper>`. This lets explicit re-authentication write fresh credentials from a new session keyring without restarting a long-lived tmux or server process. The recovery path requires `keyctl` and `node` on `PATH`; missing, locked, or otherwise unavailable credential stores still fail closed.
 
+Complete credential entries are held in memory for the lifetime of the Pi process on every supported credential-store platform. The MCP SDK reads the access token before every outbound request, so caching avoids a credential-store lookup on each tool call; on Linux this specifically avoids overloading the Secret Service daemon. The cache is filled on the first read for a server and covers both present and absent entries. Authenticating, refreshing, and logging out all update it immediately, so credential changes made through Pi take effect at once. Status-panel inspection deliberately bypasses it and still reads the store directly.
+
+A credential changed or deleted by another process while Pi is running is not observed immediately. The affected server picks it up after the first credential-backed authentication failure in that `needs-auth` episode: Pi discards the cached entry, and the following read reloads from the credential store. Restarting Pi also clears the cache. Set `PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1` to turn the cache off entirely and restore a credential-store read per request.
+
 Older versions stored plaintext entries at `~/.pi/agent/mcp-oauth/sha256-<server-hash>/tokens.json`, or under `settings.oauthDir` / `MCP_OAUTH_DIR`. On first read after upgrade, a valid legacy entry is imported into the OS credential store and the plaintext `tokens.json` file is removed. These directories are now legacy import locations, not persistent credential stores or isolation namespaces.
 
 The stored `serverUrl` field ensures credentials are invalidated if the server URL changes.
@@ -256,6 +260,8 @@ For private servers with known-broken metadata, `oauth.skipIssuerMetadataValidat
 ### OS Credential Store
 
 Persistent OAuth credentials are written to the OS credential store. Legacy plaintext files are read only for one-way migration and are removed after successful import. On Linux, revoked session-keyring errors can be retried once through a fresh `keyctl session` helper during explicit re-authentication.
+
+Credential entries reside in process memory for the lifetime of the Pi process on every supported credential-store platform rather than being re-read per request. They are never written anywhere but the OS credential store, and the process-memory copy is discarded on exit.
 
 ### URL Validation
 

--- a/__tests__/mcp-auth-cache.test.ts
+++ b/__tests__/mcp-auth-cache.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  type AuthEntry,
   getAuthEntry,
   getTestAuthSecretStoreReadCount,
   inspectAuthForUrl,
@@ -126,6 +127,19 @@ describe("OAuth credential-entry cache — coherence", () => {
     expect(getTestAuthSecretStoreReadCount() - before).toBe(2);
   });
 
+
+  it("keeps inspection uncached after an ordinary read warms the cache", () => {
+    saveAuthEntry("inspected", { tokens: { accessToken: "a" } }, SERVER_URL);
+    enableAuthEntryCache();
+    resetAuthEntryCache();
+
+    expect(getAuthEntry("inspected")).toBeDefined();
+    const before = getTestAuthSecretStoreReadCount();
+
+    expect(inspectAuthForUrl("inspected", SERVER_URL).status).toBe("present");
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(1);
+  });
+
   it("does not cache store failures and reconstructs chunked entries once", () => {
     enableAuthEntryCache();
     process.env[STORE_ENV] = "unavailable";
@@ -139,6 +153,32 @@ describe("OAuth credential-entry cache — coherence", () => {
     const afterFirst = getTestAuthSecretStoreReadCount();
     expect(getAuthEntry("chunked")?.tokens?.accessToken).toHaveLength(5000);
     expect(getTestAuthSecretStoreReadCount()).toBe(afterFirst);
+  });
+
+
+  it("leaves every read going to the store when the gate is off", () => {
+    saveAuthEntry("gated", { tokens: { accessToken: "a" } }, SERVER_URL);
+    const before = getTestAuthSecretStoreReadCount();
+
+    expect(getAuthEntry("gated")).toBeDefined();
+    expect(getAuthEntry("gated")).toBeDefined();
+
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(2);
+  });
+
+  it("normalizes publication exactly as a later store reload does", () => {
+    enableAuthEntryCache();
+    saveAuthEntry("normalized", {
+      tokens: { accessToken: "a", unexpected: "discard" },
+      unexpected: true,
+    } as unknown as AuthEntry, SERVER_URL);
+
+    const onHit = getAuthEntry("normalized");
+    resetAuthEntryCache();
+    const onMiss = getAuthEntry("normalized");
+
+    expect(onHit).toEqual({ tokens: { accessToken: "a" }, serverUrl: SERVER_URL });
+    expect(onMiss).toEqual(onHit);
   });
 });
 
@@ -161,6 +201,7 @@ describe("OAuth credential-entry cache — invalidation", () => {
 
     expect(getAuthEntry("appearing")).toBeUndefined();
     writeBehindTheCache("appearing", "created");
+    expect(getAuthEntry("appearing")).toBeUndefined();
     invalidateAuthEntryCache("appearing");
     expect(getAuthEntry("appearing")?.tokens?.accessToken).toBe("created");
 
@@ -183,5 +224,18 @@ describe("OAuth credential-entry cache — invalidation", () => {
 
     process.env[DISABLE_ENV] = "1";
     expect(() => invalidateAuthEntryCache("keep")).not.toThrow();
+  });
+
+
+  it("evicts a removed credential even when the gate is turned off", () => {
+    enableAuthEntryCache();
+    saveAuthEntry("toggled", { tokens: { accessToken: "t" } }, SERVER_URL);
+    expect(getAuthEntry("toggled")).toBeDefined();
+
+    process.env[DISABLE_ENV] = "1";
+    removeAuthEntry("toggled");
+    delete process.env[DISABLE_ENV];
+
+    expect(getAuthEntry("toggled")).toBeUndefined();
   });
 });

--- a/__tests__/mcp-auth-cache.test.ts
+++ b/__tests__/mcp-auth-cache.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getAuthEntry,
+  getTestAuthSecretStoreReadCount,
+  inspectAuthForUrl,
+  invalidateAuthEntryCache,
+  removeAuthEntry,
+  resetAuthEntryCache,
+  resetTestAuthSecretStore,
+  saveAuthEntry,
+  updateTokens,
+} from "../mcp-auth.ts";
+
+const STORE_ENV = "PI_MCP_ADAPTER_TEST_AUTH_STORE";
+const DISABLE_ENV = "PI_MCP_ADAPTER_DISABLE_AUTH_CACHE";
+const RECOVERY_OVERRIDE_ENV = "PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY";
+const SERVER_URL = "https://example.com/mcp";
+
+function enableAuthEntryCache(): void {
+  delete process.env[DISABLE_ENV];
+}
+
+function useAuthCacheHarness(): void {
+  const originalEnv: Record<string, string | undefined> = {
+    MCP_OAUTH_DIR: process.env.MCP_OAUTH_DIR,
+    [STORE_ENV]: process.env[STORE_ENV],
+    [DISABLE_ENV]: process.env[DISABLE_ENV],
+  };
+  let authDir: string;
+
+  beforeEach(() => {
+    authDir = mkdtempSync(join(tmpdir(), "pi-mcp-auth-cache-"));
+    process.env.MCP_OAUTH_DIR = authDir;
+    resetTestAuthSecretStore();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(authDir, { recursive: true, force: true });
+  });
+}
+
+describe("OAuth credential-entry cache — foundation", () => {
+  useAuthCacheHarness();
+
+  it("disables the cache suite-wide by default", () => {
+    expect(process.env[DISABLE_ENV]).toBe("1");
+  });
+
+  it("counts every attempted secure-store read and resets independently", () => {
+    expect(getAuthEntry("counted")).toBeUndefined();
+    expect(getAuthEntry("counted")).toBeUndefined();
+    expect(getTestAuthSecretStoreReadCount()).toBe(2);
+    resetAuthEntryCache();
+    expect(getTestAuthSecretStoreReadCount()).toBe(2);
+    resetTestAuthSecretStore();
+    expect(getTestAuthSecretStoreReadCount()).toBe(0);
+  });
+
+  it("opts in independently of Linux keyring recovery", () => {
+    const recoveryBefore = process.env[RECOVERY_OVERRIDE_ENV];
+    enableAuthEntryCache();
+    expect(process.env[DISABLE_ENV]).toBeUndefined();
+    expect(process.env[RECOVERY_OVERRIDE_ENV]).toBe(recoveryBefore);
+  });
+});
+
+describe("OAuth credential-entry cache — coherence", () => {
+  useAuthCacheHarness();
+
+  it("caches present and absent reads", () => {
+    saveAuthEntry("present", { tokens: { accessToken: "a" } }, SERVER_URL);
+    enableAuthEntryCache();
+    resetAuthEntryCache();
+    const before = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("present")?.tokens?.accessToken).toBe("a");
+    expect(getAuthEntry("present")?.tokens?.accessToken).toBe("a");
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(1);
+
+    const absentBefore = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("absent")).toBeUndefined();
+    expect(getAuthEntry("absent")).toBeUndefined();
+    expect(getTestAuthSecretStoreReadCount() - absentBefore).toBe(1);
+  });
+
+  it("publishes writes, updates, and evicts removals", () => {
+    enableAuthEntryCache();
+    saveAuthEntry("entry", { tokens: { accessToken: "old" } }, SERVER_URL);
+    const before = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("entry")?.tokens?.accessToken).toBe("old");
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(0);
+    updateTokens("entry", { accessToken: "new" }, SERVER_URL);
+    expect(getAuthEntry("entry")?.tokens?.accessToken).toBe("new");
+    removeAuthEntry("entry");
+    const beforeAbsentRead = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("entry")).toBeUndefined();
+    expect(getTestAuthSecretStoreReadCount() - beforeAbsentRead).toBeGreaterThan(0);
+  });
+
+  it("isolates nested mutations and bypasses status inspection", () => {
+    saveAuthEntry("aliased", {
+      tokens: { accessToken: "a" },
+      clientInfo: { clientId: "c", redirectUris: ["https://a.example"] },
+    }, SERVER_URL);
+    enableAuthEntryCache();
+    resetAuthEntryCache();
+    const entry = getAuthEntry("aliased")!;
+    entry.tokens!.issuer = "https://evil.example";
+    entry.clientInfo!.redirectUris!.push("https://evil.example");
+    const onHit = getAuthEntry("aliased")!;
+    expect(onHit.tokens?.issuer).toBeUndefined();
+    expect(onHit.clientInfo?.redirectUris).toEqual(["https://a.example"]);
+    onHit.tokens!.issuer = "https://also-evil.example";
+    expect(getAuthEntry("aliased")?.tokens?.issuer).toBeUndefined();
+
+    resetAuthEntryCache();
+    const before = getTestAuthSecretStoreReadCount();
+    inspectAuthForUrl("aliased", SERVER_URL);
+    inspectAuthForUrl("aliased", SERVER_URL);
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(2);
+  });
+
+  it("does not cache store failures and reconstructs chunked entries once", () => {
+    enableAuthEntryCache();
+    process.env[STORE_ENV] = "unavailable";
+    expect(() => getAuthEntry("failing")).toThrow(/OS secure credential store/);
+    expect(() => getAuthEntry("failing")).toThrow(/OS secure credential store/);
+    process.env[STORE_ENV] = "memory";
+
+    saveAuthEntry("chunked", { tokens: { accessToken: "x".repeat(5000) } }, SERVER_URL);
+    resetAuthEntryCache();
+    getAuthEntry("chunked");
+    const afterFirst = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("chunked")?.tokens?.accessToken).toHaveLength(5000);
+    expect(getTestAuthSecretStoreReadCount()).toBe(afterFirst);
+  });
+});
+
+describe("OAuth credential-entry cache — invalidation", () => {
+  useAuthCacheHarness();
+
+  function writeBehindTheCache(serverName: string, accessToken: string): void {
+    process.env[DISABLE_ENV] = "1";
+    saveAuthEntry(serverName, { tokens: { accessToken } }, SERVER_URL);
+    delete process.env[DISABLE_ENV];
+  }
+
+  it("reloads externally changed, absent, and chunked credentials", () => {
+    enableAuthEntryCache();
+    saveAuthEntry("rotated", { tokens: { accessToken: "old" } }, SERVER_URL);
+    writeBehindTheCache("rotated", "new");
+    expect(getAuthEntry("rotated")?.tokens?.accessToken).toBe("old");
+    invalidateAuthEntryCache("rotated");
+    expect(getAuthEntry("rotated")?.tokens?.accessToken).toBe("new");
+
+    expect(getAuthEntry("appearing")).toBeUndefined();
+    writeBehindTheCache("appearing", "created");
+    invalidateAuthEntryCache("appearing");
+    expect(getAuthEntry("appearing")?.tokens?.accessToken).toBe("created");
+
+    const token = "x".repeat(5000);
+    saveAuthEntry("chunked", { tokens: { accessToken: token } }, SERVER_URL);
+    invalidateAuthEntryCache("chunked");
+    const before = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("chunked")?.tokens?.accessToken).toBe(token);
+    expect(getTestAuthSecretStoreReadCount() - before).toBeGreaterThan(1);
+  });
+
+  it("only evicts its target and is harmless while disabled", () => {
+    enableAuthEntryCache();
+    saveAuthEntry("keep", { tokens: { accessToken: "k" } }, SERVER_URL);
+    saveAuthEntry("drop", { tokens: { accessToken: "d" } }, SERVER_URL);
+    invalidateAuthEntryCache("drop");
+    const before = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("keep")?.tokens?.accessToken).toBe("k");
+    expect(getTestAuthSecretStoreReadCount() - before).toBe(0);
+
+    process.env[DISABLE_ENV] = "1";
+    expect(() => invalidateAuthEntryCache("keep")).not.toThrow();
+  });
+});

--- a/__tests__/mcp-auth-cache.test.ts
+++ b/__tests__/mcp-auth-cache.test.ts
@@ -18,6 +18,7 @@ import {
 const STORE_ENV = "PI_MCP_ADAPTER_TEST_AUTH_STORE";
 const DISABLE_ENV = "PI_MCP_ADAPTER_DISABLE_AUTH_CACHE";
 const RECOVERY_OVERRIDE_ENV = "PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY";
+const DISABLE_KEYRING_RECOVERY_ENV = "PI_MCP_ADAPTER_DISABLE_KEYRING_RECOVERY";
 const SERVER_URL = "https://example.com/mcp";
 
 function enableAuthEntryCache(): void {
@@ -29,6 +30,7 @@ function useAuthCacheHarness(): void {
     MCP_OAUTH_DIR: process.env.MCP_OAUTH_DIR,
     [STORE_ENV]: process.env[STORE_ENV],
     [DISABLE_ENV]: process.env[DISABLE_ENV],
+    [DISABLE_KEYRING_RECOVERY_ENV]: process.env[DISABLE_KEYRING_RECOVERY_ENV],
   };
   let authDir: string;
 
@@ -54,14 +56,37 @@ describe("OAuth credential-entry cache — foundation", () => {
     expect(process.env[DISABLE_ENV]).toBe("1");
   });
 
-  it("counts every attempted secure-store read and resets independently", () => {
-    expect(getAuthEntry("counted")).toBeUndefined();
-    expect(getAuthEntry("counted")).toBeUndefined();
-    expect(getTestAuthSecretStoreReadCount()).toBe(2);
-    resetAuthEntryCache();
-    expect(getTestAuthSecretStoreReadCount()).toBe(2);
-    resetTestAuthSecretStore();
-    expect(getTestAuthSecretStoreReadCount()).toBe(0);
+  it("counts reads and resets independently for memory and size-limited stores", () => {
+    for (const store of ["memory", "sizelimited"]) {
+      process.env[STORE_ENV] = store;
+      resetTestAuthSecretStore();
+
+      expect(getAuthEntry("counted")).toBeUndefined();
+      expect(getAuthEntry("counted")).toBeUndefined();
+      expect(getTestAuthSecretStoreReadCount()).toBe(2);
+
+      resetAuthEntryCache();
+      expect(getTestAuthSecretStoreReadCount()).toBe(2);
+
+      resetTestAuthSecretStore();
+      expect(getTestAuthSecretStoreReadCount()).toBe(0);
+    }
+    process.env[STORE_ENV] = "memory";
+  });
+
+  it("counts throwing reads for unavailable and key-revoked stores", () => {
+    const recoveryBefore = process.env[DISABLE_KEYRING_RECOVERY_ENV];
+    process.env[DISABLE_KEYRING_RECOVERY_ENV] = "1";
+    for (const store of ["unavailable", "keyrevoked"]) {
+      process.env[STORE_ENV] = store;
+      resetTestAuthSecretStore();
+
+      expect(() => getAuthEntry("counted")).toThrow();
+      expect(getTestAuthSecretStoreReadCount()).toBe(1);
+    }
+    if (recoveryBefore === undefined) delete process.env[DISABLE_KEYRING_RECOVERY_ENV];
+    else process.env[DISABLE_KEYRING_RECOVERY_ENV] = recoveryBefore;
+    process.env[STORE_ENV] = "memory";
   });
 
   it("opts in independently of Linux keyring recovery", () => {
@@ -69,6 +94,11 @@ describe("OAuth credential-entry cache — foundation", () => {
     enableAuthEntryCache();
     expect(process.env[DISABLE_ENV]).toBeUndefined();
     expect(process.env[RECOVERY_OVERRIDE_ENV]).toBe(recoveryBefore);
+  });
+
+
+  it("restores the suite-wide disable after an opt-in test", () => {
+    expect(process.env[DISABLE_ENV]).toBe("1");
   });
 });
 
@@ -125,6 +155,10 @@ describe("OAuth credential-entry cache — coherence", () => {
     inspectAuthForUrl("aliased", SERVER_URL);
     inspectAuthForUrl("aliased", SERVER_URL);
     expect(getTestAuthSecretStoreReadCount() - before).toBe(2);
+
+    const beforeOrdinaryRead = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("aliased")).toBeDefined();
+    expect(getTestAuthSecretStoreReadCount() - beforeOrdinaryRead).toBe(1);
   });
 
 
@@ -146,6 +180,7 @@ describe("OAuth credential-entry cache — coherence", () => {
     expect(() => getAuthEntry("failing")).toThrow(/OS secure credential store/);
     expect(() => getAuthEntry("failing")).toThrow(/OS secure credential store/);
     process.env[STORE_ENV] = "memory";
+    expect(getAuthEntry("failing")).toBeUndefined();
 
     saveAuthEntry("chunked", { tokens: { accessToken: "x".repeat(5000) } }, SERVER_URL);
     resetAuthEntryCache();
@@ -224,6 +259,9 @@ describe("OAuth credential-entry cache — invalidation", () => {
 
     process.env[DISABLE_ENV] = "1";
     expect(() => invalidateAuthEntryCache("keep")).not.toThrow();
+    const beforeDisabledRead = getTestAuthSecretStoreReadCount();
+    expect(getAuthEntry("keep")?.tokens?.accessToken).toBe("k");
+    expect(getTestAuthSecretStoreReadCount() - beforeDisabledRead).toBe(1);
   });
 
 

--- a/__tests__/server-manager-auth-cache-recovery-integration.test.ts
+++ b/__tests__/server-manager-auth-cache-recovery-integration.test.ts
@@ -1,0 +1,155 @@
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuthEntry,
+  getTestAuthSecretStoreReadCount,
+  resetTestAuthSecretStore,
+  saveAuthEntry,
+} from "../mcp-auth.ts";
+
+type TransportOptions = { authProvider?: { tokens: () => Promise<{ access_token?: string } | undefined> } };
+
+const mocks = vi.hoisted(() => ({
+  clients: [] as unknown[],
+  transports: [] as { options: TransportOptions }[],
+  connectSteps: [] as (() => Promise<void> | void)[],
+}));
+
+vi.mock("@modelcontextprotocol/client", async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  Client: vi.fn().mockImplementation(() => {
+    const client = {
+      setRequestHandler: vi.fn(),
+      setNotificationHandler: vi.fn(),
+      connect: vi.fn(async () => { await mocks.connectSteps.shift()?.(); }),
+      listTools: vi.fn(async () => ({ tools: [] })),
+      listResources: vi.fn(async () => ({ resources: [] })),
+      listPrompts: vi.fn(async () => ({ prompts: [] })),
+      getServerCapabilities: vi.fn(() => ({})),
+      getInstructions: vi.fn(() => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    mocks.clients.push(client);
+    return client;
+  }),
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((_url: URL, options: TransportOptions) => {
+    const transport = { options, close: vi.fn(async () => undefined) };
+    mocks.transports.push(transport);
+    return transport;
+  }),
+  SSEClientTransport: vi.fn(),
+}));
+vi.mock("@modelcontextprotocol/client/stdio", () => ({ StdioClientTransport: vi.fn() }));
+vi.mock("../npx-resolver.ts", () => ({ resolveNpxBinary: vi.fn(async () => null) }));
+
+const DISABLE_ENV = "PI_MCP_ADAPTER_DISABLE_AUTH_CACHE";
+const SERVER_URL = "https://example.test/mcp";
+const OAUTH_SERVER = { url: SERVER_URL, auth: "oauth" as const };
+
+function unauthorized(): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "HTTP 401", { status: 401 });
+}
+
+function writeBehindTheCache(serverName: string, accessToken: string): void {
+  const prior = process.env[DISABLE_ENV];
+  process.env[DISABLE_ENV] = "1";
+  saveAuthEntry(serverName, { tokens: { accessToken } }, SERVER_URL);
+  if (prior === undefined) delete process.env[DISABLE_ENV];
+  else process.env[DISABLE_ENV] = prior;
+}
+
+function capturedProvider() {
+  const provider = mocks.transports.at(-1)?.options.authProvider;
+  expect(provider).toBeDefined();
+  return provider!;
+}
+
+async function expectProviderReloadsOnce(provider: NonNullable<ReturnType<typeof capturedProvider>>, accessToken: string): Promise<void> {
+  const beforeReload = getTestAuthSecretStoreReadCount();
+  expect((await provider.tokens())?.access_token).toBe(accessToken);
+  expect(getTestAuthSecretStoreReadCount() - beforeReload).toBe(1);
+  expect((await provider.tokens())?.access_token).toBe(accessToken);
+  expect(getTestAuthSecretStoreReadCount() - beforeReload).toBe(1);
+}
+
+describe("auth cache recovery with the real OAuth provider", () => {
+  const originalEnv = {
+    [DISABLE_ENV]: process.env[DISABLE_ENV],
+  };
+
+  beforeEach(() => {
+    mocks.clients.length = 0;
+    mocks.transports.length = 0;
+    mocks.connectSteps.length = 0;
+    delete process.env[DISABLE_ENV];
+    resetTestAuthSecretStore();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    resetTestAuthSecretStore();
+    vi.clearAllMocks();
+  });
+
+  it("evicts after an explicit OAuth 401 so the provider reloads an external rotation", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    saveAuthEntry("explicit", { tokens: { accessToken: "old" } }, SERVER_URL);
+    expect(getAuthEntry("explicit")?.tokens?.accessToken).toBe("old");
+    writeBehindTheCache("explicit", "new");
+    mocks.connectSteps.push(() => { throw unauthorized(); });
+
+    const connection = await new McpServerManager().connect("explicit", OAUTH_SERVER);
+    expect(connection.status).toBe("needs-auth");
+    await expectProviderReloadsOnce(capturedProvider(), "new");
+  });
+
+  it("evicts only after the second, provider-backed implicit OAuth 401", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    saveAuthEntry("implicit", { tokens: { accessToken: "old" } }, SERVER_URL);
+    expect(getAuthEntry("implicit")?.tokens?.accessToken).toBe("old");
+    writeBehindTheCache("implicit", "new");
+    mocks.connectSteps.push(
+      () => { throw unauthorized(); },
+      () => { throw unauthorized(); },
+    );
+
+    const connection = await new McpServerManager().connect("implicit", { url: SERVER_URL });
+
+    expect(connection.status).toBe("needs-auth");
+    expect(mocks.transports).toHaveLength(2);
+    expect(mocks.transports[0]?.options.authProvider).toBeUndefined();
+    await expectProviderReloadsOnce(capturedProvider(), "new");
+  });
+
+  it("keeps concurrent recovery connects single-flight", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    saveAuthEntry("shared", { tokens: { accessToken: "old" } }, SERVER_URL);
+    expect(getAuthEntry("shared")?.tokens?.accessToken).toBe("old");
+    writeBehindTheCache("shared", "new");
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>(resolve => { release = resolve; });
+    const started = new Promise<void>(resolve => { entered = resolve; });
+    mocks.connectSteps.push(async () => {
+      entered();
+      await blocked;
+      throw unauthorized();
+    });
+
+    const manager = new McpServerManager();
+    const first = manager.connect("shared", OAUTH_SERVER);
+    await started;
+    const second = manager.connect("shared", OAUTH_SERVER);
+    release();
+    const [firstConnection, secondConnection] = await Promise.all([first, second]);
+
+    expect(firstConnection).toBe(secondConnection);
+    expect(firstConnection.status).toBe("needs-auth");
+    expect(mocks.clients).toHaveLength(1);
+    expect(mocks.transports).toHaveLength(1);
+    await expectProviderReloadsOnce(capturedProvider(), "new");
+  });
+});

--- a/__tests__/server-manager-auth-cache-recovery.test.ts
+++ b/__tests__/server-manager-auth-cache-recovery.test.ts
@@ -1,0 +1,162 @@
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TransportOptions = { authProvider?: unknown };
+const mocks = vi.hoisted(() => ({
+  connectErrors: [] as unknown[],
+  listToolsErrors: [] as unknown[],
+  listResourcesErrors: [] as unknown[],
+  listPromptsErrors: [] as unknown[],
+  capabilities: {} as { resources?: {}; prompts?: {} },
+  invalidated: [] as string[],
+  connectSteps: [] as (() => Promise<void> | void)[],
+}));
+
+vi.mock("@modelcontextprotocol/client", async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  Client: vi.fn().mockImplementation(() => ({
+    setRequestHandler: vi.fn(), setNotificationHandler: vi.fn(),
+    connect: vi.fn(async () => {
+      const step = mocks.connectSteps.shift();
+      if (step) return step();
+      const error = mocks.connectErrors.shift();
+      if (error) throw error;
+    }),
+    listTools: vi.fn(async () => { const error = mocks.listToolsErrors.shift(); if (error) throw error; return { tools: [] }; }),
+    listResources: vi.fn(async () => { const error = mocks.listResourcesErrors.shift(); if (error) throw error; return { resources: [] }; }),
+    listPrompts: vi.fn(async () => { const error = mocks.listPromptsErrors.shift(); if (error) throw error; return { prompts: [] }; }),
+    getServerCapabilities: vi.fn(() => mocks.capabilities), getInstructions: vi.fn(() => undefined), close: vi.fn(async () => undefined),
+  })),
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => ({ url, options, close: vi.fn(async () => undefined) })),
+  SSEClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => ({ url, options, close: vi.fn(async () => undefined) })),
+}));
+vi.mock("@modelcontextprotocol/client/stdio", () => ({ StdioClientTransport: vi.fn() }));
+vi.mock("../npx-resolver.ts", () => ({ resolveNpxBinary: vi.fn(async () => null) }));
+vi.mock("../mcp-auth.ts", async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  invalidateAuthEntryCache: vi.fn((name: string) => mocks.invalidated.push(name)),
+}));
+
+function unauthorized(): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "HTTP 401", { status: 401 });
+}
+const OAUTH_SERVER = { url: "https://example.test/mcp", auth: "oauth" as const };
+
+describe("auth cache recovery on 401", () => {
+  beforeEach(() => {
+    mocks.connectErrors.length = 0;
+    mocks.listToolsErrors.length = 0;
+    mocks.listResourcesErrors.length = 0;
+    mocks.listPromptsErrors.length = 0;
+    mocks.capabilities = {};
+    mocks.invalidated.length = 0;
+    mocks.connectSteps.length = 0;
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("invalidates once for terminal transport and post-handshake 401s", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(unauthorized());
+    const manager = new McpServerManager();
+    const transport = await manager.connect("transport", OAUTH_SERVER);
+    expect(transport.status).toBe("needs-auth");
+    expect(transport.credentialsInvalidated).toBe(true);
+
+    mocks.listToolsErrors.push(unauthorized());
+    const postHandshake = await manager.connect("post-handshake", OAUTH_SERVER);
+    expect(postHandshake.status).toBe("needs-auth");
+    expect(mocks.invalidated).toEqual(["transport", "post-handshake"]);
+  });
+
+
+  it("invalidates on capability-advertised resources and prompts 401s", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    mocks.capabilities = { resources: {} };
+    mocks.listResourcesErrors.push(unauthorized());
+    expect((await manager.connect("resources-401", OAUTH_SERVER)).status).toBe("needs-auth");
+
+    mocks.capabilities = { prompts: {} };
+    mocks.listPromptsErrors.push(unauthorized());
+    expect((await manager.connect("prompts-401", OAUTH_SERVER)).status).toBe("needs-auth");
+
+    expect(mocks.invalidated).toEqual(["resources-401", "prompts-401"]);
+  });
+
+
+  it("keeps non-401 optional discovery failures non-fatal", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    mocks.capabilities = { resources: {}, prompts: {} };
+    mocks.listResourcesErrors.push(new Error("resources unavailable"));
+    mocks.listPromptsErrors.push(new Error("prompts unavailable"));
+
+    expect((await manager.connect("optional-failures", OAUTH_SERVER)).status).toBe("connected");
+    expect(mocks.invalidated).toEqual([]);
+  });
+
+  it("does not invalidate on the initial implicit challenge", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(unauthorized());
+    const connection = await new McpServerManager().connect("implicit", { url: "https://example.test/mcp" });
+    expect(connection.status).toBe("connected");
+    expect(mocks.invalidated).toEqual([]);
+  });
+
+  it("invalidates once on the terminal provider-backed implicit OAuth 401", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(unauthorized(), unauthorized());
+
+    const connection = await new McpServerManager().connect("implicit-terminal", { url: "https://example.test/mcp" });
+
+    expect(connection.status).toBe("needs-auth");
+    expect(mocks.invalidated).toEqual(["implicit-terminal"]);
+  });
+
+  it("keeps concurrent terminal recovery connects single-flight", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>(resolve => { release = resolve; });
+    const started = new Promise<void>(resolve => { entered = resolve; });
+    mocks.connectSteps.push(async () => {
+      entered();
+      await blocked;
+      throw unauthorized();
+    });
+
+    const manager = new McpServerManager();
+    const first = manager.connect("concurrent", OAUTH_SERVER);
+    await started;
+    const second = manager.connect("concurrent", OAUTH_SERVER);
+    release();
+    const [firstConnection, secondConnection] = await Promise.all([first, second]);
+
+    expect(firstConnection).toBe(secondConnection);
+    expect(firstConnection.status).toBe("needs-auth");
+    expect(mocks.invalidated).toEqual(["concurrent"]);
+  });
+
+  it("bounds health-check reconnects and resets after explicit close", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    for (let pass = 0; pass < 3; pass++) {
+      mocks.connectErrors.push(unauthorized());
+      expect((await manager.connect("parked", OAUTH_SERVER)).status).toBe("needs-auth");
+    }
+    expect(mocks.invalidated).toEqual(["parked"]);
+    await manager.close("parked");
+    mocks.connectErrors.push(unauthorized());
+    await manager.connect("parked", OAUTH_SERVER);
+    expect(mocks.invalidated).toEqual(["parked", "parked"]);
+  });
+
+  it("does not invalidate non-OAuth servers", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(unauthorized());
+    await expect(new McpServerManager().connect("plain", { url: "https://example.test/mcp", auth: false })).rejects.toThrow("HTTP 401");
+    expect(mocks.invalidated).toEqual([]);
+  });
+});

--- a/__tests__/session-recovery.test.ts
+++ b/__tests__/session-recovery.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { ProtocolError, SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+
+const authCacheMocks = vi.hoisted(() => ({
+  invalidate: vi.fn(),
+}));
+
+vi.mock("../mcp-auth.ts", async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  invalidateAuthEntryCache: authCacheMocks.invalidate,
+}));
+
 import { SessionRecoveryAuthRequiredError, isTerminatedSession, withSessionRecovery } from "../session-recovery.ts";
 import type { ServerConnection } from "../server-manager.ts";
 import type { McpConfig } from "../types.ts";
@@ -157,6 +167,20 @@ describe("withSessionRecovery", () => {
     expect(fn).toHaveBeenNthCalledWith(2, fresh);
     expect(manager.reconnect).toHaveBeenCalledWith("demo", config.mcpServers.demo, stale);
     expect(manager.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates OAuth credentials after a runtime 401 and preserves the error", async () => {
+    const connection = makeConnection("session-1");
+    const manager = makeManager({ getConnection: () => connection, reconnect: async () => connection });
+    const oauthConfig: McpConfig = {
+      mcpServers: { demo: { url: "https://example.test/mcp", auth: "oauth" } },
+    };
+    const err = httpError(401, "Unauthorized");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withSessionRecovery({ manager: manager as any, config: oauthConfig }, "demo", fn)).rejects.toBe(err);
+    expect(authCacheMocks.invalidate).toHaveBeenCalledWith("demo");
+    expect(manager.reconnect).not.toHaveBeenCalled();
   });
 
   it("does not recover unrelated -32000 MCP errors", async () => {

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -37,6 +37,7 @@ const KEYRING_RECOVERY_KEYCTL_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL';
 const KEYRING_RECOVERY_NODE_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE';
 const KEYRING_RECOVERY_HELPER_ENV = 'PI_MCP_ADAPTER_KEYRING_RECOVERY_HELPER';
 const TEST_LINUX_KEYRING_RECOVERY_ENV = 'PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY';
+const AUTH_CACHE_DISABLED_ENV = 'PI_MCP_ADAPTER_DISABLE_AUTH_CACHE';
 const KEYRING_RECOVERY_TIMEOUT_MS = 10_000;
 const AUTH_CHUNK_MANIFEST_KEY = '__piMcpAdapterOAuthChunked';
 
@@ -148,8 +149,20 @@ interface AuthEntryChunkManifest {
 let KeyringEntryClass: KeyringEntryConstructor | undefined;
 const memoryAuthEntries = new Map<string, string>();
 
+let testAuthSecretStoreReadCount = 0;
+const authEntryCache = new Map<string, AuthEntry | undefined>();
+
+function isAuthEntryCacheEnabled(): boolean {
+  return process.env[AUTH_CACHE_DISABLED_ENV] !== '1';
+}
+
+function cloneAuthEntry(entry: AuthEntry | undefined): AuthEntry | undefined {
+  return entry === undefined ? undefined : structuredClone(entry);
+}
+
 const memoryAuthSecretStore: AuthSecretStore = {
   read(account) {
+    testAuthSecretStoreReadCount++;
     return memoryAuthEntries.get(account);
   },
   write(account, payload) {
@@ -190,6 +203,7 @@ const sizeLimitedAuthSecretStore: AuthSecretStore = {
 
 const unavailableAuthSecretStore: AuthSecretStore = {
   read() {
+    testAuthSecretStoreReadCount++;
     throw new Error('simulated secure credential store unavailable');
   },
   write() {
@@ -206,6 +220,7 @@ function createKeyRevokedTestError(): Error {
 
 const keyRevokedAuthSecretStore: AuthSecretStore = {
   read() {
+    testAuthSecretStoreReadCount++;
     throw createKeyRevokedTestError();
   },
   write() {
@@ -218,6 +233,16 @@ const keyRevokedAuthSecretStore: AuthSecretStore = {
 
 export function resetTestAuthSecretStore(): void {
   memoryAuthEntries.clear();
+  authEntryCache.clear();
+  testAuthSecretStoreReadCount = 0;
+}
+
+export function resetAuthEntryCache(): void {
+  authEntryCache.clear();
+}
+
+export function getTestAuthSecretStoreReadCount(): number {
+  return testAuthSecretStoreReadCount;
 }
 
 export function getTestAuthSecretStoreEntries(): [string, string][] {
@@ -649,6 +674,18 @@ function writeSecureAuthEntryToStore(store: AuthSecretStore, serverName: string,
       error,
     );
   }
+
+  publishAuthEntryToCache(serverName, payload);
+}
+
+function publishAuthEntryToCache(serverName: string, payload: string): void {
+  if (!isAuthEntryCacheEnabled()) return;
+  const normalized = JSON.parse(payload) as AuthEntry;
+  if (!normalized) {
+    authEntryCache.delete(serverName);
+    return;
+  }
+  authEntryCache.set(serverName, cloneAuthEntry(normalized));
 }
 
 function writeSecureAuthEntry(serverName: string, entry: AuthEntry): void {
@@ -704,12 +741,23 @@ function readAuthEntry(
   options?: AuthStorageOptions,
   behavior: { migrateLegacy?: boolean } = {},
 ): AuthEntry | undefined {
+  // Status-only reads deliberately bypass the cache because they do not
+  // migrate legacy entries.
+  const cacheable = behavior.migrateLegacy !== false && isAuthEntryCacheEnabled();
+  if (cacheable && authEntryCache.has(serverName)) {
+    return cloneAuthEntry(authEntryCache.get(serverName));
+  }
+
+  let entry: AuthEntry | undefined;
   try {
-    return readAuthEntryFromStore(getAuthSecretStore(), serverName, options, behavior);
+    entry = readAuthEntryFromStore(getAuthSecretStore(), serverName, options, behavior);
   } catch (error) {
     if (!shouldAttemptLinuxKeyringRecovery(error)) throw error;
-    return readAuthEntryFromStore(linuxKeyringRecoveryAuthSecretStore, serverName, options, behavior);
+    entry = readAuthEntryFromStore(linuxKeyringRecoveryAuthSecretStore, serverName, options, behavior);
   }
+
+  if (cacheable) authEntryCache.set(serverName, cloneAuthEntry(entry));
+  return entry;
 }
 
 /**
@@ -794,7 +842,15 @@ export function removeAuthEntry(serverName: string, options?: AuthStorageOptions
     if (!shouldAttemptLinuxKeyringRecovery(error)) throw error;
     removeAuthEntryFromStore(linuxKeyringRecoveryAuthSecretStore, serverName);
   }
+  authEntryCache.delete(serverName);
   removeLegacyAuthEntry(serverName, options);
+}
+
+/**
+ * Forget a cached entry so the next ordinary read reloads secure storage.
+ */
+export function invalidateAuthEntryCache(serverName: string): void {
+  authEntryCache.delete(serverName);
 }
 
 /**

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -680,7 +680,8 @@ function writeSecureAuthEntryToStore(store: AuthSecretStore, serverName: string,
 
 function publishAuthEntryToCache(serverName: string, payload: string): void {
   if (!isAuthEntryCacheEnabled()) return;
-  const normalized = JSON.parse(payload) as AuthEntry;
+  // Cache the same normalized shape a fresh persistent-store read returns.
+  const normalized = toAuthEntry(JSON.parse(payload) as unknown);
   if (!normalized) {
     authEntryCache.delete(serverName);
     return;

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -188,6 +188,7 @@ const keyringAuthSecretStore: AuthSecretStore = {
 /** Mimics the Windows Credential Manager per-value ceiling for tests. */
 const sizeLimitedAuthSecretStore: AuthSecretStore = {
   read(account) {
+    testAuthSecretStoreReadCount++;
     return memoryAuthEntries.get(account);
   },
   write(account, payload) {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test --test-concurrency=1 oauth-public-api.test.ts mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts",
-    "test:oauth-provider": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory node --import tsx --test mcp-oauth-provider.test.ts",
+    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test --test-concurrency=1 oauth-public-api.test.ts mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts",
+    "test:oauth-provider": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test mcp-oauth-provider.test.ts",
     "test:conformance": "bash conformance/run.sh"
   },
   "repository": {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -31,7 +31,7 @@ import { createJsonSchemaValidator } from "./json-schema-validator.ts";
 import { logger } from "./logger.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
-import type { AuthStorageOptions } from "./mcp-auth.ts";
+import { invalidateAuthEntryCache, type AuthStorageOptions } from "./mcp-auth.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
 import {
   handleUrlElicitation,
@@ -129,7 +129,10 @@ export interface ServerConnection {
   lastUsedAt: number;
   inFlight: number;
   status: "connected" | "closed" | "needs-auth";
+  /** True once this needs-auth episode discarded the cached credential. */
+  credentialsInvalidated?: boolean;
 }
+
 
 type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void;
 type MetadataListChangedListener = (serverName: string, reason: string) => void;
@@ -238,10 +241,12 @@ export class McpServerManager {
       return existing;
     }
 
+    const credentialsInvalidated = existing?.status === "needs-auth"
+      && existing.credentialsInvalidated === true;
     const generation = this.closeGenerations.get(name) ?? 0;
     const attemptController = new AbortController();
     const attemptSignal = combineAbortSignals(ownedSignal, attemptController.signal);
-    const connectionAttempt = this.createConnection(name, definition, attemptSignal, ownedSignal);
+    const connectionAttempt = this.createConnection(name, definition, attemptSignal, ownedSignal, credentialsInvalidated);
     const promise = definition.url
       ? connectionAttempt.catch(async error => { throw await this.enrichHttpConnectionError(definition, error); })
       : connectionAttempt;
@@ -324,6 +329,7 @@ export class McpServerManager {
     definition: ServerDefinition,
     signal?: AbortSignal,
     requestSignal?: AbortSignal,
+    credentialsInvalidated = false,
   ): Promise<ServerConnection> {
     throwIfAborted(signal);
 
@@ -338,6 +344,7 @@ export class McpServerManager {
     let client: Client;
     let transport: Transport;
     let clientConnected = false;
+    let invalidated = credentialsInvalidated;
     let transportAlreadyTraced = false;
     let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
     const configuredTransports = [definition.command, definition.url, definition.socket]
@@ -387,9 +394,11 @@ export class McpServerManager {
         requestOptions,
         signal,
         traceObserver,
+        invalidated,
       );
       client = httpConnection.client;
       transport = httpConnection.transport;
+      invalidated = httpConnection.credentialsInvalidated;
       if (httpConnection.status === "needs-auth") {
         return {
           client,
@@ -401,6 +410,7 @@ export class McpServerManager {
           lastUsedAt: Date.now(),
           inFlight: 0,
           status: "needs-auth",
+          credentialsInvalidated: invalidated,
         };
       }
       clientConnected = true;
@@ -477,6 +487,10 @@ export class McpServerManager {
       // A cleanup failure remains a setup failure rather than being hidden
       // behind needs-auth.
       if (isUnauthorizedHttpError(error) && supportsOAuth(definition) && cleanupFailures.length === 0) {
+        if (!invalidated) {
+          invalidateAuthEntryCache(name);
+          invalidated = true;
+        }
         return {
           client,
           transport,
@@ -487,6 +501,7 @@ export class McpServerManager {
           lastUsedAt: Date.now(),
           inFlight: 0,
           status: "needs-auth",
+          credentialsInvalidated: invalidated,
         };
       }
 
@@ -694,7 +709,8 @@ export class McpServerManager {
     requestOptions: RequestOptions | undefined,
     signal?: AbortSignal,
     traceObserver?: McpTraceObserver,
-  ): Promise<{ client: Client; transport: Transport; status: "connected" | "needs-auth" }> {
+    credentialsInvalidated = false,
+  ): Promise<{ client: Client; transport: Transport; status: "connected" | "needs-auth"; credentialsInvalidated: boolean }> {
     throwIfAborted(signal);
     const serverUrl = resolveServerUrl(definition)!;
     const url = new URL(serverUrl);
@@ -791,9 +807,10 @@ export class McpServerManager {
     // OAuth challenge; use SSE only for definitive endpoint incompatibility.
     // Agent Plugins set httpTransport, and their declared transport is used without fallback.
     let kind: "streamable-http" | "sse" = definition.httpTransport ?? "streamable-http";
+    let invalidated = credentialsInvalidated;
     for (;;) {
       const result = await attempt(kind);
-      if (result.status === "connected") return result;
+      if (result.status === "connected") return { ...result, credentialsInvalidated: invalidated };
       if (result.error instanceof AggregateError
         && result.error.message === "MCP connection abort cleanup failed") {
         throw result.error;
@@ -806,7 +823,16 @@ export class McpServerManager {
       }
       if (isUnauthorizedHttpError(result.error)) {
         if (supportsOAuth(definition)) {
-          return { client: result.client, transport: result.transport, status: "needs-auth" };
+          if (!invalidated) {
+            invalidateAuthEntryCache(serverName);
+            invalidated = true;
+          }
+          return {
+            client: result.client,
+            transport: result.transport,
+            status: "needs-auth",
+            credentialsInvalidated: invalidated,
+          };
         }
         throw result.error;
       }
@@ -850,6 +876,7 @@ export class McpServerManager {
       return { prompts, failed: false };
     } catch (error) {
       if (requestOptions?.signal?.aborted) throwIfAborted(requestOptions.signal);
+      if (isUnauthorizedHttpError(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       logger.debug(`MCP: prompts/list failed: ${message}`);
       return { prompts: [], failed: true };
@@ -871,10 +898,11 @@ export class McpServerManager {
       } while (cursor);
 
       return allResources;
-    } catch {
+    } catch (error) {
       if (requestOptions?.signal?.aborted) {
         throwIfAborted(requestOptions.signal);
       }
+      if (isUnauthorizedHttpError(error)) throw error;
       // The server advertises resources but the listing failed
       return [];
     }

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -20,10 +20,12 @@
 //     many things other than "your session is gone"
 //   - treat generic -32000/ConnectionClosed errors as session expiry
 //   - treat AbortError/cancellation as a session failure
-import { ProtocolError, SdkHttpError } from "@modelcontextprotocol/client";
+import { ProtocolError, SdkHttpError, UnauthorizedError } from "@modelcontextprotocol/client";
 import { logger } from "./logger.ts";
 import { throwIfAborted } from "./abort.ts";
 import { isServerDisabled, type McpConfig } from "./types.ts";
+import { supportsOAuth } from "./mcp-auth-flow.ts";
+import { invalidateAuthEntryCache } from "./mcp-auth.ts";
 import type { McpServerManager, ServerConnection } from "./server-manager.ts";
 
 /**
@@ -106,6 +108,11 @@ export async function withSessionRecovery<T>(
   try {
     return await fn(connection);
   } catch (err) {
+    const definition = deps.config.mcpServers[serverName];
+    if (definition && supportsOAuth(definition)
+      && (err instanceof UnauthorizedError || (err instanceof SdkHttpError && err.status === 401))) {
+      invalidateAuthEntryCache(serverName);
+    }
     if (!isTerminatedSession(err, hadSessionId)) {
       throw err;
     }
@@ -114,7 +121,6 @@ export async function withSessionRecovery<T>(
     // connection's definition, in case config changed since connect. If the
     // server was removed from config in the meantime there is nothing to
     // reconnect to, so surface the original error.
-    const definition = deps.config.mcpServers[serverName];
     if (!definition) {
       throw err;
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     environment: "node",
     env: {
       PI_MCP_ADAPTER_TEST_AUTH_STORE: "memory",
+      // Cache tests opt in explicitly to keep existing tests platform-neutral.
+      PI_MCP_ADAPTER_DISABLE_AUTH_CACHE: "1",
     },
     include: ["__tests__/**/*.test.ts"],
     coverage: {


### PR DESCRIPTION
The MCP SDK reads OAuth credentials from the OS keyring before every outbound request.
On Linux, these reads go through the Secret Service API.
Frequent keyring access can overwhelm some Secret Service daemons, causing instability and disrupting both MCP operations and the broader system.

This PR introduces an in-memory cache for OAuth credential entries for the lifetime of the Pi process.
Credentials will be persisted to the keyring when they are refreshed or removed.

## Summary

- cache present and absent OAuth credential entries in memory to avoid repeated OS credential-store reads on every MCP request
- keep the cache coherent across credential writes, token refreshes, and logout while returning cloned entries to prevent mutation
- bypass the cache for status inspection and invalidate it after the first OAuth-backed 401 so credentials changed by another process reload on retry
- add `PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1` as an escape hatch
- document cache behavior, security implications, and external credential-change handling

## Testing

- added cache coverage for hits, misses, mutations, writes, removals, chunked entries, disabled caching, and credential-store failures
- added server-manager unit and integration coverage for 401 invalidation, retry behavior, and concurrent authentication failures
- manual user testing to confirm minimal Secret Service API calls preventing daemon overload