### PR TITLE
feat: add startup connection notice setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `settings.notifyOnStartupConnect` to suppress successful MCP startup connection notices. Thanks @pierre-mgmt for issue #341.
+
 ### Fixed
 - Kept `mcpScript` tool-call replies flowing when Pi runs as a Bun-compiled binary by starting worker execution without module-level top-level await. Thanks @AndreiKopylov for issue #340 and @thesobercoder for the verified fix.
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
     "requestTimeoutMs": 30000,
     "showStatusIcon": true,
     "mcpFooterStatus": "full",
+    "notifyOnStartupConnect": true,
     "hostConfigDiscovery": "off",
     "approveTools": ["github_delete_*", "notion_update_*"],
     "oauthDir": ".pi/mcp-oauth",
@@ -328,6 +329,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
 | `mcpFooterStatus` | MCP footer verbosity: `"full"` (default), `"compact"` for `MCP connected/enabled`, or `"off"` to clear the persistent footer status. `/mcp status` remains available. |
+| `notifyOnStartupConnect` | Show successful startup connection notices (default: `true`). Set to `false` to suppress routine `MCP: N servers connected (M tools)` notices. Connection errors and authentication warnings remain visible. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
 | `agentPluginPaths` | Agent Plugins package directories to load MCP servers from. Relative paths resolve from the active project cwd. |
 | `approveTools` | `true` to require approval before every MCP tool call, or an array of glob patterns such as `["github_delete_*", "notion_update_*"]`. Per-server `approveTools` overrides this. |

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -222,6 +222,70 @@ describe("lazy-keep-alive initializeMcp integration", () => {
     expect(ui.setStatus).toHaveBeenCalledWith("mcp", "MCP: connecting to 1 servers...");
   });
 
+  it("suppresses successful startup notices when configured", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: { notifyOnStartupConnect: false },
+      mcpServers: { srv: { command: "demo", lifecycle: "eager" } },
+    };
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { setStatus: vi.fn(), notify: vi.fn() };
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: true,
+      mode: "tui",
+      ui,
+    } as any);
+
+    expect(ui.notify).not.toHaveBeenCalledWith("MCP: 1 servers connected (0 tools)", "info");
+  });
+
+  it("keeps startup notices enabled independently of the footer setting by default", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: { mcpFooterStatus: "off" },
+      mcpServers: { srv: { command: "demo", lifecycle: "eager" } },
+    };
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { setStatus: vi.fn(), notify: vi.fn() };
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: true,
+      mode: "tui",
+      ui,
+    } as any);
+
+    expect(ui.notify).toHaveBeenCalledWith("MCP: 1 servers connected (0 tools)", "info");
+    expect(ui.setStatus).toHaveBeenCalledWith("mcp", undefined);
+  });
+
+  it("keeps startup connection failures visible when success notices are suppressed", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.config = {
+      settings: { notifyOnStartupConnect: false },
+      mcpServers: { srv: { command: "demo", lifecycle: "eager" } },
+    };
+    mocks.manager.connect.mockRejectedValueOnce(new Error("startup failed"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { initializeMcp } = await import("../init.ts");
+    const ui = { setStatus: vi.fn(), notify: vi.fn() };
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: true,
+      mode: "tui",
+      ui,
+    } as any);
+
+    expect(ui.notify).toHaveBeenCalledWith("MCP: Failed to connect to srv: startup failed", "error");
+    expect(consoleError).toHaveBeenCalledWith("MCP: Failed to connect to srv: startup failed");
+  });
+
   it("does not record or notify an aborted eager startup", async () => {
     mkdirSync(tempDir, { recursive: true });
     writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));

--- a/init.ts
+++ b/init.ts
@@ -327,7 +327,7 @@ export async function initializeMcp(
 
   const connectedCount = results.filter(r => r.connection).length;
   const failedCount = results.filter(r => r.error).length;
-  if (ui && connectedCount > 0) {
+  if (ui && connectedCount > 0 && config.settings?.notifyOnStartupConnect !== false) {
     const totalTools = totalToolCount(state);
     const msg = failedCount > 0
       ? `MCP: ${connectedCount}/${startupServers.length} servers connected (${totalTools} tools)`

--- a/types.ts
+++ b/types.ts
@@ -480,6 +480,8 @@ export interface McpSettings {
   showStatusIcon?: boolean;
   /** Footer status verbosity: full details, compact connected/enabled count, or no footer status. Defaults to full. */
   mcpFooterStatus?: McpFooterStatus;
+  /** Show successful startup connection notifications. Defaults to true. */
+  notifyOnStartupConnect?: boolean;
   /** Discover detected host-specific MCP configs only when explicitly enabled. */
   hostConfigDiscovery?: HostConfigDiscovery;
   /** Agent Plugin package directories to load MCP servers from. */


### PR DESCRIPTION
Fixes #341.

This adds `settings.notifyOnStartupConnect`, a default-on setting that suppresses only successful routine MCP startup connection notices when set to `false`. Connection failures, authentication-required messages, `/mcp status`, and the `/mcp` panel are unchanged. The setting is independent of `mcpFooterStatus`.

Validation:
- `npx vitest run __tests__/lifecycle-lazy-keep-alive-init.test.ts`
- `npm run typecheck`
- fresh review on `0e90257`: no issues found
- exact-head review on `daa36e2`: no issues found
- rebase validation on `2d530ed`: focused test and typecheck passed
- exact-head review on `2d530ed`: no issues found

Credit is included in `CHANGELOG.md` for @pierre-mgmt.
