### PR TITLE
fix: resume mcpScript replies under compiled Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Kept `mcpScript` tool-call replies flowing when Pi runs as a Bun-compiled binary by starting worker execution without module-level top-level await. Thanks @AndreiKopylov for issue #340 and @thesobercoder for the verified fix.
+
 ## [2.24.0] - 2026-08-13
 
 ### Added

--- a/mcp-script-worker.mjs
+++ b/mcp-script-worker.mjs
@@ -106,23 +106,25 @@ const capturedConsole = Object.freeze({
   debug: (...args) => emit(`[console.debug] ${formatWithOptions({ colors: false, depth: 4 }, ...args)}`),
 });
 
-try {
-  const context = vm.createContext(Object.assign(Object.create(null), {
-    tools,
-    emit,
-    console: capturedConsole,
-  }), {
-    codeGeneration: { strings: false, wasm: false },
-    name: "mcpScript",
-  });
-  const script = new vm.Script(`(async () => {\n${workerData.code}\n})()`, { filename: "mcpScript.js" });
-  const returnValue = await Promise.resolve(script.runInContext(context));
-  parentPort.postMessage(returnValue === undefined
-    ? { type: "done" }
-    : { type: "done", returnBlock: toContentBlock(returnValue) });
-} catch (error) {
-  parentPort.postMessage({
-    type: "error",
-    message: error instanceof Error ? error.message : String(error),
-  });
-}
+void (async () => {
+  try {
+    const context = vm.createContext(Object.assign(Object.create(null), {
+      tools,
+      emit,
+      console: capturedConsole,
+    }), {
+      codeGeneration: { strings: false, wasm: false },
+      name: "mcpScript",
+    });
+    const script = new vm.Script(`(async () => {\n${workerData.code}\n})()`, { filename: "mcpScript.js" });
+    const returnValue = await Promise.resolve(script.runInContext(context));
+    parentPort.postMessage(returnValue === undefined
+      ? { type: "done" }
+      : { type: "done", returnBlock: toContentBlock(returnValue) });
+  } catch (error) {
+    parentPort.postMessage({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+})();


### PR DESCRIPTION
Fixes #340.

This keeps `mcpScript` request replies flowing when Pi runs as a Bun-compiled binary. The worker now starts its final awaited execution from an invoked async function instead of suspending the worker ES module in top-level await. The worker protocol, VM context, emit behavior, trace shape, timeout handling, and Node path stay unchanged.

Validation:
- `./node_modules/.bin/vitest run __tests__/mcp-code.test.ts`
- `npm run typecheck`
- `node --check mcp-script-worker.mjs`
- temporary compiled-Bun base-versus-fixed reproducer
- fresh review on `723c4e2`: no issues found
- exact-head review on `70c835a`: no issues found

Credit is included in `CHANGELOG.md` for @AndreiKopylov and @thesobercoder.
