### PR TITLE
fix: preserve raw MCP script results

### DIFF
--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -197,6 +197,26 @@ describe("runMcpScript", () => {
     expect(result.details).toMatchObject({ calls: [{ path: "fixture_echo", ok: true }] });
   });
 
+  it("keeps oversized raw tool results available to the script", async () => {
+    const value = "x".repeat(1_000);
+    const guardedState = {
+      ...state,
+      config: {
+        settings: { outputGuard: { detailsMaxBytes: 100 } },
+        mcpServers: { fixture: definition },
+      },
+    } as unknown as McpExtensionState;
+
+    const result = await runMcpScript(
+      guardedState,
+      `return (await tools.fixture_echo({ value: ${JSON.stringify(value)} })).data;`,
+    );
+
+    expect(JSON.parse(textBlocks(result).at(-1)!)).toMatchObject({
+      structuredContent: { echoed: value },
+    });
+  });
+
   it("records approval-gate outcomes in the call trace", async () => {
     const gatedState = {
       ...state,

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -160,7 +160,11 @@ export async function runMcpScript(
     calls[index] = { operation: "call", path, ok: true, durationMs: Date.now() - startedAt, startedAt };
     return {
       ok: true as const,
-      data: details.mcpResult !== undefined ? details.mcpResult : textFromContent(result.content),
+      data: details.scriptMcpResult !== undefined
+        ? details.scriptMcpResult
+        : details.mcpResult !== undefined
+          ? details.mcpResult
+          : textFromContent(result.content),
     };
   };
 

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1263,7 +1263,7 @@ export async function executeCall(
         content: guarded.content,
         details: {
           mode: "call",
-          ...guardedMcpDetails(guarded),
+          ...(origin === "script" ? { scriptMcpResult: result } : guardedMcpDetails(guarded)),
           ...callIdentity,
           uiOpen: uiSummary.uiOpen,
           uiViewer: uiSummary.uiViewer,
@@ -1289,7 +1289,7 @@ export async function executeCall(
     const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
     return {
       content: guarded.content,
-      details: { mode: "call", ...guardedMcpDetails(guarded), ...callIdentity },
+      details: { mode: "call", ...(origin === "script" ? { scriptMcpResult: result } : guardedMcpDetails(guarded)), ...callIdentity },
     };
   } catch (error) {
     if (error instanceof SessionRecoveryAuthRequiredError) {


### PR DESCRIPTION
## What changed

Preserve raw MCP results for script-origin calls so `mcpScript` can consume them even when presentation details are size-guarded. Direct and proxy presentation remain guarded.

## Why

Large successful tool results were reduced to guarded display content before scripts could inspect them.

## Validation

- `npx vitest run __tests__/mcp-code.test.ts` (21 passed)
- `npx tsc --noEmit`
