### PR TITLE
fix: share filtered selector candidate scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Matched adapter-owned config and state paths to the host agent directory when Pi is rebranded, including its environment override and config directory. Thanks @mindplay-dk for issue #356.
-- Avoided an O(tools²) cross-server tool-name collision scan at startup for unfiltered large `mcp-cache.json` tool sets by computing `otherCurrentCandidates` only when a server configures `includeTools` or `excludeTools`. This partially mitigates issue #354 while the filtered-server path remains open. Thanks @mjlbach for PR #357 and @cataldoc for issue #354.
+- Avoided O(tools²) cross-server tool-name collision scans at startup by skipping collision candidates when selectors are absent and sharing one indexed candidate set when `includeTools` or `excludeTools` is configured. Thanks @mjlbach for PR #357 and @cataldoc for issue #354.
 
 ## [2.25.0] - 2026-08-13
 

--- a/__tests__/collision-scan-lazy.test.ts
+++ b/__tests__/collision-scan-lazy.test.ts
@@ -51,6 +51,22 @@ function makeTwoServerConfig(filters: Partial<ServerEntry> = {}): { config: McpC
   return { config, cache };
 }
 
+function makeLargeFilteredConfig(toolCount: number, extra: Partial<ServerEntry> = {}): { config: McpConfig; cache: MetadataCache } {
+  const definition = makeServer("a", { includeTools: ["*"], ...extra });
+  const config: McpConfig = { mcpServers: { a: definition } };
+  const tools = Array.from({ length: toolCount }, (_, index) => ({
+    name: `tool_${index}`,
+    description: `Tool ${index}`,
+  }));
+  return {
+    config,
+    cache: {
+      version: 1,
+      servers: { a: makeCacheEntry(definition, tools) },
+    },
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -62,10 +78,10 @@ describe("cross-server collision scan is skipped without tool filters", () => {
     expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
   });
 
-  it("buildProxyDescription generates candidates when excludeTools is configured", () => {
-    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+  it("buildProxyDescription builds filtered candidates once", () => {
+    const { config, cache } = makeLargeFilteredConfig(40);
     buildProxyDescription(config, cache, []);
-    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 
   it("resolveDirectTools does not generate candidates without filters", () => {
@@ -81,19 +97,10 @@ describe("cross-server collision scan is skipped without tool filters", () => {
     expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
   });
 
-  it("resolveDirectTools generates candidates when includeTools is configured", () => {
-    const definition = makeServer("a", { directTools: true, includeTools: ["a_search"] });
-    const other = makeServer("b");
-    const config: McpConfig = { mcpServers: { a: definition, b: other } };
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        a: makeCacheEntry(definition, [{ name: "search", description: "Search" }]),
-        b: makeCacheEntry(other, [{ name: "search", description: "Search" }]),
-      },
-    };
+  it("resolveDirectTools builds filtered candidates once", () => {
+    const { config, cache } = makeLargeFilteredConfig(40, { directTools: true });
     resolveDirectTools(config, cache, "server");
-    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 
   it("reconstructToolMetadata does not generate candidates without filters", () => {
@@ -102,10 +109,10 @@ describe("cross-server collision scan is skipped without tool filters", () => {
     expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
   });
 
-  it("reconstructToolMetadata generates candidates when excludeTools is configured", () => {
-    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+  it("reconstructToolMetadata builds filtered candidates once", () => {
+    const { config, cache } = makeLargeFilteredConfig(40);
     reconstructToolMetadata("a", cache.servers.a, "server", config.mcpServers.a, config.mcpServers, cache);
-    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 
   it("buildToolMetadata does not generate candidates without filters", () => {
@@ -121,8 +128,8 @@ describe("cross-server collision scan is skipped without tool filters", () => {
     expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
   });
 
-  it("buildToolMetadata generates candidates when excludeTools is configured", () => {
-    const { config, cache } = makeTwoServerConfig({ excludeTools: ["a_search"] });
+  it("buildToolMetadata builds filtered candidates once", () => {
+    const { config, cache } = makeLargeFilteredConfig(40);
     buildToolMetadata(
       cache.servers.a.tools,
       [],
@@ -131,6 +138,6 @@ describe("cross-server collision scan is skipped without tool filters", () => {
       "server",
       config.mcpServers,
     );
-    expect(mockedGetToolNameCandidates).toHaveBeenCalled();
+    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 });

--- a/__tests__/resolve-server-from-tool-name.test.ts
+++ b/__tests__/resolve-server-from-tool-name.test.ts
@@ -4,6 +4,7 @@ import {
 	getServerPrefix,
 	formatPromptCommandName,
 	formatToolName,
+	createToolSelectorCandidateIndex,
 	getToolNameCandidates,
 	isToolExcluded,
 	isToolAllowed,
@@ -194,8 +195,36 @@ describe("direct tool selector candidates", () => {
 		expect(isToolExcluded("do_thing", "my-server", "server", ["my-server_do_thing"], new Set())).toBe(true);
 	});
 
-	it("does not apply normalized legacy emitted selectors through current collisions", () => {
-		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_thing"], new Set(["my_server_do_thing"]))).toBe(false);
+	it("does not apply normalized legacy emitted selectors through indexed exact collisions", () => {
+		const emptyIndex = createToolSelectorCandidateIndex(new Set());
+		const collisionIndex = createToolSelectorCandidateIndex(new Set(["my_server_do_thing"]));
+
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_thing"], emptyIndex)).toBe(true);
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_thing"], collisionIndex)).toBe(false);
+	});
+
+	it("skips indexed collision work when excludes are empty", () => {
+		const index = createToolSelectorCandidateIndex(new Set(["my_server_do_other"]));
+
+		expect(isToolExcluded("do-thing", "my-server", "server", undefined, index)).toBe(false);
+		expect(isToolExcluded("do-thing", "my-server", "server", [], index)).toBe(false);
+		expect(index.matchingCountByPattern.size).toBe(0);
+		expect(index.matcherByPattern.size).toBe(0);
+	});
+
+	it("caches indexed glob collision counts and matchers", () => {
+		const index = createToolSelectorCandidateIndex(new Set(["my_server_do_other", "unrelated"]));
+
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_*"], index)).toBe(false);
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_*"], index)).toBe(false);
+		expect(index.matchingCountByPattern).toEqual(new Map([["my_server_do_*", 1]]));
+		expect(index.matcherByPattern.size).toBe(1);
+
+		const currentOnlyIndex = createToolSelectorCandidateIndex(
+			getToolNameCandidates("do-thing", "my-server", "server", false),
+		);
+		expect(isToolExcluded("do-thing", "my-server", "server", ["my_server_do_*"], currentOnlyIndex)).toBe(true);
+		expect(currentOnlyIndex.matcherByPattern.size).toBe(1);
 	});
 });
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -11,7 +11,7 @@ import { formatSchema } from "./tool-metadata.ts";
 import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
+import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
@@ -150,12 +150,10 @@ export function resolveDirectTools(
     if (!toolFilter) continue;
 
     const effectivePrefix = resolveToolPrefix(definition, prefix);
-    // `otherCurrentCandidates` is only consumed when include/exclude selectors
-    // are configured, so skip the O(tools²) cross-server scan otherwise.
     const hasToolFilters =
       (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
       (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-    const getOtherCurrentCandidates = (toolName: string): Set<string> => {
+    const selectorCandidateIndex = hasToolFilters ? (() => {
       const candidates = new Set<string>();
       for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
         const otherCache = cache.servers[otherServerName];
@@ -172,14 +170,13 @@ export function resolveDirectTools(
           }
         }
       }
-      for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
-      return candidates;
-    };
+      return createToolSelectorCandidateIndex(candidates);
+    })() : undefined;
 
     for (const tool of serverCache.tools ?? []) {
       if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
       if (toolFilter !== true && !toolFilter.includes(tool.name)) continue;
-      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) continue;
+      if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) continue;
       const prefixedName = formatToolName(tool.name, serverName, effectivePrefix);
       if (BUILTIN_NAMES.has(prefixedName)) {
         console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`);
@@ -205,7 +202,7 @@ export function resolveDirectTools(
       for (const resource of serverCache.resources ?? []) {
         const baseName = `read_${resourceNameToToolName(resource.name)}`;
         if (toolFilter !== true && !toolFilter.includes(baseName)) continue;
-        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) continue;
+        if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) continue;
         const prefixedName = formatToolName(baseName, serverName, effectivePrefix);
         if (BUILTIN_NAMES.has(prefixedName)) {
           console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`);
@@ -260,13 +257,10 @@ export function buildProxyDescription(
     const cachedEntry = cache?.servers?.[serverName];
     const entry = cachedEntry && isServerCacheValid(cachedEntry, definition) ? cachedEntry : undefined;
     const effectivePrefix = resolveToolPrefix(definition, prefix);
-    // `otherCurrentCandidates` is only consumed when include/exclude selectors
-    // are configured, so skip the O(tools²) cross-server scan otherwise.
     const hasToolFilters =
       (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
       (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-    const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
-      if (!cache) return undefined;
+    const selectorCandidateIndex = hasToolFilters && cache ? (() => {
       const candidates = new Set<string>();
       for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
         const otherEntry = cache.servers[otherServerName];
@@ -283,17 +277,16 @@ export function buildProxyDescription(
           }
         }
       }
-      for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
-      return candidates;
-    };
+      return createToolSelectorCandidateIndex(candidates);
+    })() : undefined;
     const toolCount = (entry?.tools ?? []).filter(
       (tool) => isUiToolVisibleToModel(tool.uiVisibility)
-        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined),
+        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex),
     ).length;
     const resourceCount = definition?.exposeResources !== false
       ? (entry?.resources ?? []).filter((resource) => {
           const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined);
+          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex);
         }).length
       : 0;
     const totalItems = toolCount + resourceCount;

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -19,7 +19,7 @@ import type {
   ToolMetadata,
   PromptMetadata,
 } from "./types.ts";
-import { formatPromptCommandName, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
+import { createToolSelectorCandidateIndex, formatPromptCommandName, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -184,13 +184,10 @@ export function reconstructToolMetadata(
   const metadata: ToolMetadata[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
-  // `otherCurrentCandidates` is only consumed when include/exclude selectors
-  // are configured, so skip the O(tools²) cross-server scan otherwise.
   const hasToolFilters =
     (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
     (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-  const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
-    if (!configuredServers || !cache) return undefined;
+  const selectorCandidateIndex = hasToolFilters && configuredServers && cache ? (() => {
     const candidates = new Set<string>();
     for (const [otherServerName, otherDefinition] of Object.entries(configuredServers)) {
       const otherEntry = cache.servers[otherServerName];
@@ -207,16 +204,15 @@ export function reconstructToolMetadata(
         }
       }
     }
-    for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
-    return candidates;
-  };
+    return createToolSelectorCandidateIndex(candidates);
+  })() : undefined;
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
     if (!isUiToolVisibleToModel(tool.uiVisibility)) {
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) {
       continue;
     }
 
@@ -241,7 +237,7 @@ export function reconstructToolMetadata(
     for (const resource of entry.resources ?? []) {
       if (!resource?.name || !resource?.uri) continue;
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) {
         continue;
       }
 

--- a/tool-metadata.ts
+++ b/tool-metadata.ts
@@ -1,7 +1,7 @@
 import { getToolUiResourceUri } from "./ui-app-bridge-helpers.ts";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpTool, McpResource, ServerEntry, ToolPrefix } from "./types.ts";
-import { formatToolName, getToolNameCandidates, isToolAllowed, resolveToolPrefix } from "./types.ts";
+import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { extractToolUiStreamMode } from "./utils.ts";
 import { extractUiToolVisibility, isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
@@ -20,53 +20,68 @@ export function buildToolMetadata(
   const failedTools: string[] = [];
   const seenNames = new Set<string>();
   const effectivePrefix = resolveToolPrefix(definition, prefix);
-  // `otherCurrentCandidates` is only consumed when include/exclude selectors
-  // are configured, so skip the O(tools²) cross-server scan otherwise.
   const hasToolFilters =
     (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
     (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-  const getOtherCurrentCandidates = (toolName: string): Set<string> | undefined => {
-    if (!configuredServers) return undefined;
+  const selectorCandidateIndex = hasToolFilters && configuredServers ? (() => {
     const candidates = new Set<string>();
-    const addCandidates = (originalName: string, candidateServerName: string, candidatePrefix: ToolPrefix) => {
-      for (const candidate of getToolNameCandidates(originalName, candidateServerName, candidatePrefix, false)) candidates.add(candidate);
+    const additionalCandidatesByToolName = new Map<string, Set<string>>();
+    const evaluatedToolNames = new Set<string>();
+    const addCandidates = (
+      target: Set<string>,
+      originalName: string,
+      candidateServerName: string,
+      candidatePrefix: ToolPrefix,
+    ) => {
+      for (const candidate of getToolNameCandidates(originalName, candidateServerName, candidatePrefix, false)) target.add(candidate);
     };
 
     for (const tool of tools) {
-      if (tool?.name) addCandidates(tool.name, serverName, effectivePrefix);
+      if (!tool?.name) continue;
+      evaluatedToolNames.add(tool.name);
+      addCandidates(candidates, tool.name, serverName, effectivePrefix);
     }
     if (definition.exposeResources !== false) {
       for (const resource of resources) {
-        if (resource?.name && resource?.uri) addCandidates(`read_${resourceNameToToolName(resource.name)}`, serverName, effectivePrefix);
+        const baseName = `read_${resourceNameToToolName(resource.name)}`;
+        evaluatedToolNames.add(baseName);
+        if (resource?.name && resource?.uri) addCandidates(candidates, baseName, serverName, effectivePrefix);
       }
     }
     for (const [otherServerName, otherDefinition] of Object.entries(configuredServers)) {
       if (otherServerName === serverName) continue;
+      const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
       const knownTools = knownMetadata?.get(otherServerName);
       if (knownTools) {
-        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
         for (const tool of knownTools) {
           candidates.add(tool.name);
-          addCandidates(tool.originalName, otherServerName, otherPrefix);
+          addCandidates(candidates, tool.originalName, otherServerName, otherPrefix);
         }
       } else if (!knownMetadata || includeMissingConfiguredCandidates) {
-        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
-        addCandidates(toolName, otherServerName, otherPrefix);
-        if (includeMissingConfiguredCandidates) {
-          for (const candidate of getToolNameCandidates(toolName, otherServerName, otherPrefix, false)) candidates.add(candidate.replace(/-/g, "_"));
+        for (const toolName of evaluatedToolNames) {
+          let additionalCandidates = additionalCandidatesByToolName.get(toolName);
+          if (!additionalCandidates) {
+            additionalCandidates = new Set<string>();
+            additionalCandidatesByToolName.set(toolName, additionalCandidates);
+          }
+          addCandidates(additionalCandidates, toolName, otherServerName, otherPrefix);
+          if (includeMissingConfiguredCandidates) {
+            for (const candidate of getToolNameCandidates(toolName, otherServerName, otherPrefix, false)) {
+              additionalCandidates.add(candidate.replace(/-/g, "_"));
+            }
+          }
         }
       }
     }
-    for (const candidate of getToolNameCandidates(toolName, serverName, effectivePrefix, false)) candidates.delete(candidate);
-    return candidates;
-  };
+    return createToolSelectorCandidateIndex(candidates, additionalCandidatesByToolName);
+  })() : undefined;
 
   for (const tool of tools) {
     if (!tool?.name) {
       failedTools.push("(unnamed)");
       continue;
     }
-    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(tool.name) : undefined)) {
+    if (!isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) {
       continue;
     }
 
@@ -102,7 +117,7 @@ export function buildToolMetadata(
   if (definition.exposeResources !== false) {
     for (const resource of resources) {
       const baseName = `read_${resourceNameToToolName(resource.name)}`;
-      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, hasToolFilters ? getOtherCurrentCandidates(baseName) : undefined)) {
+      if (!isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex)) {
         continue;
       }
 

--- a/types.ts
+++ b/types.ts
@@ -791,6 +791,25 @@ function globToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
+export interface ToolSelectorCandidateIndex {
+  readonly allCurrentCandidates: ReadonlySet<string>;
+  readonly matchingCountByPattern: Map<string, number>;
+  readonly matcherByPattern: Map<string, RegExp>;
+  readonly additionalCurrentCandidatesByToolName?: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+export function createToolSelectorCandidateIndex(
+  allCurrentCandidates: Set<string>,
+  additionalCurrentCandidatesByToolName?: ReadonlyMap<string, ReadonlySet<string>>,
+): ToolSelectorCandidateIndex {
+  return {
+    allCurrentCandidates,
+    matchingCountByPattern: new Map<string, number>(),
+    matcherByPattern: new Map<string, RegExp>(),
+    ...(additionalCurrentCandidatesByToolName ? { additionalCurrentCandidatesByToolName } : {}),
+  };
+}
+
 export function matchesToolPattern(candidates: Set<string>, patterns?: unknown): boolean {
   if (!Array.isArray(patterns) || patterns.length === 0) return false;
 
@@ -807,24 +826,71 @@ export function matchesToolPattern(candidates: Set<string>, patterns?: unknown):
   return false;
 }
 
+export type ToolSelectorCandidateContext = Set<string> | ToolSelectorCandidateIndex;
+
+function indexHasOtherCurrentMatch(
+  index: ToolSelectorCandidateIndex,
+  toolName: string,
+  currentCandidates: Set<string>,
+  pattern: string,
+): boolean {
+  const additionalCandidates = index.additionalCurrentCandidatesByToolName?.get(toolName);
+  const hasCandidate = (candidate: string): boolean =>
+    index.allCurrentCandidates.has(candidate) || additionalCandidates?.has(candidate) === true;
+  const isGlob = pattern.includes("*") || pattern.includes("?");
+  if (!isGlob) {
+    return hasCandidate(pattern) && !currentCandidates.has(pattern);
+  }
+
+  let matcher = index.matcherByPattern.get(pattern);
+  if (!matcher) {
+    matcher = globToRegExp(pattern);
+    index.matcherByPattern.set(pattern, matcher);
+  }
+  let matchingCount = index.matchingCountByPattern.get(pattern);
+  if (matchingCount === undefined) {
+    matchingCount = 0;
+    for (const candidate of index.allCurrentCandidates) {
+      if (matcher.test(candidate)) matchingCount++;
+    }
+    index.matchingCountByPattern.set(pattern, matchingCount);
+  }
+
+  let totalMatchingCount = matchingCount;
+  if (additionalCandidates) {
+    for (const candidate of additionalCandidates) {
+      if (!index.allCurrentCandidates.has(candidate) && matcher.test(candidate)) totalMatchingCount++;
+    }
+  }
+  if (totalMatchingCount === 0) return false;
+
+  let currentMatchingCount = 0;
+  for (const candidate of currentCandidates) {
+    if (hasCandidate(candidate) && matcher.test(candidate)) currentMatchingCount++;
+  }
+  return totalMatchingCount > currentMatchingCount;
+}
+
 function matchesToolSelector(
   toolName: string,
   serverName: string,
   prefix: ToolPrefix,
   patterns: unknown,
-  otherCurrentCandidates?: Set<string>,
+  otherCurrentCandidates?: ToolSelectorCandidateContext,
 ): boolean {
+  if (!Array.isArray(patterns) || patterns.length === 0) return false;
   const currentCandidates = getToolNameCandidates(toolName, serverName, prefix, false);
   if (matchesToolPattern(currentCandidates, patterns)) return true;
   if (!otherCurrentCandidates) return matchesToolPattern(getToolNameCandidates(toolName, serverName, prefix), patterns);
   const legacyCandidates = getToolNameCandidates(toolName, serverName, prefix);
   for (const candidate of currentCandidates) legacyCandidates.delete(candidate);
-  if (!Array.isArray(patterns)) return false;
-  return patterns.some(pattern =>
-    typeof pattern === "string"
-    && !matchesToolPattern(otherCurrentCandidates, [pattern])
-    && matchesToolPattern(legacyCandidates, [pattern]),
-  );
+  return patterns.some(pattern => {
+    if (typeof pattern !== "string" || !matchesToolPattern(legacyCandidates, [pattern])) return false;
+    const hasCollision = otherCurrentCandidates instanceof Set
+      ? matchesToolPattern(otherCurrentCandidates, [pattern])
+      : indexHasOtherCurrentMatch(otherCurrentCandidates, toolName, currentCandidates, pattern);
+    return !hasCollision;
+  });
 }
 
 export function isToolIncluded(
@@ -832,7 +898,7 @@ export function isToolIncluded(
   serverName: string,
   prefix: ToolPrefix,
   includeTools?: unknown,
-  otherCurrentCandidates?: Set<string>,
+  otherCurrentCandidates?: ToolSelectorCandidateContext,
 ): boolean {
   if (!Array.isArray(includeTools) || includeTools.length === 0) return true;
   return matchesToolSelector(toolName, serverName, prefix, includeTools, otherCurrentCandidates);
@@ -843,7 +909,7 @@ export function isToolExcluded(
   serverName: string,
   prefix: ToolPrefix,
   excludeTools?: unknown,
-  otherCurrentCandidates?: Set<string>,
+  otherCurrentCandidates?: ToolSelectorCandidateContext,
 ): boolean {
   return matchesToolSelector(toolName, serverName, prefix, excludeTools, otherCurrentCandidates);
 }
@@ -854,7 +920,7 @@ export function isToolAllowed(
   prefix: ToolPrefix,
   includeTools?: unknown,
   excludeTools?: unknown,
-  otherCurrentCandidates?: Set<string>,
+  otherCurrentCandidates?: ToolSelectorCandidateContext,
 ): boolean {
   return isToolIncluded(toolName, serverName, prefix, includeTools, otherCurrentCandidates)
     && !isToolExcluded(toolName, serverName, prefix, excludeTools, otherCurrentCandidates);


### PR DESCRIPTION
## Summary

Fixes #354 by removing the remaining filtered-selector O(tools²) startup path.

The selector matcher now shares one indexed current-candidate set per filtered startup consumer, while preserving current and legacy selector collision semantics. Glob match counts and matchers are cached per pattern.

## Validation

- `npx vitest run __tests__/collision-scan-lazy.test.ts __tests__/direct-tools.test.ts __tests__/resolve-server-from-tool-name.test.ts`
- `npm run typecheck`
- `git diff --check`