### PR TITLE
fix: honor rebranded Pi config directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Matched adapter-owned config and state paths to the host agent directory when Pi is rebranded, including its environment override and config directory. Thanks @mindplay-dk for issue #356.
 - Avoided an O(tools²) cross-server tool-name collision scan at startup for unfiltered large `mcp-cache.json` tool sets by computing `otherCurrentCandidates` only when a server configures `includeTools` or `excludeTools`. This partially mitigates issue #354 while the filtered-server path remains open. Thanks @mjlbach for PR #357 and @cataldoc for issue #354.
 
 ## [2.25.0] - 2026-08-13

--- a/__tests__/agent-dir-paths.test.ts
+++ b/__tests__/agent-dir-paths.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -7,9 +7,12 @@ describe("Pi agent dir paths", () => {
   const originalHome = process.env.HOME;
   const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
   const originalOAuthDir = process.env.MCP_OAUTH_DIR;
+  const originalPackageDir = process.env.PI_PACKAGE_DIR;
+  const originalArcAgentDir = process.env.ARC_CODING_AGENT_DIR;
 
   beforeEach(() => {
     vi.resetModules();
+    delete process.env.PI_PACKAGE_DIR;
   });
 
   afterEach(() => {
@@ -23,6 +26,16 @@ describe("Pi agent dir paths", () => {
       delete process.env.MCP_OAUTH_DIR;
     } else {
       process.env.MCP_OAUTH_DIR = originalOAuthDir;
+    }
+    if (originalPackageDir === undefined) {
+      delete process.env.PI_PACKAGE_DIR;
+    } else {
+      process.env.PI_PACKAGE_DIR = originalPackageDir;
+    }
+    if (originalArcAgentDir === undefined) {
+      delete process.env.ARC_CODING_AGENT_DIR;
+    } else {
+      process.env.ARC_CODING_AGENT_DIR = originalArcAgentDir;
     }
   });
 
@@ -59,6 +72,28 @@ describe("Pi agent dir paths", () => {
     const { getAgentDir } = await import("../agent-dir.ts");
 
     expect(getAgentDir()).toBe(join(home, "custom-pi-agent"));
+  });
+
+  it("uses the branded host environment key and config directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-agent-dir-home-"));
+    const packageDir = mkdtempSync(join(tmpdir(), "pi-mcp-package-dir-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-agent-dir-"));
+    process.env.HOME = home;
+    writeFileSync(join(packageDir, "package.json"), JSON.stringify({ piConfig: { name: "arc", configDir: ".arc" } }));
+    process.env.PI_PACKAGE_DIR = packageDir;
+
+    const { getAgentDir } = await import("../agent-dir.ts");
+
+    expect(getAgentDir()).toBe(join(home, ".arc", "agent"));
+
+    process.env.ARC_CODING_AGENT_DIR = agentDir;
+    expect(getAgentDir()).toBe(agentDir);
+
+    process.env.ARC_CODING_AGENT_DIR = "~/custom-agent";
+    expect(getAgentDir()).toBe(join(home, "custom-agent"));
+
+    process.env.ARC_CODING_AGENT_DIR = "relative-agent";
+    expect(getAgentDir()).toBe(join(process.cwd(), "relative-agent"));
   });
 
   it("keeps MCP_OAUTH_DIR as the explicit OAuth storage override", async () => {

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -12,6 +12,8 @@ function writeJson(path: string, value: unknown): void {
 describe("cli init helper", () => {
   const originalHome = process.env.HOME;
   const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const originalPackageDir = process.env.PI_PACKAGE_DIR;
+  const originalArcAgentDir = process.env.ARC_CODING_AGENT_DIR;
   const originalCwd = process.cwd();
 
   beforeEach(() => {
@@ -24,6 +26,16 @@ describe("cli init helper", () => {
       delete process.env.PI_CODING_AGENT_DIR;
     } else {
       process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    if (originalPackageDir === undefined) {
+      delete process.env.PI_PACKAGE_DIR;
+    } else {
+      process.env.PI_PACKAGE_DIR = originalPackageDir;
+    }
+    if (originalArcAgentDir === undefined) {
+      delete process.env.ARC_CODING_AGENT_DIR;
+    } else {
+      process.env.ARC_CODING_AGENT_DIR = originalArcAgentDir;
     }
     process.chdir(originalCwd);
   });
@@ -155,6 +167,32 @@ describe("cli init helper", () => {
     const config = JSON.parse(readFileSync(piConfigPath, "utf-8"));
     expect(config.imports).toContain("claude-code");
     expect(logs.join("\n")).toContain(piConfigPath);
+  });
+
+
+  it("writes init output to the branded host agent directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-cli-branded-home-"));
+    const packageDir = mkdtempSync(join(tmpdir(), "pi-mcp-cli-branded-package-"));
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-cli-branded-agent-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-cli-branded-project-"));
+    process.env.HOME = home;
+    process.env.PI_PACKAGE_DIR = packageDir;
+    process.env.ARC_CODING_AGENT_DIR = agentDir;
+    process.chdir(project);
+
+    writeJson(join(packageDir, "package.json"), { piConfig: { name: "arc", configDir: ".arc" } });
+
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const { main } = await import("../cli.js");
+    const exitCode = await main(["init", "--dry-run", "--discover-host-configs"], line => logs.push(line), line => errors.push(line));
+
+    expect(exitCode).toBe(0);
+    expect(errors).toEqual([]);
+    expect(logs.join("\n")).toContain(`Pi global override: ${join(agentDir, "mcp.json")}`);
+    expect(logs.join("\n")).toContain(`Project Pi override: ${join(process.cwd(), ".arc", "mcp.json")}`);
+    expect(logs.join("\n")).toContain(`Dry run: would update ${join(agentDir, "mcp.json")}`);
+    expect(existsSync(join(home, ".pi", "agent", "mcp.json"))).toBe(false);
   });
 
   it("runs when invoked through a symlinked bin path", () => {

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -10,6 +10,7 @@ function writeJson(path: string, value: unknown): void {
 
 describe("config discovery", () => {
   const originalHome = process.env.HOME;
+  const originalPackageDir = process.env.PI_PACKAGE_DIR;
   const originalCwd = process.cwd();
 
   beforeEach(() => {
@@ -18,6 +19,11 @@ describe("config discovery", () => {
 
   afterEach(() => {
     process.env.HOME = originalHome;
+    if (originalPackageDir === undefined) {
+      delete process.env.PI_PACKAGE_DIR;
+    } else {
+      process.env.PI_PACKAGE_DIR = originalPackageDir;
+    }
     process.chdir(originalCwd);
   });
 
@@ -232,6 +238,28 @@ describe("config discovery", () => {
       autoAuth: true,
       oauthDir: ".pi/oauth",
     });
+  });
+
+  it("loads the branded project Pi override path", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-config-branded-home-"));
+    const packageDir = mkdtempSync(join(tmpdir(), "pi-mcp-config-branded-package-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-config-branded-project-"));
+    process.env.HOME = home;
+    process.env.PI_PACKAGE_DIR = packageDir;
+    process.chdir(project);
+
+    writeJson(join(packageDir, "package.json"), { piConfig: { name: "arc", configDir: ".arc" } });
+    writeJson(join(project, ".arc", "mcp.json"), {
+      mcpServers: {
+        brandedProject: { command: "branded" },
+      },
+    });
+
+    const { getProjectPiConfigPath, loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+
+    expect(getProjectPiConfigPath(project)).toBe(join(project, ".arc", "mcp.json"));
+    expect(config.mcpServers.brandedProject).toMatchObject({ command: "branded" });
   });
 
   it("replaces transport-specific fields when an override switches to or from a socket", async () => {

--- a/__tests__/mcp-panel-keybindings.test.ts
+++ b/__tests__/mcp-panel-keybindings.test.ts
@@ -1,4 +1,7 @@
 import { KeybindingsManager, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createMcpPanel } from "../mcp-panel.ts";
 import { createMcpSetupPanel, type SetupPanelCallbacks } from "../mcp-setup-panel.ts";
@@ -313,5 +316,38 @@ describe("mcp-setup-panel custom keybindings", () => {
     expect(output).toContain("3. ~/.agents/mcp/mcp.json");
     expect(output).toContain("6. .pi/mcp.json");
     panel.dispose();
+  });
+
+  it("shows the branded project Pi override path in config precedence", () => {
+    const originalPackageDir = process.env.PI_PACKAGE_DIR;
+    const packageDir = mkdtempSync(join(tmpdir(), "pi-mcp-panel-package-"));
+    writeFileSync(join(packageDir, "package.json"), JSON.stringify({ piConfig: { name: "arc", configDir: ".arc" } }));
+    process.env.PI_PACKAGE_DIR = packageDir;
+
+    try {
+      const panel = createMcpSetupPanel(
+        createEmptyDiscovery(),
+        createSetupCallbacks(),
+        {
+          mode: "setup",
+          onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+        },
+        { requestRender: () => {} },
+        () => {},
+      );
+
+      panel.handleInput(DOWN);
+      panel.handleInput(DOWN);
+      const output = panel.render(100).join("\n");
+
+      expect(output).toContain("6. .arc/mcp.json");
+      panel.dispose();
+    } finally {
+      if (originalPackageDir === undefined) {
+        delete process.env.PI_PACKAGE_DIR;
+      } else {
+        process.env.PI_PACKAGE_DIR = originalPackageDir;
+      }
+    }
   });
 });

--- a/agent-dir.ts
+++ b/agent-dir.ts
@@ -2,10 +2,18 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
+export function getConfigDirName(): string {
+  const configDir = readPiConfig()?.configDir;
+  return typeof configDir === "string" && configDir.trim() ? configDir.trim() : ".pi";
+}
+
 export function getAgentDir(): string {
-  const configured = process.env.PI_CODING_AGENT_DIR?.trim();
+  const piConfig = readPiConfig();
+  const name = piConfig?.name;
+  const appName = typeof name === "string" && name.trim() ? name.trim() : "pi";
+  const configured = process.env[`${appName.toUpperCase()}_CODING_AGENT_DIR`]?.trim();
   if (!configured) {
-    return join(homedir(), ".pi", "agent");
+    return join(homedir(), getConfigDirName(), "agent");
   }
   if (configured === "~") {
     return homedir();
@@ -31,12 +39,12 @@ export function getAgentPath(...segments: string[]): string {
  *
  * Falls back to "pi", which is what pi's own APP_NAME resolves to.
  */
-function readPiConfig(): { name?: unknown; clientUri?: unknown } | undefined {
+function readPiConfig(): { name?: unknown; configDir?: unknown; clientUri?: unknown } | undefined {
   const dir = process.env.PI_PACKAGE_DIR?.trim()
   if (!dir) return undefined
   try {
     const manifest = JSON.parse(readFileSync(join(resolve(dir), "package.json"), "utf8")) as {
-      piConfig?: { name?: unknown; clientUri?: unknown }
+      piConfig?: { name?: unknown; configDir?: unknown; clientUri?: unknown }
     }
     return manifest.piConfig
   } catch {

--- a/cli.js
+++ b/cli.js
@@ -14,15 +14,36 @@ function expandHome(input) {
   return path.resolve(input);
 }
 
-const AGENT_DIR = process.env.PI_CODING_AGENT_DIR?.trim()
-  ? expandHome(process.env.PI_CODING_AGENT_DIR.trim())
-  : path.join(HOME, ".pi", "agent");
+function readPiConfig() {
+  const dir = process.env.PI_PACKAGE_DIR?.trim();
+  if (!dir) return undefined;
+  try {
+    return JSON.parse(fs.readFileSync(path.join(path.resolve(dir), "package.json"), "utf8")).piConfig;
+  } catch {
+    return undefined;
+  }
+}
+
+function getConfigDirName() {
+  const configDir = readPiConfig()?.configDir;
+  return typeof configDir === "string" && configDir.trim() ? configDir.trim() : ".pi";
+}
+
+function getAgentDir() {
+  const piConfig = readPiConfig();
+  const appName = typeof piConfig?.name === "string" && piConfig.name.trim() ? piConfig.name.trim() : "pi";
+  const configured = process.env[`${appName.toUpperCase()}_CODING_AGENT_DIR`]?.trim();
+  if (configured) return expandHome(configured);
+  return path.join(HOME, getConfigDirName(), "agent");
+}
+
+const AGENT_DIR = getAgentDir();
 const PI_CONFIG_PATH = path.join(AGENT_DIR, "mcp.json");
 const GENERIC_GLOBAL_CONFIG_PATH = path.join(HOME, ".config", "mcp", "mcp.json");
 const AGENTS_GLOBAL_CONFIG_PATH = path.join(HOME, ".agents", "mcp.json");
 const AGENTS_NESTED_GLOBAL_CONFIG_PATH = path.join(HOME, ".agents", "mcp", "mcp.json");
 const PROJECT_CONFIG_PATH = path.resolve(process.cwd(), ".mcp.json");
-const PROJECT_PI_CONFIG_PATH = path.resolve(process.cwd(), ".pi", "mcp.json");
+const PROJECT_PI_CONFIG_PATH = path.resolve(process.cwd(), getConfigDirName(), "mcp.json");
 
 const IMPORT_PATHS = {
   cursor: [path.join(HOME, ".cursor", "mcp.json")],

--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { parse as parseToml } from "smol-toml";
 import stripJsonComments from "strip-json-comments";
-import { getAgentPath } from "./agent-dir.ts";
+import { getAgentPath, getConfigDirName } from "./agent-dir.ts";
 import { getAgentPluginSummaries, loadAgentPluginConfigs, type AgentPluginSummary } from "./agent-plugin-loader.ts";
 import { isServerDisabled, type HostConfigDiscovery, type McpConfig, type ServerEntry, type McpSettings, type ImportKind, type ServerProvenance } from "./types.ts";
 import { toStringRecord } from "./utils.ts";
@@ -15,7 +15,7 @@ const AGENTS_GLOBAL_CONFIG_PATHS = [
   join(homedir(), ".agents", "mcp", "mcp.json"),
 ] as const;
 const PROJECT_CONFIG_NAME = ".mcp.json";
-const PROJECT_PI_CONFIG_NAME = ".pi/mcp.json";
+const PROJECT_PI_CONFIG_NAME = "mcp.json";
 const REPOPROMPT_BINARY_CANDIDATES = [
   join(homedir(), "RepoPrompt", "repoprompt_cli"),
   "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp",
@@ -177,7 +177,7 @@ export function getProjectConfigPath(cwd = process.cwd()): string {
 }
 
 export function getProjectPiConfigPath(cwd = process.cwd()): string {
-  return resolve(cwd, PROJECT_PI_CONFIG_NAME);
+  return resolve(cwd, getConfigDirName(), PROJECT_PI_CONFIG_NAME);
 }
 
 export function getConfigDiscoveryPaths(overridePath?: string, cwd = process.cwd()): ConfigDiscoveryPath[] {

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -1,6 +1,7 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import type { ImportKind } from "./types.ts";
+import { getConfigDirName } from "./agent-dir.ts";
 import { KNOWN_SERVER_PRESETS, type ConfigWritePreview, type KnownServerPreset, type McpDiscoverySummary } from "./config.ts";
 import type { McpOnboardingState } from "./onboarding-state.ts";
 
@@ -556,7 +557,7 @@ export class McpSetupPanel {
           "3. ~/.agents/mcp/mcp.json",
           "4. <Pi agent dir>/mcp.json",
           "5. .mcp.json",
-          "6. .pi/mcp.json",
+          `6. ${getConfigDirName()}/mcp.json`,
           `Host discovery: ${this.discovery.hostConfigDiscovery}. Conflicts reported: ${this.discovery.conflicts.length}.`,
           ...this.discovery.conflicts.slice(0, 8).map((conflict) =>
             `${conflict.serverName}: ${conflict.sources.map((source) => source.path).join(" -> ")} (winner: ${conflict.winner.path})`,


### PR DESCRIPTION
## Summary

Fixes #356 by deriving Pi-owned global and project paths from the host package `piConfig`, including branded config directories such as `.arc`.

Also updates the setup panel precedence text so rebranded hosts show the active project override path.

## Validation

- `npx vitest run __tests__/agent-dir-paths.test.ts __tests__/cli.test.ts __tests__/config.test.ts __tests__/mcp-panel-keybindings.test.ts`
- `npm run typecheck`
- `git diff --check`