### PR TITLE
fix: preserve valid direct-tool prefix characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Kept `mcpScript` tool-call replies flowing when Pi runs as a Bun-compiled binary by starting worker execution without module-level top-level await. Thanks @AndreiKopylov for issue #340 and @thesobercoder for the verified fix.
+- Fixed direct-tool server prefixes to preserve provider-valid underscores and hyphens, including `codebase-memory-mcp`, while retaining safe escaping, collision handling, and exact proxy routing. Thanks @mightymatth for issue #342 and @JasonLandbridge for issue #343.
 
 ## [2.24.0] - 2026-08-13
 

--- a/__tests__/abort-signal.test.ts
+++ b/__tests__/abort-signal.test.ts
@@ -73,6 +73,43 @@ describe("AbortSignal propagation", () => {
     expect(state.manager.decrementInFlight).toHaveBeenCalledWith("demo");
   });
 
+  it("prefers an exact proxy tool name over an earlier normalized match", async () => {
+    const underscoreCallTool = vi.fn(async () => ({ content: [{ type: "text", text: "underscore" }] }));
+    const hyphenCallTool = vi.fn(async () => ({ content: [{ type: "text", text: "hyphen" }] }));
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: {
+          my_server: { command: "underscore" },
+          "my-server": { command: "hyphen" },
+        },
+      },
+      manager: {
+        getConnection: vi.fn((server: string) => ({
+          status: "connected",
+          client: server === "my_server" ? { callTool: underscoreCallTool } : { callTool: hyphenCallTool },
+        })),
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+        getRequestOptions: vi.fn(() => undefined),
+      },
+      toolMetadata: new Map([
+        ["my_server", [{ name: "my_server_get", originalName: "get", description: "Underscore" }]],
+        ["my-server", [{ name: "my-server_get", originalName: "get", description: "Hyphen" }]],
+      ]),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    const result = await executeCall(state, "my-server_get", {});
+
+    expect(result.details).toMatchObject({ server: "my-server", tool: "get" });
+    expect(hyphenCallTool).toHaveBeenCalledWith({ name: "get", arguments: {}, _meta: undefined }, undefined);
+    expect(underscoreCallTool).not.toHaveBeenCalled();
+  });
+
   it("proxy tool calls pass AbortSignal to MCP callTool and settle if the MCP SDK promise hangs", async () => {
     const controller = new AbortController();
     const callTool = vi.fn(() => new Promise<never>(() => {}));

--- a/__tests__/commands-status-failure.test.ts
+++ b/__tests__/commands-status-failure.test.ts
@@ -8,6 +8,7 @@ vi.mock("../init.ts", () => ({
   markKeepAliveAfterConnect: vi.fn(),
   recordFailure: vi.fn(),
   updateMetadataCache: vi.fn(),
+  notifyToolMetadataUpdated: vi.fn(),
   updateStatusBar: vi.fn(),
 }));
 
@@ -27,6 +28,34 @@ describe("MCP status failure reasons", () => {
       "info",
     );
     expect(ui.notify.mock.calls[0][0]).not.toContain("https://secret.invalid/status");
+  });
+
+  it("uses known metadata during reconnect filtering", async () => {
+    const { reconnectServer } = await import("../commands.ts");
+    const connection = {
+      status: "connected",
+      tools: [{ name: "search-records", description: "Search" }],
+      resources: [],
+      prompts: [],
+    };
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: {
+          "my-server": { command: "hyphen", excludeTools: ["search_records"] },
+          my_2d_server: { command: "escaped" },
+        },
+      },
+      manager: { close: vi.fn(async () => {}), connect: vi.fn(async () => connection) },
+      toolMetadata: new Map([["my_2d_server", [{ name: "my_2d_server_search_records", originalName: "search_records", description: "Other" }]]]),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+    } as any;
+
+    await expect(reconnectServer(state, { hasUI: false } as any, "my-server")).resolves.toBe(true);
+    expect(state.toolMetadata.get("my-server")?.map((tool: any) => tool.name)).toEqual(["my-server_search-records"]);
   });
 
   it("sanitizes captured diagnostics in reconnect notifications", async () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -12,6 +12,7 @@ import { buildToolMetadata } from "../tool-metadata.ts";
 import { formatToolName } from "../types.ts";
 import type { McpConfig } from "../types.ts";
 import { reconstructToolMetadata } from "../metadata-cache.ts";
+import { updateServerMetadata } from "../init.ts";
 
 const originalHashEnv = {
   MCP_HASH_CWD: process.env.MCP_HASH_CWD,
@@ -37,7 +38,7 @@ describe("formatToolName", () => {
     expect(formatToolName("namespace.tool", "demo", "server")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo-mcp", "short")).toBe("demo_namespace_tool");
     expect(formatToolName("namespace.tool", "demo", "none")).toBe("namespace_tool");
-    expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo_2d_mcp_namespace_tool");
+    expect(formatToolName("namespace.tool", "demo-mcp", "mcp")).toBe("mcp__demo-mcp_namespace_tool");
   });
 
   it("sanitizes server names in live tool and resource metadata", () => {
@@ -131,6 +132,70 @@ describe("buildProxyDescription", () => {
     expect(description).not.toContain("figma (3 tools)");
   });
 
+  it("keeps safe cached tools in proxy server summaries", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
+        my_2d_server: { command: "escaped", excludeTools: ["my_2d_server_do_thing"] },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([serverName, definition]) => [serverName, {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [{ name: "do_thing", description: serverName }],
+        resources: [],
+      }])),
+    };
+
+    expect(buildProxyDescription(config, cache, [])).toContain("Servers: my-server (1 tools)");
+  });
+
+  it("does not expose cached app-only tools to model-facing surfaces", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: { demo: { command: "demo", directTools: true } },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        demo: {
+          configHash: computeServerHash(config.mcpServers.demo),
+          cachedAt: Date.now(),
+          tools: [{ name: "app_only", description: "App", uiVisibility: ["app"] }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
+    expect(buildProxyDescription(config, cache, [])).not.toContain("Servers: demo (1 tools)");
+  });
+
+  it("ignores invalid cache entries in proxy descriptions", () => {
+    const config: McpConfig = {
+      mcpServers: { demo: { command: "new", includeTools: ["demo_search"] } },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        demo: {
+          configHash: "stale",
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Stale" }],
+          resources: [],
+          instructions: "stale instructions",
+        },
+      },
+    };
+
+    const description = buildProxyDescription(config, cache, []);
+    expect(description).not.toContain("Servers: demo (1 tools)");
+    expect(description).not.toContain("stale instructions");
+  });
+
   it("includes a truncated instructions snippet for servers that provide one", () => {
     const config: McpConfig = {
       mcpServers: {
@@ -142,7 +207,7 @@ describe("buildProxyDescription", () => {
       version: 1,
       servers: {
         demo: {
-          configHash: "hash",
+          configHash: computeServerHash(config.mcpServers.demo),
           cachedAt: Date.now(),
           tools: [{ name: "read_skill", description: "Read a skill" }],
           resources: [],
@@ -410,6 +475,111 @@ describe("excludeTools filtering", () => {
     expect(reconstructed.map((tool) => tool.name)).toEqual(["figma_get_nodes"]);
   });
 
+  it("matches normalized legacy server-prefix exclusions across metadata paths", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "my-server": { command: "demo", directTools: true, excludeTools: ["my_server_do_thing"] },
+      },
+    };
+    const entry = {
+      configHash: computeServerHash(config.mcpServers["my-server"]),
+      cachedAt: Date.now(),
+      tools: [{ name: "do_thing", description: "Do thing" }],
+      resources: [],
+    };
+    const cache: MetadataCache = { version: 1, servers: { "my-server": entry } };
+
+    expect(buildToolMetadata(entry.tools as any, [], config.mcpServers["my-server"], "my-server", "server", config.mcpServers).metadata).toEqual([]);
+    expect(reconstructToolMetadata("my-server", entry, "server", config.mcpServers["my-server"], config.mcpServers, cache)).toEqual([]);
+    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
+    expect(buildProxyDescription(config, cache, [])).not.toContain("my-server (1 tools)");
+  });
+
+  it("ignores invalid cache entries for collision candidates", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "my-server": { command: "hyphen", directTools: true, excludeTools: ["my_2d_server_search_records"] },
+        my_2d_server: { command: "escaped", args: ["changed"] },
+      },
+    };
+    const currentEntry = {
+      configHash: computeServerHash(config.mcpServers["my-server"]),
+      cachedAt: Date.now(),
+      tools: [{ name: "search-records", description: "Current" }],
+      resources: [],
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": currentEntry,
+        my_2d_server: {
+          configHash: "stale",
+          cachedAt: Date.now(),
+          tools: [{ name: "search_records", description: "Stale" }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(reconstructToolMetadata("my-server", currentEntry, "server", config.mcpServers["my-server"], config.mcpServers, cache)).toEqual([]);
+    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
+    expect(buildProxyDescription(config, cache, [])).not.toContain("my-server (1 tools)");
+  });
+
+  it("ignores cached app-only tools for reconstructed metadata collision candidates", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "current", excludeTools: ["my_server_do_thing"] },
+        my_server: { command: "app" },
+      },
+    };
+    const currentEntry = {
+      configHash: computeServerHash(config.mcpServers["my-server"]),
+      cachedAt: Date.now(),
+      tools: [{ name: "do_thing", description: "Current" }],
+      resources: [],
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": currentEntry,
+        my_server: {
+          configHash: computeServerHash(config.mcpServers.my_server),
+          cachedAt: Date.now(),
+          tools: [{ name: "do_thing", description: "App only", uiVisibility: ["app"] }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(reconstructToolMetadata("my-server", currentEntry, "server", config.mcpServers["my-server"], config.mcpServers, cache)).toEqual([]);
+  });
+
+  it("keeps cached metadata filtering scoped to current server identities", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
+        my_2d_server: { command: "escaped", excludeTools: ["my_2d_server_do_thing"] },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([serverName, definition]) => [serverName, {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [{ name: "do_thing", description: serverName }],
+        resources: [],
+      }])),
+    };
+
+    expect(reconstructToolMetadata("my-server", cache.servers["my-server"]!, "server", config.mcpServers["my-server"], config.mcpServers, cache).map(tool => tool.name)).toEqual(["my-server_do_thing"]);
+    expect(reconstructToolMetadata("my_2d_server", cache.servers.my_2d_server!, "server", config.mcpServers.my_2d_server, config.mcpServers, cache)).toEqual([]);
+  });
+
   it("filters included tools from live and cached metadata before applying exclusions", () => {
     const definition = {
       command: "npx",
@@ -578,8 +748,37 @@ describe("excludeTools filtering", () => {
 
     expect(resolveDirectTools(config, cache, "server").map((spec) => [spec.serverName, spec.prefixedName])).toEqual([
       ["a b", "a_20_b_search"],
-      ["a-20-b", "a_2d_20_2d_b_search"],
+      ["a-20-b", "a-20-b_search"],
     ]);
+  });
+
+  it("keeps provider-valid server prefix characters and skips escaped-name collisions", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "my_server": { command: "underscore" },
+        "my-server": { command: "hyphen" },
+        "my server": { command: "space" },
+        "my_20_server": { command: "escaped" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([serverName, definition]) => [serverName, {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [{ name: "get", description: serverName }],
+        resources: [],
+      }])),
+    };
+
+    expect(resolveDirectTools(config, cache, "server").map((spec) => [spec.serverName, spec.prefixedName])).toEqual([
+      ["my_server", "my_server_get"],
+      ["my-server", "my-server_get"],
+      ["my server", "my_20_server_get"],
+    ]);
+    expect(warn).toHaveBeenCalledWith('MCP: skipping duplicate direct tool "my_20_server_get" from "my_20_server"');
   });
 
   it("honors per-server toolPrefix during direct tool registration from cache", () => {
@@ -680,6 +879,230 @@ describe("excludeTools filtering", () => {
     expect(specs.map((spec) => spec.prefixedName)).toEqual(["figma_get_nodes", "figma_read_figjam"]);
   });
 
+  it("applies safe legacy exclusions alongside unrelated current selectors", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "my-server": { command: "demo", excludeTools: ["my-server_other", "my_2d_server_search_records"] },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": {
+          configHash: computeServerHash(config.mcpServers["my-server"]),
+          cachedAt: Date.now(),
+          tools: [
+            { name: "search-records", description: "Search" },
+            { name: "other", description: "Other" },
+          ],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
+    expect(buildToolMetadata(cache.servers["my-server"]!.tools as any, [], config.mcpServers["my-server"], "my-server", "server", config.mcpServers).metadata).toEqual([]);
+  });
+
+  it("keeps a same-server tool when another current sibling matches the selector", () => {
+    const definition = { command: "demo", excludeTools: ["search_records"] };
+    const tools = [
+      { name: "search-records", description: "Hyphen" },
+      { name: "search_records", description: "Underscore" },
+    ] as any;
+
+    expect(buildToolMetadata(tools, [], definition, "demo", "server", { demo: definition }).metadata.map(tool => tool.name)).toEqual(["demo_search-records"]);
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: definition } },
+      toolMetadata: new Map(),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+      manager: { getConnection: () => ({ status: "connected", tools, resources: [], prompts: [] }) },
+    } as any;
+    updateServerMetadata(state, "demo");
+    expect(state.toolMetadata.get("demo")?.map((tool: any) => tool.name)).toEqual(["demo_search-records"]);
+  });
+
+  it("ignores stale same-server metadata during live updates", () => {
+    const definition = { command: "demo", excludeTools: ["demo_search_records"] };
+    const staleMetadata = [{ name: "demo_search_records", originalName: "search_records", description: "Old" }];
+    const tools = [{ name: "search-records", description: "New" }] as any;
+
+    expect(buildToolMetadata(tools, [], definition, "demo", "server", { demo: definition }, new Map([["demo", staleMetadata]])).metadata).toEqual([]);
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: definition } },
+      toolMetadata: new Map([["demo", staleMetadata]]),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+      manager: { getConnection: () => ({ status: "connected", tools, resources: [], prompts: [] }) },
+    } as any;
+    updateServerMetadata(state, "demo");
+    expect(state.toolMetadata.get("demo")).toEqual([]);
+  });
+
+  it("does not synthesize unavailable servers when live metadata is known", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "demo", excludeTools: ["my_2d_server_search_records"] },
+        my_2d_server: { command: "unknown" },
+      },
+    };
+
+    expect(buildToolMetadata(
+      [{ name: "search-records", description: "Search" }] as any,
+      [],
+      config.mcpServers["my-server"],
+      "my-server",
+      "server",
+      config.mcpServers,
+      new Map(),
+    ).metadata).toEqual([]);
+  });
+
+  it("uses missing configured candidates only for startup metadata", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "demo", excludeTools: ["my_server_do_thing"] },
+        my_server: { command: "other" },
+      },
+    };
+
+    expect(buildToolMetadata(
+      [{ name: "do_thing", description: "Current" }] as any,
+      [],
+      config.mcpServers["my-server"],
+      "my-server",
+      "server",
+      config.mcpServers,
+      new Map(),
+      true,
+    ).metadata.map(tool => tool.name)).toEqual(["my-server_do_thing"]);
+  });
+
+  it("normalizes missing startup candidates for hyphenated tool names", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "demo", excludeTools: ["my_server_do_thing"] },
+        my_server: { command: "other" },
+      },
+    };
+
+    expect(buildToolMetadata(
+      [{ name: "do-thing", description: "Current" }] as any,
+      [],
+      config.mcpServers["my-server"],
+      "my-server",
+      "server",
+      config.mcpServers,
+      new Map(),
+      true,
+    ).metadata.map(tool => tool.name)).toEqual(["my-server_do-thing"]);
+  });
+
+  it("uses known live metadata to keep a safe legacy selector scoped", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_search_records"] },
+        my_2d_server: { command: "escaped" },
+      },
+    };
+    const knownMetadata = new Map([["my_2d_server", [{ name: "my_2d_server_search_records", originalName: "search_records", description: "Other" }]]]);
+
+    expect(buildToolMetadata(
+      [{ name: "search-records", description: "Search" }] as any,
+      [],
+      config.mcpServers["my-server"],
+      "my-server",
+      "server",
+      config.mcpServers,
+      knownMetadata,
+    ).metadata.map(tool => tool.name)).toEqual(["my-server_search-records"]);
+  });
+
+  it("uses known state metadata during live updates", async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: {
+          "my-server": { command: "hyphen", excludeTools: ["search_records"] },
+          my_2d_server: { command: "escaped" },
+        },
+      },
+      toolMetadata: new Map([["my_2d_server", [{ name: "my_2d_server_search_records", originalName: "search_records", description: "Other" }]]]),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+      manager: {
+        getConnection: (name: string) => name === "my-server" ? {
+          status: "connected",
+          tools: [{ name: "search-records", description: "Search" }],
+          resources: [],
+          prompts: [],
+          client: { callTool },
+        } : undefined,
+        getRequestOptions: () => undefined,
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    updateServerMetadata(state, "my-server");
+    expect(state.toolMetadata.get("my-server").map((tool: any) => tool.name)).toEqual(["my-server_search-records"]);
+    const { executeCall } = await import("../proxy-modes.ts");
+    await expect(executeCall(state, "my-server_search-records", {})).resolves.toMatchObject({ details: { server: "my-server", tool: "search-records" } });
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
+  it("does not apply live legacy exclusions to another server's current tool name", () => {
+    const configuredServers = {
+      "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
+      my_2d_server: { command: "escaped", excludeTools: ["my_2d_server_do_thing"] },
+    };
+    const tools = [{ name: "do_thing", description: "Do thing" }] as any;
+
+    expect(buildToolMetadata(tools, [], configuredServers["my-server"], "my-server", "server", configuredServers).metadata.map(tool => tool.name)).toEqual([
+      "my-server_do_thing",
+    ]);
+    expect(buildToolMetadata(tools, [], configuredServers.my_2d_server, "my_2d_server", "server", configuredServers).metadata).toEqual([]);
+  });
+
+  it("does not apply legacy exclusions to another server's current tool name", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
+        my_2d_server: { command: "escaped", excludeTools: ["my_2d_server_do_thing"] },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([serverName, definition]) => [serverName, {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [{ name: "do_thing", description: serverName }],
+        resources: [],
+      }])),
+    };
+
+    expect(resolveDirectTools(config, cache, "server").map(spec => [spec.serverName, spec.prefixedName])).toEqual([
+      ["my-server", "my-server_do_thing"],
+    ]);
+  });
+
   it("matches mcp-prefixed exclusions when toolPrefix is mcp", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "mcp" },
