### PR TITLE
chore: remove unused TypeScript code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `settings.notifyOnStartupConnect` to suppress successful MCP startup connection notices. Thanks @pierre-mgmt for issue #341.
 - Added compact self-rendered MCP proxy and direct-tool result rows by default, with `settings.toolResultRendering: "boxed"` for the legacy boxed row and `settings.collapsedResultLines` for 1-3 collapsed result lines. Thanks @pierre-mgmt for issue #349.
 
+### Changed
+- Removed unused TypeScript declarations found by stricter compiler checks.
+
 ### Fixed
 - Kept `mcpScript` tool-call replies flowing when Pi runs as a Bun-compiled binary by starting worker execution without module-level top-level await. Thanks @AndreiKopylov for issue #340 and @thesobercoder for the verified fix.
 - Fixed direct-tool server prefixes to preserve provider-valid underscores and hyphens, including `codebase-memory-mcp`, while retaining safe escaping, collision handling, and exact proxy routing. Thanks @mightymatth for issue #342 and @JasonLandbridge for issue #343.

--- a/agent-plugin-loader.ts
+++ b/agent-plugin-loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import { getAgentPath } from "./agent-dir.ts";
 import type { McpConfig, ServerEntry } from "./types.ts";

--- a/commands.ts
+++ b/commands.ts
@@ -12,7 +12,6 @@ import {
   previewSharedServerEntry,
   previewStarterProjectConfig,
   writeDirectToolsConfig,
-  writeProjectServerDisabledOverride,
   writeSharedServerEntry,
   writeStarterProjectConfig,
 } from "./config.ts";

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -459,11 +459,3 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
 }
-
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -19,7 +19,6 @@ export class McpLifecycleManager {
   private activeHealthCheck: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
   private stopped = false;
-  private healthSignal: AbortSignal | undefined;
   private removeHealthAbortListener: (() => void) | undefined;
 
   constructor(
@@ -58,10 +57,8 @@ export class McpLifecycleManager {
     const signal = typeof signalOrInterval === "number" ? undefined : signalOrInterval;
     const intervalMs = typeof signalOrInterval === "number" ? signalOrInterval : maybeIntervalMs;
     this.stopped = false;
-    this.healthSignal = signal;
     if (signal?.aborted) {
       this.stopped = true;
-      this.healthSignal = undefined;
       return;
     }
     const stop = () => {
@@ -138,7 +135,6 @@ export class McpLifecycleManager {
     this.healthCheckInterval = undefined;
     this.removeHealthAbortListener?.();
     this.removeHealthAbortListener = undefined;
-    this.healthSignal = undefined;
     await this.activeHealthCheck;
     this.activeHealthCheck = undefined;
     this.onReconnect = undefined;

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -16,7 +16,6 @@ process.env.MCP_OAUTH_DIR = TEST_DIR
 import {
   authenticate,
   startAuth,
-  completeAuth,
   getAuthStatus,
   getValidToken,
   removeAuth,
@@ -25,7 +24,6 @@ import {
   initializeOAuth,
   shutdownOAuth,
   waitForAuthorizationResponse,
-  type AuthStatus,
 } from "./mcp-auth-flow.ts"
 import { isCallbackServerRunning } from "./mcp-callback-server.ts"
 import { updateTokens, updateClientInfo, getAuthForUrl, clearAllCredentials } from "./mcp-auth.ts"

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -633,7 +633,6 @@ export async function completeAuthFromInput(
   const signal = combineAbortSignals(runtime.signal, options.signal)
   throwIfAborted(signal)
   const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
-  const authStorageOptions = runtimeState.pendingAuths.get(key)?.authStorageOptions ?? fallbackAuthStorageOptions
   const oauthState = runtimeState.pendingAuthStates.get(key)
   throwIfAborted(signal)
   const parsed = parseAuthorizationRedirectInput(input, oauthState)
@@ -899,7 +898,7 @@ export async function getValidToken(
  * @returns The current auth status
  */
 export async function getAuthStatus(serverName: string, options: AuthenticateOptions = {}): Promise<AuthStatus> {
-  const runtime = getRuntime(options)
+  getRuntime(options)
   const authStorageOptions = options.authStorageOptions ?? {}
   const hasTokens = await hasStoredTokens(serverName, authStorageOptions)
   if (!hasTokens) return "not_authenticated"

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -415,7 +415,6 @@ describe("McpOAuthProvider", () => {
 
     it("should calculate expires_in from stored expiresAt", async () => {
       const provider = createProvider()
-      const futureTime = Math.floor(Date.now() / 1000) + 3600
 
       await provider.saveTokens({
         access_token: "access",

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -118,8 +118,8 @@ class CollapsibleText implements Component {
     private readonly text: string,
     private readonly expanded: boolean,
     private readonly maxCollapsedLines: number,
-    private readonly ellipsis: string,
-    private readonly expandHint: string,
+    ellipsis: string,
+    expandHint: string,
     private readonly preTruncated = false,
   ) {
     this.fullText = new Text(text, 0, 0);


### PR DESCRIPTION
## Summary

This is a small TypeScript cleanup pass. It removes unused imports, fields, locals, and one dead helper found by running stricter compiler checks.

There is no intended runtime behavior change.

## Validation

- `npx tsc --noEmit --pretty false --noUnusedLocals --noUnusedParameters`
- `npm run typecheck -- --pretty false`
- `npx vitest run __tests__/tool-result-renderer.test.ts __tests__/host-html-template.test.ts __tests__/lifecycle-lazy-keep-alive.test.ts --reporter=dot`
- `npm run test:oauth`
- `npm pack --dry-run`
- `npm install --prefix examples/interactive-visualizer --no-package-lock --no-audit --no-fund`
- `npm run --prefix examples/interactive-visualizer build`
- `npm test -- --reporter=dot`
- `git diff --check`
