### PR TITLE
feat: compact MCP result rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `settings.notifyOnStartupConnect` to suppress successful MCP startup connection notices. Thanks @pierre-mgmt for issue #341.
+- Added compact self-rendered MCP proxy and direct-tool result rows by default, with `settings.toolResultRendering: "boxed"` for the legacy boxed row and `settings.collapsedResultLines` for 1-3 collapsed result lines. Thanks @pierre-mgmt for issue #349.
 
 ### Fixed
 - Kept `mcpScript` tool-call replies flowing when Pi runs as a Bun-compiled binary by starting worker execution without module-level top-level await. Thanks @AndreiKopylov for issue #340 and @thesobercoder for the verified fix.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
     "requestTimeoutMs": 30000,
     "showStatusIcon": true,
     "mcpFooterStatus": "full",
+    "toolResultRendering": "compact",
+    "collapsedResultLines": 1,
     "notifyOnStartupConnect": true,
     "hostConfigDiscovery": "off",
     "approveTools": ["github_delete_*", "notion_update_*"],
@@ -329,6 +331,8 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `requestTimeoutMs` | Global request timeout in milliseconds for live MCP calls (if omitted or `<= 0`, the MCP SDK default timeout is used) |
 | `showStatusIcon` | Show the plug icon in MCP status and connection text (default: `true`). Set to `false` for plain `MCP: ...` text. |
 | `mcpFooterStatus` | MCP footer verbosity: `"full"` (default), `"compact"` for `MCP connected/enabled`, or `"off"` to clear the persistent footer status. `/mcp status` remains available. |
+| `toolResultRendering` | MCP tool result row style: `"compact"` (default) uses self-rendered rows, or `"boxed"` restores the legacy Pi boxed tool row. |
+| `collapsedResultLines` | Number of result text lines to show before expansion: `1`, `2`, or `3`. Defaults to `1` in compact mode and `3` in boxed mode. |
 | `notifyOnStartupConnect` | Show successful startup connection notices (default: `true`). Set to `false` to suppress routine `MCP: N servers connected (M tools)` notices. Connection errors and authentication warnings remain visible. |
 | `hostConfigDiscovery` | Host-specific config policy: `"off"` (default), `"prompt"` (detect/report only), or `"on"` (explicitly load detected host configs as the lowest-precedence fallback) |
 | `agentPluginPaths` | Agent Plugins package directories to load MCP servers from. Relative paths resolve from the active project cwd. |
@@ -651,7 +655,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 
 `mcp({ connect: "server-name" })` refreshes an already connected server, so new tools, resources, prompts, and instructions can load without restarting Pi.
 
-MCP proxy and direct-tool results render compactly by default: long text shows the first three terminal-wrapped lines plus a `Ctrl+O to expand` hint, while the full result remains available when expanded and is still returned unchanged to the model.
+MCP proxy and direct-tool results use compact self-rendered rows by default. Collapsed success output shows the call title and the first result line, with a `Ctrl+O to expand` hint when more text is hidden. The full result remains available when expanded and is still returned unchanged to the model. Set `settings.toolResultRendering` to `"boxed"` to restore the legacy boxed Pi row, or set `settings.collapsedResultLines` to `2` or `3` when you want more collapsed text.
 
 Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are ranked by weighted matches across name, server, description, and any configured `searchKeywords`, then returned one page at a time (`limit` defaults to 12). Use `details.nextOffset` for the next page. Regex search is still available with `regex: true`, but regex results are paginated without ranking.
 
@@ -725,4 +729,5 @@ Advertised tool `outputSchema` values support JSON Schema draft-07 and 2020-12. 
 
 - Cross-session server sharing not yet implemented (each Pi session runs its own server processes)
 - Compact MCP result rendering summarizes text, but inline images are still controlled by Pi's image display settings and may render below the compact text summary.
+- Pi still owns one separator row before self-rendered tool output, so compact mode reduces adapter rendering height but cannot promise true zero-gap rows.
 - MCP sampling support is text-only; context inclusion, tools, stop sequences, audio, and image content are rejected with explicit errors.

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -224,6 +224,51 @@ describe("mcpAdapter session lifecycle", () => {
     }));
   });
 