@@ -710,7 +1133,7 @@ describe("excludeTools filtering", () => {
 
     const specs = resolveDirectTools(config, cache, "mcp");
 
-    expect(specs.map((spec) => spec.prefixedName)).toEqual(["mcp__my_2d_server_other_tool"]);
+    expect(specs.map((spec) => spec.prefixedName)).toEqual(["mcp__my-server_other_tool"]);
   });
 
   it("matches prefixed exclusions even when toolPrefix is none", () => {

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   config: { settings: {}, mcpServers: {} } as any,
   manager: undefined as any,
   getMissingConfiguredDirectToolServers: vi.fn(() => [] as string[]),
+  isServerCacheValid: vi.fn(() => false),
   buildToolMetadata: vi.fn(() => ({ metadata: [], failedTools: [] })),
 }));
 
@@ -26,7 +27,7 @@ vi.mock("../metadata-cache.ts", () => ({
   computeServerHash: vi.fn(() => "hash"),
   getMetadataCachePath: vi.fn(() => mocks.cachePath),
   getMissingConfiguredDirectToolServers: mocks.getMissingConfiguredDirectToolServers,
-  isServerCacheValid: vi.fn(() => false),
+  isServerCacheValid: mocks.isServerCacheValid,
   loadMetadataCache: vi.fn(() => mocks.cache),
   reconstructToolMetadata: vi.fn(() => []),
   reconstructPromptMetadata: vi.fn(() => []),
@@ -102,6 +103,7 @@ describe("lazy-keep-alive initializeMcp integration", () => {
     };
     mocks.manager = createManager();
     mocks.getMissingConfiguredDirectToolServers.mockReset().mockReturnValue([]);
+    mocks.isServerCacheValid.mockReset().mockReturnValue(false);
     mocks.buildToolMetadata.mockClear();
   });
 
@@ -113,6 +115,82 @@ describe("lazy-keep-alive initializeMcp integration", () => {
       process.env.MCP_DIRECT_TOOLS = originalDirectTools;
     }
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("provides all successful startup metadata for collision filtering", async () => {
+    mocks.cache = null;
+    mocks.config = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "hyphen", lifecycle: "eager", excludeTools: ["search_records"] },
+        my_2d_server: { command: "escaped", lifecycle: "eager" },
+      },
+    };
+    mocks.manager = {
+      ...createManager(),
+      connect: vi.fn(async (name: string) => ({
+        status: "connected",
+        tools: [{ name: name === "my-server" ? "search-records" : "search_records", description: name }],
+        resources: [],
+      })),
+      getAllConnections: vi.fn(() => new Map()),
+    };
+    const { initializeMcp } = await import("../init.ts");
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+    } as any);
+
+    const knownMetadata = mocks.buildToolMetadata.mock.calls[0]?.[6] as Map<string, { originalName: string }[]>;
+    expect(knownMetadata.get("my-server")?.map(tool => tool.originalName)).toEqual(["search-records"]);
+    expect(knownMetadata.get("my_2d_server")?.map(tool => tool.originalName)).toEqual(["search_records"]);
+    expect(mocks.buildToolMetadata.mock.calls[0]?.[7]).toBe(true);
+  });
+
+  it("does not treat cached lazy metadata as successful startup metadata", async () => {
+    mocks.isServerCacheValid.mockReturnValue(true);
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.cache = {
+      version: 1,
+      servers: {
+        my_server: {
+          configHash: "hash",
+          cachedAt: Date.now(),
+          tools: [{ name: "other", description: "Cached lazy tool" }],
+          resources: [],
+        },
+      },
+    };
+    mocks.config = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "eager", lifecycle: "eager", excludeTools: ["my_server_do_thing"] },
+        my_server: { command: "lazy" },
+      },
+    };
+    mocks.manager = {
+      ...createManager(),
+      connect: vi.fn(async () => ({
+        status: "connected",
+        tools: [{ name: "do_thing", description: "Startup tool" }],
+        resources: [],
+      })),
+      getAllConnections: vi.fn(() => new Map()),
+    };
+    const { initializeMcp } = await import("../init.ts");
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+    } as any);
+
+    const knownMetadata = mocks.buildToolMetadata.mock.calls[0]?.[6] as Map<string, { originalName: string }[]>;
+    expect(knownMetadata.get("my-server")?.map(tool => tool.originalName)).toEqual(["do_thing"]);
+    expect(knownMetadata.has("my_server")).toBe(false);
+    expect(mocks.buildToolMetadata.mock.calls[0]?.[7]).toBe(true);
   });
 
   it("marks no-cache bootstrap spawns for health-check reconnects", async () => {

--- a/__tests__/mcp-panel-exclude-tools.test.ts
+++ b/__tests__/mcp-panel-exclude-tools.test.ts
@@ -67,6 +67,104 @@ describe("mcp-panel include/exclude tools", () => {
     panel.dispose();
   });
 
+  it("keeps tools whose legacy exclusion collides with another current server tool", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
+        my_2d_server: { command: "escaped" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([name, definition]) => [name, {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [{ name: "do_thing", description: name }],
+        resources: [],
+      }])),
+    };
+    const panel = createMcpPanel(
+      config, cache, new Map(),
+      { reconnect: async () => true, canAuthenticate: () => false, authenticate: async () => ({ ok: false }), getConnectionStatus: () => "idle", refreshCacheAfterReconnect: () => cache.servers["my-server"]! },
+      { requestRender: () => {} }, () => {},
+    );
+
+    panel.handleInput("d");
+    panel.handleInput("o");
+    const output = stripAnsi(panel.render(120).join("\n"));
+    expect(output).toContain("my-server");
+    expect(output).toContain("my_2d_server");
+    expect((output.match(/do_thing/g) ?? []).length).toBe(2);
+    panel.handleInput("ctrl+r");
+    const refreshed = stripAnsi(panel.render(120).join("\n"));
+    expect((refreshed.match(/do_thing/g) ?? []).length).toBe(2);
+    panel.dispose();
+  });
+
+  it("does not show cached app-only tools after initial load or reconnect", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: { demo: { command: "demo" } },
+    };
+    const entry = {
+      configHash: computeServerHash(config.mcpServers.demo),
+      cachedAt: Date.now(),
+      tools: [{ name: "app_only", description: "App", uiVisibility: ["app"] }],
+      resources: [],
+    };
+    const cache: MetadataCache = { version: 1, servers: { demo: entry } };
+    const panel = createMcpPanel(
+      config, cache, new Map(),
+      { reconnect: async () => true, canAuthenticate: () => false, authenticate: async () => ({ ok: false }), getConnectionStatus: () => "idle", refreshCacheAfterReconnect: () => entry },
+      { requestRender: () => {} }, () => {},
+    );
+
+    expect(stripAnsi(panel.render(120).join("\n"))).not.toContain("app_only");
+    panel.handleInput("ctrl+r");
+    expect(stripAnsi(panel.render(120).join("\n"))).not.toContain("app_only");
+    panel.dispose();
+  });
+
+  it("ignores invalid cache entries for panel display and collision context", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server" },
+      mcpServers: {
+        "my-server": { command: "current", excludeTools: ["my_server_do_thing"] },
+        my_server: { command: "other" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": {
+          configHash: computeServerHash(config.mcpServers["my-server"]),
+          cachedAt: Date.now(),
+          tools: [{ name: "do_thing", description: "Current" }],
+          resources: [],
+        },
+        my_server: {
+          configHash: "stale",
+          cachedAt: Date.now(),
+          tools: [{ name: "do_thing", description: "Stale" }],
+          resources: [],
+        },
+      },
+    };
+    const panel = createMcpPanel(
+      config, cache, new Map(),
+      { reconnect: async () => true, canAuthenticate: () => false, authenticate: async () => ({ ok: false }), getConnectionStatus: () => "idle", refreshCacheAfterReconnect: () => null },
+      { requestRender: () => {} }, () => {},
+    );
+
+    const output = stripAnsi(panel.render(120).join("\n"));
+    expect(output).toContain("my-server");
+    expect(output).toContain("my_server  (not cached)");
+    expect(output).not.toContain("my-server  0/1");
+    expect(output).not.toContain("do_thing");
+    panel.dispose();
+  });
+
   it("hides non-included tools from the panel view", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "server" },

