### PR TITLE
fix: don't hang /mcp panels in rpc, json and print modes

### DIFF
--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -27,7 +27,7 @@ describe("authenticateServer", () => {
     await openMcpAuthPanel({
       programmaticConfig: false,
       config: { mcpServers: { disabled: { url: "https://example.test/mcp", auth: "oauth", disabled: true } } },
-    } as any, { getFlag: vi.fn() } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
     expect(ui.custom).not.toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe("authenticateServer", () => {
       const definition = { url: "${MCP_AUTH_URL}", auth: "oauth" as const };
       const result = await authenticateServer("sentry", {
         mcpServers: { sentry: definition },
-      }, { hasUI: true, ui } as any);
+      }, { hasUI: true, mode: "tui", ui } as any);
 
       expect(result.ok).toBe(true);
       expect(mocks.authenticate).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe("authenticateServer", () => {
     try {
       const result = await authenticateServer("sentry", {
         mcpServers: { sentry: { url: "https://${MCP_AUTH_URL}/mcp", auth: "oauth" } },
-      }, { hasUI: true, ui } as any);
+      }, { hasUI: true, mode: "tui", ui } as any);
 
       expect(result.ok).toBe(false);
       expect(result.message).toBe("Missing environment variable in MCP server URL: MCP_AUTH_URL");
@@ -97,7 +97,7 @@ describe("authenticateServer", () => {
       config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
       authStorageOptions: {},
       manager: { close },
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result).toEqual({ ok: false, message: "simulated secure credential store unavailable" });
     expect(close).not.toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe("authenticateServer", () => {
       config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
       authStorageOptions: {},
       manager: { close: vi.fn(async () => { throw new Error("close failed"); }) },
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result).toEqual({ ok: false, message: "close failed" });
     expect(ui.notify).toHaveBeenCalledWith(
@@ -147,7 +147,7 @@ describe("authenticateServer", () => {
       mcpServers: {
         sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
       },
-    }, { hasUI: true, ui } as any);
+    }, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result.ok).toBe(true);
     expect(mocks.authenticate).toHaveBeenCalledWith(

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -66,7 +66,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(mocks.createMcpSetupPanel).toHaveBeenCalled();
     expect(mocks.createMcpPanel).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(mocks.createMcpPanel).toHaveBeenCalled();
     const options = mocks.createMcpPanel.mock.calls[0]?.[6];
@@ -124,7 +124,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
 
     expect(mocks.createMcpPanel).toHaveBeenCalled();
     expect(warning).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
 
     expect(mocks.createMcpSetupPanel).toHaveBeenCalled();
     const discovery = mocks.createMcpSetupPanel.mock.calls[0]?.[0];
@@ -177,7 +177,7 @@ describe("commands onboarding", () => {
       manager: { close },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     await pendingCallbackRejection;
     expect(result.ok).toBe(true);
@@ -205,7 +205,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     const callbacks = mocks.createMcpPanel.mock.calls[0]?.[3];
     expect(callbacks.getConnectionStatus("legacy")).toBe("needs-auth");
@@ -244,7 +244,7 @@ describe("commands onboarding", () => {
     } as any;
     const { openMcpPanel } = await import("../commands.ts");
 
-    await openMcpPanel(state, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    await openMcpPanel(state, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     const callbacks = mocks.createMcpPanel.mock.calls[0]?.[3];
     await expect(callbacks.reconnect("notion")).resolves.toBe(true);

--- a/__tests__/commands-panel-auth-storage.test.ts
+++ b/__tests__/commands-panel-auth-storage.test.ts
@@ -51,7 +51,7 @@ describe("MCP panels with unavailable OAuth credential storage", () => {
     await expect(openPanel(
       createState(),
       { getFlag: () => undefined } as any,
-      { hasUI: true, cwd: "/tmp", ui } as any,
+      { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any,
     )).resolves.toEqual({ configChanged: false });
 
     expect(getRendered()).toContain("failed");

--- a/__tests__/commands-panel-non-tui.test.ts
+++ b/__tests__/commands-panel-non-tui.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../init.ts", () => ({
+  getFailureAgeSeconds: vi.fn(() => null),
+  getFailureMessage: vi.fn(() => undefined),
+  clearFailure: vi.fn(),
+  lazyConnect: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
+  recordFailure: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  notifyToolMetadataUpdated: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+const state = () =>
+  ({
+    config: { mcpServers: { demo: { command: "node" } } },
+    manager: { getConnection: () => undefined },
+    toolMetadata: new Map(),
+    promptMetadata: new Map(),
+    failureTracker: new Map(),
+  }) as any;
+
+// In rpc/print mode `ctx.ui.custom()` is a headless stub: it resolves without
+// invoking the factory, so anything that awaits `done` never settles. These
+// tests pin the text fallbacks that keep `/mcp` from hanging in those modes.
+// Failing them looks like a hung command, not a failed assertion, so the stub
+// mirrors the real behaviour: it never calls back.
+const nonTuiUi = () => {
+  const notify = vi.fn();
+  const custom = vi.fn(() => new Promise<never>(() => {}));
+  return { notify, custom, ui: { notify, custom } };
+};
+
+const withTimeout = <T>(promise: Promise<T>, label: string) =>
+  Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`${label} hung waiting for a custom UI panel`)), 1000),
+    ),
+  ]);
+
+describe("MCP panels outside the terminal UI", () => {
+  it("/mcp falls back to the text status instead of hanging on an overlay", async () => {
+    const { openMcpPanel } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpPanel(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpPanel",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("MCP Server Status:"), "info");
+  });
+
+  it("/mcp setup explains where the panel is available", async () => {
+    const { openMcpSetup } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpSetup(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpSetup",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("terminal UI"), "info");
+  });
+
+  it("/mcp-auth points at the per-server command", async () => {
+    const { openMcpAuthPanel } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpAuthPanel(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpAuthPanel",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/mcp-auth <server>"), "info");
+  });
+
+  it("still renders the overlay in the terminal UI", async () => {
+    const { openMcpSetup } = await import("../commands.ts");
+    const { ui, custom } = nonTuiUi();
+
+    // `custom` never settles, so poll for the call rather than awaiting the
+    // panel or racing a fixed delay against the dynamic panel import.
+    void openMcpSetup(state(), {} as any, { hasUI: true, mode: "tui", cwd: "/repo", ui } as any);
+    const deadline = Date.now() + 5000;
+    while (custom.mock.calls.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(custom).toHaveBeenCalled();
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -28,6 +28,19 @@ function terminalHyperlink(label: string, url: string): string {
   return `\u001B]8;;${sanitizeTerminalText(url)}\u001B\\${sanitizeTerminalText(label)}\u001B]8;;\u001B\\`;
 }
 
+/**
+ * True when this run mode can display a `ctx.ui.custom()` overlay.
+ *
+ * `ctx.hasUI` only reports that *some* UI context is bound. In rpc/print mode
+ * that context is a headless stub whose `custom()` returns immediately without
+ * ever invoking the factory or the `done` callback, so a panel awaited through
+ * `new Promise(resolve => ctx.ui.custom(...))` never settles and the command
+ * hangs. Overlay panels therefore additionally require `ctx.mode === "tui"`.
+ */
+function canRenderPanel(ctx: ExtensionContext): boolean {
+  return ctx.hasUI && ctx.mode === "tui";
+}
+
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
 
@@ -399,6 +412,10 @@ export async function openMcpSetup(
   options: { includeHostConfigs?: boolean } = {},
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (!canRenderPanel(ctx)) {
+    ctx.ui.notify(`The interactive MCP setup panel is only available in the terminal UI (current mode: ${ctx.mode}). Edit .mcp.json directly, or run /mcp status to review servers.`, "info");
+    return { configChanged: false };
+  }
   if (state.programmaticConfig) {
     ctx.ui.notify("MCP setup is unavailable when config is supplied by createMcpAdapter().", "info");
     return { configChanged: false };
@@ -533,6 +550,11 @@ export async function openMcpPanel(
     }
     return { configChanged: false };
   }
+  if (!canRenderPanel(ctx)) {
+    // No overlay here, but the same information is available as text.
+    await showStatus(state, ctx);
+    return { configChanged: false };
+  }
   if (Object.keys(state.config.mcpServers).length === 0) {
     return openMcpSetup(state, pi, ctx, configOverridePath, "empty", { includeHostConfigs: false });
   }
@@ -587,6 +609,10 @@ export async function openMcpAuthPanel(
   configOverridePath?: string,
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (!canRenderPanel(ctx)) {
+    ctx.ui.notify(`The interactive MCP auth panel is only available in the terminal UI (current mode: ${ctx.mode}). Use /mcp-auth <server> to authenticate a specific server.`, "info");
+    return { configChanged: false };
+  }
   if (state.programmaticConfig) {
     ctx.ui.notify("Use /mcp-auth <server> to authenticate a server from the in-memory SDK config.", "info");
     return { configChanged: false };


### PR DESCRIPTION
## Problem

`/mcp` and `/mcp setup` hang forever — no output, no response — for any host that embeds the adapter through `pi --mode rpc`.

`openMcpPanel`, `openMcpSetup` and `openMcpAuthPanel` guard on `ctx.hasUI` before showing their overlay. But pi documents `hasUI` as:

> Whether dialog-capable UI is available (**true in TUI and RPC modes**)

So the guard passes outside the terminal UI, and each function then awaits a panel like this:

```ts
await new Promise<void>((resolve) => {
  ctx.ui.custom((tui, _theme, keybindings, done) => createMcpPanel(..., () => {
    done(undefined);
    resolve();
  }), { overlay: true, ... });
});
```

Outside the TUI, `ctx.ui.custom()` is a headless stub — pi's `modes/rpc/rpc-mode.js` implements it as:

```js
async custom() {
    // Custom UI not supported in RPC mode
    return undefined;
},
```

The factory is never invoked, so `done` and `resolve` never fire and the promise never settles. The command handler stays blocked indefinitely.

### Reproduction

Against pi 0.83.0, driving the adapter over stdio RPC:

| command | before | after |
|---|---|---|
| `/mcp` | **0 frames, no response** (hangs) | server status text + `response success` |
| `/mcp status` | **0 frames, no response** (hangs) | server status text + `response success` |
| `/mcp tools` | works (uses `ctx.ui.notify`) | unchanged |

`/mcp tools` already worked, which is what pointed at `ctx.ui.custom()` as the specific culprit rather than the command plumbing.

## Fix

Guard overlay panels with the mode pi documents for exactly this purpose:

> `mode: ExtensionMode` — Current run mode. **Use `"tui"` to guard terminal-only UI such as custom components.**

...and fall back to output that already exists in this file rather than adding new surface area:

- `/mcp` and `/mcp status` → render the text status via the existing `showStatus()`
- `/mcp setup` and the auth panel → explain where the panel is available and point at the non-interactive alternative

`hasUI` checks are left in place, so the `!hasUI` behaviour is unchanged.

## Tests

Added `__tests__/commands-panel-non-tui.test.ts`. The stub `custom()` in it never calls back, mirroring the real RPC stub, so a regression shows up as the test's own hang-detector firing rather than a vague assertion failure. Reverting the `commands.ts` change fails 3 of its 4 cases, one with `openMcpSetup hung waiting for a custom UI panel`.

Three existing fixtures that exercise the overlay path only set `hasUI: true`; they now also set `mode: "tui"` to match what pi actually passes.

`npm run typecheck` is clean. Full suite is unchanged relative to `main`: the only failures are the pre-existing `interactive-visualizer-server` and `request-headers-command` ones, which pass in isolation and flake by ±1 under full-suite load on both `main` and this branch.

## Note on scope

This fixes the hang. It does not make the panels *render* outside a terminal — a host that wants the real interactive panel still has to implement `ctx.ui.custom()` itself. Degrading to text seemed like the right default here, since it uses renderers this file already has and matches how `/mcp tools` and `/mcp prompts` already behave.