### PR TITLE
fix: sanitize server prefixes for tool names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Kept remote `/mcp-auth` authorization links reachable before the callback input opens. Thanks @trevorleibert-mixpanel for PR #331.
 - Cached OAuth credentials in memory and refreshed them after OAuth-backed 401 responses. Thanks @daniel-sampliner for PR #335.
+- Sanitized MCP server-name prefixes for provider-safe tool names while preserving server resolution. Thanks @triple-dex for issue #334.
 
 ## [2.23.0] - 2026-08-11
 

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -37,7 +37,7 @@ describe("formatToolName", () => {
     expect(formatToolName("namespace.tool", "demo", "server")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo-mcp", "short")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo", "none")).toBe("namespace_tool");
-    expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo_mcp_namespace_tool");
+    expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo_2d_mcp_namespace_tool");
   });
 
   it("sanitizes server names in live tool and resource metadata", () => {
@@ -50,8 +50,8 @@ describe("formatToolName", () => {
     );
 
     expect(metadata.map((tool) => tool.name)).toEqual([
-      "my_server_find",
-      "my_server_read_guide",
+      "my_20_server_find",
+      "my_20_server_read_guide",
     ]);
   });
 });
@@ -550,6 +550,38 @@ describe("excludeTools filtering", () => {
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes"]);
   });
 
+  it("registers servers that previously collided after prefix escaping", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "a b": { command: "first" },
+        "a-20-b": { command: "second" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "a b": {
+          configHash: computeServerHash(config.mcpServers["a b"]),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "First" }],
+          resources: [],
+        },
+        "a-20-b": {
+          configHash: computeServerHash(config.mcpServers["a-20-b"]),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Second" }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server").map((spec) => [spec.serverName, spec.prefixedName])).toEqual([
+      ["a b", "a_20_b_search"],
+      ["a-20-b", "a_2d_20_2d_b_search"],
+    ]);
+  });
+
   it("honors per-server toolPrefix during direct tool registration from cache", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "none" },
@@ -656,7 +688,7 @@ describe("excludeTools filtering", () => {
           command: "npx",
           args: ["-y", "my-server"],
           directTools: true,
-          excludeTools: ["mcp__my_server_do_thing"],
+          excludeTools: ["mcp__my_2d_server_do_thing"],
         },
       },
     };
