### PR TITLE
Add per-request HTTP header command hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added per-server `requestHeadersCommand` support for deriving fail-closed HTTP headers from the exact outbound request on every Streamable HTTP or SSE call. Thanks @kgreen18 for PR #353.
 - Added `settings.warnOnLargeDirectTools` to suppress the advisory for 75 or more resolved direct tools. Thanks @Roshvan for issue #358.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `cwd` | Working directory; supports `${VAR}`, `$env:VAR`, and `~` expansion |
 | `url` | HTTP endpoint (StreamableHTTP with SSE fallback); supports raw `${VAR}` and `$env:VAR` interpolation, and missing URL variables fail before any request is sent |
 | `headers` | HTTP headers; supports `${VAR}` and `$env:VAR` interpolation. A value beginning with `!` runs a command when the HTTP server connects or OAuth authenticates; use `!!` for a literal leading `!`. |
+| `requestHeadersCommand` | Trusted executable run for every HTTP request. It receives a versioned JSON envelope containing `method`, `url`, and the exact `bodyBase64` on stdin, and must return a JSON object of headers on stdout. `command`, `args`, and `env` support environment interpolation. Use for caller-bound request signatures; failures stop the request. |
 | `auth` | `"bearer"` or `"oauth"` |
 | `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
 | `oauth.clientId` | Pre-registered OAuth client ID. MCP 2026 prefers pre-registered clients or Client ID Metadata Documents; this adapter falls back to Dynamic Client Registration when the ID is omitted and the server supports it. |

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -900,6 +900,25 @@ describe("config discovery", () => {
     expect(JSON.stringify(entry)).not.toContain("secret-bearer-token");
   });
 
+  it("drops an inherited request headers command when a url-only override repoints the server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-rhc-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-rhc-project-"));
+    writeBakedAndOverride(
+      home,
+      project,
+      { url: URL_A, requestHeadersCommand: { command: "sign-old-url", args: ["${REQUEST_SECRET}"] } },
+      { url: URL_B },
+    );
+
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    const entry = config.mcpServers.litellm;
+    expect(entry).toEqual({ url: URL_B });
+    expect(entry.requestHeadersCommand).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain("REQUEST_SECRET");
+  });
+
   it("drops inherited oauth config when a url-only override repoints the server", async () => {
     const home = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-oauth-home-"));
     const project = mkdtempSync(join(tmpdir(), "pi-mcp-urlauth-oauth-project-"));

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -354,6 +354,30 @@ describe("metadata cache hashing", () => {
     );
   });
 
+  it("hashes the effective per-request header command", () => {
+    process.env.MCP_SIGNER_ACTOR = "actor-one";
+    const first = computeServerHash({
+      url: "https://example.test/mcp",
+      requestHeadersCommand: {
+        command: "node",
+        args: ["sign.mjs", "${MCP_SIGNER_ACTOR}"],
+        env: { ACTOR: "$env:MCP_SIGNER_ACTOR" },
+      },
+    });
+
+    process.env.MCP_SIGNER_ACTOR = "actor-two";
+    const second = computeServerHash({
+      url: "https://example.test/mcp",
+      requestHeadersCommand: {
+        command: "node",
+        args: ["sign.mjs", "${MCP_SIGNER_ACTOR}"],
+        env: { ACTOR: "$env:MCP_SIGNER_ACTOR" },
+      },
+    });
+
+    expect(first).not.toBe(second);
+  });
+
   it("hashes tilde cwd as the home directory", () => {
     expect(computeServerHash({ command: "node", cwd: "~/server" })).toBe(
       computeServerHash({ command: "node", cwd: join(homedir(), "server") }),

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -90,9 +90,10 @@ describe("per-request HTTP header commands", () => {
   it("kills a command that keeps running after timeout", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const script = commandScript(`
+import { writeFileSync } from "node:fs";
 process.on("SIGTERM", () => {});
 setTimeout(() => {
-  require("node:fs").writeFileSync(${JSON.stringify(marker)}, "alive");
+  writeFileSync(${JSON.stringify(marker)}, "alive");
 }, 100);
 setInterval(() => {}, 1000);
 `);
@@ -157,7 +158,7 @@ setInterval(() => {}, 1000);
 import { writeFileSync } from "node:fs";
 setTimeout(() => {
   writeFileSync(${JSON.stringify(marker)}, "alive");
-}, 100);
+}, 150);
 setInterval(() => {}, 1000);
 `);
     const spawner = commandScript(`
@@ -169,13 +170,54 @@ import { spawn } from "node:child_process";
 spawn(process.execPath, [${JSON.stringify(spawner)}], { stdio: "ignore" });
 setInterval(() => {}, 1000);
 `);
-    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 50 });
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 75 });
 
     await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
-      "HTTP request headers command timed out after 50ms",
+      "HTTP request headers command timed out after 75ms",
     );