+  it("uses compact self-rendered rows for proxy and direct tools by default", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"], directTools: true },
+      },
+    });
+    mocks.resolveDirectTools.mockReturnValue([
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search demo",
+      },
+    ]);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({
+      name: "demo_search",
+      renderShell: "self",
+    }));
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({
+      name: "mcp",
+      renderShell: "self",
+    }));
+  });
+
+  it("keeps legacy boxed rows when configured", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      settings: { toolResultRendering: "boxed" },
+      mcpServers: {},
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({
+      name: "mcp",
+      renderShell: "default",
+    }));
+  });
+
   it("does not leak TypeBox internal markers into registered tool parameter schemas", async () => {
     const { default: mcpAdapter } = await import("../index.ts");
     const { api } = createPi();

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -2,6 +2,7 @@ import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/p
 import { describe, expect, it } from "vitest";
 import {
   createMcpDirectToolCallRenderer,
+  resolveMcpToolRenderOptions,
   formatMcpDirectToolCallLines,
   formatMcpProxyToolCallLines,
   formatMcpToolResultIdentity,
@@ -142,7 +143,7 @@ describe("MCP tool result renderer", () => {
     expect(formatMcpToolResultIdentity({ mode: "list", server: "figma", tool: "get_nodes" })).toBeNull();
   });
 
-  it("collapses a single line that wraps beyond the compact viewport height", () => {
+  it("renders collapsed results as a compact single line by default", () => {
     const output = renderMcpToolResult(
       result([{
         type: "text",
@@ -154,8 +155,8 @@ describe("MCP tool result renderer", () => {
     ).render(20).join("\n");
 
     expect(output).toContain("segment-1");
+    expect(output).toContain("Ctrl+O");
     expect(output).toContain("…");
-    expect(output).toContain("Ctrl+O to expand");
     expect(output).not.toContain("segment-8");
   });
 
@@ -187,12 +188,13 @@ describe("MCP tool result renderer", () => {
     expect(second.join("\n")).toContain("Ctrl+O to expand");
   });
 
-  it("shows proxy call result identity without hiding the third content line", () => {
+  it("keeps legacy boxed rendering available", () => {
     const output = renderMcpToolResult(
       result([{ type: "text", text: "one\ntwo\nthree\nfour" }], { mode: "call", server: "figma", tool: "get_nodes" }),
       collapsedOptions,
       plainTheme,
       { isError: false },
+      { resultRendering: "boxed", collapsedResultLines: 3 },
     ).render(80).join("\n");
 
     expect(output).toContain("MCP figma/get_nodes");
@@ -201,6 +203,38 @@ describe("MCP tool result renderer", () => {
     expect(output).toContain("three");
     expect(output).not.toContain("four");
     expect(output).toContain("Ctrl+O to expand");
+  });
+
+  it("combines the compact final result with the call title", () => {
+    const state: { compactTitle?: string } = {};
+    const call = createMcpDirectToolCallRenderer("demo_search")(
+      {},
+      plainTheme,
+      { isError: false, isPartial: false, expanded: false, state },
+    );
+    const output = renderMcpToolResult(
+      result([{ type: "text", text: "ok\nextra" }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false, state },
+    ).render(80).join("\n");
+
+    expect(call.render(80)).toEqual([]);
+    expect(output).toContain("demo_search → ok");
+    expect(output).toContain("Ctrl+O to expand");
+    expect(output).not.toContain("extra");
+  });
+
+  it("resolves compact and boxed rendering settings", () => {
+    expect(resolveMcpToolRenderOptions()).toEqual({ resultRendering: "compact", collapsedResultLines: 1 });
+    expect(resolveMcpToolRenderOptions({ toolResultRendering: "boxed" })).toEqual({
+      resultRendering: "boxed",
+      collapsedResultLines: 3,
+    });
+    expect(resolveMcpToolRenderOptions({ collapsedResultLines: 2 })).toEqual({
+      resultRendering: "compact",
+      collapsedResultLines: 2,
+    });
   });
 
   it("shows the full wrapped single line when expanded", () => {

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ import { logger } from "./logger.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { formatTerminalError, getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { createOAuthRuntime, shutdownOAuth } from "./mcp-auth-flow.ts";
-import { createMcpDirectToolCallRenderer, renderMcpProxyToolCall, renderMcpToolResult } from "./tool-result-renderer.ts";
+import { createMcpDirectToolCallRenderer, createMcpProxyToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions } from "./tool-result-renderer.ts";
 import { toolErrorOverride } from "./error-signal.ts";
 import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
@@ -124,6 +124,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const envDirectToolOverride = envRaw?.split(",").map(s => s.trim()).filter(Boolean);
   const registeredDirectTools = new Map<string, string>();
   const fallbackDeactivatedTools = new Set<string>();
+  const toolRenderOptions = resolveMcpToolRenderOptions(earlyConfig.settings);
+  const toolRenderShell = toolRenderOptions.resultRendering === "compact" ? "self" : "default";
+  const renderMcpToolResult = createMcpToolResultRenderer(toolRenderOptions);
   let proxyToolRegistered = false;
   let proxyToolDescription: string | null = null;
   let directToolsFrozen = false;
@@ -158,7 +161,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
       parameters: toToolParameters(normalizeDirectToolInputSchema(spec.inputSchema)),
       execute: createDirectToolExecutor(() => state, () => initPromise, spec),
-      renderCall: createMcpDirectToolCallRenderer(spec.prefixedName),
+      renderShell: toolRenderShell,
+      renderCall: createMcpDirectToolCallRenderer(spec.prefixedName, toolRenderOptions),
       renderResult: renderMcpToolResult,
     });
   }
@@ -695,7 +699,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       label: "MCP",
       description,
       promptSnippet: "MCP gateway — status, search, describe, auth, and single MCP tool calls",
-      renderCall: renderMcpProxyToolCall,
+      renderShell: toolRenderShell,
+      renderCall: createMcpProxyToolCallRenderer(toolRenderOptions),
       parameters: Type.Object({
         tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
         args: Type.Optional(Type.Union([

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
-import { type Component, Text } from "@earendil-works/pi-tui";
+import { type Component, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 type McpToolResultDetails = Record<string, unknown> & { error?: unknown };
 type McpToolContentBlock = AgentToolResult<McpToolResultDetails>["content"][number];
@@ -23,8 +23,27 @@ export interface McpProxyToolCallInput {
   action?: string;
 }
 
+interface McpToolRenderState {
+  compactTitle?: string;
+}
+
 interface McpToolRenderContext {
   isError: boolean;
+  isPartial?: boolean;
+  expanded?: boolean;
+  state?: McpToolRenderState;
+}
+
+export type McpToolResultRendering = "compact" | "boxed";
+
+export interface McpToolRenderOptions {
+  resultRendering: McpToolResultRendering;
+  collapsedResultLines: 1 | 2 | 3;
+}
+
+export interface McpToolRenderSettings {
+  toolResultRendering?: unknown;
+  collapsedResultLines?: unknown;
 }
 
 export interface McpToolResultDisplay {
@@ -33,9 +52,61 @@ export interface McpToolResultDisplay {
 }
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
-const DEFAULT_MAX_COLLAPSED_LINES = 3;
+const DEFAULT_BOXED_COLLAPSED_LINES = 3;
+const DEFAULT_COMPACT_COLLAPSED_LINES = 1;
 const DEFAULT_MAX_COLLAPSED_CHARS = 8000;
 const COLLAPSED_RENDER_CHAR_SLACK = 8;
+
+class EmptyComponent implements Component {
+  render(): string[] {
+    return [];
+  }
+
+  invalidate(): void {}
+}
+
+class CompactMcpToolResult implements Component {
+  private rendered: { width: number; lines: string[] } | null = null;
+
+  constructor(
+    private readonly title: string,
+    private readonly display: McpToolResultDisplay,
+    private readonly theme: RenderTheme,
+  ) {}
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, Math.floor(width));
+    if (this.rendered?.width === safeWidth) return this.rendered.lines;
+
+    const resultLines = this.display.lines.filter((line, index, lines) => {
+      return !(this.display.truncated && index === lines.length - 1 && line === "…");
+    });
+    const lines = resultLines.length > 0 ? resultLines : [""];
+    const bodies = lines.map((line, index) => {
+      const prefix = index === 0 && this.title ? `${this.theme.fg("toolTitle", this.title)} → ` : "";
+      return `${prefix}${this.theme.fg("toolOutput", line)}`;
+    });
+    const hiddenText = this.display.truncated || bodies.some((body) => visibleWidth(body) > safeWidth);
+    const rendered = bodies.map((body, index) => {
+      const suffix = hiddenText && index === bodies.length - 1 ? " … (Ctrl+O to expand)" : "";
+      if (!suffix) return truncateToWidth(body, safeWidth, "…");
+      if (safeWidth >= suffix.length + 20) {
+        return `${truncateToWidth(body, safeWidth - suffix.length, "…")}${this.theme.fg("muted", suffix)}`;
+      }
+      const shortSuffix = " (Ctrl+O)";
+      if (safeWidth >= shortSuffix.length + 5) {
+        return `${truncateToWidth(body, safeWidth - shortSuffix.length, "…")}${this.theme.fg("muted", shortSuffix)}`;
+      }
+      return truncateToWidth(this.theme.fg("muted", shortSuffix.trim()), safeWidth, "…");
+    });
+    this.rendered = { width: safeWidth, lines: rendered };
+    return rendered;
+  }
+
+  invalidate(): void {
+    this.rendered = null;
+  }
+}
 
 class CollapsibleText implements Component {
   private readonly fullText: Text;
@@ -168,13 +239,52 @@ function renderToolCallLines(lines: string[], theme?: RenderTheme) {
   return new Text([styledTitle, ...styledRest].join("\n"), 0, 0);
 }
 
-export function renderMcpProxyToolCall(args: McpProxyToolCallInput, theme?: RenderTheme) {
-  return renderToolCallLines(formatMcpProxyToolCallLines(args), theme);
+export function resolveMcpToolRenderOptions(settings?: McpToolRenderSettings): McpToolRenderOptions {
+  const resultRendering = settings?.toolResultRendering === "boxed" ? "boxed" : "compact";
+  const collapsedLines = settings?.collapsedResultLines;
+  const defaultLines = resultRendering === "boxed" ? DEFAULT_BOXED_COLLAPSED_LINES : DEFAULT_COMPACT_COLLAPSED_LINES;
+  return {
+    resultRendering,
+    collapsedResultLines: collapsedLines === 1 || collapsedLines === 2 || collapsedLines === 3 ? collapsedLines : defaultLines,
+  };
 }
 
-export function createMcpDirectToolCallRenderer(displayName: string) {
-  return (args: Record<string, unknown>, theme?: RenderTheme) => {
-    return renderToolCallLines(formatMcpDirectToolCallLines(displayName, args), theme);
+function shouldUseCompactFinalRender(options: McpToolRenderOptions, context?: McpToolRenderContext): boolean {
+  return options.resultRendering === "compact"
+    && context !== undefined
+    && context.isPartial === false
+    && context.expanded !== true
+    && context.isError !== true;
+}
+
+function renderToolCall(
+  lines: string[],
+  theme: RenderTheme | undefined,
+  context: McpToolRenderContext | undefined,
+  options: McpToolRenderOptions,
+) {
+  if (context?.state) context.state.compactTitle = lines[0] ?? "mcp";
+  if (shouldUseCompactFinalRender(options, context)) return new EmptyComponent();
+  return renderToolCallLines(lines, theme);
+}
+
+export function renderMcpProxyToolCall(
+  args: McpProxyToolCallInput,
+  theme?: RenderTheme,
+  context?: McpToolRenderContext,
+) {
+  return renderToolCall(formatMcpProxyToolCallLines(args), theme, context, resolveMcpToolRenderOptions());
+}
+
+export function createMcpProxyToolCallRenderer(options: McpToolRenderOptions) {
+  return (args: McpProxyToolCallInput, theme?: RenderTheme, context?: McpToolRenderContext) => {
+    return renderToolCall(formatMcpProxyToolCallLines(args), theme, context, options);
+  };
+}
+
+export function createMcpDirectToolCallRenderer(displayName: string, options = resolveMcpToolRenderOptions()) {
+  return (args: Record<string, unknown>, theme?: RenderTheme, context?: McpToolRenderContext) => {
+    return renderToolCall(formatMcpDirectToolCallLines(displayName, args), theme, context, options);
   };
 }
 
@@ -254,7 +364,7 @@ export function formatMcpToolResultIdentity(details: McpToolResultDetails | unde
 export function formatMcpToolResultLines(
   result: Pick<AgentToolResult<McpToolResultDetails>, "content">,
   expanded: boolean,
-  maxCollapsedLines = 3,
+  maxCollapsedLines = DEFAULT_BOXED_COLLAPSED_LINES,
   maxCollapsedChars = DEFAULT_MAX_COLLAPSED_CHARS,
 ): McpToolResultDisplay {
   if (!expanded) {
@@ -271,6 +381,7 @@ export function renderMcpToolResult(
   options: ToolRenderResultOptions,
   theme?: RenderTheme,
   context?: McpToolRenderContext,
+  renderOptions = resolveMcpToolRenderOptions(),
 ) {
   const activeTheme = theme ?? plainTheme;
   if (options.isPartial) {
@@ -279,7 +390,13 @@ export function renderMcpToolResult(
 
   const hasErrorDetails = Boolean(result.details.error);
   const expanded = options.expanded || context?.isError === true || hasErrorDetails;
-  const display = formatMcpToolResultLines(result, expanded);
+  if (!expanded && renderOptions.resultRendering === "compact") {
+    const display = formatMcpToolResultLines(result, false, renderOptions.collapsedResultLines);
+    const title = context?.state?.compactTitle ?? formatMcpToolResultIdentity(result.details) ?? "";
+    return new CompactMcpToolResult(title, display, activeTheme);
+  }
+
+  const display = formatMcpToolResultLines(result, expanded, renderOptions.collapsedResultLines);
   const identity = formatMcpToolResultIdentity(result.details);
   const output = [
     ...(identity ? [activeTheme.fg("muted", identity)] : []),
@@ -289,9 +406,18 @@ export function renderMcpToolResult(
   return new CollapsibleText(
     output,
     expanded,
-    DEFAULT_MAX_COLLAPSED_LINES + (identity ? 1 : 0),
+    renderOptions.collapsedResultLines + (identity ? 1 : 0),
     activeTheme.fg("muted", "…"),
     activeTheme.fg("muted", "(Ctrl+O to expand)"),
     display.truncated,
   );
+}
+
+export function createMcpToolResultRenderer(renderOptions: McpToolRenderOptions) {
+  return (
+    result: AgentToolResult<McpToolResultDetails>,
+    options: ToolRenderResultOptions,
+    theme?: RenderTheme,
+    context?: McpToolRenderContext,
+  ) => renderMcpToolResult(result, options, theme, context, renderOptions);
 }

--- a/types.ts
+++ b/types.ts
@@ -491,6 +491,10 @@ export interface McpSettings {
   directTools?: boolean;
   /** Register the trusted MCP-only JavaScript scripting tool. Defaults to true; set false to hide it. */
   scriptMode?: boolean;
+  /** Render MCP tool results as compact self-rendered rows by default, or as the legacy boxed row. */
+  toolResultRendering?: "compact" | "boxed";
+  /** Number of result text lines to show before expansion. Supports 1, 2, or 3. Defaults to 1 in compact mode and 3 in boxed mode. */
+  collapsedResultLines?: 1 | 2 | 3;
   /** Default approval gate for matching tools/resources; per-server settings override it. */
   approveTools?: boolean | string[];
   disableProxyTool?: boolean;


### PR DESCRIPTION
## Summary

This adds adapter-owned compact MCP result rows for the proxy and direct tools. Compact mode is the default, while `settings.toolResultRendering: "boxed"` keeps the legacy Pi boxed row available.

It also adds `settings.collapsedResultLines` for 1-3 collapsed result lines. The default is 1 line in compact mode and 3 lines in boxed mode.

This does not claim true zero-gap rendering. Pi still owns one separator row before self-rendered tool output, and the README now documents that host limitation.

Addresses #349.

## Validation

- `npx vitest run __tests__/tool-result-renderer.test.ts __tests__/index-lifecycle.test.ts --reporter=dot`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test -- --reporter=dot`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 npm run test:oauth`
- `npm run test:conformance`
- `npm pack --dry-run`