@@ -678,7 +710,7 @@ describe("excludeTools filtering", () => {
 
     const specs = resolveDirectTools(config, cache, "mcp");
 
-    expect(specs.map((spec) => spec.prefixedName)).toEqual(["mcp__my_server_other_tool"]);
+    expect(specs.map((spec) => spec.prefixedName)).toEqual(["mcp__my_2d_server_other_tool"]);
   });
 
   it("matches prefixed exclusions even when toolPrefix is none", () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -39,6 +39,21 @@ describe("formatToolName", () => {
     expect(formatToolName("namespace.tool", "demo", "none")).toBe("namespace_tool");
     expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo_mcp_namespace_tool");
   });
+
+  it("sanitizes server names in live tool and resource metadata", () => {
+    const { metadata } = buildToolMetadata(
+      [{ name: "find", description: "Find" }] as any,
+      [{ name: "guide", uri: "file://guide" }] as any,
+      { command: "demo" },
+      "my server",
+      "server",
+    );
+
+    expect(metadata.map((tool) => tool.name)).toEqual([
+      "my_server_find",
+      "my_server_read_guide",
+    ]);
+  });
 });
 
 describe("buildProxyDescription", () => {

--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -51,20 +51,20 @@ function commandCtx(overrides: Partial<ExtensionCommandContext> = {}): Extension
 
 describe("prompt command naming", () => {
   it("mirrors Claude Code's mcp__<server>__<prompt> convention", () => {
-    expect(formatPromptCommandName("plan", "agent-board", "server")).toBe("mcp__agent_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board", "server")).toBe("mcp__agent_2d_board__plan");
   });
 
   it("honors the toolPrefix short mode", () => {
-    expect(formatPromptCommandName("plan", "agent-board-mcp", "short")).toBe("mcp__agent_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board-mcp", "short")).toBe("mcp__agent_2d_board__plan");
   });
 
   it("falls back to the server name when toolPrefix is 'none'", () => {
-    expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent_2d_board__plan");
   });
 
   it("sanitizes server names with spaces", () => {
-    expect(formatPromptCommandName("plan", "agent board", "server")).toBe("mcp__agent_board__plan");
-    expect(formatPromptCommandName("plan", "agent board", "none")).toBe("mcp__agent_board__plan");
+    expect(formatPromptCommandName("plan", "agent board", "server")).toBe("mcp__agent_20_board__plan");
+    expect(formatPromptCommandName("plan", "agent board", "none")).toBe("mcp__agent_20_board__plan");
   });
 
   it("sanitizes prompt names with unusual characters", () => {

--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -62,6 +62,11 @@ describe("prompt command naming", () => {
     expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent_board__plan");
   });
 
+  it("sanitizes server names with spaces", () => {
+    expect(formatPromptCommandName("plan", "agent board", "server")).toBe("mcp__agent_board__plan");
+    expect(formatPromptCommandName("plan", "agent board", "none")).toBe("mcp__agent_board__plan");
+  });
+
   it("sanitizes prompt names with unusual characters", () => {
     expect(sanitizePromptName("weekly.report")).toBe("weekly_report");
     expect(sanitizePromptName("with spaces & symbols")).toBe("with_spaces_symbols");

--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
 	resolveServerFromToolName,
 	getServerPrefix,
+	formatPromptCommandName,
 	formatToolName,
+	getToolNameCandidates,
 } from "../types.ts";
 
 describe("resolveServerFromToolName", () => {
@@ -26,10 +28,25 @@ describe("resolveServerFromToolName", () => {
 
 		it("round-trips server names with spaces", () => {
 			const tool = formatToolName("web_search", "my server", "server");
-			expect(tool).toBe("my_server_web_search");
+			expect(tool).toBe("my_20_server_web_search");
 			expect(resolveServerFromToolName(tool, ["my server"], "server")).toBe(
 				"my server",
 			);
+		});
+
+		it("keeps colliding sanitized server names distinct across mappings", () => {
+			const spacedTool = formatToolName("search", "my server", "server");
+			const underscoredTool = formatToolName("search", "my_server", "server");
+
+			expect(spacedTool).toBe("my_20_server_search");
+			expect(underscoredTool).toBe("my_5f_server_search");
+			expect(new Set([spacedTool, underscoredTool]).size).toBe(2);
+			expect(resolveServerFromToolName(spacedTool, ["my server", "my_server"], "server")).toBe("my server");
+			expect(resolveServerFromToolName(underscoredTool, ["my server", "my_server"], "server")).toBe("my_server");
+			expect(formatPromptCommandName("plan", "my server", "server")).toBe("mcp__my_20_server__plan");
+			expect(formatPromptCommandName("plan", "my_server", "server")).toBe("mcp__my_5f_server__plan");
+			expect(getToolNameCandidates("search", "my server", "server")).toContain(spacedTool);
+			expect(getToolNameCandidates("search", "my_server", "server")).toContain(underscoredTool);
 		});
 
 		it("resolves when multiple servers are configured and only one prefix matches", () => {
@@ -43,8 +60,7 @@ describe("resolveServerFromToolName", () => {
 		});
 
 		it("picks the longest matching prefix when server names share a stem", () => {
-			// "searxng" (prefix "searxng", len 7) vs "searxng-extra" (prefix "searxng_extra", len 13)
-			const tool = "searxng_extra_deep_search";
+			const tool = "searxng_2d_extra_deep_search";
 			expect(
 				resolveServerFromToolName(tool, ["searxng", "searxng-extra"], "server"),
 			).toBe("searxng-extra");
@@ -68,13 +84,16 @@ describe("resolveServerFromToolName", () => {
 				"-mcp",
 			);
 		});
+
+		it("fails safe when suffix removal creates an ambiguous prefix", () => {
+			expect(resolveServerFromToolName("foo_query", ["foo", "foo-mcp"], "short")).toBeUndefined();
+		});
 	});
 
 	describe("mcp prefix mode", () => {
 		it("resolves the mcp__namespaced format", () => {
-			// getServerPrefix replaces dashes with underscores: my-server -> mcp__my_server
 			expect(
-				resolveServerFromToolName("mcp__my_server_run", ["my-server"], "mcp"),
+				resolveServerFromToolName("mcp__my_2d_server_run", ["my-server"], "mcp"),
 			).toBe("my-server");
 		});
 	});
@@ -154,56 +173,22 @@ describe("resolveServerFromToolName", () => {
 	});
 });
 
-describe("ambiguous prefix collisions (fail safe)", () => {
-	it("returns undefined when two servers normalize to the same prefix", () => {
-		// my-server and my_server both -> my_server under "server" mode
+describe("distinct normalized server prefixes", () => {
+	it("resolves distinct space and hyphen prefixes", () => {
 		expect(
-			resolveServerFromToolName("my_server_run", ["my-server", "my_server"], "server"),
-		).toBe(undefined);
+			resolveServerFromToolName("a_20_b_run", ["a b", "a-20-b"], "server"),
+		).toBe("a b");
+		expect(
+			resolveServerFromToolName("a_2d_20_2d_b_run", ["a b", "a-20-b"], "server"),
+		).toBe("a-20-b");
 	});
 
-	it("returns undefined regardless of collision order", () => {
+	it("resolves distinct hyphen and underscore prefixes under mcp mode", () => {
 		expect(
-			resolveServerFromToolName("my_server_run", ["my_server", "my-server"], "server"),
-		).toBe(undefined);
-	});
-
-	it("does not false-trigger on a single server whose name contains a dash", () => {
-		// Only one configured server, no collision: dashes are fine.
-		expect(
-			resolveServerFromToolName("my_server_run", ["my-server"], "server"),
+			resolveServerFromToolName("mcp__my_2d_server_run", ["my-server", "my_server"], "mcp"),
 		).toBe("my-server");
-	});
-
-	it("returns undefined when a collision happens under mcp mode too", () => {
-		// both -> mcp__my_server
 		expect(
-			resolveServerFromToolName(
-				"mcp__my_server_run",
-				["my-server", "my_server"],
-				"mcp",
-			),
-		).toBe(undefined);
-	});
-
-	it("still resolves when the colliding servers are unrelated to the call", () => {
-		// colliding my-server/my_server exist, but the call targets searxng.
-		expect(
-			resolveServerFromToolName(
-				"searxng_search",
-				["my-server", "my_server", "searxng"],
-				"server",
-			),
-		).toBe("searxng");
-	});
-
-	it("is deterministic: a collision between only two of many servers still fails safe", () => {
-		expect(
-			resolveServerFromToolName(
-				"my_server_run",
-				["searxng", "my-server", "my_server", "github"],
-				"server",
-			),
-		).toBe(undefined);
+			resolveServerFromToolName("mcp__my_5f_server_run", ["my-server", "my_server"], "mcp"),
+		).toBe("my_server");
 	});
 });

--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -24,6 +24,14 @@ describe("resolveServerFromToolName", () => {
 			);
 		});
 
+		it("round-trips server names with spaces", () => {
+			const tool = formatToolName("web_search", "my server", "server");
+			expect(tool).toBe("my_server_web_search");
+			expect(resolveServerFromToolName(tool, ["my server"], "server")).toBe(
+				"my server",
+			);
+		});
+
 		it("resolves when multiple servers are configured and only one prefix matches", () => {
 			expect(
 				resolveServerFromToolName(

--- a/types.ts
+++ b/types.ts
@@ -642,18 +642,22 @@ export interface McpPanelResult {
 /**
  * Get server prefix based on tool prefix mode.
  */
+function sanitizeServerPrefix(serverName: string): string {
+  return serverName.replace(/[^A-Za-z0-9_]+/g, "_");
+}
+
 export function getServerPrefix(
   serverName: string,
   mode: ToolPrefix
 ): string {
   if (mode === "none") return "";
   if (mode === "short") {
-    let short = serverName.replace(/-?mcp$/i, "").replace(/-/g, "_");
+    let short = sanitizeServerPrefix(serverName.replace(/-?mcp$/i, ""));
     if (!short) short = "mcp";
     return short;
   }
-  if (mode === "mcp") return `mcp__${serverName.replace(/-/g, "_")}`;
-  return serverName.replace(/-/g, "_");
+  if (mode === "mcp") return `mcp__${sanitizeServerPrefix(serverName)}`;
+  return sanitizeServerPrefix(serverName);
 }
 
 /**
@@ -729,7 +733,7 @@ export function formatPromptCommandName(
   serverName: string,
   prefix: ToolPrefix,
 ): string {
-  const serverPart = getServerPrefix(serverName, prefix) || serverName.replace(/-/g, "_") || "server";
+  const serverPart = getServerPrefix(serverName, prefix) || sanitizeServerPrefix(serverName) || "server";
   return `mcp__${serverPart}__${sanitizePromptName(promptName)}`;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -643,7 +643,9 @@ export interface McpPanelResult {
  * Get server prefix based on tool prefix mode.
  */
 function sanitizeServerPrefix(serverName: string): string {
-  return serverName.replace(/[^A-Za-z0-9_]+/g, "_");
+  return Array.from(serverName, char =>
+    /^[A-Za-z0-9]$/.test(char) ? char : `_${char.codePointAt(0)!.toString(16)}_`,
+  ).join("");
 }
 
 export function getServerPrefix(
@@ -711,11 +713,9 @@ export function resolveServerFromToolName(
   if (candidates.length === 0) return undefined;
   candidates.sort((a, b) => b.prefix.length - a.prefix.length);
   const best = candidates[0];
-  // Fail safe: two distinct server names can normalize to the same prefix
-  // (e.g. my-server and my_server both -> my_server under "server" mode).
-  // When that happens the owning server is ambiguous; return undefined so a
-  // downstream permission gate falls back to its existing wildcard path rather
-  // than enforcing a rule against the wrong server.
+  // Fail safe: short mode can intentionally map names such as foo and foo-mcp
+  // to the same prefix. Return undefined so a downstream permission gate uses
+  // its existing wildcard path rather than enforcing a rule against the wrong server.
   if (candidates.some((c) => c.prefix === best!.prefix && c.name !== best!.name)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- sanitize server-derived tool and prompt prefixes so configured server names with spaces produce provider-safe names
- keep formatter and reverse server resolution aligned through the shared prefix path
- add focused coverage for tool/resource metadata, prompt names, reverse mapping, and changelog credit for @triple-dex

Closes #334.

## Testing

- `npx vitest run __tests__/direct-tools.test.ts __tests__/resolve-server-from-tool-name.test.ts __tests__/prompts.test.ts`
- `npm run typecheck`
- `git diff --check`