-    await delay(200);
+    await delay(220);
     expect(existsSync(marker)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed and kills the command when descendant tracking fails", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const script = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 100);
+setInterval(() => {}, 1000);
+`);
+    process.env.PI_MCP_ADAPTER_TEST_FAIL_PS = "1";
+    try {
+      const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 25 });
+
+      await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+        "HTTP request headers command cleanup failed: ps exited with code 1",
+      );
+      await delay(200);
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      delete process.env.PI_MCP_ADAPTER_TEST_FAIL_PS;
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed when descendant tracking fails before successful output", async () => {
+    const script = commandScript(`
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({ "x-derived": "ok" }));
+}, 75);
+`);
+    process.env.PI_MCP_ADAPTER_TEST_FAIL_PS = "1";
+    try {
+      const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+
+      await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+        "HTTP request headers command cleanup failed: ps exited with code 1",
+      );
+    } finally {
+      delete process.env.PI_MCP_ADAPTER_TEST_FAIL_PS;
+    }
   });
 
   it("validates configuration before issuing a request", () => {

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -112,6 +112,58 @@ setTimeout(() => {
     );
   });
 
+  it.skipIf(process.platform === "win32")("kills helpers when the command returns valid output", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const helper = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 150);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(helper)}], { stdio: "ignore" }).unref();
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({ "x-derived": "ok" }));
+}, 75);
+`);
+    const fetch = createRequestHeadersCommandFetch(
+      { command: process.execPath, args: [script] },
+      async () => new Response("ok"),
+    );
+
+    const response = await fetch("https://mcp.example.test/mcp");
+    expect(response.status).toBe(200);
+    await delay(220);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("kills helpers when the command returns malformed output", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const helper = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 150);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(helper)}], { stdio: "ignore" }).unref();
+setTimeout(() => {
+  process.stdout.write("not-json");
+}, 75);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command returned invalid JSON",
+    );
+    await delay(220);
+    expect(existsSync(marker)).toBe(false);
+  });
+
   it("kills a command that keeps running after timeout", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const script = commandScript(`

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { createRequestHeadersCommandFetch } from "../request-headers-command.ts";
+
+function commandScript(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-"));
+  const path = join(dir, "command.mjs");
+  writeFileSync(path, source);
+  return path;
+}
+
+const readEnvelope = `
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => { input += chunk; });
+process.stdin.on("end", () => {
+  const request = JSON.parse(input);
+  const body = Buffer.from(request.bodyBase64, "base64").toString("utf8");
+  process.stdout.write(JSON.stringify({
+    "x-derived-method": request.method,
+    "x-derived-body": body,
+    "x-derived-actor": process.env.TEST_ACTOR,
+  }));
+});
+`;
+
+describe("per-request HTTP header commands", () => {
+  it("derives headers from the exact request and preserves existing headers", async () => {
+    const script = commandScript(readEnvelope);
+    let forwarded: Request | undefined;
+    const fetch = createRequestHeadersCommandFetch({
+      command: process.execPath,
+      args: [script],
+      env: { TEST_ACTOR: "actor-123" },
+    }, async (input, init) => {
+      forwarded = new Request(input, init);
+      return new Response("ok");
+    });
+
+    await fetch("https://mcp.example.test/mcp", {
+      method: "POST",
+      headers: { "x-existing": "kept" },
+      body: "exact MCP bytes",
+    });
+
+    expect(forwarded?.headers.get("x-existing")).toBe("kept");
+    expect(forwarded?.headers.get("x-derived-method")).toBe("POST");
+    expect(forwarded?.headers.get("x-derived-body")).toBe("exact MCP bytes");
+    expect(forwarded?.headers.get("x-derived-actor")).toBe("actor-123");
+  });
+
+  it("runs for every request instead of caching derived headers", async () => {
+    const script = commandScript(readEnvelope);
+    const bodies: string[] = [];
+    const fetch = createRequestHeadersCommandFetch({
+      command: process.execPath,
+      args: [script],
+    }, async (input, init) => {
+      bodies.push(new Request(input, init).headers.get("x-derived-body") ?? "");
+      return new Response("ok");
+    });
+
+    await fetch("https://mcp.example.test/mcp", { method: "POST", body: "one" });
+    await fetch("https://mcp.example.test/mcp", { method: "POST", body: "two" });
+    expect(bodies).toEqual(["one", "two"]);
+  });
+
+  it("fails closed when the command exits unsuccessfully", async () => {
+    const script = commandScript("process.exit(7);\n");
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command exited with code 7",
+    );
+  });
+
+  it("fails closed on malformed command output", async () => {
+    const script = commandScript('process.stdout.write("not-json");\n');
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command returned invalid JSON",
+    );
+  });
+
+  it("validates configuration before issuing a request", () => {
+    expect(() => createRequestHeadersCommandFetch({ command: "" })).toThrow(
+      "requires a non-empty command",
+    );
+    expect(() => createRequestHeadersCommandFetch({ command: "node", timeoutMs: 0 })).toThrow(
+      "timeoutMs must be an integer between 1 and 60000",
+    );
+  });
+});

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -108,13 +108,38 @@ setInterval(() => {}, 1000);
   it.skipIf(process.platform === "win32")("kills descendant commands after timeout", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const descendant = commandScript(`
+import { writeFileSync } from "node:fs";
 setTimeout(() => {
-  require("node:fs").writeFileSync(${JSON.stringify(marker)}, "alive");
+  writeFileSync(${JSON.stringify(marker)}, "alive");
 }, 100);
 setInterval(() => {}, 1000);
 `);
     const script = commandScript(`
-require("node:child_process").spawn(process.execPath, [${JSON.stringify(descendant)}], { stdio: "ignore" });
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(descendant)}], { stdio: "ignore" });
+setInterval(() => {}, 1000);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 25 });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command timed out after 25ms",
+    );
+    await delay(200);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("kills descendants that move into another process group", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const descendant = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 100);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(descendant)}], { detached: true, stdio: "ignore" });
 setInterval(() => {}, 1000);
 `);
     const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 25 });

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -9,6 +9,10 @@ function commandScript(source: string): string {
   const path = join(dir, "command.mjs");
   writeFileSync(path, source);
   return path;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 const readEnvelope = `
@@ -81,6 +85,45 @@ describe("per-request HTTP header commands", () => {
     await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
       "HTTP request headers command returned invalid JSON",
     );
+  });
+
+  it("kills a command that keeps running after timeout", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const script = commandScript(`
+process.on("SIGTERM", () => {});
+setTimeout(() => {
+  require("node:fs").writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 100);
+setInterval(() => {}, 1000);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 25 });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command timed out after 25ms",
+    );
+    await delay(200);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("kills descendant commands after timeout", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const descendant = commandScript(`
+setTimeout(() => {
+  require("node:fs").writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 100);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+require("node:child_process").spawn(process.execPath, [${JSON.stringify(descendant)}], { stdio: "ignore" });
+setInterval(() => {}, 1000);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 25 });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command timed out after 25ms",
+    );
+    await delay(200);
+    expect(existsSync(marker)).toBe(false);
   });
 
   it("validates configuration before issuing a request", () => {

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -256,7 +256,7 @@ setInterval(() => {}, 1000);
     expect(existsSync(marker)).toBe(false);
   });
 
