### PR TITLE
Add per-server searchKeywords for tool search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added per-server `searchKeywords` so `mcp({ search })` and `mcpScript` `tools.search` understand user-defined synonyms and aliases for tools. Keywords are keyed by tool name or glob and boost ranked and regex search only. They never appear in tool schemas, describe output, or the metadata cache.
+- Added per-server `searchKeywords` so `mcp({ search })` and `mcpScript` `tools.search` understand user-defined synonyms and aliases for tools. Keywords are keyed by tool name or glob and boost ranked and regex search only. They never appear in tool schemas, describe output, or the metadata cache. Thanks @Serisium for PR #336.
 
 ### Fixed
 - Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added per-server `searchKeywords` so `mcp({ search })` and `mcpScript` `tools.search` understand user-defined synonyms and aliases for tools. Keywords are keyed by tool name or glob and boost ranked and regex search only. They never appear in tool schemas, describe output, or the metadata cache.
+
 ### Fixed
 - Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `toolPrefix` | Override global `settings.toolPrefix` for this server (`"server"`, `"short"`, `"none"`, or `"mcp"`) |
 | `includeTools` | `string[]` of tool names or glob patterns to expose (matches original names like `get_screenshot`, generated resource names like `read_figjam`, and prefixed names like `figma_get_screenshot`) |
 | `excludeTools` | `string[]` of tool names or glob patterns to hide (applied after `includeTools`) |
+| `searchKeywords` | `{ "tool-or-glob": ["keyword", ...] }` — extra keywords that boost `mcp({ search })` ranking for matching tools; never shown to the model |
 | `debug` | Show server stderr (default: false) |
 | `trace` | Enable metadata-only JSONL protocol tracing for this server; payloads, prompts, tool arguments/results, authorization data, and URLs are never persisted |
 | `disabled` | Keep the server visible in config and status, but prevent connections, authentication, tools, and resource calls (only literal `true` disables it) |
@@ -650,9 +651,32 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 
 MCP proxy and direct-tool results render compactly by default: long text shows the first three terminal-wrapped lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
 
-Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are ranked by weighted matches across name, server, and description, then returned one page at a time (`limit` defaults to 12). Use `details.nextOffset` for the next page. Regex search is still available with `regex: true`, but regex results are paginated without ranking.
+Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are ranked by weighted matches across name, server, description, and any configured `searchKeywords`, then returned one page at a time (`limit` defaults to 12). Use `details.nextOffset` for the next page. Regex search is still available with `regex: true`, but regex results are paginated without ranking.
 
 Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`. When `describe` or `tool` cannot resolve a name, the result includes top suggestions so the agent can correct a typo or missing prefix in the same turn.
+
+### Search keywords
+
+Search uses literal matching so a tool whose name and description use different vocabulary than the query won't be found. Per-server `searchKeywords` adds extra vocabulary for matching tools:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "searchKeywords": {
+        "search_code": ["grep"],
+        "*": ["gh"]
+      }
+    }
+  }
+}
+```
+
+With this config, `mcp({ search: "grep" })` finds `github_search_code` even though neither its name nor description contains that word. Similarly, `mcp({ search: "gh" })` finds all tools provided by the github server.
+
+Keys match a tool's original name, prefixed name, or a glob (`*` applies to every tool on the server) and all matching entries combine. Keywords are weighted like description text, with an extra boost when the query exactly matches a configured phrase. They affect ranked and regex search only (including `tools.search` in `mcpScript`): they never appear in tool schemas, `describe` output, direct-tool registration, or the metadata cache, and search with keywords works offline from cached metadata.
 
 When `includeSchemas` is enabled, search and describe render common JSON Schema parameters as compact TypeScript shapes like `{ query: string; limit?: number; }`, with the older schema formatter retained as a fallback for unsupported schemas.
 

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -125,6 +125,50 @@ describe("proxy discovery", () => {
     });
   });
 
