### PR TITLE
fix: validate persisted npx cache entries

### DIFF
--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -141,6 +141,35 @@ describe("npx-resolver", () => {
     });
   });
 
+  it("ignores malformed version-2 cache entries", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    const cachePath = join(agentDir, "mcp-npx-cache.json");
+    writeFileSync(cachePath, JSON.stringify({
+      version: 2,
+      entries: {
+        [JSON.stringify(["npx", "demo-pkg", ""])]: {
+          resolvedBin: 123,
+          resolvedAt: "recent",
+          isJs: "yes",
+        },
+      },
+    }), "utf-8");
+    const binPath = writeCachedPackage(npmCache, "demo-pkg");
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
+
+    expect(result?.binPath).toBe(binPath);
+    expect(readFileSync(cachePath, "utf-8")).not.toContain("\"resolvedBin\": 123");
+  });
+
   it("uses cross-spawn to read npm's cache directory", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));

--- a/__tests__/npx-resolver.test.ts
+++ b/__tests__/npx-resolver.test.ts
@@ -170,6 +170,34 @@ describe("npx-resolver", () => {
     expect(readFileSync(cachePath, "utf-8")).not.toContain("\"resolvedBin\": 123");
   });
 
+  it("ignores persisted prototype keys during cache lookup", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));
+    const npmCache = mkdtempSync(join(tmpdir(), "pi-mcp-npx-cache-"));
+
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.NPM_CONFIG_CACHE = npmCache;
+
+    const poisonedBin = writeCachedPackage(npmCache, "poison-pkg");
+    const demoBin = writeCachedPackage(npmCache, "demo-pkg");
+    writeFileSync(join(agentDir, "mcp-npx-cache.json"), `{
+      "version": 2,
+      "entries": {
+        "__proto__": {
+          "resolvedBin": ${JSON.stringify(poisonedBin)},
+          "resolvedAt": ${Date.now()},
+          "isJs": true
+        }
+      }
+    }`, "utf-8");
+
+    const { resolveNpxBinary } = await import("../npx-resolver.ts");
+    const result = await resolveNpxBinary("npx", ["-y", "demo-pkg"]);
+
+    expect(result?.binPath).toBe(demoBin);
+  });
+
   it("uses cross-spawn to read npm's cache directory", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-npx-home-"));
     const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-npx-agent-"));

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -434,18 +434,54 @@ function getNpxCachePath(): string {
   return getAgentPath("mcp-npx-cache.json");
 }
 
+function readNpxCachePayload(cachePath: string): unknown | null {
+  if (!existsSync(cachePath)) return null;
+  try {
+    return JSON.parse(readFileSync(cachePath, "utf-8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function toNpxCacheEntry(value: unknown): NpxCacheEntry | null {
+  const raw = asRecord(value);
+  if (!raw) return null;
+  if (typeof raw.resolvedBin !== "string") return null;
+  if (typeof raw.resolvedAt !== "number" || !Number.isFinite(raw.resolvedAt)) return null;
+  if (typeof raw.isJs !== "boolean") return null;
+  if (raw.packageVersion !== undefined && typeof raw.packageVersion !== "string") return null;
+  return {
+    resolvedBin: raw.resolvedBin,
+    resolvedAt: raw.resolvedAt,
+    ...(raw.packageVersion !== undefined ? { packageVersion: raw.packageVersion } : {}),
+    isJs: raw.isJs,
+  };
+}
+
+function toNpxCache(value: unknown): NpxCache | null {
+  const raw = asRecord(value);
+  if (!raw || raw.version !== CACHE_VERSION) return null;
+  const rawEntries = asRecord(raw.entries);
+  if (!rawEntries) return null;
+
+  const entries: Record<string, NpxCacheEntry> = {};
+  for (const [key, rawEntry] of Object.entries(rawEntries)) {
+    const entry = toNpxCacheEntry(rawEntry);
+    if (entry) entries[key] = entry;
+  }
+  return { version: CACHE_VERSION, entries };
+}
+
 function clearLegacyCache(): boolean {
   const cachePath = getNpxCachePath();
-  if (!existsSync(cachePath)) return false;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(cachePath, "utf-8"));
-  } catch {
-    return false;
-  }
-
-  if (!parsed || typeof parsed !== "object" || (parsed as Record<string, unknown>).version !== 1) return false;
+  const raw = asRecord(readNpxCachePayload(cachePath));
+  if (raw?.version !== 1) return false;
   try {
     unlinkSync(cachePath);
   } catch {
@@ -463,21 +499,7 @@ clearLegacyCache();
 function loadCache(): NpxCache | null {
   if (clearLegacyCache()) return null;
 
-  const cachePath = getNpxCachePath();
-  if (!existsSync(cachePath)) return null;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(cachePath, "utf-8"));
-  } catch {
-    return null;
-  }
-
-  if (!parsed || typeof parsed !== "object") return null;
-  const raw = parsed as Record<string, unknown>;
-  if (raw.version !== CACHE_VERSION) return null;
-  if (!raw.entries || typeof raw.entries !== "object") return null;
-  return raw as unknown as NpxCache;
+  return toNpxCache(readNpxCachePayload(getNpxCachePath()));
 }
 
 function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
@@ -486,17 +508,11 @@ function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
     const dir = dirname(cachePath);
     mkdirSync(dir, { recursive: true });
 
-    let merged: NpxCache = { version: CACHE_VERSION, entries: {} };
-    try {
-      if (existsSync(cachePath)) {
-        const existing = JSON.parse(readFileSync(cachePath, "utf-8")) as NpxCache;
-        if (existing && existing.version === CACHE_VERSION && existing.entries) {
-          merged.entries = { ...existing.entries };
-        }
-      }
-    } catch {
-      // Ignore parse errors
-    }
+    const existing = toNpxCache(readNpxCachePayload(cachePath));
+    const merged: NpxCache = {
+      version: CACHE_VERSION,
+      entries: existing ? { ...existing.entries } : {},
+    };
 
     merged.entries[key] = entry;
     const tmpPath = `${cachePath}.${process.pid}.tmp`;

--- a/npx-resolver.ts
+++ b/npx-resolver.ts
@@ -449,6 +449,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function createCacheEntries(): Record<string, NpxCacheEntry> {
+  return Object.create(null) as Record<string, NpxCacheEntry>;
+}
+
 function toNpxCacheEntry(value: unknown): NpxCacheEntry | null {
   const raw = asRecord(value);
   if (!raw) return null;
@@ -470,7 +474,7 @@ function toNpxCache(value: unknown): NpxCache | null {
   const rawEntries = asRecord(raw.entries);
   if (!rawEntries) return null;
 
-  const entries: Record<string, NpxCacheEntry> = {};
+  const entries = createCacheEntries();
   for (const [key, rawEntry] of Object.entries(rawEntries)) {
     const entry = toNpxCacheEntry(rawEntry);
     if (entry) entries[key] = entry;
@@ -509,10 +513,9 @@ function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
     mkdirSync(dir, { recursive: true });
 
     const existing = toNpxCache(readNpxCachePayload(cachePath));
-    const merged: NpxCache = {
-      version: CACHE_VERSION,
-      entries: existing ? { ...existing.entries } : {},
-    };
+    const entries = createCacheEntries();
+    if (existing) Object.assign(entries, existing.entries);
+    const merged: NpxCache = { version: CACHE_VERSION, entries };
 
     merged.entries[key] = entry;
     const tmpPath = `${cachePath}.${process.pid}.tmp`;


### PR DESCRIPTION
## Summary

Validate persisted npm/npx resolver cache entries before trusting them. Invalid v2 cache entries are ignored and replaced by fresh resolution.

## Validation

- npm test -- __tests__/npx-resolver.test.ts
- npm run typecheck
- git diff --check

Fresh review passed with no findings: /Users/nicobailon/Documents/docs/pi-mcp-adapter-ts-polish-20260813T044911Z-review.md

No changelog entry. This is internal cache parsing hardening.