-  it.skipIf(process.platform === "win32")("fails closed and kills the command when descendant tracking fails", async () => {
+  it.skipIf(process.platform === "win32")("fails closed before running the command when process discovery fails", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const script = commandScript(`
 import { writeFileSync } from "node:fs";
@@ -279,7 +279,7 @@ setInterval(() => {}, 1000);
     }
   });
 
-  it.skipIf(process.platform === "win32")("fails closed and kills helpers when tracking fails before successful output", async () => {
+  it.skipIf(process.platform === "win32")("fails closed before running helpers when process discovery fails before successful output", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const helper = commandScript(`
 import { writeFileSync } from "node:fs";
@@ -309,7 +309,7 @@ setTimeout(() => {
     }
   });
 
-  it.skipIf(process.platform === "win32")("fails closed and kills helpers when tracking fails before unsuccessful output", async () => {
+  it.skipIf(process.platform === "win32")("fails closed before running helpers when process discovery fails before unsuccessful output", async () => {
     const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
     const helper = commandScript(`
 import { writeFileSync } from "node:fs";

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -232,6 +232,36 @@ setTimeout(() => {
     }
   });
 
+  it.skipIf(process.platform === "win32")("fails closed and kills helpers when tracking fails before unsuccessful output", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const helper = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 150);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(helper)}], { stdio: "ignore" }).unref();
+setTimeout(() => {
+  process.exit(1);
+}, 75);
+`);
+    process.env.PI_MCP_ADAPTER_TEST_FAIL_PS = "1";
+    try {
+      const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+
+      await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+        "HTTP request headers command cleanup failed: ps exited with code 1",
+      );
+      await delay(220);
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      delete process.env.PI_MCP_ADAPTER_TEST_FAIL_PS;
+    }
+  });
+
   it("validates configuration before issuing a request", () => {
     expect(() => createRequestHeadersCommandFetch({ command: "" })).toThrow(
       "requires a non-empty command",

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -202,8 +202,18 @@ setInterval(() => {}, 1000);
     }
   });
 
-  it.skipIf(process.platform === "win32")("fails closed when descendant tracking fails before successful output", async () => {
+  it.skipIf(process.platform === "win32")("fails closed and kills helpers when tracking fails before successful output", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const helper = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 150);
+setInterval(() => {}, 1000);
+`);
     const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(helper)}], { stdio: "ignore" }).unref();
 setTimeout(() => {
   process.stdout.write(JSON.stringify({ "x-derived": "ok" }));
 }, 75);
@@ -215,6 +225,8 @@ setTimeout(() => {
       await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
         "HTTP request headers command cleanup failed: ps exited with code 1",
       );
+      await delay(220);
+      expect(existsSync(marker)).toBe(false);
     } finally {
       delete process.env.PI_MCP_ADAPTER_TEST_FAIL_PS;
     }

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -79,6 +79,31 @@ describe("per-request HTTP header commands", () => {
     );
   });
 
+  it.skipIf(process.platform === "win32")("kills helpers when the command exits unsuccessfully", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const helper = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 150);
+setInterval(() => {}, 1000);
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(helper)}], { stdio: "ignore" }).unref();
+setTimeout(() => {
+  process.exit(7);
+}, 75);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command exited with code 7",
+    );
+    await delay(220);
+    expect(existsSync(marker)).toBe(false);
+  });
+
   it("fails closed on malformed command output", async () => {
     const script = commandScript('process.stdout.write("not-json");\n');
     const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -151,6 +151,33 @@ setInterval(() => {}, 1000);
     expect(existsSync(marker)).toBe(false);
   });
 
+  it.skipIf(process.platform === "win32")("kills descendants that reparent before timeout", async () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-")), "marker");
+    const descendant = commandScript(`
+import { writeFileSync } from "node:fs";
+setTimeout(() => {
+  writeFileSync(${JSON.stringify(marker)}, "alive");
+}, 100);
+setInterval(() => {}, 1000);
+`);
+    const spawner = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(descendant)}], { detached: true, stdio: "ignore" }).unref();
+`);
+    const script = commandScript(`
+import { spawn } from "node:child_process";
+spawn(process.execPath, [${JSON.stringify(spawner)}], { stdio: "ignore" });
+setInterval(() => {}, 1000);
+`);
+    const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script], timeoutMs: 50 });
+
+    await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+      "HTTP request headers command timed out after 50ms",
+    );
+    await delay(200);
+    expect(existsSync(marker)).toBe(false);
+  });
+
   it("validates configuration before issuing a request", () => {
     expect(() => createRequestHeadersCommandFetch({ command: "" })).toThrow(
       "requires a non-empty command",

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -18,6 +18,7 @@ type TransportOptions = {
   };
   authProvider?: OAuthProviderLike;
   skipIssuerMetadataValidation?: boolean;
+  fetch?: (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
 };
 
 type HttpTransportMock = {
@@ -208,6 +209,26 @@ describe("McpServerManager HTTP bearer auth", () => {
 
     expect(mocks.httpTransports.at(-1)!.options.requestInit?.headers?.["X-Goog-Api-Key"]).toBe("api-key");
     expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
+  });
+
+  it("passes the per-request header command fetch to Streamable HTTP and SSE", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    mocks.connectErrors.push(new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "POST is not supported",
+      { status: 405 },
+    ));
+
+    const manager = new McpServerManager();
+    await manager.connect("signed", {
+      url: "https://example.test/mcp",
+      requestHeadersCommand: { command: process.execPath, args: ["--version"] },
+    });
+
+    expect(mocks.httpTransports).toHaveLength(1);
+    expect(mocks.sseTransports).toHaveLength(1);
+    expect(mocks.httpTransports[0].options.fetch).toBeTypeOf("function");
+    expect(mocks.sseTransports[0].options.fetch).toBe(mocks.httpTransports[0].options.fetch);
   });
 
   it("preserves OAuth redirect URI, client metadata, and issuer opt-out for HTTP transports", async () => {

--- a/config.ts
+++ b/config.ts
@@ -471,7 +471,7 @@ function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
 // different url, these MUST NOT be inherited from the lower-precedence entry —
 // otherwise the original endpoint's credentials would be shipped to the new
 // url. See the SECURITY note in mergeServerMaps.
-const URL_BOUND_AUTH_FIELDS = ["headers", "bearerToken", "bearerTokenEnv"] as const;
+const URL_BOUND_AUTH_FIELDS = ["headers", "bearerToken", "bearerTokenEnv", "requestHeadersCommand"] as const;
 
 function mergeServerMaps(
   base: Record<string, ServerEntry>,

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -24,6 +24,7 @@ import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
   interpolateEnvRecord,
+  interpolateEnvVars,
   resolveBearerToken,
   resolveConfigPath,
   resolveServerUrl,
@@ -90,6 +91,14 @@ export function computeServerHash(definition: ServerEntry): string {
     cwd: resolveConfigPath(definition.cwd),
     url: resolveServerUrl(definition),
     headers: interpolateEnvRecord(definition.headers),
+    requestHeadersCommand: definition.requestHeadersCommand
+      ? {
+          command: interpolateEnvVars(definition.requestHeadersCommand.command),
+          args: definition.requestHeadersCommand.args?.map(interpolateEnvVars),
+          env: interpolateEnvRecord(definition.requestHeadersCommand.env),
+          timeoutMs: definition.requestHeadersCommand.timeoutMs,
+        }
+      : undefined,
     auth: definition.auth,
     protocolVersion: definition.protocolVersion,
     bearerToken: resolveBearerToken(definition),

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ui-app-bridge-helpers.ts",
     "config.ts",
     "server-manager.ts",
+    "request-headers-command.ts",
     "unix-socket-transport.ts",
     "json-schema-validator.ts",
     "session-recovery.ts",

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -245,12 +245,12 @@ async function invokeRequestHeadersCommand(
     });
     child.on("close", code => {
       if (settled) return;
-      if (code !== 0) {
-        finish(new Error(`HTTP request headers command exited with code ${code ?? "unknown"}`));
-        return;
-      }
       if (trackingError) {
         failAfterKill(trackingError.message);
+        return;
+      }
+      if (code !== 0) {
+        finish(new Error(`HTTP request headers command exited with code ${code ?? "unknown"}`));
         return;
       }
       let parsed: unknown;

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -13,7 +13,9 @@ function isNoSuchProcessError(error: unknown): boolean {
 
 function collectPosixDescendantPids(rootPid: number): number[] {
   const result = spawnSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf8" });
-  if (result.status !== 0) return [];
+  if (result.status !== 0) {
+    throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
+  }
 
   const childrenByParent = new Map<number, number[]>();
   for (const line of result.stdout.split("\n")) {
@@ -36,9 +38,21 @@ function collectPosixDescendantPids(rootPid: number): number[] {
   return descendants;
 }
 
-function killPid(pid: number): void {
+function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {
+  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.toLowerCase().includes("not found");
+}
+
+function signalPid(pid: number, signal: NodeJS.Signals): void {
   try {
-    process.kill(pid, "SIGKILL");
+    process.kill(pid, signal);
+  } catch (error) {
+    if (!isNoSuchProcessError(error)) throw error;
+  }
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
   } catch (error) {
     if (!isNoSuchProcessError(error)) throw error;
   }
@@ -47,20 +61,18 @@ function killPid(pid: number): void {
 function killRequestHeadersCommand(child: ChildProcess): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
-      stdio: "ignore",
+      encoding: "utf8",
       windowsHide: true,
     });
-    if (result.status === 0) return;
+    if (result.status === 0 || isTaskkillNoSuchProcess(result)) return;
+    throw new Error(`HTTP request headers command cleanup failed: taskkill exited with code ${result.status ?? "unknown"}`);
   }
 
-  const descendantPids = USE_PROCESS_GROUP && child.pid !== undefined ? collectPosixDescendantPids(child.pid) : [];
   if (USE_PROCESS_GROUP && child.pid !== undefined) {
-    try {
-      process.kill(-child.pid, "SIGKILL");
-    } catch (error) {
-      if (!isNoSuchProcessError(error)) throw error;
-    }
-    for (const pid of descendantPids) killPid(pid);
+    signalProcessGroup(child.pid, "SIGSTOP");
+    const descendantPids = collectPosixDescendantPids(child.pid);
+    signalProcessGroup(child.pid, "SIGKILL");
+    for (const pid of descendantPids) signalPid(pid, "SIGKILL");
     return;
   }
 
@@ -137,13 +149,19 @@ async function invokeRequestHeadersCommand(
       if (error) reject(error);
       else resolve(headers!);
     };
+    const failAfterKill = (message: string) => {
+      try {
+        killRequestHeadersCommand(child);
+        finish(new Error(message));
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    };
     const abort = () => {
-      killRequestHeadersCommand(child);
-      finish(new Error("HTTP request headers command aborted"));
+      failAfterKill("HTTP request headers command aborted");
     };
     const timer = setTimeout(() => {
-      killRequestHeadersCommand(child);
-      finish(new Error(`HTTP request headers command timed out after ${resolved.timeoutMs}ms`));
+      failAfterKill(`HTTP request headers command timed out after ${resolved.timeoutMs}ms`);
     }, resolved.timeoutMs);
 
     signal.addEventListener("abort", abort, { once: true });
@@ -157,8 +175,7 @@ async function invokeRequestHeadersCommand(
       if (settled) return;
       stdout = Buffer.concat([stdout, Buffer.from(chunk)]);
       if (stdout.byteLength > MAX_OUTPUT_BYTES) {
-        killRequestHeadersCommand(child);
-        finish(new Error("HTTP request headers command output exceeded 64 KiB"));
+        failAfterKill("HTTP request headers command output exceeded 64 KiB");
       }
     });
     child.on("close", code => {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -250,7 +250,7 @@ async function invokeRequestHeadersCommand(
         return;
       }
       if (code !== 0) {
-        finish(new Error(`HTTP request headers command exited with code ${code ?? "unknown"}`));
+        failAfterKill(`HTTP request headers command exited with code ${code ?? "unknown"}`);
         return;
       }
       let parsed: unknown;

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -63,6 +63,11 @@ function collectPosixCleanupTokenPids(cleanupToken: string): number[] {
   return pids;
 }
 
+function assertPosixProcessDiscoveryAvailable(): void {
+  collectPosixDescendantPids(process.pid);
+  collectPosixCleanupTokenPids(`${process.pid}-preflight`);
+}
+
 function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {
   return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.toLowerCase().includes("not found");
 }
@@ -102,13 +107,19 @@ function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPi
         signalPid(pid, "SIGSTOP");
         frozenPids.add(pid);
       }
-      for (let pass = 0; pass < 8; pass++) {
+      let stablePasses = 0;
+      for (let pass = 0; pass < 16; pass++) {
         const candidates = [
           ...collectPosixDescendantPids(child.pid),
           ...(cleanupToken ? collectPosixCleanupTokenPids(cleanupToken) : []),
         ];
         const newPids = candidates.filter(pid => !frozenPids.has(pid));
-        if (newPids.length === 0) return;
+        if (newPids.length === 0) {
+          stablePasses++;
+          if (stablePasses >= 2) return;
+          continue;
+        }
+        stablePasses = 0;
         for (const pid of newPids) {
           signalPid(pid, "SIGSTOP");
           frozenPids.add(pid);
@@ -180,6 +191,7 @@ async function invokeRequestHeadersCommand(
   signal: AbortSignal,
 ): Promise<Headers> {
   const resolved = resolvedCommand(config);
+  if (USE_PROCESS_GROUP) assertPosixProcessDiscoveryAvailable();
   return new Promise<Headers>((resolve, reject) => {
     let stdout = Buffer.alloc(0);
     let settled = false;

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -11,6 +11,39 @@ function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";
 }
 
+function collectPosixDescendantPids(rootPid: number): number[] {
+  const result = spawnSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf8" });
+  if (result.status !== 0) return [];
+
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of result.stdout.split("\n")) {
+    const [pidText, ppidText] = line.trim().split(/\s+/, 2);
+    const pid = Number(pidText);
+    const ppid = Number(ppidText);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    const children = childrenByParent.get(ppid);
+    if (children) children.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+
+  const descendants: number[] = [];
+  const stack = [...(childrenByParent.get(rootPid) ?? [])];
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    descendants.push(pid);
+    stack.push(...(childrenByParent.get(pid) ?? []));
+  }
+  return descendants;
+}
+
+function killPid(pid: number): void {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if (!isNoSuchProcessError(error)) throw error;
+  }
+}
+
 function killRequestHeadersCommand(child: ChildProcess): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
@@ -20,15 +53,18 @@ function killRequestHeadersCommand(child: ChildProcess): void {
     if (result.status === 0) return;
   }
 
-  try {
-    if (USE_PROCESS_GROUP && child.pid !== undefined) {
+  const descendantPids = USE_PROCESS_GROUP && child.pid !== undefined ? collectPosixDescendantPids(child.pid) : [];
+  if (USE_PROCESS_GROUP && child.pid !== undefined) {
+    try {
       process.kill(-child.pid, "SIGKILL");
-      return;
+    } catch (error) {
+      if (!isNoSuchProcessError(error)) throw error;
     }
-    child.kill("SIGKILL");
-  } catch (error) {
-    if (!isNoSuchProcessError(error)) throw error;
+    for (const pid of descendantPids) killPid(pid);
+    return;
   }
+
+  child.kill("SIGKILL");
 }
 
 export interface HttpRequestCommandEnvelope {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import type { FetchLike } from "@modelcontextprotocol/client";
 import type { HttpRequestHeadersCommand } from "./types.ts";
 import { interpolateEnvVars } from "./utils.ts";
@@ -6,13 +7,19 @@ import { interpolateEnvVars } from "./utils.ts";
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const USE_PROCESS_GROUP = process.platform !== "win32";
+const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
 
 function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";
 }
 
+function runPosixPs(args: string[]): { status: number | null; stdout: string } {
+  if (process.env.PI_MCP_ADAPTER_TEST_FAIL_PS === "1") return { status: 1, stdout: "" };
+  return spawnSync("ps", args, { encoding: "utf8" });
+}
+
 function collectPosixDescendantPids(rootPid: number): number[] {
-  const result = spawnSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf8" });
+  const result = runPosixPs(["-axo", "pid=,ppid="]);
   if (result.status !== 0) {
     throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
   }
@@ -38,6 +45,24 @@ function collectPosixDescendantPids(rootPid: number): number[] {
   return descendants;
 }
 
+function collectPosixCleanupTokenPids(cleanupToken: string): number[] {
+  const result = runPosixPs(["eww", "-axo", "pid=,command="]);
+  if (result.status !== 0) {
+    throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
+  }
+
+  const needle = `${CLEANUP_TOKEN_ENV}=${cleanupToken}`;
+  const pids: number[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.includes(needle)) continue;
+    const [pidText] = trimmed.split(/\s+/, 1);
+    const pid = Number(pidText);
+    if (Number.isInteger(pid) && pid !== process.pid) pids.push(pid);
+  }
+  return pids;
+}
+
 function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {
   return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.toLowerCase().includes("not found");
 }
@@ -58,7 +83,7 @@ function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
   }
 }
 
-function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPids = new Set<number>()): void {
+function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPids = new Set<number>(), cleanupToken?: string): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       encoding: "utf8",
@@ -78,7 +103,11 @@ function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPi
         frozenPids.add(pid);
       }
       for (let pass = 0; pass < 8; pass++) {
-        const newPids = collectPosixDescendantPids(child.pid).filter(pid => !frozenPids.has(pid));
+        const candidates = [
+          ...collectPosixDescendantPids(child.pid),
+          ...(cleanupToken ? collectPosixCleanupTokenPids(cleanupToken) : []),
+        ];
+        const newPids = candidates.filter(pid => !frozenPids.has(pid));
         if (newPids.length === 0) return;
         for (const pid of newPids) {
           signalPid(pid, "SIGSTOP");
@@ -154,20 +183,26 @@ async function invokeRequestHeadersCommand(
   return new Promise<Headers>((resolve, reject) => {
     let stdout = Buffer.alloc(0);
     let settled = false;
+    const cleanupToken = randomUUID();
     const child = spawn(resolved.command, resolved.args, {
-      env: resolved.env,
+      env: { ...resolved.env, [CLEANUP_TOKEN_ENV]: cleanupToken },
       stdio: ["pipe", "pipe", "ignore"],
       windowsHide: true,
       detached: USE_PROCESS_GROUP,
     });
 
     const trackedPosixDescendantPids = new Set<number>();
+    let trackingError: Error | undefined;
     const trackPosixDescendants = () => {
-      if (!USE_PROCESS_GROUP || child.pid === undefined || settled) return;
-      for (const pid of collectPosixDescendantPids(child.pid)) trackedPosixDescendantPids.add(pid);
+      if (!USE_PROCESS_GROUP || child.pid === undefined || settled || trackingError) return;
+      try {
+        for (const pid of collectPosixDescendantPids(child.pid)) trackedPosixDescendantPids.add(pid);
+        for (const pid of collectPosixCleanupTokenPids(cleanupToken)) trackedPosixDescendantPids.add(pid);
+      } catch (error) {
+        trackingError = error instanceof Error ? error : new Error(String(error));
+      }
     };
-    trackPosixDescendants();
-    const descendantTracker = USE_PROCESS_GROUP ? setInterval(trackPosixDescendants, 10) : undefined;
+    const descendantTracker = USE_PROCESS_GROUP ? setInterval(trackPosixDescendants, 50) : undefined;
     descendantTracker?.unref();
 
     const finish = (error?: Error, headers?: Headers) => {
@@ -181,9 +216,8 @@ async function invokeRequestHeadersCommand(
     };
     const failAfterKill = (message: string) => {
       try {
-        trackPosixDescendants();
-        killRequestHeadersCommand(child, trackedPosixDescendantPids);
-        finish(new Error(message));
+        killRequestHeadersCommand(child, trackedPosixDescendantPids, cleanupToken);
+        finish(trackingError ?? new Error(message));
       } catch (error) {
         finish(error instanceof Error ? error : new Error(String(error)));
       }
@@ -213,6 +247,10 @@ async function invokeRequestHeadersCommand(
       if (settled) return;
       if (code !== 0) {
         finish(new Error(`HTTP request headers command exited with code ${code ?? "unknown"}`));
+        return;
+      }
+      if (trackingError) {
+        finish(trackingError);
         return;
       }
       let parsed: unknown;

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -69,10 +69,26 @@ function killRequestHeadersCommand(child: ChildProcess): void {
   }
 
   if (USE_PROCESS_GROUP && child.pid !== undefined) {
-    signalProcessGroup(child.pid, "SIGSTOP");
-    const descendantPids = collectPosixDescendantPids(child.pid);
-    signalProcessGroup(child.pid, "SIGKILL");
-    for (const pid of descendantPids) signalPid(pid, "SIGKILL");
+    const frozenPids = new Set<number>();
+    let cleanupError: Error | undefined;
+    try {
+      signalProcessGroup(child.pid, "SIGSTOP");
+      for (let pass = 0; pass < 8; pass++) {
+        const newPids = collectPosixDescendantPids(child.pid).filter(pid => !frozenPids.has(pid));
+        if (newPids.length === 0) return;
+        for (const pid of newPids) {
+          signalPid(pid, "SIGSTOP");
+          frozenPids.add(pid);
+        }
+      }
+      cleanupError = new Error("HTTP request headers command cleanup failed: descendant process tree did not stabilize");
+    } catch (error) {
+      cleanupError = error instanceof Error ? error : new Error(String(error));
+    } finally {
+      signalProcessGroup(child.pid, "SIGKILL");
+      for (const pid of frozenPids) signalPid(pid, "SIGKILL");
+    }
+    if (cleanupError) throw cleanupError;
     return;
   }
 

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -58,7 +58,7 @@ function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
   }
 }
 
-function killRequestHeadersCommand(child: ChildProcess): void {
+function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPids = new Set<number>()): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       encoding: "utf8",
@@ -73,6 +73,10 @@ function killRequestHeadersCommand(child: ChildProcess): void {
     let cleanupError: Error | undefined;
     try {
       signalProcessGroup(child.pid, "SIGSTOP");
+      for (const pid of trackedPosixDescendantPids) {
+        signalPid(pid, "SIGSTOP");
+        frozenPids.add(pid);
+      }
       for (let pass = 0; pass < 8; pass++) {
         const newPids = collectPosixDescendantPids(child.pid).filter(pid => !frozenPids.has(pid));
         if (newPids.length === 0) return;
@@ -157,17 +161,28 @@ async function invokeRequestHeadersCommand(
       detached: USE_PROCESS_GROUP,
     });
 
+    const trackedPosixDescendantPids = new Set<number>();
+    const trackPosixDescendants = () => {
+      if (!USE_PROCESS_GROUP || child.pid === undefined || settled) return;
+      for (const pid of collectPosixDescendantPids(child.pid)) trackedPosixDescendantPids.add(pid);
+    };
+    trackPosixDescendants();
+    const descendantTracker = USE_PROCESS_GROUP ? setInterval(trackPosixDescendants, 10) : undefined;
+    descendantTracker?.unref();
+
     const finish = (error?: Error, headers?: Headers) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (descendantTracker) clearInterval(descendantTracker);
       signal.removeEventListener("abort", abort);
       if (error) reject(error);
       else resolve(headers!);
     };
     const failAfterKill = (message: string) => {
       try {
-        killRequestHeadersCommand(child);
+        trackPosixDescendants();
+        killRequestHeadersCommand(child, trackedPosixDescendantPids);
         finish(new Error(message));
       } catch (error) {
         finish(error instanceof Error ? error : new Error(String(error)));

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -214,13 +214,16 @@ async function invokeRequestHeadersCommand(
       if (error) reject(error);
       else resolve(headers!);
     };
-    const failAfterKill = (message: string) => {
+    const finishAfterKill = (error?: Error, headers?: Headers) => {
       try {
         killRequestHeadersCommand(child, trackedPosixDescendantPids, cleanupToken);
-        finish(trackingError ?? new Error(message));
-      } catch (error) {
-        finish(error instanceof Error ? error : new Error(String(error)));
+        finish(error, headers);
+      } catch (cleanupError) {
+        finish(cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError)));
       }
+    };
+    const failAfterKill = (message: string) => {
+      finishAfterKill(trackingError ?? new Error(message));
     };
     const abort = () => {
       failAfterKill("HTTP request headers command aborted");
@@ -257,22 +260,22 @@ async function invokeRequestHeadersCommand(
       try {
         parsed = JSON.parse(stdout.toString("utf8"));
       } catch {
-        finish(new Error("HTTP request headers command returned invalid JSON"));
+        finishAfterKill(new Error("HTTP request headers command returned invalid JSON"));
         return;
       }
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        finish(new Error("HTTP request headers command must return a JSON object"));
+        finishAfterKill(new Error("HTTP request headers command must return a JSON object"));
         return;
       }
       const entries = Object.entries(parsed);
       if (entries.some(([, value]) => typeof value !== "string")) {
-        finish(new Error("HTTP request headers command values must be strings"));
+        finishAfterKill(new Error("HTTP request headers command values must be strings"));
         return;
       }
       try {
-        finish(undefined, new Headers(entries as Array<[string, string]>));
+        finishAfterKill(undefined, new Headers(entries as Array<[string, string]>));
       } catch {
-        finish(new Error("HTTP request headers command returned an invalid header"));
+        finishAfterKill(new Error("HTTP request headers command returned an invalid header"));
       }
     });
 

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import type { FetchLike } from "@modelcontextprotocol/client";
 import type { HttpRequestHeadersCommand } from "./types.ts";
 import { interpolateEnvVars } from "./utils.ts";
@@ -12,6 +12,14 @@ function isNoSuchProcessError(error: unknown): boolean {
 }
 
 function killRequestHeadersCommand(child: ChildProcess): void {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    if (result.status === 0) return;
+  }
+
   try {
     if (USE_PROCESS_GROUP && child.pid !== undefined) {
       process.kill(-child.pid, "SIGKILL");

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -1,0 +1,168 @@
+import { spawn } from "node:child_process";
+import type { FetchLike } from "@modelcontextprotocol/client";
+import type { HttpRequestHeadersCommand } from "./types.ts";
+import { interpolateEnvVars } from "./utils.ts";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+export interface HttpRequestCommandEnvelope {
+  version: 1;
+  method: string;
+  url: string;
+  bodyBase64: string;
+}
+
+function resolvedCommand(config: HttpRequestHeadersCommand): {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+} {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("HTTP request headers command must be an object");
+  }
+  if (typeof config.command !== "string" || config.command.trim() === "") {
+    throw new Error("HTTP request headers command requires a non-empty command");
+  }
+  if (config.args !== undefined && (!Array.isArray(config.args) || config.args.some(arg => typeof arg !== "string"))) {
+    throw new Error("HTTP request headers command args must be strings");
+  }
+  if (config.env !== undefined && (
+    typeof config.env !== "object"
+    || Array.isArray(config.env)
+    || Object.values(config.env).some(value => typeof value !== "string")
+  )) {
+    throw new Error("HTTP request headers command env values must be strings");
+  }
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 60_000) {
+    throw new Error("HTTP request headers command timeoutMs must be an integer between 1 and 60000");
+  }
+  return {
+    command: interpolateEnvVars(config.command),
+    args: (config.args ?? []).map(interpolateEnvVars),
+    env: {
+      ...process.env,
+      ...Object.fromEntries(
+        Object.entries(config.env ?? {}).map(([key, value]) => [key, interpolateEnvVars(value)]),
+      ),
+    },
+    timeoutMs,
+  };
+}
+
+async function invokeRequestHeadersCommand(
+  config: HttpRequestHeadersCommand,
+  envelope: HttpRequestCommandEnvelope,
+  signal: AbortSignal,
+): Promise<Headers> {
+  const resolved = resolvedCommand(config);
+  return new Promise<Headers>((resolve, reject) => {
+    let stdout = Buffer.alloc(0);
+    let settled = false;
+    const child = spawn(resolved.command, resolved.args, {
+      env: resolved.env,
+      stdio: ["pipe", "pipe", "ignore"],
+      windowsHide: true,
+    });
+
+    const finish = (error?: Error, headers?: Headers) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", abort);
+      if (error) reject(error);
+      else resolve(headers!);
+    };
+    const abort = () => {
+      child.kill();
+      finish(new Error("HTTP request headers command aborted"));
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(new Error(`HTTP request headers command timed out after ${resolved.timeoutMs}ms`));
+    }, resolved.timeoutMs);
+
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+
+    child.on("error", () => finish(new Error("HTTP request headers command failed to start")));
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout = Buffer.concat([stdout, Buffer.from(chunk)]);
+      if (stdout.byteLength > MAX_OUTPUT_BYTES) {
+        child.kill();
+        finish(new Error("HTTP request headers command output exceeded 64 KiB"));
+      }
+    });
+    child.on("close", code => {
+      if (settled) return;
+      if (code !== 0) {
+        finish(new Error(`HTTP request headers command exited with code ${code ?? "unknown"}`));
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout.toString("utf8"));
+      } catch {
+        finish(new Error("HTTP request headers command returned invalid JSON"));
+        return;
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        finish(new Error("HTTP request headers command must return a JSON object"));
+        return;
+      }
+      const entries = Object.entries(parsed);
+      if (entries.some(([, value]) => typeof value !== "string")) {
+        finish(new Error("HTTP request headers command values must be strings"));
+        return;
+      }
+      try {
+        finish(undefined, new Headers(entries as Array<[string, string]>));
+      } catch {
+        finish(new Error("HTTP request headers command returned an invalid header"));
+      }
+    });
+
+    child.stdin.on("error", () => {});
+    child.stdin.end(JSON.stringify(envelope));
+  });
+}
+
+/** Wrap fetch so a trusted command can derive headers from the exact request. */
+export function createRequestHeadersCommandFetch(
+  config: HttpRequestHeadersCommand,
+  delegate: FetchLike = globalThis.fetch,
+): FetchLike {
+  // Validate static configuration before the first request.
+  resolvedCommand(config);
+  return async (input: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
+    const request = new Request(input, init);
+    const body = Buffer.from(await request.clone().arrayBuffer());
+    const derived = await invokeRequestHeadersCommand(config, {
+      version: 1,
+      method: request.method.toUpperCase(),
+      url: request.url,
+      bodyBase64: body.toString("base64"),
+    }, request.signal);
+    const headers = new Headers(request.headers);
+    derived.forEach((value, name) => headers.set(name, value));
+    return delegate(new URL(request.url), {
+      method: request.method,
+      headers,
+      ...(request.method === "GET" || request.method === "HEAD" ? {} : { body }),
+      signal: request.signal,
+      cache: request.cache,
+      credentials: request.credentials,
+      integrity: request.integrity,
+      keepalive: request.keepalive,
+      mode: request.mode,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+    });
+  };
+}

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -250,7 +250,7 @@ async function invokeRequestHeadersCommand(
         return;
       }
       if (trackingError) {
-        finish(trackingError);
+        failAfterKill(trackingError.message);
         return;
       }
       let parsed: unknown;

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -46,7 +46,7 @@ function collectPosixDescendantPids(rootPid: number): number[] {
 }
 
 function collectPosixCleanupTokenPids(cleanupToken: string): number[] {
-  const result = runPosixPs(["eww", "-axo", "pid=,command="]);
+  const result = runPosixPs(["axeww", "-o", "pid=,command="]);
   if (result.status !== 0) {
     throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
   }

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -1,10 +1,27 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import type { FetchLike } from "@modelcontextprotocol/client";
 import type { HttpRequestHeadersCommand } from "./types.ts";
 import { interpolateEnvVars } from "./utils.ts";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
+const USE_PROCESS_GROUP = process.platform !== "win32";
+
+function isNoSuchProcessError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";
+}
+
+function killRequestHeadersCommand(child: ChildProcess): void {
+  try {
+    if (USE_PROCESS_GROUP && child.pid !== undefined) {
+      process.kill(-child.pid, "SIGKILL");
+      return;
+    }
+    child.kill("SIGKILL");
+  } catch (error) {
+    if (!isNoSuchProcessError(error)) throw error;
+  }
+}
 
 export interface HttpRequestCommandEnvelope {
   version: 1;
@@ -65,6 +82,7 @@ async function invokeRequestHeadersCommand(
       env: resolved.env,
       stdio: ["pipe", "pipe", "ignore"],
       windowsHide: true,
+      detached: USE_PROCESS_GROUP,
     });
 
     const finish = (error?: Error, headers?: Headers) => {
@@ -76,11 +94,11 @@ async function invokeRequestHeadersCommand(
       else resolve(headers!);
     };
     const abort = () => {
-      child.kill();
+      killRequestHeadersCommand(child);
       finish(new Error("HTTP request headers command aborted"));
     };
     const timer = setTimeout(() => {
-      child.kill();
+      killRequestHeadersCommand(child);
       finish(new Error(`HTTP request headers command timed out after ${resolved.timeoutMs}ms`));
     }, resolved.timeoutMs);
 
@@ -92,9 +110,10 @@ async function invokeRequestHeadersCommand(
 
     child.on("error", () => finish(new Error("HTTP request headers command failed to start")));
     child.stdout.on("data", (chunk: Buffer | string) => {
+      if (settled) return;
       stdout = Buffer.concat([stdout, Buffer.from(chunk)]);
       if (stdout.byteLength > MAX_OUTPUT_BYTES) {
-        child.kill();
+        killRequestHeadersCommand(child);
         finish(new Error("HTTP request headers command output exceeded 64 KiB"));
       }
     });

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -56,6 +56,7 @@ import {
   traceTransportKind,
   wrapTransportWithMcpTrace,
 } from "./mcp-trace.ts";
+import { createRequestHeadersCommandFetch } from "./request-headers-command.ts";
 
 const MAX_CAPTURED_STDERR_BYTES = 8 * 1024;
 const MAX_CAPTURED_STDERR_LINES = 3;
@@ -746,6 +747,9 @@ export class McpServerManager {
     }
 
     const requestInit = Object.keys(headers).length > 0 ? { headers } : undefined;
+    const requestFetch = definition.requestHeadersCommand
+      ? createRequestHeadersCommandFetch(definition.requestHeadersCommand)
+      : undefined;
     const createAuthProvider = (): McpOAuthProvider => new McpOAuthProvider(
       serverName,
       serverUrl,
@@ -772,6 +776,7 @@ export class McpServerManager {
       const authProvider = "provider" in authState ? authState.provider : undefined;
       const transportOptions = {
         ...(requestInit !== undefined ? { requestInit } : {}),
+        ...(requestFetch !== undefined ? { fetch: requestFetch } : {}),
         ...(authProvider !== undefined ? { authProvider } : {}),
         ...(authProvider !== undefined
           && definition.oauth !== false

--- a/types.ts
+++ b/types.ts
@@ -356,6 +356,19 @@ export interface OAuthConfig {
   skipIssuerMetadataValidation?: boolean;
 }
 
+/**
+ * Trusted executable invoked for every outbound HTTP request. The adapter
+ * writes a versioned JSON request envelope to stdin and expects a JSON object
+ * containing headers on stdout. This is intended for caller-bound signing
+ * schemes whose headers depend on the exact request body.
+ */
+export interface HttpRequestHeadersCommand {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  timeoutMs?: number;
+}
+
 // Server configuration
 export interface ServerEntry {
   command?: string;
@@ -367,6 +380,8 @@ export interface ServerEntry {
   // HTTP fields
   url?: string;
   headers?: Record<string, string>;
+  /** Add or replace HTTP headers by running a trusted command for each request. */
+  requestHeadersCommand?: HttpRequestHeadersCommand;
   /** 
    * Authentication type:
    * - 'oauth' - Use OAuth 2.1 (auto-discovers endpoints, supports dynamic client registration)


### PR DESCRIPTION
## What changed

- add a per-server `requestHeadersCommand` hook for Streamable HTTP and SSE transports
- invoke the trusted command for every outbound request with a versioned JSON envelope containing the exact method, URL, and body bytes
- merge returned JSON headers into the request and fail closed on command, timeout, output-size, or validation errors
- include the effective command configuration in metadata-cache hashing

## Why

Some MCP consumers need caller-bound headers whose values depend on the exact request body, such as an HMAC signature or a short-lived delegated credential. Static headers resolved when configuration loads cannot safely represent a different caller for each request.

The hook is transport-generic: the adapter knows only how to exchange a request envelope for headers. Authentication and signing policy remain owned by the invoking agent.

## Security properties

- commands are spawned directly without a shell
- the exact request body is cloned before dispatch and supplied as base64
- stdout is capped at 64 KiB and must be a JSON object of string header values
- non-zero exit, timeout, abort, malformed output, and invalid headers stop the request
- stderr is not copied into adapter errors

## Verification

- `npm run typecheck`
- focused transport/cache tests: 74 passed
- full suite after the same example-build pre-step as CI: 97 files, 1,098 tests passed