+  it("finds tools through configured search keywords", () => {
+    const state = createState();
+    state.config.mcpServers.demo!.searchKeywords = { find: ["zzalias finder"] };
+
+    expect(executeSearch(createState(), "zzalias").details).toMatchObject({ count: 0 });
+    expect(executeSearch(state, "zzalias").details).toMatchObject({
+      count: 1,
+      matches: [{ server: "demo", tool: "demo_find", score: expect.any(Number) }],
+    });
+  });
+
+  it("matches keyword keys by prefixed name and glob", () => {
+    const prefixed = createState();
+    prefixed.config.mcpServers.demo!.searchKeywords = { demo_find: ["zzalias"] };
+    expect(executeSearch(prefixed, "zzalias").details).toMatchObject({ count: 1, matches: [{ tool: "demo_find" }] });
+
+    const glob = createState();
+    glob.config.mcpServers.demo!.searchKeywords = { "*": ["zzalias"] };
+    expect(executeSearch(glob, "zzalias").details).toMatchObject({ count: 2 });
+  });
+
+  it("matches keywords in regex search mode", () => {
+    const state = createState();
+    state.config.mcpServers.demo!.searchKeywords = { find: ["zzalias finder"] };
+
+    expect(executeSearch(state, "^zzali", true).details).toMatchObject({
+      count: 1,
+      matches: [{ server: "demo", tool: "demo_find", score: 0 }],
+    });
+  });
+
+  it("keeps keywords out of search and describe output", () => {
+    const state = createState();
+    state.config.mcpServers.demo!.searchKeywords = { find: ["zzalias finder"] };
+
+    const search = executeSearch(state, "zzalias");
+    expect(search.content[0].text).toContain("demo_find");
+    // Only the echoed query may mention the keyword — never the configured phrase.
+    expect(JSON.stringify(search)).not.toContain("zzalias finder");
+
+    const describeResult = executeDescribe(state, "demo_find");
+    expect(JSON.stringify(describeResult)).not.toContain("zzalias");
+  });
+
   it("suggests the matching tool for a prefix-mangled describe name", () => {
     const result = executeDescribe(createState(), "demo_sear");
 

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -176,6 +176,17 @@ describe("proxy discovery", () => {
     expect(result.content[0].text).toContain("Did you mean: demo_search");
   });
 
+  it("does not suggest tools through configured search keywords", async () => {
+    const state = createState();
+    state.config.mcpServers.demo!.searchKeywords = { find: ["zzalias"] };
+
+    expect(executeSearch(state, "zzalias").details).toMatchObject({ count: 1, matches: [{ tool: "demo_find" }] });
+    expect(executeDescribe(state, "zzalias").details).toMatchObject({ suggestions: [] });
+
+    const call = await executeCall(state, "zzalias");
+    expect(call.details).toMatchObject({ error: "tool_not_found", suggestions: [] });
+  });
+
   it("tells callers to invoke native Pi tools directly", async () => {
     const result = await executeCall(
       createState(),

--- a/__tests__/search-ranking.test.ts
+++ b/__tests__/search-ranking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { paginate, scoreToolMatch } from "../search-ranking.ts";
+import { paginate, resolveSearchKeywords, scoreToolMatch } from "../search-ranking.ts";
+import type { ServerEntry } from "../types.ts";
 
 const tool = (name: string, description: string) => ({
   name,
@@ -26,6 +27,45 @@ describe("search ranking", () => {
     expect(scoreToolMatch(tool("sync_icon", "Sync an icon."), "better-icons", "synchronize")).not.toBeNull();
   });
 
+  it("matches through configured keywords where the query would otherwise miss", () => {
+    const advanced = tool("search_records_advanced", "Advanced record search with filters");
+
+    expect(scoreToolMatch(advanced, "demo", "fuzzy lookup")).toBeNull();
+    expect(scoreToolMatch(advanced, "demo", "fuzzy lookup", ["fuzzy lookup", "legacy"])).not.toBeNull();
+    // Single-token queries pass the coverage gate through keyword tokens too.
+    expect(scoreToolMatch(advanced, "demo", "fuzzy")).toBeNull();
+    expect(scoreToolMatch(advanced, "demo", "fuzzy", ["fuzzy lookup"])).not.toBeNull();
+  });
+
+  it("ranks an exact keyword alias above a description phrase match", () => {
+    const aliased = scoreToolMatch(
+      tool("search_records_advanced", "Advanced record search with filters"),
+      "demo",
+      "fuzzy lookup",
+      ["fuzzy lookup"],
+    )!;
+    const description = scoreToolMatch(tool("record_search", "Fuzzy lookup across records"), "demo", "fuzzy lookup")!;
+
+    expect(aliased).toBeGreaterThan(description);
+  });
+
+  it("scores an exact alias above incidental cross-phrase token matches", () => {
+    const advanced = tool("search_records_advanced", "Advanced record search with filters");
+    const keywords = ["fuzzy lookup", "legacy"];
+
+    // "lookup legacy" spans two phrases; it may token-match but must not get
+    // the phrase-level bonus a real alias hit gets.
+    const exact = scoreToolMatch(advanced, "demo", "fuzzy lookup", keywords)!;
+    const crossPhrase = scoreToolMatch(advanced, "demo", "lookup legacy", keywords)!;
+    expect(exact).toBeGreaterThan(crossPhrase);
+  });
+
+  it("does not change scoring when the keyword list is empty", () => {
+    const advanced = tool("search_records_advanced", "Advanced record search");
+
+    expect(scoreToolMatch(advanced, "demo", "advanced", [])).toEqual(scoreToolMatch(advanced, "demo", "advanced"));
+  });
+
   it("paginates including offsets beyond the result set", () => {
     expect(paginate(["a", "b", "c"], 1, 1)).toEqual({
       items: ["b"], total: 3, hasMore: true, nextOffset: 2,
@@ -33,5 +73,39 @@ describe("search ranking", () => {
     expect(paginate(["a", "b", "c"], 5, 1)).toEqual({
       items: [], total: 3, hasMore: false, nextOffset: null,
     });
+  });
+});
+
+describe("resolveSearchKeywords", () => {
+  const definition = (searchKeywords: unknown): ServerEntry =>
+    ({ command: "npx", searchKeywords }) as ServerEntry;
+
+  it("matches keys by original name, prefixed name, and glob", () => {
+    expect(resolveSearchKeywords(definition({ search_records_advanced: ["fuzzy lookup"] }), "search_records_advanced", "demo", "server"))
+      .toEqual(["fuzzy lookup"]);
+    expect(resolveSearchKeywords(definition({ demo_search_records_advanced: ["fuzzy lookup"] }), "search_records_advanced", "demo", "server"))
+      .toEqual(["fuzzy lookup"]);
+    expect(resolveSearchKeywords(definition({ "search_*": ["records"] }), "search_records_advanced", "demo", "server"))
+      .toEqual(["records"]);
+    expect(resolveSearchKeywords(definition({ "*": ["records"] }), "anything", "demo", "server"))
+      .toEqual(["records"]);
+  });
+
+  it("unions and dedupes values from all matching keys", () => {
+    const entry = definition({
+      "search_*": ["records", "fuzzy lookup"],
+      search_records_advanced: ["fuzzy lookup", "legacy"],
+    });
+
+    expect(resolveSearchKeywords(entry, "search_records_advanced", "demo", "server"))
+      .toEqual(["records", "fuzzy lookup", "legacy"]);
+  });
+
+  it("returns nothing for non-matching keys or malformed config", () => {
+    expect(resolveSearchKeywords(definition({ other_tool: ["nope"] }), "search_records_advanced", "demo", "server")).toEqual([]);
+    expect(resolveSearchKeywords(definition({ search_records_advanced: "not-an-array" }), "search_records_advanced", "demo", "server")).toEqual([]);
+    expect(resolveSearchKeywords(definition({ search_records_advanced: ["ok", 42, "  "] }), "search_records_advanced", "demo", "server")).toEqual(["ok"]);
+    expect(resolveSearchKeywords(definition(["not", "a", "record"]), "search_records_advanced", "demo", "server")).toEqual([]);
+    expect(resolveSearchKeywords(undefined, "search_records_advanced", "demo", "server")).toEqual([]);
   });
 });

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -16,7 +16,7 @@ import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } 
 import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
-import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts";
+import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
@@ -503,11 +503,15 @@ export function executeSearch(
     }
 
     matches = [];
+    const globalPrefix = state.config.settings?.toolPrefix ?? "server";
     for (const [serverName, metadata] of state.toolMetadata.entries()) {
-      if (isServerDisabled(state.config.mcpServers[serverName])) continue;
+      const definition = state.config.mcpServers[serverName];
+      if (isServerDisabled(definition)) continue;
       if (server && serverName !== server) continue;
       for (const tool of metadata) {
-        if (pattern.test(tool.name) || pattern.test(tool.description)) matches.push({ server: serverName, tool, score: 0 });
+        const matched = pattern.test(tool.name) || pattern.test(tool.description)
+          || resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix).some(keyword => pattern.test(keyword));
+        if (matched) matches.push({ server: serverName, tool, score: 0 });
       }
     }
   } else if (query.trim().length === 0) {

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -1,6 +1,6 @@
 import type { McpExtensionState } from "./state.ts";
-import type { ToolMetadata } from "./types.ts";
-import { getServerPrefix, isServerDisabled } from "./types.ts";
+import type { ServerEntry, ToolMetadata, ToolPrefix } from "./types.ts";
+import { getServerPrefix, getToolNameCandidates, isServerDisabled, matchesToolPattern, resolveToolPrefix } from "./types.ts";
 
 /**
  * Shortest field token allowed to stem-match a longer query token.
@@ -14,12 +14,43 @@ const FIELD_WEIGHTS = {
   originalName: 10,
   server: 8,
   description: 5,
+  keywords: 5,
 } as const;
 
 export interface RankedToolMatch {
   server: string;
   tool: ToolMetadata;
   score: number;
+}
+
+/**
+ * Resolve the configured searchKeywords entries that apply to a tool.
+ * Keys match by original name, prefixed name, or glob — the same candidate
+ * set includeTools/excludeTools use — and all matching entries are unioned.
+ */
+export function resolveSearchKeywords(
+  definition: ServerEntry | undefined,
+  toolOriginalName: string,
+  serverName: string,
+  globalPrefix: ToolPrefix,
+): string[] {
+  const map = definition?.searchKeywords;
+  if (!map || typeof map !== "object" || Array.isArray(map)) return [];
+  const candidates = getToolNameCandidates(toolOriginalName, serverName, resolveToolPrefix(definition, globalPrefix));
+  const keywords: string[] = [];
+  const seen = new Set<string>();
+  for (const [pattern, values] of Object.entries(map)) {
+    if (!Array.isArray(values)) continue;
+    if (!matchesToolPattern(candidates, [pattern])) continue;
+    for (const value of values) {
+      if (typeof value !== "string") continue;
+      const trimmed = value.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      keywords.push(trimmed);
+    }
+  }
+  return keywords;
 }
 
 export function normalizeSearchText(value: string): string {
@@ -33,7 +64,7 @@ export function tokenize(value: string): string[] {
   return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean);
 }
 
-export function scoreToolMatch(tool: ToolMetadata, server: string, query: string): number | null {
+export function scoreToolMatch(tool: ToolMetadata, server: string, query: string, keywords?: string[]): number | null {
   const normalizedQuery = normalizeSearchText(query).trim();
   const queryTokens = tokenize(query);
   if (queryTokens.length === 0) return null;
@@ -78,6 +109,43 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
     }
   }
 
+  // Configured keywords are discrete phrases, so the phrase-level bonus is
+  // computed per phrase (best match wins) rather than on a joined string,
+  // which would phrase-match queries spanning two unrelated keywords.
+  if (keywords !== undefined && keywords.length > 0) {
+    const weight = FIELD_WEIGHTS.keywords;
+    const phrases = keywords.map(keyword => normalizeSearchText(keyword).trim()).filter(Boolean);
+    let phraseScore = 0;
+    for (const phrase of phrases) {
+      if (phrase === normalizedQuery) {
+        phraseScore = Math.max(phraseScore, weight * 14);
+        phraseMatched = true;
+        wholeFieldExact = true;
+      } else if (phrase.startsWith(normalizedQuery)) {
+        phraseScore = Math.max(phraseScore, weight * 9);
+        phraseMatched = true;
+      } else if (phrase.includes(normalizedQuery)) {
+        phraseScore = Math.max(phraseScore, weight * 6);
+        phraseMatched = true;
+      }
+    }
+    score += phraseScore;
+
+    const keywordTokens = phrases.flatMap(tokenize);
+    for (const token of queryTokens) {
+      if (keywordTokens.includes(token)) {
+        score += weight * 4;
+        matchedTokens.add(token);
+      } else if (keywordTokens.some(keywordToken => keywordToken.startsWith(token) || (keywordToken.length >= MIN_STEM_LENGTH && token.startsWith(keywordToken)))) {
+        score += weight * 2;
+        matchedTokens.add(token);
+      } else if (phrases.some(phrase => phrase.includes(token))) {
+        score += weight;
+        matchedTokens.add(token);
+      }
+    }
+  }
+
   const coverage = matchedTokens.size / queryTokens.length;
   if (!phraseMatched && (queryTokens.length <= 2 ? coverage !== 1 : coverage < 0.6)) return null;
 
@@ -90,11 +158,17 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
 
 export function rankToolMatches(state: McpExtensionState, query: string, server?: string): RankedToolMatch[] {
   const matches: RankedToolMatch[] = [];
+  const globalPrefix = state.config.settings?.toolPrefix ?? "server";
   for (const [serverName, metadata] of state.toolMetadata.entries()) {
     if (server && serverName !== server) continue;
-    if (isServerDisabled(state.config.mcpServers[serverName])) continue;
+    const definition = state.config.mcpServers[serverName];
+    if (isServerDisabled(definition)) continue;
+    const hasKeywords = definition?.searchKeywords !== undefined;
     for (const tool of metadata) {
-      const score = scoreToolMatch(tool, serverName, query);
+      const keywords = hasKeywords
+        ? resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix)
+        : undefined;
+      const score = scoreToolMatch(tool, serverName, query, keywords);
       if (score !== null) matches.push({ server: serverName, tool, score });
     }
   }

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -156,14 +156,19 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
   return score;
 }
 
-export function rankToolMatches(state: McpExtensionState, query: string, server?: string): RankedToolMatch[] {
+export function rankToolMatches(
+  state: McpExtensionState,
+  query: string,
+  server?: string,
+  includeKeywords = true,
+): RankedToolMatch[] {
   const matches: RankedToolMatch[] = [];
   const globalPrefix = state.config.settings?.toolPrefix ?? "server";
   for (const [serverName, metadata] of state.toolMetadata.entries()) {
     if (server && serverName !== server) continue;
     const definition = state.config.mcpServers[serverName];
     if (isServerDisabled(definition)) continue;
-    const hasKeywords = definition?.searchKeywords !== undefined;
+    const hasKeywords = includeKeywords && definition?.searchKeywords !== undefined;
     for (const tool of metadata) {
       const keywords = hasKeywords
         ? resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix)
@@ -197,5 +202,5 @@ export function rankSuggestions(state: McpExtensionState, name: string, limit: n
     .sort((a, b) => b.length - a.length)
     .map(candidate => name.slice(candidate.length + 1));
   const query = stripped[0] ?? name;
-  return rankToolMatches(state, query).slice(0, limit).map(match => match.tool.name);
+  return rankToolMatches(state, query, undefined, false).slice(0, limit).map(match => match.tool.name);
 }

--- a/types.ts
+++ b/types.ts
@@ -395,6 +395,13 @@ export interface ServerEntry {
   // Include/exclude specific MCP tools/resources by original or prefixed name
   includeTools?: string[];
   excludeTools?: string[];
+  /**
+   * Extra search keywords per tool, keyed by original name, prefixed name, or
+   * glob (same matching rules as includeTools/excludeTools). Keywords boost
+   * mcp({ search }) ranking only — they never appear in tool schemas,
+   * describe output, or the metadata cache.
+   */
+  searchKeywords?: Record<string, string[]>;
   // Require interactive approval before calling matching MCP tools/resources.
   approveTools?: boolean | string[];
   // Debug


### PR DESCRIPTION
## Motivation

Exa's hosted MCP server recently retired `deep_search_exa` in favor of `web_search_advanced_exa`. I still type the old vocabulary out of habit, and discovery comes up empty because search matches literally against name, server, and description:

```
mcp({ search: "deep search" })  → No tools matching "deep search"
mcp({ search: "advanced" })     → exa_web_search_advanced_exa
```

Vendor renames and team vocabulary that differs from a server's phrasing can't be fixed client-side today — the tool's metadata is whatever the server sends.

## What this adds

A per-server `searchKeywords` map from tool name (or glob) to extra keyword phrases:

```json
{
  "mcpServers": {
    "exa": {
      "url": "https://mcp.exa.ai/mcp",
      "searchKeywords": {
        "web_search_advanced_exa": ["deep search"],
        "*": ["websearch"]
      }
    }
  }
}
```

With this config, `mcp({ search: "deep search" })` ranks `exa_web_search_advanced_exa` first. Keys match by original name, prefixed name, or glob — the same candidate rules as `includeTools`/`excludeTools`, reusing the same helpers — and all matching entries union.

## Design decisions

- **Ranking only, never model-visible.** Keywords are resolved at rank time in `search-ranking.ts` as a config overlay; they never enter `ToolMetadata`, tool schemas, `describe` output, direct-tool registration, or `mcp-cache.json`. This is enforced structurally (they aren't stored anywhere that renders) and guarded by tests.
- **Offline-safe.** Search already works from cached metadata without connections; keywords are read from config at query time, so that's preserved. `searchKeywords` is deliberately excluded from `computeServerHash` so editing keywords never invalidates the metadata cache.
- **Scoring.** Keywords are a fifth field at weight 5 (description parity). Each configured phrase is scored individually for the exact/prefix/substring phrase bonus — so a query that exactly matches a configured alias gets the whole-field-exact boost, while a query spanning two unrelated phrases doesn't — and keyword tokens feed the existing coverage gate (which is what turns single-token queries like `"deep"` from zero results into a hit). Regex search mode also tests patterns against keywords, and `mcpScript`'s `tools.search` inherits everything through the shared `rankToolMatches` path.
- **No behavior change without config.** Passing no keywords (or an empty list) scores byte-identically to before; the existing ranking tests pass unchanged.

## Prior art

- **MCP spec** has no keyword/tags/alias field on the Tool definition (`name, title, description, inputSchema, outputSchema, annotations, _meta`), so this has to live in client config.
- **Microsoft Foundry agents** ship the same feature as `tool_configs.<tool>.additional_search_text`: "used only for search ranking — it's never exposed to the model in the tool schema" ([docs](https://github.com/MicrosoftDocs/azure-ai-docs/blob/main/articles/foundry/agents/how-to/tools/tool-search.md)).
- **ToolRegistry** (Python) indexes `ToolMetadata.search_hint` at description weight for the same purpose: "add synonyms, related concepts, or domain-specific terms that improve discoverability" ([docs](https://toolregistry.readthedocs.io/en/latest/usage/tool_discovery/)).
- Renaming/aliasing the model-visible tool name (Cloudflare MCP portals, MetaMCP, github-mcp-server's deprecation aliases) is a related but distinct feature and deliberately out of scope here.

## Testing

- Unit tests for the new `resolveSearchKeywords` (key forms, glob, `*`, union/dedupe, malformed config) and for keyword scoring (coverage rescue, exact-alias ranking, cross-phrase behavior, empty-list no-op).
- End-to-end `executeSearch` tests: ranked and regex search through keywords, prefixed/glob keys, and a leak guard asserting keywords never appear in search or describe output.
- `npm run typecheck`, `vitest` (touched suites 27/27; full suite green apart from pre-existing Node-20-only environment failures unrelated to this change), and `npm run test:oauth` all pass locally; CI on Node 22 covers the rest.

## Notes

- Naming: happy to rename the field (`searchHints`, `additionalSearchText`, …) if you prefer.
- The CHANGELOG entry is in `[Unreleased]`; I'll append the PR number to it once one exists.
