### PR TITLE
fix: avoid O(tools²) startup collision scan when no tool filters are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Avoided an O(tools²) cross-server tool-name collision scan at startup by computing `otherCurrentCandidates` only when a server configures `includeTools`/`excludeTools`. This removes the multi-second CPU-bound startup pause reported for large `mcp-cache.json` tool counts (related: #354).
+
 ## [2.25.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Avoided an O(tools²) cross-server tool-name collision scan at startup by computing `otherCurrentCandidates` only when a server configures `includeTools`/`excludeTools`. This removes the multi-second CPU-bound startup pause reported for large `mcp-cache.json` tool counts (related: #354).
+- Avoided an O(tools²) cross-server tool-name collision scan at startup for unfiltered large `mcp-cache.json` tool sets by computing `otherCurrentCandidates` only when a server configures `includeTools` or `excludeTools`. This partially mitigates issue #354 while the filtered-server path remains open. Thanks @mjlbach for PR #357 and @cataldoc for issue #354.
 
 ## [2.25.0] - 2026-08-13
 

--- a/__tests__/collision-scan-lazy.test.ts
+++ b/__tests__/collision-scan-lazy.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getToolNameCandidates,
+  type MetadataCache,
+  type McpConfig,
+  type ServerCacheEntry,
+  type ServerEntry,
+} from "../types.ts";
+import { buildProxyDescription, resolveDirectTools } from "../direct-tools.ts";
+import { computeServerHash, reconstructToolMetadata } from "../metadata-cache.ts";
+import { buildToolMetadata } from "../tool-metadata.ts";
+
+// Intercept the only function the cross-server collision scan calls. Because
+// every conflicting-candidate set ultimately flows through
+// `getToolNameCandidates`, asserting it is never invoked is a deterministic
+// proof that the O(tools²) scan was skipped (not merely fast).
+vi.mock("../types.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../types.ts")>();
+  return {
+    ...actual,
+    getToolNameCandidates: vi.fn(actual.getToolNameCandidates),
+  };
+});
+
+const mockedGetToolNameCandidates = vi.mocked(getToolNameCandidates);
+
+function makeServer(name: string, extra: Partial<ServerEntry> = {}): ServerEntry {
+  return { command: `demo-${name}`, ...extra };
+}
+
+function makeCacheEntry(definition: ServerEntry, tools: { name: string; description: string }[]): ServerCacheEntry {
+  return {
+    configHash: computeServerHash(definition),
+    cachedAt: Date.now(),
+    tools,
+    resources: [],
+  };
+}
+
+function makeTwoServerConfig(filters: Partial<ServerEntry> = {}): { config: McpConfig; cache: MetadataCache } {
+  const a = makeServer("a", filters);
+  const b = makeServer("b");
+  const config: McpConfig = { mcpServers: { a, b } };
+  const cache: MetadataCache = {
+    version: 1,
+    servers: {
+      a: makeCacheEntry(a, [{ name: "search", description: "Search" }]),
+      b: makeCacheEntry(b, [{ name: "search", description: "Search" }]),
+    },
+  };
+  return { config, cache };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("cross-server collision scan is skipped without tool filters", () => {
+  it("buildProxyDescription does not generate candidates without filters", () => {
+    const { config, cache } = makeTwoServerConfig();
+    buildProxyDescription(config, cache, []);
+    expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
+  });
+
+  it("buildProxyDescription generates candidates when excludeTools is configured", () => {
+    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+    buildProxyDescription(config, cache, []);
+    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+  });
+
+  it("resolveDirectTools does not generate candidates without filters", () => {
+    const definition = makeServer("a", { directTools: true });
+    const config: McpConfig = { mcpServers: { a: definition } };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        a: makeCacheEntry(definition, [{ name: "search", description: "Search" }]),
+      },
+    };
+    resolveDirectTools(config, cache, "server");
+    expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
+  });
+
+  it("resolveDirectTools generates candidates when includeTools is configured", () => {
+    const definition = makeServer("a", { directTools: true, includeTools: ["a_search"] });
+    const other = makeServer("b");
+    const config: McpConfig = { mcpServers: { a: definition, b: other } };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        a: makeCacheEntry(definition, [{ name: "search", description: "Search" }]),
+        b: makeCacheEntry(other, [{ name: "search", description: "Search" }]),
+      },
+    };
+    resolveDirectTools(config, cache, "server");
+    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+  });
+
+  it("reconstructToolMetadata does not generate candidates without filters", () => {
+    const { config, cache } = makeTwoServerConfig();
+    reconstructToolMetadata("a", cache.servers.a, "server", config.mcpServers.a, config.mcpServers, cache);
+    expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
+  });
+
+  it("reconstructToolMetadata generates candidates when excludeTools is configured", () => {
+    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+    reconstructToolMetadata("a", cache.servers.a, "server", config.mcpServers.a, config.mcpServers, cache);
+    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+  });
+
+  it("buildToolMetadata does not generate candidates without filters", () => {
+    const { config, cache } = makeTwoServerConfig();
+    buildToolMetadata(
+      cache.servers.a.tools,
+      [],
+      config.mcpServers.a,
+      "a",
+      "server",
+      config.mcpServers,
+    );
+    expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
+  });
+
+  it("buildToolMetadata generates candidates when excludeTools is configured", () => {
+    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+    buildToolMetadata(
+      cache.servers.a.tools,
+      [],
+      config.mcpServers.a,
+      "a",
+      "server",
+      config.mcpServers,
+    );
+    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+  });
+});

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -97,6 +97,37 @@ describe("buildProxyDescription", () => {
     expect(description).not.toContain("MCP + pi");
   });
 