--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -51,15 +51,15 @@ function commandCtx(overrides: Partial<ExtensionCommandContext> = {}): Extension
 
 describe("prompt command naming", () => {
   it("mirrors Claude Code's mcp__<server>__<prompt> convention", () => {
-    expect(formatPromptCommandName("plan", "agent-board", "server")).toBe("mcp__agent_2d_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board", "server")).toBe("mcp__agent-board__plan");
   });
 
   it("honors the toolPrefix short mode", () => {
-    expect(formatPromptCommandName("plan", "agent-board-mcp", "short")).toBe("mcp__agent_2d_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board-mcp", "short")).toBe("mcp__agent-board__plan");
   });
 
   it("falls back to the server name when toolPrefix is 'none'", () => {
-    expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent_2d_board__plan");
+    expect(formatPromptCommandName("plan", "agent-board", "none")).toBe("mcp__agent-board__plan");
   });
 
   it("sanitizes server names with spaces", () => {

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -140,6 +140,79 @@ describe("proxy auto auth", () => {
     expect(state.toolMetadata.get("demo")?.[0]).toMatchObject({ originalName: "fresh" });
   });
 
+  it("keeps a same-server tool when another current sibling matches the selector", async () => {
+    const { executeConnect } = await import("../proxy-modes.ts");
+    const connection = {
+      status: "connected",
+      tools: [
+        { name: "search-records", description: "Hyphen" },
+        { name: "search_records", description: "Underscore" },
+      ],
+      resources: [],
+      prompts: [],
+    };
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: { command: "demo", excludeTools: ["search_records"] } } },
+      manager: { getConnection: vi.fn(() => undefined), connect: vi.fn(async () => connection) },
+      toolMetadata: new Map(),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      ui: undefined,
+    } as any;
+
+    await expect(executeConnect(state, "demo")).resolves.toMatchObject({ details: { mode: "list", server: "demo", count: 1 } });
+    expect(state.toolMetadata.get("demo")?.map((tool: any) => tool.name)).toEqual(["demo_search-records"]);
+  });
+
+  it("ignores stale same-server metadata during executeConnect", async () => {
+    const { executeConnect } = await import("../proxy-modes.ts");
+    const definition = { command: "demo", excludeTools: ["demo_search_records"] };
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: definition } },
+      manager: {
+        getConnection: vi.fn(() => undefined),
+        connect: vi.fn(async () => ({ status: "connected", tools: [{ name: "search-records", description: "New" }], resources: [], prompts: [] })),
+      },
+      toolMetadata: new Map([["demo", [{ name: "demo_search_records", originalName: "search_records", description: "Old" }]]]),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      ui: undefined,
+    } as any;
+
+    await expect(executeConnect(state, "demo")).resolves.toMatchObject({ details: { mode: "list", server: "demo", count: 0 } });
+    expect(state.toolMetadata.get("demo")).toEqual([]);
+  });
+
+  it("uses known metadata during executeConnect filtering", async () => {
+    const { executeConnect } = await import("../proxy-modes.ts");
+    const connection = {
+      status: "connected",
+      tools: [{ name: "search-records", description: "Search" }],
+      resources: [],
+      prompts: [],
+    };
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: {
+          "my-server": { command: "hyphen", excludeTools: ["search_records"] },
+          my_2d_server: { command: "escaped" },
+        },
+      },
+      manager: {
+        getConnection: vi.fn(() => undefined),
+        connect: vi.fn(async () => connection),
+      },
+      toolMetadata: new Map([["my_2d_server", [{ name: "my_2d_server_search_records", originalName: "search_records", description: "Other" }]]]),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      ui: undefined,
+    } as any;
+
+    await expect(executeConnect(state, "my-server")).resolves.toMatchObject({ details: { mode: "list", server: "my-server", count: 1 } });
+    expect(state.toolMetadata.get("my-server")?.map((tool: any) => tool.name)).toEqual(["my-server_search-records"]);
+  });
+
   it("auto-authenticates and retries executeConnect once", async () => {
     const { executeConnect } = await import("../proxy-modes.ts");
 
@@ -479,6 +552,98 @@ describe("proxy auto auth", () => {
     const result = await inFlight;
 
     expect(result.details).toMatchObject({ error: "aborted", message: "owner stopped" });
+  });
+
+  it("fails closed when lazy metadata has duplicate exact tool names", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const firstCall = vi.fn();
+    const secondCall = vi.fn();
+    mocks.lazyConnect.mockImplementation(async (state: any, serverName: string) => {
+      state.toolMetadata.set(serverName, [{ name: "my_20_server_get", originalName: "get", description: serverName }]);
+      return true;
+    });
+    const state = {
+      config: {
+        settings: { toolPrefix: "server" },
+        mcpServers: { "my server": { command: "first" }, my_20_server: { command: "second" } },
+      },
+      toolMetadata: new Map(),
+      manager: {
+        getConnection: (serverName: string) => ({ status: "connected", client: serverName === "my server" ? { callTool: firstCall } : { callTool: secondCall } }),
+        getRequestOptions: () => undefined,
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    await expect(executeCall(state, "my_20_server_get", {})).resolves.toMatchObject({ details: { error: "ambiguous_tool" } });
+    expect(mocks.lazyConnect).toHaveBeenCalledTimes(2);
+    expect(firstCall).not.toHaveBeenCalled();
+    expect(secondCall).not.toHaveBeenCalled();
+  });
+
+  it("prefers a lazy exact match over a normalized fallback", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const exactCall = vi.fn(async () => ({ content: [{ type: "text", text: "exact" }] }));
+    const fallbackCall = vi.fn();
+    mocks.lazyConnect.mockImplementation(async (state: any, serverName: string) => {
+      state.toolMetadata.set(serverName, [serverName === "foo"
+        ? { name: "foo_ge_t", originalName: "ge_t", description: "Exact" }
+        : { name: "foo_ge-t", originalName: "ge-t", description: "Fallback" },
+      ]);
+      return true;
+    });
+    const state = {
+      config: {
+        settings: { toolPrefix: "short" },
+        mcpServers: { foo: { command: "exact" }, "foo-mcp": { command: "fallback" } },
+      },
+      toolMetadata: new Map(),
+      manager: {
+        getConnection: (serverName: string) => ({ status: "connected", client: serverName === "foo" ? { callTool: exactCall } : { callTool: fallbackCall } }),
+        getRequestOptions: () => undefined,
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    await expect(executeCall(state, "foo_ge_t", {})).resolves.toMatchObject({ details: { server: "foo", tool: "ge_t" } });
+    expect(exactCall).toHaveBeenCalledOnce();
+    expect(fallbackCall).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when lazy metadata has duplicate normalized tool names", async () => {
+    const { executeCall } = await import("../proxy-modes.ts");
+    const callTool = vi.fn();
+    mocks.lazyConnect.mockImplementation(async (state: any, serverName: string) => {
+      state.toolMetadata.set(serverName, [
+        { name: "demo_a-b_c", originalName: "a-b_c", description: "First" },
+        { name: "demo_a_b-c", originalName: "a_b-c", description: "Second" },
+      ]);
+      return true;
+    });
+    const state = {
+      config: { settings: { toolPrefix: "server" }, mcpServers: { demo: { command: "demo" } } },
+      toolMetadata: new Map(),
+      manager: {
+        getConnection: () => ({ status: "connected", client: { callTool } }),
+        getRequestOptions: () => undefined,
+        touch: vi.fn(),
+        incrementInFlight: vi.fn(),
+        decrementInFlight: vi.fn(),
+      },
+      failureTracker: new Map(),
+      completedUiSessions: [],
+    } as any;
+
+    await expect(executeCall(state, "demo_a_b_c", {})).resolves.toMatchObject({ details: { error: "ambiguous_tool" } });
+    expect(callTool).not.toHaveBeenCalled();
   });
 
   it("shares one cold connect across concurrent proxy calls and applies timeout during bootstrap", async () => {

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
 
@@ -185,6 +185,87 @@ describe("proxy discovery", () => {
 
     const call = await executeCall(state, "zzalias");
     expect(call.details).toMatchObject({ error: "tool_not_found", suggestions: [] });
+  });
+
+  it("prefers an exact describe name over an earlier normalized fallback", () => {
+    const state = {
+      config: { mcpServers: { "demo-a": { command: "fallback" }, demo: { command: "exact" } } },
+      toolMetadata: new Map([
+        ["demo-a", [{ name: "demo-a_b", originalName: "b", description: "Fallback" }]],
+        ["demo", [{ name: "demo_a_b", originalName: "a_b", description: "Exact" }]],
+      ]),
+      manager: { getConnection: () => undefined },
+      failureTracker: new Map(),
+    } as unknown as McpExtensionState;
+
+    expect(executeDescribe(state, "demo_a_b").details).toMatchObject({
+      server: "demo",
+      tool: { originalName: "a_b" },
+    });
+  });
+
+  it("fails closed for duplicate unqualified proxy names", async () => {
+    const firstCall = vi.fn(async () => ({ content: [{ type: "text", text: "first" }] }));
+    const secondCall = vi.fn(async () => ({ content: [{ type: "text", text: "second" }] }));
+    const state = {
+      config: {
+        mcpServers: {
+          "my server": { command: "first" },
+          my_20_server: { command: "second" },
+        },
+      },
+      toolMetadata: new Map([
+        ["my server", [{ name: "my_20_server_get", originalName: "get", description: "First" }]],
+        ["my_20_server", [{ name: "my_20_server_get", originalName: "get", description: "Second" }]],
+      ]),
+      manager: {
+        getConnection: (server: string) => ({ status: "connected", client: server === "my server" ? { callTool: firstCall } : { callTool: secondCall } }),
+        touch: () => {},
+        incrementInFlight: () => {},
+        decrementInFlight: () => {},
+        getRequestOptions: () => undefined,
+      },
+      failureTracker: new Map(),
+      serverInstructions: new Map(),
+      completedUiSessions: [],
+    } as unknown as McpExtensionState;
+
+    expect(executeDescribe(state, "my_20_server_get").details).toMatchObject({ error: "ambiguous_tool" });
+    await expect(executeCall(state, "my_20_server_get", {})).resolves.toMatchObject({ details: { error: "ambiguous_tool" } });
+    expect(firstCall).not.toHaveBeenCalled();
+    expect(secondCall).not.toHaveBeenCalled();
+    await expect(executeCall(state, "my_20_server_get", {}, "my server")).resolves.toMatchObject({ details: { server: "my server", tool: "get" } });
+    expect(firstCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed for same-server normalized fallback collisions", async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "called" }] }));
+    const state = {
+      config: { mcpServers: { demo: { command: "demo" } } },
+      toolMetadata: new Map([["demo", [
+        { name: "demo_a-b_c", originalName: "a-b_c", description: "First" },
+        { name: "demo_a_b-c", originalName: "a_b-c", description: "Second" },
+      ]]]),
+      manager: {
+        getConnection: () => ({ status: "connected", client: { callTool } }),
+        touch: () => {},
+        incrementInFlight: () => {},
+        decrementInFlight: () => {},
+        getRequestOptions: () => undefined,
+      },
+      failureTracker: new Map(),
+      serverInstructions: new Map(),
+      completedUiSessions: [],
+    } as unknown as McpExtensionState;
+
+    expect(executeDescribe(state, "demo_a_b_c").details).toMatchObject({ error: "ambiguous_tool" });
+    await expect(executeCall(state, "demo_a_b_c", {})).resolves.toMatchObject({ details: { error: "ambiguous_tool" } });
+    await expect(executeCall(state, "demo_a_b_c", {}, "demo")).resolves.toMatchObject({ details: { error: "ambiguous_tool" } });
+    expect(callTool).not.toHaveBeenCalled();
+    expect(executeDescribe(state, "demo_a-b_c").details).toMatchObject({ server: "demo", tool: { originalName: "a-b_c" } });
+    expect(executeDescribe(state, "demo_a_b-c").details).toMatchObject({ server: "demo", tool: { originalName: "a_b-c" } });
+    await expect(executeCall(state, "demo_a-b_c", {}, "demo")).resolves.toMatchObject({ details: { server: "demo", tool: "a-b_c" } });
+    expect(callTool).toHaveBeenCalledTimes(1);
   });
 
   it("tells callers to invoke native Pi tools directly", async () => {

--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -5,6 +5,9 @@ import {
 	formatPromptCommandName,
 	formatToolName,
 	getToolNameCandidates,
+	isToolExcluded,
+	isToolAllowed,
+	matchesToolPattern,
 } from "../types.ts";
 
 describe("resolveServerFromToolName", () => {
@@ -39,12 +42,12 @@ describe("resolveServerFromToolName", () => {
 			const underscoredTool = formatToolName("search", "my_server", "server");
 
 			expect(spacedTool).toBe("my_20_server_search");
-			expect(underscoredTool).toBe("my_5f_server_search");
+			expect(underscoredTool).toBe("my_server_search");
 			expect(new Set([spacedTool, underscoredTool]).size).toBe(2);
 			expect(resolveServerFromToolName(spacedTool, ["my server", "my_server"], "server")).toBe("my server");
 			expect(resolveServerFromToolName(underscoredTool, ["my server", "my_server"], "server")).toBe("my_server");
 			expect(formatPromptCommandName("plan", "my server", "server")).toBe("mcp__my_20_server__plan");
-			expect(formatPromptCommandName("plan", "my_server", "server")).toBe("mcp__my_5f_server__plan");
+			expect(formatPromptCommandName("plan", "my_server", "server")).toBe("mcp__my_server__plan");
 			expect(getToolNameCandidates("search", "my server", "server")).toContain(spacedTool);
 			expect(getToolNameCandidates("search", "my_server", "server")).toContain(underscoredTool);
 		});
@@ -60,7 +63,7 @@ describe("resolveServerFromToolName", () => {
 		});
 
 		it("picks the longest matching prefix when server names share a stem", () => {
-			const tool = "searxng_2d_extra_deep_search";
+			const tool = "searxng-extra_deep_search";
 			expect(
 				resolveServerFromToolName(tool, ["searxng", "searxng-extra"], "server"),
 			).toBe("searxng-extra");
@@ -93,7 +96,7 @@ describe("resolveServerFromToolName", () => {
 	describe("mcp prefix mode", () => {
 		it("resolves the mcp__namespaced format", () => {
 			expect(
-				resolveServerFromToolName("mcp__my_2d_server_run", ["my-server"], "mcp"),
+				resolveServerFromToolName("mcp__my-server_run", ["my-server"], "mcp"),
 			).toBe("my-server");
 		});
 	});
@@ -173,22 +176,45 @@ describe("resolveServerFromToolName", () => {
 	});
 });
 
+describe("direct tool selector candidates", () => {
+	it("keeps hyphen and underscore prefixes distinct while matching legacy escaped prefixes", () => {
+		const hyphenCandidates = getToolNameCandidates("do_thing", "my-server", "server");
+		const underscoreCandidates = getToolNameCandidates("do_thing", "my_server", "server");
+
+		expect(matchesToolPattern(hyphenCandidates, ["my-server_do_thing"])).toBe(true);
+		expect(matchesToolPattern(hyphenCandidates, ["my_server_do_thing"])).toBe(true);
+		expect(matchesToolPattern(underscoreCandidates, ["my-server_do_thing"])).toBe(false);
+		expect(matchesToolPattern(hyphenCandidates, ["my_2d_server_do_thing"])).toBe(true);
+	});
+
+	it("matches normalized legacy emitted selectors when they are safe", () => {
+		expect(isToolExcluded("do_thing", "my-server", "server", ["my_server_do_thing"], new Set())).toBe(true);
+		expect(isToolAllowed("do_thing", "my-server", "server", undefined, ["my_server_do_thing"], new Set())).toBe(false);
+		expect(isToolExcluded("do_thing", "my-server", "server", ["my_2d_server_do_thing"], new Set())).toBe(true);
+		expect(isToolExcluded("do_thing", "my-server", "server", ["my-server_do_thing"], new Set())).toBe(true);
+	});
+
+	it("does not apply normalized legacy emitted selectors through current collisions", () => {
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_thing"], new Set(["my_server_do_thing"]))).toBe(false);
+	});
+});
+
 describe("distinct normalized server prefixes", () => {
 	it("resolves distinct space and hyphen prefixes", () => {
 		expect(
 			resolveServerFromToolName("a_20_b_run", ["a b", "a-20-b"], "server"),
 		).toBe("a b");
 		expect(
-			resolveServerFromToolName("a_2d_20_2d_b_run", ["a b", "a-20-b"], "server"),
+			resolveServerFromToolName("a-20-b_run", ["a b", "a-20-b"], "server"),
 		).toBe("a-20-b");
 	});
 
 	it("resolves distinct hyphen and underscore prefixes under mcp mode", () => {
 		expect(
-			resolveServerFromToolName("mcp__my_2d_server_run", ["my-server", "my_server"], "mcp"),
+			resolveServerFromToolName("mcp__my-server_run", ["my-server", "my_server"], "mcp"),
 		).toBe("my-server");
 		expect(
-			resolveServerFromToolName("mcp__my_5f_server_run", ["my-server", "my_server"], "mcp"),
+			resolveServerFromToolName("mcp__my_server_run", ["my-server", "my_server"], "mcp"),
 		).toBe("my_server");
 	});
 });

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -67,14 +67,14 @@ function createState(options: {
 }
 
 describe("tool approval", () => {
-  it("matches original, prefixed, normalized, and read_* resource tool names", () => {
+  it("matches original, prefixed, and read_* resource tool names", () => {
     const cases: Array<{ config: McpConfig; meta: ToolMetadata }> = [
       {
-        config: { mcpServers: { demo: { approveTools: ["search_records"] } } },
+        config: { mcpServers: { demo: { approveTools: ["search-records"] } } },
         meta: tool,
       },
       {
-        config: { mcpServers: { demo: { approveTools: ["demo_search_records"] } } },
+        config: { mcpServers: { demo: { approveTools: ["demo_search-records"] } } },
         meta: tool,
       },
       {
@@ -86,6 +86,78 @@ describe("tool approval", () => {
     for (const { config, meta } of cases) {
       expect(isToolCallApprovalRequired(config, Object.keys(config.mcpServers)[0], meta)).toBe(true);
     }
+  });
+
+  it("gates exact global selectors without applying them through a legacy collision", () => {
+    const config: McpConfig = {
+      settings: { approveTools: ["my_2d_server_do_thing"] },
+      mcpServers: {
+        "my-server": { command: "hyphen" },
+        my_2d_server: { command: "escaped" },
+      },
+    };
+    const hyphenTool: ToolMetadata = { name: "my-server_do-thing", originalName: "do-thing", description: "" };
+    const escapedTool: ToolMetadata = { name: "my_2d_server_do_thing", originalName: "do_thing", description: "" };
+    const metadata = new Map([
+      ["my-server", [hyphenTool]],
+      ["my_2d_server", [escapedTool]],
+    ]);
+
+    expect(isToolCallApprovalRequired(config, "my-server", hyphenTool, metadata)).toBe(false);
+    expect(isToolCallApprovalRequired(config, "my_2d_server", escapedTool, metadata)).toBe(true);
+  });
+
+  it("matches safe server-scoped normalized approval selectors", async () => {
+    const scopedTool: ToolMetadata = { name: "my-server_do_thing", originalName: "do_thing", description: "" };
+    const config: McpConfig = { mcpServers: { "my-server": { command: "demo", approveTools: ["my_server_do_thing"] } } };
+    const metadata = new Map([["my-server", [scopedTool]]]);
+
+    expect(isToolCallApprovalRequired(config, "my-server", scopedTool, metadata)).toBe(true);
+    const { state, callTool } = createState({ interactive: false });
+    state.config = config;
+    state.toolMetadata = metadata;
+    await expect(executeCall(state, scopedTool.name, {})).resolves.toMatchObject({
+      details: { error: "approval_required", server: "my-server", tool: "do_thing" },
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("matches safe global normalized approval selectors", async () => {
+    const scopedTool: ToolMetadata = { name: "my-server_do_thing", originalName: "do_thing", description: "" };
+    const config: McpConfig = {
+      settings: { approveTools: ["my_server_do_thing"] },
+      mcpServers: { "my-server": { command: "demo" } },
+    };
+    const metadata = new Map([["my-server", [scopedTool]]]);
+
+    expect(isToolCallApprovalRequired(config, "my-server", scopedTool, metadata)).toBe(true);
+    const { state, callTool } = createState({ interactive: false });
+    state.config = config;
+    state.toolMetadata = metadata;
+    await expect(executeCall(state, scopedTool.name, {})).resolves.toMatchObject({
+      details: { error: "approval_required", server: "my-server", tool: "do_thing" },
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("does not gate a same-server legacy collision", async () => {
+    const hyphenTool: ToolMetadata = { name: "demo_search-records", originalName: "search-records", description: "" };
+    const underscoreTool: ToolMetadata = { name: "demo_search_records", originalName: "search_records", description: "" };
+    const config: McpConfig = {
+      settings: { approveTools: ["demo_search_records"] },
+      mcpServers: { demo: { command: "demo" } },
+    };
+    const metadata = new Map([["demo", [hyphenTool, underscoreTool]]]);
+
+    expect(isToolCallApprovalRequired(config, "demo", hyphenTool, metadata)).toBe(false);
+    expect(isToolCallApprovalRequired(config, "demo", underscoreTool, metadata)).toBe(true);
+
+    const { state, callTool } = createState({ interactive: false });
+    state.config = config;
+    state.toolMetadata = metadata;
+    await expect(executeCall(state, hyphenTool.name, {})).resolves.toMatchObject({ details: { server: "demo", tool: "search-records" } });
+    await expect(executeCall(state, underscoreTool.name, {})).resolves.toMatchObject({ details: { error: "approval_required", server: "demo", tool: "search_records" } });
+    expect(callTool).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed headlessly with a structured approval_required result", async () => {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -693,6 +693,113 @@ describe("UiServer", () => {
       expect(onMessage).toHaveBeenCalledWith(params);
     });
 
+    it("uses app-callable siblings for iframe approval collisions", async () => {
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [
+            { name: "search-records", _meta: { ui: { visibility: ["app"] } } },
+            { name: "search_records", _meta: { ui: { visibility: ["app"] } } },
+          ],
+        }),
+      });
+      const config: McpConfig = {
+        settings: { approveTools: ["demo_search_records"] },
+        mcpServers: { demo: { command: "demo" } },
+      };
+      const state = { config, approvedToolCalls: new Map(), toolMetadata: new Map() } as unknown as McpExtensionState;
+      handle = await startUiServer(createServerOptions({ manager, config, state, serverName: "demo" }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: { name: "search-records", arguments: {} } },
+      });
+
+      expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "called" }] } });
+      expect(callTool).toHaveBeenCalledOnce();
+    });
+
+    it("uses live resources for iframe approval collisions", async () => {
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{ name: "read-records", _meta: { ui: { visibility: ["app"] } } }],
+          resources: [{ name: "records", uri: "file://records" }],
+        }),
+      });
+      const config: McpConfig = {
+        settings: { approveTools: ["demo_read_records"] },
+        mcpServers: { demo: { command: "demo" } },
+      };
+      const state = { config, approvedToolCalls: new Map(), toolMetadata: new Map() } as unknown as McpExtensionState;
+      handle = await startUiServer(createServerOptions({ manager, config, state, serverName: "demo" }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: { name: "read-records", arguments: {} } },
+      });
+
+      expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "called" }] } });
+      expect(callTool).toHaveBeenCalledOnce();
+    });
+
+    it("uses other-server metadata for iframe approval collisions", async () => {
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{ name: "search-records", _meta: { ui: { visibility: ["app"] } } }],
+        }),
+      });
+      const config: McpConfig = {
+        settings: { approveTools: ["search_records"] },
+        mcpServers: { "my-server": { command: "demo" }, other: { command: "other" } },
+      };
+      const state = {
+        config,
+        approvedToolCalls: new Map(),
+        toolMetadata: new Map([["other", [{ name: "other_search_records", originalName: "search_records", description: "Other" }]]]),
+      } as unknown as McpExtensionState;
+      handle = await startUiServer(createServerOptions({ manager, config, state, serverName: "my-server" }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: { name: "search-records", arguments: {} } },
+      });
+
+      expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "called" }] } });
+      expect(callTool).toHaveBeenCalledOnce();
+    });
+
+    it("gates stateless iframe calls with safe legacy global approval selectors", async () => {
+      const callTool = vi.fn();
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{ name: "search-records", _meta: { ui: { visibility: ["app"] } } }],
+        }),
+      });
+      const config: McpConfig = {
+        settings: { approveTools: ["demo_search_records"] },
+        mcpServers: { demo: { command: "demo" } },
+      };
+      handle = await startUiServer(createServerOptions({ manager, config, serverName: "demo" }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: { name: "search-records", arguments: {} } },
+      });
+
+      expect(res.body).toMatchObject({ ok: true, result: { details: { error: "approval_required", tool: "search-records" } } });
+      expect(callTool).not.toHaveBeenCalled();
+    });
+
     it("returns a gated iframe call as an approval_denied tool result", async () => {
       const mockClient = { callTool: vi.fn() };
       const manager = createMockManager({

--- a/commands.ts
+++ b/commands.ts
@@ -170,7 +170,7 @@ export async function reconnectServer(
     }
 
     const prefix = state.config.settings?.toolPrefix ?? "server";
-    const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
+    const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix, state.config.mcpServers, state.toolMetadata);
     state.toolMetadata.set(name, metadata);
     if (!connection.promptDiscoveryFailed) {
       state.promptMetadata?.set(name, reconstructPromptMetadata(name, connection.prompts ?? [], prefix, definition));

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -11,7 +11,8 @@ import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatToolName, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
+import { formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
+import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
 import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
@@ -149,10 +150,31 @@ export function resolveDirectTools(
     if (!toolFilter) continue;
 
     const effectivePrefix = resolveToolPrefix(definition, prefix);
+    const getOtherCurrentCandidates = (toolName: string): Set<string> => {
+      const candidates = new Set<string>();
+      for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
+        const otherCache = cache.servers[otherServerName];
+        if (!otherCache || !isServerCacheValid(otherCache, otherDefinition) || isServerDisabled(otherDefinition)) continue;
+        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
+        for (const otherTool of otherCache.tools ?? []) {
+          if (!isUiToolVisibleToModel(otherTool.uiVisibility)) continue;
+          for (const candidate of getToolNameCandidates(otherTool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
+        }
+        if (otherDefinition.exposeResources !== false) {
+          for (const resource of otherCache.resources ?? []) {
+            const baseName = `read_${resourceNameToToolName(resource.name)}`;
+            for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
+          }
+        }
+      }
+      for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
+      return candidates;
+    };
 
     for (const tool of serverCache.tools ?? []) {
+      if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
-      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) continue;
+      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) continue;
       const prefixedName = formatToolName(tool.name, serverName, effectivePrefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);
@@ -178,7 +200,7 @@ export function resolveDirectTools(
       for (const resource of serverCache.resources ?? []) {
         const baseName = `read_${resourceNameToToolName(resource.name)}`;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
-        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) continue;
+        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) continue;
         const prefixedName = formatToolName(baseName, serverName, effectivePrefix);
         if (BUILTIN_NAMES.has(prefixedName)) {
           console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`);
@@ -230,15 +252,38 @@ export function buildProxyDescription(
   for (const serverName of Object.keys(config.mcpServers)) {
     const definition = config.mcpServers[serverName];
     if (!definition || isServerDisabled(definition)) continue;
-    const entry = cache?.servers?.[serverName];
+    const cachedEntry = cache?.servers?.[serverName];
+    const entry = cachedEntry && isServerCacheValid(cachedEntry, definition) ? cachedEntry : undefined;
     const effectivePrefix = resolveToolPrefix(definition, prefix);
+    const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
+      if (!cache) return undefined;
+      const candidates = new Set<string>();
+      for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
+        const otherEntry = cache.servers[otherServerName];
+        if (!otherEntry || !isServerCacheValid(otherEntry, otherDefinition) || isServerDisabled(otherDefinition)) continue;
+        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
+        for (const otherTool of otherEntry.tools ?? []) {
+          if (!isUiToolVisibleToModel(otherTool.uiVisibility)) continue;
+          for (const candidate of getToolNameCandidates(otherTool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
+        }
+        if (otherDefinition.exposeResources !== false) {
+          for (const resource of otherEntry.resources ?? []) {
+            const baseName = `read_${resourceNameToToolName(resource.name)}`;
+            for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
+          }
+        }
+      }
+      for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
+      return candidates;
+    };
     const toolCount = (entry?.tools ?? []).filter(
-      (tool) => isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools),
+      (tool) => isUiToolVisibleToModel(tool.uiVisibility)
+        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name)),
     ).length;
     const resourceCount = definition?.exposeResources !== false
       ? (entry?.resources ?? []).filter((resource) => {
           const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools);
+          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName));
         }).length
       : 0;
     const totalItems = toolCount + resourceCount;
@@ -264,7 +309,9 @@ export function buildProxyDescription(
   const instructionSummaries: string[] = [];
   for (const serverName of Object.keys(config.mcpServers)) {
     if (isServerDisabled(config.mcpServers[serverName])) continue;
-    const instructions = cache?.servers?.[serverName]?.instructions;
+    const definition = config.mcpServers[serverName];
+    const entry = definition && cache?.servers?.[serverName];
+    const instructions = entry && definition && isServerCacheValid(entry, definition) ? entry.instructions : undefined;
     if (!instructions) continue;
     const snippet = truncateAtWord(instructions.replace(/\s+/g, " ").trim(), INSTRUCTIONS_SNIPPET_LENGTH);
     instructionSummaries.push(`  ${serverName}: ${snippet}`);

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import { isServerDisabled, type McpAdapterOptions, type PromptMetadata, type ToolMetadata } from "./types.ts";
+import { formatToolName, isServerDisabled, resolveToolPrefix, type McpAdapterOptions, type PromptMetadata, type ToolMetadata } from "./types.ts";
 import { existsSync } from "node:fs";
 import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
@@ -21,6 +21,7 @@ import {
 } from "./metadata-cache.ts";
 import { McpServerManager } from "./server-manager.ts";
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.ts";
+import { resourceNameToToolName } from "./resource-tools.ts";
 import { UiResourceHandler } from "./ui-resource-handler.ts";
 import { formatMcpStatus, openUrl, parallelLimit, sanitizeTerminalText } from "./utils.ts";
 import { logger } from "./logger.ts";
@@ -242,7 +243,7 @@ export async function initializeMcp(
 
     const cachedEntry = cache?.servers?.[name];
     if (cachedEntry && isServerCacheValid(cachedEntry, definition)) {
-      const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition);
+      const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition, config.mcpServers, cache ?? undefined);
       toolMetadata.set(name, metadata);
       if (Array.isArray(cachedEntry.resources)) {
         resourceCounts.set(name, cachedEntry.resources.length);
@@ -288,6 +289,29 @@ export async function initializeMcp(
   if (initialSignal?.aborted) return state;
   owner.throwIfInactive();
 
+  const startupKnownMetadata = new Map<string, ToolMetadata[]>();
+  for (const { name, definition, connection } of results) {
+    if (!connection) continue;
+    const effectivePrefix = resolveToolPrefix(definition, prefix);
+    const metadata: ToolMetadata[] = [
+      ...connection.tools.filter(tool => tool?.name).map(tool => ({
+        name: formatToolName(tool.name, name, effectivePrefix),
+        originalName: tool.name,
+        description: tool.description ?? "",
+      })),
+      ...(definition.exposeResources !== false ? connection.resources.filter(resource => resource?.name && resource?.uri).map(resource => {
+        const originalName = `read_${resourceNameToToolName(resource.name)}`;
+        return {
+          name: formatToolName(originalName, name, effectivePrefix),
+          originalName,
+          description: resource.description ?? `Read resource: ${resource.uri}`,
+          resourceUri: resource.uri,
+        };
+      }) : []),
+    ];
+    startupKnownMetadata.set(name, metadata);
+  }
+
   for (const { name, definition, connection, error } of results) {
     owner.throwIfInactive();
     if (error || !connection) {
@@ -301,7 +325,7 @@ export async function initializeMcp(
       continue;
     }
 
-    const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix);
+    const { metadata, failedTools } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix, config.mcpServers, startupKnownMetadata, true);
     toolMetadata.set(name, metadata);
     resourceCounts.set(name, connection.resources.length);
     if (!connection.promptDiscoveryFailed) {
@@ -437,7 +461,7 @@ export function updateServerMetadata(state: McpExtensionState, serverName: strin
 
   const prefix = state.config.settings?.toolPrefix ?? "server";
 
-  const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
+  const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix, state.config.mcpServers, state.toolMetadata);
   state.toolMetadata.set(serverName, metadata);
   state.resourceCounts?.set(serverName, connection.resources.length);
   if (!connection.promptDiscoveryFailed) {

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,11 +1,12 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { copyToClipboard } from "@earendil-works/pi-coding-agent";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
-import { isServerDisabled, isToolAllowed } from "./types.ts";
+import { getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { sanitizeTerminalText, stripOscSequences } from "./utils.ts";
-import type { MetadataCache, ServerCacheEntry, CachedTool } from "./metadata-cache.ts";
+import { isServerCacheValid, type MetadataCache, type ServerCacheEntry, type CachedTool } from "./metadata-cache.ts";
+import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 
 interface PanelTheme {
   border: string;
@@ -170,8 +171,8 @@ class McpPanel {
   private static readonly INACTIVITY_MS = 60_000;
 
   constructor(
-    config: McpConfig,
-    cache: MetadataCache | null,
+    private config: McpConfig,
+    private cache: MetadataCache | null,
     provenance: Map<string, ServerProvenance>,
     private callbacks: McpPanelCallbacks,
     tui: { requestRender(): void },
@@ -187,7 +188,8 @@ class McpPanel {
     for (const [serverName, definition] of Object.entries(config.mcpServers)) {
       if (this.authOnly && !callbacks.canAuthenticate(serverName)) continue;
       const prov = provenance.get(serverName);
-      const serverCache = cache?.servers?.[serverName];
+      const cachedEntry = this.cache?.servers?.[serverName];
+      const serverCache = cachedEntry && isServerCacheValid(cachedEntry, definition) ? cachedEntry : undefined;
 
       const globalDirect = config.settings?.directTools;
       let toolFilter: true | string[] | false = false;
@@ -200,7 +202,8 @@ class McpPanel {
       const tools: ToolState[] = [];
       if (serverCache && !this.authOnly && !isServerDisabled(definition)) {
         for (const tool of serverCache.tools ?? []) {
-          if (!isToolAllowed(tool.name, serverName, this.prefix, definition.includeTools, definition.excludeTools)) {
+          if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+          if (!isToolAllowed(tool.name, serverName, this.prefix, definition.includeTools, definition.excludeTools, this.getOtherCurrentCandidates(serverName, definition, serverCache, tool.name))) {
             continue;
           }
 
@@ -216,7 +219,7 @@ class McpPanel {
         if (definition.exposeResources !== false) {
           for (const resource of serverCache.resources ?? []) {
             const baseName = `read_${resourceNameToToolName(resource.name)}`;
-            if (!isToolAllowed(baseName, serverName, this.prefix, definition.includeTools, definition.excludeTools)) {
+            if (!isToolAllowed(baseName, serverName, this.prefix, definition.includeTools, definition.excludeTools, this.getOtherCurrentCandidates(serverName, definition, serverCache, baseName))) {
               continue;
             }
 
@@ -563,6 +566,8 @@ class McpPanel {
       if (server.connectionStatus === "connected") {
         const entry = this.callbacks.refreshCacheAfterReconnect(server.name);
         if (entry) {
+          this.cache ??= { version: 1, servers: {} };
+          this.cache.servers[server.name] = entry;
           this.rebuildServerTools(server, entry);
         }
         server.hasCachedData = true;
@@ -636,13 +641,44 @@ class McpPanel {
     this.cursorIndex = Math.max(0, Math.min(this.visibleItems.length - 1, this.cursorIndex + delta));
   }
 
+  private getOtherCurrentCandidates(
+    serverName: string,
+    definition: McpConfig["mcpServers"][string],
+    currentEntry: ServerCacheEntry,
+    toolName: string,
+  ): Set<string> {
+    const candidates = new Set<string>();
+    for (const [otherServerName, otherDefinition] of Object.entries(this.config.mcpServers)) {
+      if (isServerDisabled(otherDefinition)) continue;
+      const cachedEntry = this.cache?.servers?.[otherServerName];
+      const entry = otherServerName === serverName
+        ? currentEntry
+        : cachedEntry && isServerCacheValid(cachedEntry, otherDefinition) ? cachedEntry : undefined;
+      if (!entry) continue;
+      const otherPrefix = resolveToolPrefix(otherDefinition, this.prefix);
+      for (const tool of entry.tools ?? []) {
+        if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+        for (const candidate of getToolNameCandidates(tool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
+      }
+      if (otherDefinition.exposeResources !== false) {
+        for (const resource of entry.resources ?? []) {
+          const baseName = `read_${resourceNameToToolName(resource.name)}`;
+          for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
+        }
+      }
+    }
+    for (const candidate of getToolNameCandidates(toolName, serverName, resolveToolPrefix(definition, this.prefix), false)) candidates.delete(candidate);
+    return candidates;
+  }
+
   private rebuildServerTools(server: ServerState, entry: ServerCacheEntry): void {
     const existingState = new Map<string, boolean>();
     for (const t of server.tools) existingState.set(t.name, t.isDirect);
 
     const newTools: ToolState[] = [];
     for (const tool of entry.tools ?? []) {
-      if (!isToolAllowed(tool.name, server.name, this.prefix, server.includeTools, server.excludeTools)) {
+      if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+      if (!isToolAllowed(tool.name, server.name, this.prefix, server.includeTools, server.excludeTools, this.getOtherCurrentCandidates(server.name, server, entry, tool.name))) {
         continue;
       }
 
@@ -660,7 +696,7 @@ class McpPanel {
     if (server.exposeResources) {
       for (const resource of entry.resources ?? []) {
         const baseName = `read_${resourceNameToToolName(resource.name)}`;
-        if (!isToolAllowed(baseName, server.name, this.prefix, server.includeTools, server.excludeTools)) {
+        if (!isToolAllowed(baseName, server.name, this.prefix, server.includeTools, server.excludeTools, this.getOtherCurrentCandidates(server.name, server, entry, baseName))) {
           continue;
         }
 

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -19,7 +19,7 @@ import type {
   ToolMetadata,
   PromptMetadata,
 } from "./types.ts";
-import { formatPromptCommandName, formatToolName, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
+import { formatPromptCommandName, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -177,18 +177,41 @@ export function reconstructToolMetadata(
   serverName: string,
   entry: ServerCacheEntry,
   prefix: ToolPrefix,
-  definition: Pick<ServerEntry, "exposeResources" | "includeTools" | "excludeTools" | "toolPrefix">
+  definition: Pick<ServerEntry, "exposeResources" | "includeTools" | "excludeTools" | "toolPrefix">,
+  configuredServers?: Record<string, ServerEntry>,
+  cache?: MetadataCache,
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
+  const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
+    if (!configuredServers || !cache) return undefined;
+    const candidates = new Set<string>();
+    for (const [otherServerName, otherDefinition] of Object.entries(configuredServers)) {
+      const otherEntry = cache.servers[otherServerName];
+      if (!otherEntry || !isServerCacheValid(otherEntry, otherDefinition) || isServerDisabled(otherDefinition)) continue;
+      const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
+      for (const otherTool of otherEntry.tools ?? []) {
+        if (!isUiToolVisibleToModel(otherTool.uiVisibility)) continue;
+        for (const candidate of getToolNameCandidates(otherTool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
+      }
+      if (otherDefinition.exposeResources !== false) {
+        for (const resource of otherEntry.resources ?? []) {
+          const baseName = `read_${resourceNameToToolName(resource.name)}`;
+          for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
+        }
+      }
+    }
+    for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
+    return candidates;
+  };
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
     if (!isUiToolVisibleToModel(tool.uiVisibility)) {
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) {
       continue;
     }
 
@@ -213,7 +236,7 @@ export function reconstructToolMetadata(
     for (const resource of entry.resources ?? []) {
       if (!resource?.name || !resource?.uri) continue;
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) {
         continue;
       }
 

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -37,6 +37,36 @@ type AutoAuthResult =
   | { status: "success" }
   | { status: "failed"; message: string };
 
+function getToolMatches(metadata: ToolMetadata[] | undefined, toolName: string, exact: boolean): ToolMetadata[] {
+  if (!metadata) return [];
+  if (exact) return metadata.filter(tool => tool.name === toolName);
+  const normalizedName = toolName.replace(/-/g, "_");
+  return metadata.filter(tool => tool.name.replace(/-/g, "_") === normalizedName);
+}
+
+function getEnabledToolMatches(state: McpExtensionState, toolName: string, exact: boolean): { server: string; tool: ToolMetadata }[] {
+  const matches: { server: string; tool: ToolMetadata }[] = [];
+  for (const [server, metadata] of state.toolMetadata) {
+    if (isServerDisabled(state.config.mcpServers[server])) continue;
+    for (const tool of getToolMatches(metadata, toolName, exact)) matches.push({ server, tool });
+  }
+  return matches;
+}
+
+function getSingleToolMatch(metadata: ToolMetadata[] | undefined, toolName: string): ToolMetadata | "ambiguous" | undefined {
+  const exactMatches = getToolMatches(metadata, toolName, true);
+  const matches = exactMatches.length > 0 ? exactMatches : getToolMatches(metadata, toolName, false);
+  return matches.length > 1 ? "ambiguous" : matches[0];
+}
+
+function ambiguousToolResult(mode: "call" | "describe", toolName: string): ProxyToolResult {
+  const message = `Tool "${toolName}" matches multiple servers. Specify a server.`;
+  return {
+    content: [{ type: "text" as const, text: message }],
+    details: { mode, error: "ambiguous_tool", requestedTool: toolName, message },
+  };
+}
+
 function disabledResult(mode: string, serverName: string): ProxyToolResult {
   const message = `Server "${serverName}" is disabled. Run /mcp enable ${serverName} and /reload to enable it.`;
   return {
@@ -404,20 +434,28 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
 }
 
 export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
-  let serverName: string | undefined;
-  let toolMeta: ToolMetadata | undefined;
+  const exactMatches = getEnabledToolMatches(state, toolName, true);
+  if (exactMatches.length > 1) return ambiguousToolResult("describe", toolName);
+  if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).length > 1) {
+    return ambiguousToolResult("describe", toolName);
+  }
+
+  let serverName = exactMatches[0]?.server;
+  let toolMeta = exactMatches[0]?.tool;
   let disabledMatch: string | undefined;
 
-  for (const [server, metadata] of state.toolMetadata.entries()) {
-    const found = findToolByName(metadata, toolName);
-    if (!found) continue;
-    if (isServerDisabled(state.config.mcpServers[server])) {
-      disabledMatch ??= server;
-      continue;
+  if (!toolMeta) {
+    for (const [server, metadata] of state.toolMetadata.entries()) {
+      const found = findToolByName(metadata, toolName);
+      if (!found) continue;
+      if (isServerDisabled(state.config.mcpServers[server])) {
+        disabledMatch ??= server;
+        continue;
+      }
+      serverName = server;
+      toolMeta = found;
+      break;
     }
-    serverName = server;
-    toolMeta = found;
-    break;
   }
 
   if (!serverName || !toolMeta) {
@@ -430,7 +468,7 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
     };
   }
 
-  const approvalMarker = isToolCallApprovalRequired(state.config, serverName, toolMeta)
+  const approvalMarker = isToolCallApprovalRequired(state.config, serverName, toolMeta, state.toolMetadata)
     ? " (requires approval)"
     : "";
   let text = `${toolMeta.name}${approvalMarker}\n`;
@@ -557,7 +595,7 @@ export function executeSearch(
 
   let text = `Found ${page.total} tool${page.total === 1 ? "" : "s"} matching "${query}":\n\n`;
   for (const match of page.items) {
-    const approvalMarker = isToolCallApprovalRequired(state.config, match.server, match.tool)
+    const approvalMarker = isToolCallApprovalRequired(state.config, match.server, match.tool, state.toolMetadata)
       ? " (requires approval)"
       : "";
     if (showSchemas) {
@@ -737,7 +775,7 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       }
     }
     const prefix = state.config.settings?.toolPrefix ?? "server";
-    const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix);
+    const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix, state.config.mcpServers, state.toolMetadata);
     state.toolMetadata.set(serverName, metadata);
     if (!connection.promptDiscoveryFailed) {
       state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix, definition));
@@ -805,14 +843,22 @@ export async function executeCall(
     };
   }
   if (serverName) {
-    toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+    const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+    if (match === "ambiguous") return ambiguousToolResult("call", toolName);
+    toolMeta = match;
     if (isServerDisabled(state.config.mcpServers[serverName])) {
       return disabledCallResult(serverName, toolMeta);
     }
   } else {
+    const exactMatches = getEnabledToolMatches(state, toolName, true);
+    if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
+    if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).length > 1) {
+      return ambiguousToolResult("call", toolName);
+    }
+
     let disabledMatch: { serverName: string; toolMeta: ToolMetadata } | undefined;
     for (const [server, metadata] of state.toolMetadata.entries()) {
-      const found = findToolByName(metadata, toolName);
+      const found = metadata.find(tool => tool.name === toolName);
       if (!found) continue;
       if (isServerDisabled(state.config.mcpServers[server])) {
         disabledMatch ??= { serverName: server, toolMeta: found };
@@ -822,13 +868,28 @@ export async function executeCall(
       toolMeta = found;
       break;
     }
+    if (!toolMeta && !disabledMatch) {
+      for (const [server, metadata] of state.toolMetadata.entries()) {
+        const found = findToolByName(metadata, toolName);
+        if (!found) continue;
+        if (isServerDisabled(state.config.mcpServers[server])) {
+          disabledMatch ??= { serverName: server, toolMeta: found };
+          continue;
+        }
+        serverName = server;
+        toolMeta = found;
+        break;
+      }
+    }
     if (!toolMeta && disabledMatch) return disabledCallResult(disabledMatch.serverName, disabledMatch.toolMeta);
   }
 
   if (serverName && !toolMeta) {
     const connected = await lazyConnect(state, serverName, ownedSignal);
     if (connected) {
-      toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+      if (match === "ambiguous") return ambiguousToolResult("call", toolName);
+      toolMeta = match;
     } else {
       const needsAuthConnection = state.manager.getConnection(serverName);
       if (needsAuthConnection?.status === "needs-auth") {
@@ -846,7 +907,9 @@ export async function executeCall(
             clearFailure(state, serverName);
             const connectedAfterAuth = await lazyConnect(state, serverName, ownedSignal);
             if (connectedAfterAuth) {
-              toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+              const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+              if (match === "ambiguous") return ambiguousToolResult("call", toolName);
+              toolMeta = match;
               if (!toolMeta) {
                 const suggestions = rankSuggestions(state, toolName, 5);
                 const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
@@ -883,6 +946,8 @@ export async function executeCall(
   let prefixMatchedServer: string | undefined;
 
   if (!serverName && !toolMeta && prefixMode !== "none") {
+    const lazyExactMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
+    const lazyFallbackMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
     const candidates = Object.keys(state.config.mcpServers)
       .filter(name => !isServerDisabled(state.config.mcpServers[name]))
       .map(name => ({ name, prefix: getServerPrefix(name, prefixMode) }))
@@ -913,11 +978,22 @@ export async function executeCall(
 
       if (!connected) continue;
       if (!prefixMatchedServer) prefixMatchedServer = configuredServer;
-      toolMeta = findToolByName(state.toolMetadata.get(configuredServer), toolName);
-      if (toolMeta) {
-        serverName = configuredServer;
-        break;
+      const metadata = state.toolMetadata.get(configuredServer);
+      const exactMatches = getToolMatches(metadata, toolName, true);
+      if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
+      if (exactMatches.length === 1) {
+        lazyExactMatches.push({ serverName: configuredServer, toolMeta: exactMatches[0]! });
+        continue;
       }
+      const fallbackMatches = getToolMatches(metadata, toolName, false);
+      if (fallbackMatches.length > 1) return ambiguousToolResult("call", toolName);
+      if (fallbackMatches.length === 1) lazyFallbackMatches.push({ serverName: configuredServer, toolMeta: fallbackMatches[0]! });
+    }
+    const lazyMatches = lazyExactMatches.length > 0 ? lazyExactMatches : lazyFallbackMatches;
+    if (lazyMatches.length > 1) return ambiguousToolResult("call", toolName);
+    if (lazyMatches.length === 1) {
+      serverName = lazyMatches[0]!.serverName;
+      toolMeta = lazyMatches[0]!.toolMeta;
     }
   }
 
@@ -1030,7 +1106,9 @@ export async function executeCall(
       notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
       markKeepAliveAfterConnect(state, serverName);
       updateStatusBar(state);
-      toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName);
+      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+      if (match === "ambiguous") return ambiguousToolResult("call", toolName);
+      toolMeta = match;
       if (!toolMeta) {
         const available = getToolNames(state, serverName);
         const hint = available.length > 0

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -24,19 +24,59 @@ export function isToolCallApprovalRequired(
   config: McpConfig,
   serverName: string,
   toolMeta: Pick<ToolMetadata, "originalName">,
+  toolMetadata?: ReadonlyMap<string, readonly ToolMetadata[]>,
 ): boolean {
   const definition = config.mcpServers[serverName];
-  const approval = definition?.approveTools !== undefined
-    ? definition.approveTools
-    : config.settings?.approveTools;
+  const serverApproval = definition?.approveTools;
+  const approval = serverApproval !== undefined ? serverApproval : config.settings?.approveTools;
 
   if (approval === true) return true;
   if (!Array.isArray(approval) || approval.length === 0) return false;
 
   const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
-  return matchesToolPattern(
-    getToolNameCandidates(toolMeta.originalName, serverName, prefix),
-    approval,
+  const currentCandidates = getToolNameCandidates(toolMeta.originalName, serverName, prefix, false);
+  if (serverApproval !== undefined) {
+    if (matchesToolPattern(currentCandidates, approval)) return true;
+    if (!toolMetadata) return matchesToolPattern(getToolNameCandidates(toolMeta.originalName, serverName, prefix), approval);
+    const legacyCandidates = getToolNameCandidates(toolMeta.originalName, serverName, prefix);
+    const legacyEmittedName = [...currentCandidates].find(candidate => candidate !== toolMeta.originalName)?.replace(/-/g, "_");
+    if (legacyEmittedName) legacyCandidates.add(legacyEmittedName);
+    for (const candidate of currentCandidates) legacyCandidates.delete(candidate);
+    const otherCurrentCandidates = new Set<string>();
+    for (const tool of toolMetadata.get(serverName) ?? []) {
+      for (const candidate of getToolNameCandidates(tool.originalName, serverName, prefix, false)) {
+        otherCurrentCandidates.add(candidate);
+      }
+    }
+    for (const candidate of currentCandidates) otherCurrentCandidates.delete(candidate);
+    return approval.some(pattern =>
+      matchesToolPattern(legacyCandidates, [pattern])
+      && !matchesToolPattern(otherCurrentCandidates, [pattern]),
+    );
+  }
+
+
+  if (matchesToolPattern(currentCandidates, approval)) return true;
+  if (!toolMetadata) return false;
+
+  const legacyCandidates = getToolNameCandidates(toolMeta.originalName, serverName, prefix);
+  const legacyEmittedName = [...currentCandidates].find(candidate => candidate !== toolMeta.originalName)?.replace(/-/g, "_");
+  if (legacyEmittedName) legacyCandidates.add(legacyEmittedName);
+  for (const candidate of currentCandidates) legacyCandidates.delete(candidate);
+  const otherCurrentCandidates = new Set<string>();
+  for (const [name, metadata] of toolMetadata) {
+    const otherPrefix = resolveToolPrefix(config.mcpServers[name], config.settings?.toolPrefix);
+    for (const tool of metadata) {
+      for (const candidate of getToolNameCandidates(tool.originalName, name, otherPrefix, false)) {
+        otherCurrentCandidates.add(candidate);
+      }
+    }
+  }
+  for (const candidate of currentCandidates) otherCurrentCandidates.delete(candidate);
+
+  return approval.some(pattern =>
+    matchesToolPattern(legacyCandidates, [pattern])
+    && !matchesToolPattern(otherCurrentCandidates, [pattern]),
   );
 }
 
@@ -94,6 +134,7 @@ export async function ensureToolCallApproved(
   args: Record<string, unknown> | undefined,
   signal?: AbortSignal,
   origin: McpToolApprovalOrigin = toolMeta.resourceUri ? "resource" : "proxy",
+  approvalMetadata?: ReadonlyMap<string, readonly ToolMetadata[]>,
 ): Promise<ToolCallApprovalResult> {
   const cacheKey = `${serverName}\u0000${toolMeta.originalName}`;
   const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
@@ -109,7 +150,7 @@ export async function ensureToolCallApproved(
   }
   if (brokerDecision === "deny") return { ok: false, reason: "denied" };
 
-  if (!isToolCallApprovalRequired(state.config, serverName, toolMeta)) {
+  if (!isToolCallApprovalRequired(state.config, serverName, toolMeta, approvalMetadata ?? state.toolMetadata)) {
     return { ok: true };
   }
 

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,7 +1,7 @@
 import { getToolUiResourceUri } from "./ui-app-bridge-helpers.ts";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from "./types.ts";
-import { formatToolName, isToolAllowed, resolveToolPrefix } from "./types.ts";
+import { formatToolName, getToolNameCandidates, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
 import { extractUiToolVisibility, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
@@ -11,19 +11,57 @@ export function buildToolMetadata(
   resources: McpResource[],
   definition: ServerEntry,
   serverName: string,
-  prefix: ToolPrefix
+  prefix: ToolPrefix,
+  configuredServers?: Record<string, ServerEntry>,
+  knownMetadata?: Map<string, ToolMetadata[]>,
+  includeMissingConfiguredCandidates = false,
 ): { metadata: ToolMetadata[]; failedTools: string[] } {
   const metadata: ToolMetadata[] = [];
   const failedTools: string[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
+  const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
+    if (!configuredServers) return undefined;
+    const candidates = new Set<string>();
+    const addCandidates = (originalName: string, candidateServerName: string, candidatePrefix: ToolPrefix) => {
+      for (const candidate of getToolNameCandidates(originalName, candidateServerName, candidatePrefix, false)) candidates.add(candidate);
+    };
+
+    for (const tool of tools) {
+      if (tool?.name) addCandidates(tool.name, serverName, effectivePrefix);
+    }
+    if (definition.exposeResources !== false) {
+      for (const resource of resources) {
+        if (resource?.name && resource?.uri) addCandidates(`read_${resourceNameToToolName(resource.name)}`, serverName, effectivePrefix);
+      }
+    }
+    for (const [otherServerName, otherDefinition] of Object.entries(configuredServers)) {
+      if (otherServerName === serverName) continue;
+      const knownTools = knownMetadata?.get(otherServerName);
+      if (knownTools) {
+        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
+        for (const tool of knownTools) {
+          candidates.add(tool.name);
+          addCandidates(tool.originalName, otherServerName, otherPrefix);
+        }
+      } else if (!knownMetadata || includeMissingConfiguredCandidates) {
+        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
+        addCandidates(toolName, otherServerName, otherPrefix);
+        if (includeMissingConfiguredCandidates) {
+          for (const candidate of getToolNameCandidates(toolName, otherServerName, otherPrefix, false)) candidates.add(candidate.replace(/-/g, "_"));
+        }
+      }
+    }
+    for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
+    return candidates;
+  };
 
   for (const tool of tools) {
     if (!tool?.name) {
       failedTools.push("(unnamed)");
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) {
       continue;
     }
 
@@ -59,7 +97,7 @@ export function buildToolMetadata(
   if (definition.exposeResources !== false) {
     for (const resource of resources) {
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) {
         continue;
       }
 

--- a/types.ts
+++ b/types.ts
@@ -644,9 +644,10 @@ export interface McpPanelResult {
 /**
  * Get server prefix based on tool prefix mode.
  */
-function sanitizeServerPrefix(serverName: string): string {
+function sanitizeServerPrefix(serverName: string, preserveProviderValid = true): string {
+  const validCharacters = preserveProviderValid ? /^[A-Za-z0-9_-]$/ : /^[A-Za-z0-9]$/;
   return Array.from(serverName, char =>
-    /^[A-Za-z0-9]$/.test(char) ? char : `_${char.codePointAt(0)!.toString(16)}_`,
+    validCharacters.test(char) ? char : `_${char.codePointAt(0)!.toString(16)}_`,
   ).join("");
 }
 
@@ -739,18 +740,44 @@ export function formatPromptCommandName(
   return `mcp__${serverPart}__${sanitizePromptName(promptName)}`;
 }
 
-function normalizeToolName(value: string): string {
-  return value.replace(/-/g, "_");
+function getLegacyServerPrefix(serverName: string, mode: ToolPrefix): string {
+  if (mode === "none") return "";
+  if (mode === "short") return sanitizeServerPrefix(serverName.replace(/-?mcp$/i, ""), false) || "mcp";
+  if (mode === "mcp") return `mcp__${sanitizeServerPrefix(serverName, false)}`;
+  return sanitizeServerPrefix(serverName, false);
 }
 
-export function getToolNameCandidates(toolName: string, serverName: string, prefix: ToolPrefix): Set<string> {
-  return new Set<string>([
-    normalizeToolName(toolName),
-    normalizeToolName(formatToolName(toolName, serverName, prefix)),
-    normalizeToolName(formatToolName(toolName, serverName, "server")),
-    normalizeToolName(formatToolName(toolName, serverName, "short")),
-    normalizeToolName(formatToolName(toolName, serverName, "mcp")),
+function formatLegacyToolName(toolName: string, serverName: string, prefix: ToolPrefix): string {
+  const serverPrefix = getLegacyServerPrefix(serverName, prefix);
+  const sanitizedToolName = toolName.replace(/[.-]/g, "_");
+  return serverPrefix ? `${serverPrefix}_${sanitizedToolName}` : sanitizedToolName;
+}
+
+export function getToolNameCandidates(toolName: string, serverName: string, prefix: ToolPrefix, includeLegacy = true): Set<string> {
+  const candidates = new Set<string>([
+    toolName,
+    formatToolName(toolName, serverName, prefix),
+    formatToolName(toolName, serverName, "server"),
+    formatToolName(toolName, serverName, "short"),
+    formatToolName(toolName, serverName, "mcp"),
   ]);
+  if (includeLegacy) {
+    const legacyToolName = toolName.replace(/-/g, "_");
+    candidates.add(legacyToolName);
+    candidates.add(formatToolName(legacyToolName, serverName, prefix));
+    candidates.add(formatToolName(legacyToolName, serverName, "server"));
+    candidates.add(formatToolName(legacyToolName, serverName, "short"));
+    candidates.add(formatToolName(legacyToolName, serverName, "mcp"));
+    candidates.add(formatLegacyToolName(toolName, serverName, prefix));
+    candidates.add(formatLegacyToolName(toolName, serverName, "server"));
+    candidates.add(formatLegacyToolName(toolName, serverName, "short"));
+    candidates.add(formatLegacyToolName(toolName, serverName, "mcp"));
+    candidates.add(formatToolName(toolName, serverName, prefix).replace(/-/g, "_"));
+    candidates.add(formatToolName(toolName, serverName, "server").replace(/-/g, "_"));
+    candidates.add(formatToolName(toolName, serverName, "short").replace(/-/g, "_"));
+    candidates.add(formatToolName(toolName, serverName, "mcp").replace(/-/g, "_"));
+  }
+  return candidates;
 }
 
 function globToRegExp(pattern: string): RegExp {
@@ -763,11 +790,10 @@ export function matchesToolPattern(candidates: Set<string>, patterns?: unknown):
 
   for (const pattern of patterns) {
     if (typeof pattern !== "string") continue;
-    const normalized = normalizeToolName(pattern);
-    if (!normalized.includes("*") && !normalized.includes("?") && candidates.has(normalized)) {
+    if (!pattern.includes("*") && !pattern.includes("?") && candidates.has(pattern)) {
       return true;
     }
-    if ((normalized.includes("*") || normalized.includes("?")) && [...candidates].some(candidate => globToRegExp(normalized).test(candidate))) {
+    if ((pattern.includes("*") || pattern.includes("?")) && [...candidates].some(candidate => globToRegExp(pattern).test(candidate))) {
       return true;
     }
   }
@@ -775,23 +801,45 @@ export function matchesToolPattern(candidates: Set<string>, patterns?: unknown):
   return false;
 }
 
+function matchesToolSelector(
+  toolName: string,
+  serverName: string,
+  prefix: ToolPrefix,
+  patterns: unknown,
+  otherCurrentCandidates?: Set<string>,
+): boolean {
+  const currentCandidates = getToolNameCandidates(toolName, serverName, prefix, false);
+  if (matchesToolPattern(currentCandidates, patterns)) return true;
+  if (!otherCurrentCandidates) return matchesToolPattern(getToolNameCandidates(toolName, serverName, prefix), patterns);
+  const legacyCandidates = getToolNameCandidates(toolName, serverName, prefix);
+  for (const candidate of currentCandidates) legacyCandidates.delete(candidate);
+  if (!Array.isArray(patterns)) return false;
+  return patterns.some(pattern =>
+    typeof pattern === "string"
+    && !matchesToolPattern(otherCurrentCandidates, [pattern])
+    && matchesToolPattern(legacyCandidates, [pattern]),
+  );
+}
+
 export function isToolIncluded(
   toolName: string,
   serverName: string,
   prefix: ToolPrefix,
-  includeTools?: unknown
+  includeTools?: unknown,
+  otherCurrentCandidates?: Set<string>,
 ): boolean {
   if (!Array.isArray(includeTools) || includeTools.length === 0) return true;
-  return matchesToolPattern(getToolNameCandidates(toolName, serverName, prefix), includeTools);
+  return matchesToolSelector(toolName, serverName, prefix, includeTools, otherCurrentCandidates);
 }
 
 export function isToolExcluded(
   toolName: string,
   serverName: string,
   prefix: ToolPrefix,
-  excludeTools?: unknown
+  excludeTools?: unknown,
+  otherCurrentCandidates?: Set<string>,
 ): boolean {
-  return matchesToolPattern(getToolNameCandidates(toolName, serverName, prefix), excludeTools);
+  return matchesToolSelector(toolName, serverName, prefix, excludeTools, otherCurrentCandidates);
 }
 
 export function isToolAllowed(
@@ -800,7 +848,8 @@ export function isToolAllowed(
   prefix: ToolPrefix,
   includeTools?: unknown,
   excludeTools?: unknown,
+  otherCurrentCandidates?: Set<string>,
 ): boolean {
-  return isToolIncluded(toolName, serverName, prefix, includeTools)
-    && !isToolExcluded(toolName, serverName, prefix, excludeTools);
+  return isToolIncluded(toolName, serverName, prefix, includeTools, otherCurrentCandidates)
+    && !isToolExcluded(toolName, serverName, prefix, excludeTools, otherCurrentCandidates);
 }

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -18,6 +18,7 @@ import type { McpExtensionState } from "./state.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 import { extractUiToolVisibility, isUiToolCallableByApp, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
+import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   createUiModelContextUpdate,
   extractUiPromptText,
@@ -451,6 +452,23 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           ...(toolDefinition?.inputSchema !== undefined ? { inputSchema: toolDefinition.inputSchema } : {}),
           ...(uiVisibility !== undefined ? { uiVisibility } : {}),
         };
+        const approvalMetadata = new Map(options.state?.toolMetadata);
+        const definition = options.config?.mcpServers[options.serverName] ?? options.state?.config.mcpServers[options.serverName];
+        approvalMetadata.set(options.serverName, [
+          ...connection.tools.map(tool => ({
+            name: tool.name,
+            originalName: tool.name,
+            description: tool.description ?? "",
+          })),
+          ...(definition?.exposeResources !== false ? (connection.resources ?? []).map(resource => {
+            const originalName = `read_${resourceNameToToolName(resource.name)}`;
+            return {
+              name: originalName,
+              originalName,
+              description: resource.description ?? `Read resource: ${resource.uri}`,
+            };
+          }) : []),
+        ]);
         const approval = options.state
           ? await ensureToolCallApproved(
               options.state,
@@ -459,8 +477,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               callArgs.arguments,
               options.state.owner?.signal,
               "iframe",
+              approvalMetadata,
             )
-          : options.config && isToolCallApprovalRequired(options.config, options.serverName, toolMeta)
+          : options.config && isToolCallApprovalRequired(options.config, options.serverName, toolMeta, approvalMetadata)
             ? { ok: false as const, reason: "approval_required_headless" as const }
             : { ok: true as const };
         if (approval.ok === false) {


### PR DESCRIPTION
Fixes #342.
Fixes #343.

This updates direct-tool server-prefix formatting so provider-valid `_` and `-` characters stay recognizable in emitted tool names, while unsupported characters still use deterministic escaping. It also keeps the existing duplicate warning-and-skip safety and fixes proxy lookup so an exact preserved hyphen name cannot route to an underscore server through the normalized fallback.

Examples now stay readable:
- `my_server_get`
- `my-server_get`
- `codebase-memory-mcp_<tool>`

Validation:
- `npx vitest run __tests__/abort-signal.test.ts __tests__/direct-tools.test.ts __tests__/resolve-server-from-tool-name.test.ts`
- `npm run typecheck`
- fresh review on `5d246f3`: found and proved the wrong-server proxy route
- retained writer fix at `cb96af5`
- follow-up review on `cb96af5`: no issues found
- rebase and changelog validation on `6597151`: focused tests and typecheck passed
- exact-head review on `6597151`: no issues found

Credit is included in `CHANGELOG.md` for @mightymatth and @JasonLandbridge.
