### PR TITLE
fix: interpolate stdio server args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added per-server `searchKeywords` so `mcp({ search })` and `mcpScript` `tools.search` understand user-defined synonyms and aliases for tools. Keywords are keyed by tool name or glob and boost ranked and regex search only. They never appear in tool schemas, describe output, or the metadata cache. Thanks @Serisium for PR #336.
 
 ### Fixed
+- Interpolated environment placeholders in stdio server arguments. Thanks @vjik for issue #333.
 - Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.
 - Cached OAuth credentials in memory and refreshed them after OAuth-backed 401 responses. Thanks @daniel-sampliner for PR #335.
 - Sanitized MCP server-name prefixes for provider-safe tool names while preserving server resolution. Thanks @triple-dex for issue #334.

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -93,7 +93,11 @@ describe("npx-resolver", () => {
     writeFileSync(cachePath, JSON.stringify({ version: 1, entries: {} }), "utf-8");
     vi.doMock("node:fs", async (importOriginal) => {
       const fs = await importOriginal<typeof import("node:fs")>();
-      return { ...fs, unlinkSync: vi.fn(() => { throw new Error("permission denied"); }) };
+      return {
+        ...fs,
+        unlinkSync: vi.fn(() => { throw new Error("permission denied"); }),
+        writeFileSync: vi.fn(() => { throw new Error("permission denied"); }),
+      };
     });
     vi.doMock("cross-spawn", () => ({
       default: vi.fn(() => {
@@ -107,7 +111,7 @@ describe("npx-resolver", () => {
     expect(existsSync(cachePath)).toBe(true);
   });
 
-  it("returns a cached package when version-1 cleanup and cache save fail", async () => {
+  it("clears version-1 secrets and returns a cached package when cache save fails", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
     const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
@@ -117,14 +121,20 @@ describe("npx-resolver", () => {
     process.env.NPM_CONFIG_CACHE = npmCache;
 
     const cachePath = join(agentDir, "mcp-npx-cache.json");
-    writeFileSync(cachePath, JSON.stringify({ version: 1, entries: {} }), "utf-8");
+    writeFileSync(cachePath, JSON.stringify({
+      version: 1,
+      entries: { [JSON.stringify(["npx", "demo-pkg", "--token=secret-value"])]: {} },
+    }), "utf-8");
     const binPath = writeCachedPackage(npmCache, "demo-pkg");
     vi.doMock("node:fs", async (importOriginal) => {
       const fs = await importOriginal<typeof import("node:fs")>();
       return {
         ...fs,
         unlinkSync: vi.fn(() => { throw new Error("permission denied"); }),
-        writeFileSync: vi.fn(() => { throw new Error("permission denied"); }),
+        writeFileSync: vi.fn((path: string, data: string, options?: Parameters<typeof fs.writeFileSync>[2]) => {
+          if (path === cachePath && data === "") return fs.writeFileSync(path, data, options);
+          throw new Error("permission denied");
+        }),
       };
     });
 
@@ -135,7 +145,7 @@ describe("npx-resolver", () => {
       isJs: true,
     });
 
-    expect(existsSync(cachePath)).toBe(true);
+    expect(readFileSync(cachePath, "utf-8")).not.toContain("secret-value");
   });
 
   it("uses cross-spawn to read npm's cache directory", async () => {

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -48,6 +48,37 @@ describe("npx-resolver", () => {
     expect(existsSync(join(home, ".pi", "agent", "mcp-npx-cache.json"))).toBe(false);
   });
 
+  it("removes stale version-1 cache files before resolution", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    writeFileSync(
+      join(agentDir, "mcp-npx-cache.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          [JSON.stringify(["npx", "-y", "demo-pkg", "--token=secret-value"] as const)]: {},
+        },
+      }),
+      "utf-8",
+    );
+    vi.doMock("cross-spawn", () => ({
+      default: vi.fn(() => {
+        throw new Error("npm unavailable");
+      }),
+    }));
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    await expect(resolveNpxBinary("npx", ["-y", "missing-pkg"])).resolves.toBeNull();
+
+    expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(false);
+  });
+
   it("uses cross-spawn to read npm's cache directory", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -14,6 +14,7 @@ describe("npx-resolver", () => {
   });
 
   afterEach(() => {
+    vi.doUnmock("node:fs");
     process.env.HOME = originalHome;
     if (originalAgentDir === undefined) {
       delete process.env.PI_CODING_AGENT_DIR;
@@ -77,6 +78,64 @@ describe("npx-resolver", () => {
     await expect(resolveNpxBinary("npx", ["-y", "missing-pkg"])).resolves.toBeNull();
 
     expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(false);
+  });
+
+  it("continues resolution when version-1 cache deletion fails", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    const cachePath = join(agentDir, "mcp-npx-cache.json");
+    writeFileSync(cachePath, JSON.stringify({ version: 1, entries: {} }), "utf-8");
+    vi.doMock("node:fs", async (importOriginal) => {
+      const fs = await importOriginal<typeof import("node:fs")>();
+      return { ...fs, unlinkSync: vi.fn(() => { throw new Error("permission denied"); }) };
+    });
+    vi.doMock("cross-spawn", () => ({
+      default: vi.fn(() => {
+        throw new Error("npm unavailable");
+      }),
+    }));
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    await expect(resolveNpxBinary("npx", ["-y", "missing-pkg"])).resolves.toBeNull();
+
+    expect(existsSync(cachePath)).toBe(true);
+  });
+
+  it("returns a cached package when version-1 cleanup and cache save fail", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    const cachePath = join(agentDir, "mcp-npx-cache.json");
+    writeFileSync(cachePath, JSON.stringify({ version: 1, entries: {} }), "utf-8");
+    const binPath = writeCachedPackage(npmCache, "demo-pkg");
+    vi.doMock("node:fs", async (importOriginal) => {
+      const fs = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...fs,
+        unlinkSync: vi.fn(() => { throw new Error("permission denied"); }),
+        writeFileSync: vi.fn(() => { throw new Error("permission denied"); }),
+      };
+    });
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    await expect(resolveNpxBinary("npx", ["-y", "demo-pkg", "--runtime=value"])).resolves.toEqual({
+      binPath,
+      extraArgs: ["--runtime=value"],
+      isJs: true,
+    });
+
+    expect(existsSync(cachePath)).toBe(true);
   });
 
   it("uses cross-spawn to read npm's cache directory", async () => {

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -49,7 +49,7 @@ describe("npx-resolver", () => {
     expect(existsSync(join(home, ".pi", "agent", "mcp-npx-cache.json"))).toBe(false);
   });
 
-  it("removes stale version-1 cache files before resolution", async () => {
+  it("removes stale version-1 cache files on module import", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
     const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
@@ -68,14 +68,7 @@ describe("npx-resolver", () => {
       }),
       "utf-8",
     );
-    vi.doMock("cross-spawn", () => ({
-      default: vi.fn(() => {
-        throw new Error("npm unavailable");
-      }),
-    }));
-
-    const { resolveNpxBinary } = await import("../npx-resolver.ts");
-    await expect(resolveNpxBinary("npx", ["-y", "missing-pkg"])).resolves.toBeNull();
+    await import("../npx-resolver.ts");
 
     expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(false);
   });
@@ -139,13 +132,13 @@ describe("npx-resolver", () => {
     });
 
     const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    expect(readFileSync(cachePath, "utf-8")).not.toContain("secret-value");
+
     await expect(resolveNpxBinary("npx", ["-y", "demo-pkg", "--runtime=value"])).resolves.toEqual({
       binPath,
       extraArgs: ["--runtime=value"],
       isJs: true,
     });
-
-    expect(readFileSync(cachePath, "utf-8")).not.toContain("secret-value");
   });
 
   it("uses cross-spawn to read npm's cache directory", async () => {

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -27,7 +27,7 @@ describe("npx-resolver", () => {
     }
   });
 
-  it("writes mcp-npx-cache.json to PI_CODING_AGENT_DIR", async () => {
+  it("writes mcp-npx-cache.json to PI_CODING_AGENT_DIR without extra arguments", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
     const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
@@ -39,9 +39,11 @@ describe("npx-resolver", () => {
     writeCachedPackage(npmCache, "demo-pkg");
 
     const { resolveNpxBinary } = await import("../npx-resolver.ts");
-    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
+    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg", "--token=secret-value"]);
+    const cache = readFileSync(join(agentDir, "mcp-npx-cache.json"), "utf-8");
 
-    expect(result).not.toBeNull();
+    expect(result?.extraArgs).toEqual(["--token=secret-value"]);
+    expect(cache).not.toContain("secret-value");
     expect(existsSync(join(agentDir, "mcp-npx-cache.json"))).toBe(true);
     expect(existsSync(join(home, ".pi", "agent", "mcp-npx-cache.json"))).toBe(false);
   });
@@ -227,9 +229,9 @@ describe("npx-resolver", () => {
     writeFileSync(
       join(agentDir, "mcp-npx-cache.json"),
       JSON.stringify({
-        version: 1,
+        version: 2,
         entries: {
-          [JSON.stringify(["npx", "-y", "plainpkg@2.0.0"] as const)]: {
+          [JSON.stringify(["npx", "plainpkg@2.0.0", ""] as const)]: {
             resolvedBin: wrongBin,
             resolvedAt: Date.now(),
             packageVersion: "1.0.0",
@@ -245,7 +247,7 @@ describe("npx-resolver", () => {
     const cache = JSON.parse(readFileSync(join(agentDir, "mcp-npx-cache.json"), "utf-8"));
 
     expect(result?.binPath).toBe(correctBin);
-    expect(cache.entries[JSON.stringify(["npx", "-y", "plainpkg@2.0.0"])]?.packageVersion).toBe("2.0.0");
+    expect(cache.entries[JSON.stringify(["npx", "plainpkg@2.0.0", ""])]?.packageVersion).toBe("2.0.0");
   });
 });
 

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -41,6 +41,8 @@ vi.mock("../npx-resolver.ts", () => ({
   resolveNpxBinary: vi.fn(async () => null),
 }));
 
+import { resolveNpxBinary } from "../npx-resolver.ts";
+
 describe("McpServerManager stderr capture", () => {
   const originalStdioArg = process.env.MCP_TEST_STDIO_ARG;
 
@@ -81,6 +83,27 @@ describe("McpServerManager stderr capture", () => {
     });
 
     expect(mocks.transports[0].options.args).toEqual(["--first=interpolated", "--second=interpolated"]);
+  });
+
+  it("passes interpolated npx arguments to the resolver", async () => {
+    process.env.MCP_TEST_STDIO_ARG = "interpolated";
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    await manager.connect("demo", {
+      command: "npx",
+      args: ["-y", "demo-pkg", "--token=${MCP_TEST_STDIO_ARG}"],
+    });
+
+    expect(resolveNpxBinary).toHaveBeenCalledWith(
+      "npx",
+      ["-y", "demo-pkg", "--token=interpolated"],
+      expect.any(AbortSignal),
+    );
+    expect(mocks.transports[0].options).toMatchObject({
+      command: "npx",
+      args: ["-y", "demo-pkg", "--token=interpolated"],
+    });
   });
 
   it("appends captured stderr to the connection error", async () => {

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -42,12 +42,19 @@ vi.mock("../npx-resolver.ts", () => ({
 }));
 
 describe("McpServerManager stderr capture", () => {
+  const originalStdioArg = process.env.MCP_TEST_STDIO_ARG;
+
   beforeEach(() => {
     mocks.transports.length = 0;
     mocks.connectImpl = null;
   });
 
   afterEach(() => {
+    if (originalStdioArg === undefined) {
+      delete process.env.MCP_TEST_STDIO_ARG;
+    } else {
+      process.env.MCP_TEST_STDIO_ARG = originalStdioArg;
+    }
     vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
@@ -61,6 +68,19 @@ describe("McpServerManager stderr capture", () => {
 
     await manager.connect("debug", { command: "node", args: ["server.js"], debug: true });
     expect(mocks.transports[1].options.stderr).toBe("inherit");
+  });
+
+  it("interpolates environment placeholders in stdio arguments", async () => {
+    process.env.MCP_TEST_STDIO_ARG = "interpolated";
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    await manager.connect("demo", {
+      command: "node",
+      args: ["--first=${MCP_TEST_STDIO_ARG}", "--second=$env:MCP_TEST_STDIO_ARG"],
+    });
+
+    expect(mocks.transports[0].options.args).toEqual(["--first=interpolated", "--second=interpolated"]);
   });
 
   it("appends captured stderr to the connection error", async () => {

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -1,5 +1,5 @@
 // npx-resolver.ts - Resolve npx/npm exec binaries to avoid npm parent processes
-import { existsSync, readFileSync, realpathSync, readdirSync, statSync, writeFileSync, renameSync, mkdirSync, openSync, readSync, closeSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, readdirSync, statSync, writeFileSync, renameSync, mkdirSync, openSync, readSync, closeSync, unlinkSync } from "node:fs";
 import { join, dirname, extname, resolve, sep } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
 import { throwIfAborted } from "./abort.ts";
@@ -437,15 +437,23 @@ function getNpxCachePath(): string {
 function loadCache(): NpxCache | null {
   const cachePath = getNpxCachePath();
   if (!existsSync(cachePath)) return null;
+
+  let parsed: unknown;
   try {
-    const raw = JSON.parse(readFileSync(cachePath, "utf-8"));
-    if (!raw || typeof raw !== "object") return null;
-    if (raw.version !== CACHE_VERSION) return null;
-    if (!raw.entries || typeof raw.entries !== "object") return null;
-    return raw as NpxCache;
+    parsed = JSON.parse(readFileSync(cachePath, "utf-8"));
   } catch {
     return null;
   }
+
+  if (!parsed || typeof parsed !== "object") return null;
+  const raw = parsed as Record<string, unknown>;
+  if (raw.version === 1) {
+    unlinkSync(cachePath);
+    return null;
+  }
+  if (raw.version !== CACHE_VERSION) return null;
+  if (!raw.entries || typeof raw.entries !== "object") return null;
+  return raw as unknown as NpxCache;
 }
 
 function saveCacheEntry(key: string, entry: NpxCacheEntry): void {

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -451,7 +451,11 @@ function loadCache(): NpxCache | null {
     try {
       unlinkSync(cachePath);
     } catch {
-      // Cache cleanup is best effort; resolution must still proceed.
+      try {
+        writeFileSync(cachePath, "", "utf-8");
+      } catch {
+        // Cache cleanup is best effort; resolution must still proceed.
+      }
     }
     return null;
   }

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -434,7 +434,35 @@ function getNpxCachePath(): string {
   return getAgentPath("mcp-npx-cache.json");
 }
 
+function clearLegacyCache(): boolean {
+  const cachePath = getNpxCachePath();
+  if (!existsSync(cachePath)) return false;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(cachePath, "utf-8"));
+  } catch {
+    return false;
+  }
+
+  if (!parsed || typeof parsed !== "object" || (parsed as Record<string, unknown>).version !== 1) return false;
+  try {
+    unlinkSync(cachePath);
+  } catch {
+    try {
+      writeFileSync(cachePath, "", "utf-8");
+    } catch {
+      // Cache cleanup is best effort; resolution must still proceed.
+    }
+  }
+  return true;
+}
+
+clearLegacyCache();
+
 function loadCache(): NpxCache | null {
+  if (clearLegacyCache()) return null;
+
   const cachePath = getNpxCachePath();
   if (!existsSync(cachePath)) return null;
 
@@ -447,18 +475,6 @@ function loadCache(): NpxCache | null {
 
   if (!parsed || typeof parsed !== "object") return null;
   const raw = parsed as Record<string, unknown>;
-  if (raw.version === 1) {
-    try {
-      unlinkSync(cachePath);
-    } catch {
-      try {
-        writeFileSync(cachePath, "", "utf-8");
-      } catch {
-        // Cache cleanup is best effort; resolution must still proceed.
-      }
-    }
-    return null;
-  }
   if (raw.version !== CACHE_VERSION) return null;
   if (!raw.entries || typeof raw.entries !== "object") return null;
   return raw as unknown as NpxCache;

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -448,7 +448,11 @@ function loadCache(): NpxCache | null {
   if (!parsed || typeof parsed !== "object") return null;
   const raw = parsed as Record<string, unknown>;
   if (raw.version === 1) {
-    unlinkSync(cachePath);
+    try {
+      unlinkSync(cachePath);
+    } catch {
+      // Cache cleanup is best effort; resolution must still proceed.
+    }
     return null;
   }
   if (raw.version !== CACHE_VERSION) return null;
@@ -457,26 +461,30 @@ function loadCache(): NpxCache | null {
 }
 
 function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
-  const cachePath = getNpxCachePath();
-  const dir = dirname(cachePath);
-  mkdirSync(dir, { recursive: true });
-
-  let merged: NpxCache = { version: CACHE_VERSION, entries: {} };
   try {
-    if (existsSync(cachePath)) {
-      const existing = JSON.parse(readFileSync(cachePath, "utf-8")) as NpxCache;
-      if (existing && existing.version === CACHE_VERSION && existing.entries) {
-        merged.entries = { ...existing.entries };
-      }
-    }
-  } catch {
-    // Ignore parse errors
-  }
+    const cachePath = getNpxCachePath();
+    const dir = dirname(cachePath);
+    mkdirSync(dir, { recursive: true });
 
-  merged.entries[key] = entry;
-  const tmpPath = `${cachePath}.${process.pid}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8");
-  renameSync(tmpPath, cachePath);
+    let merged: NpxCache = { version: CACHE_VERSION, entries: {} };
+    try {
+      if (existsSync(cachePath)) {
+        const existing = JSON.parse(readFileSync(cachePath, "utf-8")) as NpxCache;
+        if (existing && existing.version === CACHE_VERSION && existing.entries) {
+          merged.entries = { ...existing.entries };
+        }
+      }
+    } catch {
+      // Ignore parse errors
+    }
+
+    merged.entries[key] = entry;
+    const tmpPath = `${cachePath}.${process.pid}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8");
+    renameSync(tmpPath, cachePath);
+  } catch {
+    // Cache writes are best effort; resolution must still proceed.
+  }
 }
 
 function safeRealpath(path: string): string {

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -5,7 +5,7 @@ import { getAgentPath } from "./agent-dir.ts";
 import { throwIfAborted } from "./abort.ts";
 import crossSpawn from "cross-spawn";
 
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const EXACT_PACKAGE_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
 
@@ -53,7 +53,7 @@ export async function resolveNpxBinary(
   if (!parsed) return null;
 
   const packageSpec = parsePackageSpec(parsed.packageSpec);
-  const cacheKey = JSON.stringify([command, ...args]);
+  const cacheKey = JSON.stringify([command, parsed.packageSpec, parsed.binName ?? ""]);
   const cache = loadCache();
   const cached = cache?.entries?.[cacheKey];
 

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -39,6 +39,7 @@ import {
   type ServerElicitationConfig,
 } from "./elicitation-handler.ts";
 import {
+  interpolateEnvVars,
   resolveBearerToken,
   resolveCommandSecret,
   resolveCommandSecretsRecord,
@@ -358,7 +359,7 @@ export class McpServerManager {
     if (definition.command) {
       client = this.createClient(name, definition);
       let command = definition.command;
-      let args = definition.args ?? [];
+      let args = (definition.args ?? []).map(interpolateEnvVars);
 
       if (command === "npx" || command === "npm") {
         const resolved = await resolveNpxBinary(command, args, signal);


### PR DESCRIPTION
## Summary

- interpolate `${VAR}` and `$env:VAR` placeholders in stdio server `args`
- keep interpolation at the stdio launch boundary before `npx` / `npm` resolution
- add focused manager-path coverage and changelog credit for @vjik

Closes #333.

## Testing

- `npm test -- __tests__/server-manager-stderr-capture.test.ts`
- `npm run typecheck`
- `git diff --check`