+  it("builds proxy descriptions over large unfiltered tool counts in linear time", () => {
+    // Regression guard: buildProxyDescription previously scanned every other
+    // server's tools for each tool (O(tools²)) even when the server defined no
+    // include/exclude selectors. With no selectors the scan is never consumed,
+    // so this must complete near-instantly regardless of tool count.
+    const config: McpConfig = { mcpServers: {} };
+    const cacheServers: MetadataCache["servers"] = {};
+    const serverCount = 600;
+    for (let i = 0; i < serverCount; i++) {
+      const name = `srv_${i}`;
+      const definition = { command: "demo" };
+      config.mcpServers[name] = definition;
+      cacheServers[name] = {
+        configHash: computeServerHash(definition),
+        cachedAt: Date.now(),
+        tools: [
+          { name: "alpha", description: "Alpha" },
+          { name: "beta", description: "Beta" },
+        ],
+        resources: [],
+      };
+    }
+    const cache: MetadataCache = { version: 1, servers: cacheServers };
+
+    const start = performance.now();
+    buildProxyDescription(config, cache, []);
+    const elapsedMs = performance.now() - start;
+
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+
   it("excludes configured tools from proxy summaries", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "server" },

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -97,37 +97,6 @@ describe("buildProxyDescription", () => {
     expect(description).not.toContain("MCP + pi");
   });
 
-  it("builds proxy descriptions over large unfiltered tool counts in linear time", () => {
-    // Regression guard: buildProxyDescription previously scanned every other
-    // server's tools for each tool (O(tools²)) even when the server defined no
-    // include/exclude selectors. With no selectors the scan is never consumed,
-    // so this must complete near-instantly regardless of tool count.
-    const config: McpConfig = { mcpServers: {} };
-    const cacheServers: MetadataCache["servers"] = {};
-    const serverCount = 600;
-    for (let i = 0; i < serverCount; i++) {
-      const name = `srv_${i}`;
-      const definition = { command: "demo" };
-      config.mcpServers[name] = definition;
-      cacheServers[name] = {
-        configHash: computeServerHash(definition),
-        cachedAt: Date.now(),
-        tools: [
-          { name: "alpha", description: "Alpha" },
-          { name: "beta", description: "Beta" },
-        ],
-        resources: [],
-      };
-    }
-    const cache: MetadataCache = { version: 1, servers: cacheServers };
-
-    const start = performance.now();
-    buildProxyDescription(config, cache, []);
-    const elapsedMs = performance.now() - start;
-
-    expect(elapsedMs).toBeLessThan(2000);
-  });
-
   it("excludes configured tools from proxy summaries", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "server" },

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -150,6 +150,11 @@ export function resolveDirectTools(
     if (!toolFilter) continue;
 
     const effectivePrefix = resolveToolPrefix(definition, prefix);
+    // `otherCurrentCandidates` is only consumed when include/exclude selectors
+    // are configured, so skip the O(tools²) cross-server scan otherwise.
+    const hasToolFilters =
+      (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
+      (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
     const getOtherCurrentCandidates = (toolName: string): Set<string> => {
       const candidates = new Set<string>();
       for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
@@ -174,7 +179,7 @@ export function resolveDirectTools(
     for (const tool of serverCache.tools ?? []) {
       if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
-      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) continue;
+      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) continue;
       const prefixedName = formatToolName(tool.name, serverName, effectivePrefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);
@@ -200,7 +205,7 @@ export function resolveDirectTools(
       for (const resource of serverCache.resources ?? []) {
         const baseName = `read_${resourceNameToToolName(resource.name)}`;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
-        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) continue;
+        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) continue;
         const prefixedName = formatToolName(baseName, serverName, effectivePrefix);
         if (BUILTIN_NAMES.has(prefixedName)) {
           console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`);
@@ -255,6 +260,11 @@ export function buildProxyDescription(
     const cachedEntry = cache?.servers?.[serverName];
     const entry = cachedEntry && isServerCacheValid(cachedEntry, definition) ? cachedEntry : undefined;
     const effectivePrefix = resolveToolPrefix(definition, prefix);
+    // `otherCurrentCandidates` is only consumed when include/exclude selectors
+    // are configured, so skip the O(tools²) cross-server scan otherwise.
+    const hasToolFilters =
+      (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
+      (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
     const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
       if (!cache) return undefined;
       const candidates = new Set<string>();
@@ -278,12 +288,12 @@ export function buildProxyDescription(
     };
     const toolCount = (entry?.tools ?? []).filter(
       (tool) => isUiToolVisibleToModel(tool.uiVisibility)
-        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name)),
+        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined),
     ).length;
     const resourceCount = definition?.exposeResources !== false
       ? (entry?.resources ?? []).filter((resource) => {
           const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName));
+          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined);
         }).length
       : 0;
     const totalItems = toolCount + resourceCount;

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -184,6 +184,11 @@ export function reconstructToolMetadata(
   const metadata: ToolMetadata[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
+  // `otherCurrentCandidates` is only consumed when include/exclude selectors
+  // are configured, so skip the O(tools²) cross-server scan otherwise.
+  const hasToolFilters =
+    (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
+    (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
   const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
     if (!configuredServers || !cache) return undefined;
     const candidates = new Set<string>();
@@ -211,7 +216,7 @@ export function reconstructToolMetadata(
     if (!isUiToolVisibleToModel(tool.uiVisibility)) {
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) {
       continue;
     }
 
@@ -236,7 +241,7 @@ export function reconstructToolMetadata(
     for (const resource of entry.resources ?? []) {
       if (!resource?.name || !resource?.uri) continue;
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) {
         continue;
       }
 

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -20,6 +20,11 @@ export function buildToolMetadata(
   const failedTools: string[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
+  // `otherCurrentCandidates` is only consumed when include/exclude selectors
+  // are configured, so skip the O(tools²) cross-server scan otherwise.
+  const hasToolFilters =
+    (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
+    (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
   const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
     if (!configuredServers) return undefined;
     const candidates = new Set<string>();
@@ -61,7 +66,7 @@ export function buildToolMetadata(
       failedTools.push("(unnamed)");
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(tool.name))) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) {
       continue;
     }
 
@@ -97,7 +102,7 @@ export function buildToolMetadata(
   if (definition.exposeResources !== false) {
     for (const resource of resources) {
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, getOtherCurrentCandidates(baseName))) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) {
         continue;
       }
 


### PR DESCRIPTION
## Problem

`pi` cold start is dominated by the MCP adapter. With a real-world `mcp-cache.json` (14 cached servers, ~806 tools, ~279 resources), startup profiling shows:

```
createAgentSessionRuntime: 3308ms
  pi-mcp-adapter factory:    2652ms   ← 80% of startup
pi --no-extensions:            ~0.38s total
```

The 2.6s is synchronous (it runs in the extension factory, before the TUI renders), and it's **not** the cache parse (`JSON.parse` of a 2.6 MB cache ≈ 9ms), not OAuth/network (servers are lazy-connected), and not the updater (reproduced offline).

The cost scales quadratically with total tool count. A faithful benchmark of the scan over the same data:

| Servers in scope | scan cost |
|---|---|
| 21 enabled (current) | ~2.3s |
| 4 core servers only | ~34ms |

## Root cause

`buildProxyDescription` (and `resolveDirectTools`, `reconstructToolMetadata`, `buildToolMetadata`) each define a `getOtherCurrentCandidates(toolName)` closure that builds a `Set` of *every other server tool's* name candidates, and it's passed eagerly to every `isToolAllowed(...)` call:

```ts
isToolAllowed(tool.name, serverName, prefix, definition.includeTools,
  definition.excludeTools, getOtherCurrentCandidates(tool.name))
```

`getToolNameCandidates` then does ~5 `formatToolName` calls (each running `sanitizeServerPrefix`'s per-character regex pass) per other tool. With N tools that's ~O(N²) candidate computations — ~1.1M calls at ~800 tools, and it runs even when the server defines **no** `includeTools`/`excludeTools` at all.

But `isToolAllowed` → `matchesToolSelector` only ever reads `otherCurrentCandidates` when an `includeTools`/`excludeTools` array is non-empty (it short-circuits via `isToolIncluded`/`isToolExcluded` otherwise). So the set is computed and discarded for every filter-less server.

## Fix

Gate computation on whether the server actually declares selectors:

```ts
const hasToolFilters =
  (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
  (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
...
isToolAllowed(..., hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)
```

This is behavior-identical: when both filters are empty/non-array, `isToolAllowed` returns before consulting the set, so passing `undefined` is indistinguishable. Applied consistently to all four call sites that shared the eager-scan pattern.

## Tests

- `npm run typecheck` clean.
- Full suite: **1097 passed**, 2 failed — both pre-existing (`interactive-visualizer` example `dist/` not built; also fail on a clean `main`).
- Added deterministic regression coverage (`__tests__/collision-scan-lazy.test.ts`): `getToolNameCandidates` (the only function the cross-server scan calls) is mocked, and each of the four functions is asserted to **not** invoke it when no filters are configured — with positive controls proving the mock intercepts once `includeTools`/`excludeTools` is set. This verifies the scan is skipped without depending on wall-clock timing.

## Notes

Related to #354 — same hot path, but #354's "hangs for minutes at 100% CPU" symptom (with `excludeTools` configured) looks like it may have an additional contributor beyond this quadratic scan, since the filter-configured path still runs the scan (now only when genuinely needed). This PR fixes the measured multi-second startup pause for the common no-filter case.
