### PR TITLE
fix: converge stale keep-alive tool catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Recovered MCP gateway requests nested inside proxy `args` instead of silently showing status, and now rejects invalid nested gateway requests with guidance. Thanks to [@ibrmora](https://github.com/ibrmora) for #363.
+- Refreshed remote keep-alive tool catalogs before user input, adapter-triggered turns, and during health checks, reconnecting expired Streamable HTTP sessions so long-lived Pi sessions can discover replacement catalogs without restarting. Fixes #369.
 
 ## [2.26.0] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -293,8 +293,10 @@ You can also pass only the `code` query parameter with `args: { code: "..." }`. 
 
 - **`lazy`** (default) — Don't connect at startup. Connect on first tool call. Disconnect after idle timeout. Cached metadata keeps search/list working without connections.
 - **`eager`** — Connect at startup but don't auto-reconnect if the connection drops. No idle timeout by default (set `idleTimeout` explicitly to enable).
-- **`keep-alive`** — Connect at startup. Auto-reconnect via health checks. No idle timeout. Use for servers you always need available.
-- **`lazy-keep-alive`** — Don't connect at startup. Connect on first tool call (like `lazy`). Once spawned, never idle-shut down and auto-reconnect via health checks if the process dies (like `keep-alive`). Use for servers that are expensive to start but should stay resident after their first use.
+- **`keep-alive`** — Connect at startup. Remote HTTP servers refresh their tool catalog during health checks, before user input, and before adapter-triggered turns, reconnecting when the server reports that the session expired. No idle timeout. Use for servers you always need available.
+- **`lazy-keep-alive`** — Don't connect at startup. Connect on first tool call (like `lazy`). Once spawned, never idle-shut down and use the same catalog refresh and reconnect checks as `keep-alive`. Use for servers that are expensive to start but should stay resident after their first use.
+
+For remote HTTP keep-alive servers, the authoritative `tools/list` refresh is also the fallback when `list_changed` notifications are unavailable or their stream is lost. Each `tools/list` or `ping` request is capped at 5 seconds, up to 10 servers are checked concurrently, and transient failures use bounded backoff. A successful refresh updates metadata without reconnecting; a response proving that the HTTP session expired triggers a full reconnect and reinstalls the notification handlers. Dynamic direct-tool registration follows the refreshed metadata unless `freezeDirectTools` is enabled.
 
 When any enabled server uses `eager` or `keep-alive`, initialization also starts when the extension loads. This supports hosts that embed Pi programmatically and never emit `session_start`; if a session does start later, the session-owned runtime supersedes the load-time runtime.
 
@@ -725,7 +727,7 @@ Advertised tool `outputSchema` values support JSON Schema draft-07 and 2020-12. 
 - Idle servers disconnect after 10 minutes (configurable), reconnect automatically on next use
 - npx-based servers resolve to direct binary paths, skipping the ~143 MB npm parent process
 - MCP server validates arguments, not the adapter
-- Keep-alive servers get health checks and auto-reconnect
+- Remote keep-alive servers force-refresh their tool catalog during health checks, before user input, and before adapter-triggered turns, with bounded reconnect backoff
 - Specific tools can be promoted from the proxy to first-class Pi tools via `directTools` config, so the LLM sees them directly instead of having to search
 
 ## Limitations

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -116,7 +116,10 @@ function createDeferred<T>() {
 function createState() {
   return {
     manager: { getAllConnections: () => new Map() },
-    lifecycle: { gracefulShutdown: vi.fn().mockResolvedValue(undefined) },
+    lifecycle: {
+      gracefulShutdown: vi.fn().mockResolvedValue(undefined),
+      ensureConverged: vi.fn().mockResolvedValue(undefined),
+    },
     toolMetadata: new Map(),
     config: { mcpServers: {} },
     oauthRuntime: { signal: new AbortController().signal },
@@ -413,6 +416,150 @@ describe("mcpAdapter session lifecycle", () => {
     await sessionStart;
 
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
+  });
+
+  it("waits for keep-alive convergence before Pi processes the next input", async () => {
+    const config = {
+      mcpServers: {
+        demo: { url: "https://example.test/mcp", lifecycle: "keep-alive" },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    const convergence = createDeferred<void>();
+    state.lifecycle.ensureConverged.mockReturnValue(convergence.promise);
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    let inputCompleted = false;
+    const input = Promise.resolve(handlers.get("input")?.({ type: "input", text: "hello" }, {}))
+      .then(() => { inputCompleted = true; });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(inputCompleted).toBe(false);
+    convergence.resolve();
+    await input;
+    expect(state.lifecycle.ensureConverged).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for pending lazy-keep-alive initialization before the first input", async () => {
+    const config = {
+      mcpServers: {
+        demo: { url: "https://example.test/mcp", lifecycle: "lazy-keep-alive" },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    const initialization = createDeferred<typeof state>();
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue(null);
+    mocks.initializeMcp.mockReturnValue(initialization.promise);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+
+    let inputCompleted = false;
+    const input = Promise.resolve(handlers.get("input")?.({ type: "input", text: "hello" }, {}))
+      .then(() => { inputCompleted = true; });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(inputCompleted).toBe(false);
+    initialization.resolve(state);
+    await input;
+    expect(state.lifecycle.ensureConverged).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the first-input wait when initialization stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const config = {
+        mcpServers: {
+          demo: { url: "https://example.test/mcp", lifecycle: "keep-alive" },
+        },
+      };
+      const state = createState();
+      const initialization = createDeferred<typeof state>();
+      mocks.loadMcpConfig.mockReturnValue(config);
+      mocks.initializeMcp.mockReturnValue(initialization.promise);
+
+      const { default: mcpAdapter } = await import("../index.ts");
+      const { api, handlers } = createPi();
+      mcpAdapter(api);
+      await handlers.get("session_start")?.({}, {});
+
+      let inputCompleted = false;
+      const input = Promise.resolve(handlers.get("input")?.({ type: "input", text: "hello" }, {}))
+        .then(() => { inputCompleted = true; });
+      await Promise.resolve();
+      expect(inputCompleted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await input;
+      expect(inputCompleted).toBe(true);
+      expect(state.lifecycle.ensureConverged).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reconciles direct tools during the keep-alive input barrier", async () => {
+    const config = {
+      mcpServers: {
+        demo: {
+          url: "https://example.test/mcp",
+          lifecycle: "keep-alive",
+          directTools: true,
+        },
+      },
+    };
+    const oldTool = {
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Old search",
+    };
+    const newTool = {
+      serverName: "demo",
+      originalName: "lookup",
+      prefixedName: "demo_lookup",
+      description: "New lookup",
+    };
+    const state = createState();
+    state.config = config;
+    state.lifecycle.ensureConverged.mockImplementation(async () => {
+      await state.onToolMetadataUpdated?.("demo", "keep-alive-refresh");
+    });
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({ version: 1, servers: {} });
+    mocks.resolveDirectTools
+      .mockReturnValueOnce([oldTool])
+      .mockReturnValueOnce([oldTool])
+      .mockReturnValue([newTool]);
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await handlers.get("input")?.({ type: "input", text: "hello" }, {});
+
+    expect(api.unregisterTool).toHaveBeenCalledWith("demo_search");
+    expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({
+      name: "demo_lookup",
+      description: "New lookup",
+    }));
   });
 
   it("hot-loads direct tools after session initialization refreshes metadata", async () => {

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -439,4 +439,33 @@ describe("lazy-keep-alive initializeMcp integration", () => {
 
     expect(mocks.manager.connect).toHaveBeenCalledTimes(2);
   });
+
+  it("waits for keep-alive convergence before adapter-triggered model turns", async () => {
+    const { initializeMcp } = await import("../init.ts");
+    const sendMessage = vi.fn();
+    const state = await initializeMcp({
+      getFlag: vi.fn(() => undefined),
+      sendMessage,
+    } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+      signal: undefined,
+    } as any);
+    let finishConvergence!: () => void;
+    vi.spyOn(state.lifecycle, "ensureConverged").mockReturnValue(new Promise<void>((resolve) => {
+      finishConvergence = resolve;
+    }));
+    const message = {
+      customType: "mcp-ui-prompt",
+      content: [{ type: "text" as const, text: "continue" }],
+    };
+
+    state.sendMessage?.(message, { triggerTurn: true });
+    await Promise.resolve();
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    finishConvergence();
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledWith(message, { triggerTurn: true }));
+  });
 });

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
 import { lazyConnect } from "../init.ts";
 import { McpLifecycleManager } from "../lifecycle.ts";
 import { executeCall } from "../proxy-modes.ts";
@@ -10,20 +11,29 @@ import type { ServerDefinition } from "../types.ts";
 
 interface FakeConnection {
   status: "connected" | "closed" | "needs-auth";
+  transport?: { sessionId?: string };
 }
 
 class FakeManager {
   connections = new Map<string, FakeConnection>();
   connectCalls: string[] = [];
+  refreshToolsCalls: string[] = [];
+  reconnectCalls: Array<{ name: string; staleConnection: FakeConnection }> = [];
   closeCalls: string[] = [];
   idleResponses = new Map<string, boolean>();
   connectError: Error | undefined;
+  refreshToolsError: Error | undefined;
+  reconnectError: Error | undefined;
+  reconnectStatus: FakeConnection["status"] = "connected";
 
-  setConnection(name: string, status: FakeConnection["status"] | null): void {
+  setConnection(name: string, status: FakeConnection["status"] | null, sessionId?: string): FakeConnection | undefined {
     if (status === null) {
       this.connections.delete(name);
+      return undefined;
     } else {
-      this.connections.set(name, { status });
+      const connection = { status, transport: { sessionId } };
+      this.connections.set(name, connection);
+      return connection;
     }
   }
 
@@ -35,6 +45,23 @@ class FakeManager {
     this.connectCalls.push(name);
     if (this.connectError) throw this.connectError;
     const connection: FakeConnection = { status: "connected" };
+    this.connections.set(name, connection);
+    return connection;
+  }
+
+  async refreshTools(name: string): Promise<"unchanged"> {
+    this.refreshToolsCalls.push(name);
+    if (this.refreshToolsError) throw this.refreshToolsError;
+    return "unchanged";
+  }
+
+  async reconnect(name: string, _definition: ServerDefinition, staleConnection: FakeConnection): Promise<FakeConnection> {
+    this.reconnectCalls.push({ name, staleConnection });
+    if (this.reconnectError) {
+      this.connections.delete(name);
+      throw this.reconnectError;
+    }
+    const connection: FakeConnection = { status: this.reconnectStatus, transport: { sessionId: "fresh-session" } };
     this.connections.set(name, connection);
     return connection;
   }
@@ -124,7 +151,236 @@ describe("lazy-keep-alive lifecycle", () => {
     expect(fake.connectCalls).toContain("srv");
   });
 
+  it("actively refreshes connected keep-alive servers instead of trusting local status", async () => {
+    const def = makeDefinition("keep-alive");
+    def.url = "https://example.test/mcp";
+    delete def.command;
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected");
+
+    await lifecycle.ensureConverged();
+
+    expect(fake.refreshToolsCalls).toEqual(["srv"]);
+  });
+
+  it("checks multiple connected keep-alive servers concurrently", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("one", def);
+    lifecycle.markKeepAlive("two", def);
+    fake.setConnection("one", "connected");
+    fake.setConnection("two", "connected");
+    const resolvers = new Map<string, () => void>();
+    const refreshTools = vi.spyOn(fake, "refreshTools").mockImplementation((name) =>
+      new Promise<"unchanged">((resolve) => {
+        resolvers.set(name, () => resolve("unchanged"));
+      })
+    );
+
+    const convergence = lifecycle.ensureConverged();
+    await Promise.resolve();
+
+    expect(refreshTools).toHaveBeenCalledTimes(2);
+    resolvers.get("one")?.();
+    resolvers.get("two")?.();
+    await convergence;
+  });
+
+  it("does not couple the input convergence barrier to unrelated idle shutdowns", async () => {
+    const def = makeDefinition("lazy");
+    lifecycle.registerServer("idle", def, { idleTimeout: 1 });
+    fake.setConnection("idle", "connected");
+    fake.idleResponses.set("idle", true);
+
+    await lifecycle.ensureConverged();
+
+    expect(fake.closeCalls).toEqual([]);
+  });
+
+  it("reconnects an apparently connected server when refresh proves its HTTP session expired", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    const staleConnection = fake.setConnection("srv", "connected", "stale-session")!;
+    fake.refreshToolsError = new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "Session not found",
+      { status: 404 },
+    );
+
+    await lifecycle.ensureConverged();
+
+    expect(fake.reconnectCalls).toEqual([{ name: "srv", staleConnection }]);
+  });
+
+  it("publishes metadata when a concurrent recovery replaces the connection during refresh", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "stale-session");
+    const freshConnection: FakeConnection = {
+      status: "connected",
+      transport: { sessionId: "fresh-session" },
+    };
+    vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
+      fake.connections.set("srv", freshConnection);
+      return "superseded" as never;
+    });
+    const onReconnect = vi.fn();
+    lifecycle.setReconnectCallback(onReconnect);
+
+    await lifecycle.ensureConverged();
+
+    expect(onReconnect).toHaveBeenCalledWith("srv");
+  });
+
+  it("rechecks when a refresh is superseded by the same connection closing", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    const connection = fake.setConnection("srv", "connected", "stale-session")!;
+    vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
+      connection.status = "closed";
+      return "superseded" as never;
+    });
+
+    await lifecycle.ensureConverged();
+
+    expect(fake.connectCalls).toEqual(["srv"]);
+  });
+
+  it("publishes a concurrent replacement when the stale refresh rejects", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "stale-session");
+    const freshConnection: FakeConnection = {
+      status: "connected",
+      transport: { sessionId: "fresh-session" },
+    };
+    vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
+      fake.connections.set("srv", freshConnection);
+      throw new Error("stale request closed");
+    });
+    const onReconnect = vi.fn();
+    lifecycle.setReconnectCallback(onReconnect);
+
+    await lifecycle.ensureConverged();
+
+    expect(onReconnect).toHaveBeenCalledWith("srv");
+  });
+
+  it("retries metadata publication after a concurrent replacement hook fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "stale-session");
+    const freshConnection: FakeConnection = {
+      status: "connected",
+      transport: { sessionId: "fresh-session" },
+    };
+    vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
+      fake.connections.set("srv", freshConnection);
+      return "superseded" as never;
+    });
+    const onReconnect = vi.fn()
+      .mockRejectedValueOnce(new Error("metadata cache unavailable"))
+      .mockResolvedValue(undefined);
+    lifecycle.setReconnectCallback(onReconnect);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await lifecycle.ensureConverged();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    await lifecycle.ensureConverged();
+
+    expect(onReconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it("backs off repeated refresh failures and retries after the bounded delay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "session");
+    fake.refreshToolsError = new Error("temporarily unavailable");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onHealthRestored = vi.fn();
+    lifecycle.setHealthRestoredCallback(onHealthRestored);
+
+    await lifecycle.ensureConverged();
+    await lifecycle.ensureConverged();
+    expect(fake.refreshToolsCalls).toEqual(["srv"]);
+
+    vi.advanceTimersByTime(30_000);
+    fake.refreshToolsError = undefined;
+    await lifecycle.ensureConverged();
+    expect(fake.refreshToolsCalls).toEqual(["srv", "srv"]);
+    expect(onHealthRestored).toHaveBeenCalledWith("srv");
+  });
+
+  it("reconnects immediately when a backed-off connection closes in place", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    const connection = fake.setConnection("srv", "connected", "session")!;
+    fake.refreshToolsError = new Error("temporarily unavailable");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await lifecycle.ensureConverged();
+    connection.status = "closed";
+    await lifecycle.ensureConverged();
+
+    expect(fake.connectCalls).toEqual(["srv"]);
+  });
+
+  it("keeps backoff after a stale-session reconnect closes the old connection and fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "stale-session");
+    fake.refreshToolsError = new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "Session not found",
+      { status: 404 },
+    );
+    fake.reconnectError = new Error("replacement unavailable");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await lifecycle.ensureConverged();
+    await lifecycle.ensureConverged();
+
+    expect(fake.refreshToolsCalls).toEqual(["srv"]);
+    expect(fake.reconnectCalls).toHaveLength(1);
+    expect(fake.connectCalls).toEqual([]);
+  });
+
+  it("parks a reconnect that returns needs-auth instead of reporting success or retrying", async () => {
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "stale-session");
+    fake.refreshToolsError = new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      "Session not found",
+      { status: 404 },
+    );
+    fake.reconnectStatus = "needs-auth";
+    const onReconnect = vi.fn();
+    const onAuthRequired = vi.fn();
+    lifecycle.setReconnectCallback(onReconnect);
+    lifecycle.setAuthRequiredCallback(onAuthRequired);
+
+    await lifecycle.ensureConverged();
+    await lifecycle.ensureConverged();
+
+    expect(fake.reconnectCalls).toHaveLength(1);
+    expect(fake.connectCalls).toEqual([]);
+    expect(onReconnect).not.toHaveBeenCalled();
+    expect(onAuthRequired).toHaveBeenCalledWith("srv");
+  });
+
   it("records reconnect failures and clears them after a later success", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
     const def = makeDefinition("keep-alive");
     lifecycle.markKeepAlive("srv", def);
     const onFailure = vi.fn();
@@ -142,6 +398,7 @@ describe("lazy-keep-alive lifecycle", () => {
     expect(consoleError.mock.calls[0][0]).not.toContain("clipboard-secret");
 
     fake.connectError = undefined;
+    vi.advanceTimersByTime(30_000);
     await (lifecycle as never as { checkConnections: () => Promise<void> }).checkConnections();
 
     expect(onSuccess).toHaveBeenCalledWith("srv");

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -240,6 +240,149 @@ describe("McpServerManager sampling", () => {
     expect(metadataChanged).toHaveBeenCalledWith("demo", "resources-list-changed");
   });
 
+  it("forces an authoritative tool refresh and publishes catalog changes", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const metadataChanged = vi.fn();
+    manager.setMetadataListChangedListener(metadataChanged);
+
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    const freshTools = [{ name: "fresh_tool", description: "Fresh tool" }];
+    client.listTools.mockResolvedValueOnce({ tools: freshTools });
+
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("updated");
+
+    expect(client.listTools).toHaveBeenLastCalledWith(undefined, expect.objectContaining({
+      cacheMode: "refresh",
+      timeout: 5_000,
+    }));
+    expect(connection.tools).toEqual(freshTools);
+    expect(metadataChanged).toHaveBeenCalledWith("demo", "keep-alive-refresh");
+
+    metadataChanged.mockClear();
+    client.listTools.mockResolvedValueOnce({ tools: freshTools });
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("unchanged");
+    expect(metadataChanged).not.toHaveBeenCalled();
+  });
+
+  it("keeps every page of an authoritative tool refresh", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    const initialListCalls = client.listTools.mock.calls.length;
+    client.listTools
+      .mockResolvedValueOnce({
+        tools: [{ name: "first_page_tool" }],
+        nextCursor: "page-2",
+      })
+      .mockResolvedValueOnce({ tools: [{ name: "second_page_tool" }] });
+
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("updated");
+
+    expect(connection.tools.map(tool => tool.name)).toEqual([
+      "first_page_tool",
+      "second_page_tool",
+    ]);
+    expect(client.listTools).toHaveBeenNthCalledWith(
+      initialListCalls + 1,
+      undefined,
+      expect.objectContaining({ cacheMode: "refresh", timeout: 5_000 }),
+    );
+    expect(client.listTools).toHaveBeenLastCalledWith(
+      { cursor: "page-2" },
+      expect.objectContaining({ cacheMode: "refresh", timeout: 5_000 }),
+    );
+  });
+
+  it("retries publication when a refreshed catalog listener fails", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const publicationError = new Error("cache unavailable");
+    const metadataChanged = vi.fn().mockImplementationOnce(() => { throw publicationError; });
+    manager.setMetadataListChangedListener(metadataChanged);
+
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const freshTools = [{ name: "fresh_tool", description: "Fresh tool" }];
+    mocks.clients[0].listTools.mockResolvedValueOnce({ tools: freshTools });
+
+    await expect(manager.refreshTools("demo", connection)).rejects.toBe(publicationError);
+    expect(connection.tools).toEqual([]);
+
+    mocks.clients[0].listTools.mockResolvedValueOnce({ tools: freshTools });
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("updated");
+    expect(connection.tools).toEqual(freshTools);
+  });
+
+  it("queues a failed session-reconnect publication for the next refresh", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const publicationError = new Error("cache unavailable");
+    const metadataChanged = vi.fn()
+      .mockImplementationOnce(() => { throw publicationError; })
+      .mockImplementation(() => undefined);
+    manager.setMetadataListChangedListener(metadataChanged);
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+
+    expect(manager.publishMetadataChanged("demo", connection, "session-reconnect")).toBe(false);
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("unchanged");
+
+    expect(metadataChanged).toHaveBeenNthCalledWith(1, "demo", "session-reconnect");
+    expect(metadataChanged).toHaveBeenNthCalledWith(2, "demo", "session-reconnect");
+  });
+
+  it("pings keep-alive connections whose negotiated server has no tools capability", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    const initialListCalls = client.listTools.mock.calls.length;
+    client.getServerCapabilities.mockReturnValue({ resources: {} });
+    client.ping = vi.fn(async () => ({}));
+
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("unchanged");
+
+    expect(client.ping).toHaveBeenCalledWith(expect.objectContaining({ timeout: 5_000 }));
+    expect(client.listTools).toHaveBeenCalledTimes(initialListCalls);
+  });
+
+  it("retries queued metadata publication after a no-tools ping", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    client.getServerCapabilities.mockReturnValue({ resources: {} });
+    client.ping = vi.fn(async () => ({}));
+    const metadataChanged = vi.fn()
+      .mockImplementationOnce(() => { throw new Error("cache unavailable"); })
+      .mockImplementation(() => undefined);
+    manager.setMetadataListChangedListener(metadataChanged);
+
+    expect(manager.publishMetadataChanged("demo", connection, "session-reconnect")).toBe(false);
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("unchanged");
+
+    expect(metadataChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overwrite a newer list-changed catalog with an older refresh response", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    let resolveRefresh!: (value: { tools: Array<{ name: string }> }) => void;
+    client.listTools.mockImplementationOnce(() => new Promise(resolve => { resolveRefresh = resolve; }));
+
+    const refresh = manager.refreshTools("demo", connection);
+    await Promise.resolve();
+    const notificationTools = [{ name: "notification_tool" }];
+    client.options.listChanged.tools.onChanged(null, notificationTools);
+    resolveRefresh({ tools: [{ name: "older_refresh_tool" }] });
+
+    await expect(refresh).resolves.toBe("superseded");
+    expect(connection.tools).toEqual(notificationTools);
+  });
+
   it("logs list-change callback errors without replacing cached metadata", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/__tests__/session-recovery-integration.test.ts
+++ b/__tests__/session-recovery-integration.test.ts
@@ -69,7 +69,12 @@ describe("session recovery — Streamable HTTP wire path", () => {
         res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
           jsonrpc: "2.0",
           id: message.id,
-          result: { tools: [{ name: "search", inputSchema: { type: "object", properties: {} } }] },
+          result: {
+            tools: [{
+              name: sessionCount === 1 ? "search" : "lookup",
+              inputSchema: { type: "object", properties: {} },
+            }],
+          },
         }));
         return;
       }
@@ -112,20 +117,161 @@ describe("session recovery — Streamable HTTP wire path", () => {
 
     const manager = new McpServerManager();
     const definition = { url: `http://127.0.0.1:${address.port}/mcp` };
+    const publishedCatalogs: string[][] = [];
+    manager.setMetadataListChangedListener((_serverName, reason) => {
+      if (reason === "session-reconnect") {
+        publishedCatalogs.push(manager.getConnection("demo")?.tools.map(tool => tool.name) ?? []);
+      }
+    });
+    let recoveryAttempts = 0;
+    let replaySawPublishedCatalog = false;
     try {
       await manager.connect("demo", definition);
       const result = await withSessionRecovery(
         { manager, config: { mcpServers: { demo: definition } } },
         "demo",
-        connection => connection.client.callTool({ name: "search", arguments: {} }),
+        connection => {
+          recoveryAttempts += 1;
+          if (recoveryAttempts === 2) {
+            replaySawPublishedCatalog = publishedCatalogs.some(tools => tools.includes("lookup"));
+          }
+          return connection.client.callTool({ name: "search", arguments: {} });
+        },
       );
 
       expect(result.content[0]).toMatchObject({ type: "text", text: "ok" });
       expect(toolCalls).toBe(2);
       expect(toolCallSessionIds).toHaveLength(2);
       expect(toolCallSessionIds[0]).not.toBe(toolCallSessionIds[1]);
+      expect(publishedCatalogs).toEqual([["lookup"]]);
+      expect(replaySawPublishedCatalog).toBe(true);
     } finally {
       await manager.close("demo").catch(() => {});
+      await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("polls without a notification stream and reconnects when that session later expires", async () => {
+    const { createServer } = await import("node:http");
+    const { McpLifecycleManager } = await import("../lifecycle.ts");
+    const { McpServerManager } = await import("../server-manager.ts");
+
+    let generation = 1;
+    let rejectStaleSession = false;
+    const listedSessionIds: string[] = [];
+    const server = createServer(async (req, res) => {
+      if (req.method === "GET") {
+        res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+        return;
+      }
+      if (req.method === "DELETE") {
+        res.writeHead(200).end();
+        return;
+      }
+      if (req.method !== "POST") {
+        res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+        return;
+      }
+
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      const message = JSON.parse(body) as { id?: string | number; method?: string };
+      const requestSessionId = Array.isArray(req.headers["mcp-session-id"])
+        ? req.headers["mcp-session-id"][0]
+        : req.headers["mcp-session-id"];
+
+      if (message.method === "initialize") {
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "mcp-session-id": `session-${generation}`,
+        }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: "2025-06-18",
+            capabilities: { tools: {}, resources: {} },
+            serverInfo: { name: "replaceable", version: `${generation}.0.0` },
+          },
+        }));
+        return;
+      }
+
+      if (message.method === "notifications/initialized") {
+        res.writeHead(202).end();
+        return;
+      }
+
+      if (message.method === "tools/list") {
+        listedSessionIds.push(requestSessionId ?? "");
+        if (rejectStaleSession && requestSessionId !== `session-${generation}`) {
+          res.writeHead(404).end("Session not found");
+          return;
+        }
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            tools: [{
+              name: generation === 1
+                ? "old_tool"
+                : generation === 2
+                  ? "refreshed_tool"
+                  : "new_tool",
+              inputSchema: { type: "object", properties: {} },
+            }],
+          },
+        }));
+        return;
+      }
+
+      if (message.method === "resources/list") {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: { resources: [] },
+        }));
+        return;
+      }
+
+      res.writeHead(500).end(`unexpected method: ${message.method}`);
+    });
+
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port");
+
+    const manager = new McpServerManager();
+    const definition = {
+      url: `http://127.0.0.1:${address.port}/mcp`,
+      lifecycle: "keep-alive" as const,
+    };
+    const lifecycle = new McpLifecycleManager(manager);
+    const reconnected = vi.fn();
+    lifecycle.setReconnectCallback(reconnected);
+    lifecycle.markKeepAlive("demo", definition);
+
+    try {
+      const staleConnection = await manager.connect("demo", definition);
+      expect(staleConnection.tools.map(tool => tool.name)).toEqual(["old_tool"]);
+
+      generation = 2;
+      await lifecycle.ensureConverged();
+      expect(manager.getConnection("demo")).toBe(staleConnection);
+      expect(staleConnection.tools.map(tool => tool.name)).toEqual(["refreshed_tool"]);
+      expect(reconnected).not.toHaveBeenCalled();
+
+      generation = 3;
+      rejectStaleSession = true;
+      await lifecycle.ensureConverged();
+
+      const freshConnection = manager.getConnection("demo");
+      expect(freshConnection).not.toBe(staleConnection);
+      expect(freshConnection?.tools.map(tool => tool.name)).toEqual(["new_tool"]);
+      expect(listedSessionIds).toContain("session-1");
+      expect(listedSessionIds).toContain("session-3");
+      expect(reconnected).toHaveBeenCalledWith("demo");
+    } finally {
+      await lifecycle.gracefulShutdown().catch(() => {});
       await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
     }
   });

--- a/__tests__/session-recovery.test.ts
+++ b/__tests__/session-recovery.test.ts
@@ -112,6 +112,7 @@ describe("withSessionRecovery", () => {
     return {
       getConnection: vi.fn(overrides.getConnection),
       reconnect: vi.fn(overrides.reconnect),
+      publishMetadataChanged: vi.fn(),
     };
   }
 
@@ -142,6 +143,10 @@ describe("withSessionRecovery", () => {
     expect(fn).toHaveBeenNthCalledWith(2, fresh);
     expect(manager.reconnect).toHaveBeenCalledWith("demo", config.mcpServers.demo, stale);
     expect(manager.reconnect).toHaveBeenCalledTimes(1);
+    expect(manager.publishMetadataChanged).toHaveBeenCalledWith("demo", fresh, "session-reconnect");
+    expect(manager.publishMetadataChanged.mock.invocationCallOrder[0]).toBeLessThan(
+      fn.mock.invocationCallOrder[1]!,
+    );
   });
 
   it("transparently recovers server-not-initialized MCP errors", async () => {
@@ -167,6 +172,26 @@ describe("withSessionRecovery", () => {
     expect(fn).toHaveBeenNthCalledWith(2, fresh);
     expect(manager.reconnect).toHaveBeenCalledWith("demo", config.mcpServers.demo, stale);
     expect(manager.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("still replays the tool when replacement metadata publication reports a failure", async () => {
+    const stale = makeConnection("session-1");
+    const fresh = makeConnection("session-2");
+    const manager = makeManager({
+      getConnection: () => stale,
+      reconnect: async () => fresh,
+    });
+    manager.publishMetadataChanged.mockImplementationOnce(() => {
+      throw new Error("publication failed");
+    });
+    const fn = vi.fn(async (conn: ServerConnection) => {
+      if (conn === stale) throw httpError(404, "Session not found");
+      return "ok";
+    });
+
+    await expect(withSessionRecovery({ manager: manager as any, config }, "demo", fn)).resolves.toBe("ok");
+
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
   it("invalidates OAuth credentials after a runtime 401 and preserves the error", async () => {

--- a/index.ts
+++ b/index.ts
@@ -417,6 +417,29 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
   });
 
+  pi.on("input", async () => {
+    const inputOwner = currentOwner;
+    if (!inputOwner?.isActive()) return;
+
+    if (!state && initPromise) {
+      try {
+        await awaitWithTimeout(initPromise, INIT_WAIT_TIMEOUT_MS);
+      } catch {
+        return;
+      }
+    }
+
+    const inputState = state;
+    if (!inputState || !inputOwner.isActive()) return;
+    try {
+      await inputState.lifecycle.ensureConverged(inputOwner.signal);
+    } catch (error) {
+      if (!isAbortError(error, inputOwner.signal)) {
+        logger.debug(`MCP: keep-alive convergence failed before input: ${formatTerminalError(error)}`);
+      }
+    }
+  });
+
   pi.on("session_shutdown", async () => {
     ++lifecycleGeneration;
     const currentState = state;

--- a/init.ts
+++ b/init.ts
@@ -179,8 +179,20 @@ export async function initializeMcp(
     },
     ...(ui !== undefined ? { ui } : {}),
     sendMessage: (message, options) => {
-      if (!owner.isActive()) return;
-      pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options);
+      const deliver = () => {
+        if (!owner.isActive()) return;
+        pi.sendMessage(message as unknown as Parameters<typeof pi.sendMessage>[0], options);
+      };
+      if (!options?.triggerTurn) {
+        deliver();
+        return;
+      }
+      void lifecycle.ensureConverged(owner.signal).then(deliver, error => {
+        if (!owner.isActive() || isAbortError(error, owner.signal)) return;
+        const detail = error instanceof Error ? error.message : String(error);
+        logger.debug(`MCP: pre-turn keep-alive convergence failed: ${sanitizeTerminalText(detail)}`);
+        deliver();
+      });
     },
     ...(options.statusEvents !== undefined ? { statusEvents: options.statusEvents } : {}),
   };
@@ -416,6 +428,18 @@ export async function initializeMcp(
     if (!owner.isActive()) return;
     const message = error instanceof Error ? error.message : String(error);
     recordFailure(state, serverName, message);
+    updateStatusBar(state);
+  });
+
+  lifecycle.setHealthRestoredCallback((serverName) => {
+    if (!owner.isActive()) return;
+    clearFailure(state, serverName);
+    updateStatusBar(state);
+  });
+
+  lifecycle.setAuthRequiredCallback((serverName) => {
+    if (!owner.isActive()) return;
+    clearFailure(state, serverName);
     updateStatusBar(state);
   });
 

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -1,11 +1,26 @@
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import { isServerDisabled, type ServerDefinition } from "./types.ts";
-import type { McpServerManager } from "./server-manager.ts";
+import type { McpServerManager, ServerConnection } from "./server-manager.ts";
 import { hasPendingAuth } from "./mcp-auth-flow.ts";
 import { logger } from "./logger.ts";
-import { formatTerminalError, sanitizeTerminalText } from "./utils.ts";
+import { formatTerminalError, parallelLimit, sanitizeTerminalText } from "./utils.ts";
+import { isTerminatedSession } from "./session-recovery.ts";
 
-export type ReconnectCallback = (serverName: string) => void;
+export type ReconnectCallback = (serverName: string) => void | Promise<void>;
 export type ReconnectFailureCallback = (serverName: string, error: unknown) => void;
+export type HealthRestoredCallback = (serverName: string) => void | Promise<void>;
+export type AuthRequiredCallback = (serverName: string) => void | Promise<void>;
+
+const KEEP_ALIVE_RETRY_BASE_MS = 30_000;
+const KEEP_ALIVE_RETRY_MAX_MS = 5 * 60_000;
+const KEEP_ALIVE_CHECK_CONCURRENCY = 10;
+
+interface RetryState {
+  attempts: number;
+  nextAttemptAt: number;
+  connection: ServerConnection | undefined;
+  status: ServerConnection["status"] | undefined;
+}
 
 export class McpLifecycleManager {
   private keepAliveServers = new Map<string, ServerDefinition>();
@@ -15,9 +30,14 @@ export class McpLifecycleManager {
   private healthCheckInterval: NodeJS.Timeout | undefined;
   private onReconnect: ReconnectCallback | undefined;
   private onReconnectFailure: ReconnectFailureCallback | undefined;
+  private onHealthRestored: HealthRestoredCallback | undefined;
+  private onAuthRequired: AuthRequiredCallback | undefined;
   private onIdleShutdown: ((serverName: string) => void) | undefined;
   private activeHealthCheck: Promise<void> | undefined;
+  private activeConvergence: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
+  private retryStates = new Map<string, RetryState>();
+  private pendingMetadataPublications = new Set<string>();
   private stopped = false;
   private removeHealthAbortListener: (() => void) | undefined;
 
@@ -32,6 +52,14 @@ export class McpLifecycleManager {
 
   setReconnectFailureCallback(callback: ReconnectFailureCallback): void {
     this.onReconnectFailure = callback;
+  }
+
+  setHealthRestoredCallback(callback: HealthRestoredCallback): void {
+    this.onHealthRestored = callback;
+  }
+
+  setAuthRequiredCallback(callback: AuthRequiredCallback): void {
+    this.onAuthRequired = callback;
   }
 
   markKeepAlive(name: string, definition: ServerDefinition): void {
@@ -82,29 +110,23 @@ export class McpLifecycleManager {
     this.healthCheckInterval.unref();
   }
 
+  async ensureConverged(signal?: AbortSignal): Promise<void> {
+    if (this.stopped || signal?.aborted) return;
+    if (this.activeConvergence) return this.activeConvergence;
+
+    const check = this.checkKeepAliveConnections(signal);
+    this.activeConvergence = check;
+    try {
+      await check;
+    } finally {
+      if (this.activeConvergence === check) this.activeConvergence = undefined;
+    }
+  }
+
   private async checkConnections(signal?: AbortSignal): Promise<void> {
     if (this.stopped || signal?.aborted) return;
-    for (const [name, definition] of this.keepAliveServers) {
-      if (isServerDisabled(definition)) continue;
-      const connection = this.manager.getConnection(name);
-      if (!connection || connection.status !== "connected") {
-        if (this.hasPendingAuthForServer(name)) {
-          logger.debug(`Skipping reconnect for ${name} while OAuth authorization is pending`);
-          continue;
-        }
-        try {
-          await this.manager.connect(name, definition, signal);
-          if (this.stopped || signal?.aborted) return;
-          logger.debug(`Reconnected to ${name}`);
-          this.onReconnect?.(name);
-        } catch (error) {
-          if (this.stopped || signal?.aborted) return;
-          this.onReconnectFailure?.(name, error);
-          const message = error instanceof Error ? error.message : String(error);
-          console.error(`MCP: Failed to reconnect to ${name}: ${sanitizeTerminalText(message)}`);
-        }
-      }
-    }
+    await this.ensureConverged(signal);
+    if (this.stopped || signal?.aborted) return;
 
     for (const [name] of this.allServers) {
       if (this.keepAliveServers.has(name)) continue;
@@ -115,6 +137,205 @@ export class McpLifecycleManager {
         this.onIdleShutdown?.(name);
       }
     }
+  }
+
+  private async checkKeepAliveConnections(signal?: AbortSignal): Promise<void> {
+    if (this.stopped || signal?.aborted) return;
+    await parallelLimit(
+      [...this.keepAliveServers],
+      KEEP_ALIVE_CHECK_CONCURRENCY,
+      ([name, definition]) => this.checkKeepAliveConnection(name, definition, signal),
+    );
+  }
+
+  private async checkKeepAliveConnection(
+    name: string,
+    definition: ServerDefinition,
+    signal?: AbortSignal,
+    retrySuperseded = true,
+  ): Promise<void> {
+    if (isServerDisabled(definition) || this.stopped || signal?.aborted) return;
+    const connection = this.manager.getConnection(name);
+    if (connection?.status === "needs-auth") {
+      this.pendingMetadataPublications.delete(name);
+      return;
+    }
+    if (!this.shouldAttemptConnection(name, connection)) return;
+    if (!connection || connection.status !== "connected") {
+      if (this.hasPendingAuthForServer(name)) {
+        logger.debug(`Skipping reconnect for ${name} while OAuth authorization is pending`);
+        return;
+      }
+      let freshConnection: ServerConnection;
+      try {
+        freshConnection = await this.manager.connect(name, definition, signal);
+      } catch (error) {
+        if (this.stopped || signal?.aborted) return;
+        this.reportConnectionFailure(name, error, "reconnect", this.manager.getConnection(name));
+        return;
+      }
+      if (this.stopped || signal?.aborted) return;
+      if (freshConnection.status === "needs-auth") {
+        await this.notifyAuthRequired(name);
+        return;
+      }
+      if (freshConnection.status !== "connected") {
+        this.reportConnectionFailure(
+          name,
+          new Error(`MCP server ${name} did not return a connected session`),
+          "reconnect",
+          freshConnection,
+        );
+        return;
+      }
+      logger.debug(`Reconnected to ${name}`);
+      await this.publishConnectedMetadata(name, freshConnection);
+      return;
+    }
+
+    if (this.pendingMetadataPublications.has(name)) {
+      await this.publishConnectedMetadata(name, connection);
+      return;
+    }
+    if (!definition.url) return;
+    const hadSessionId = (connection.transport as { sessionId?: string } | undefined)?.sessionId != null;
+    let refreshResult: Awaited<ReturnType<McpServerManager["refreshTools"]>>;
+    try {
+      refreshResult = await this.manager.refreshTools(name, connection, signal);
+    } catch (error) {
+      if (this.stopped || signal?.aborted) return;
+      const current = this.manager.getConnection(name);
+      if (current !== connection || connection.status !== "connected") {
+        await this.handleSupersededConnection(name, definition, connection, signal, retrySuperseded);
+        return;
+      }
+      if (!shouldReconnectAfterRefresh(error, hadSessionId)) {
+        this.reportConnectionFailure(name, error, "refresh", connection);
+        return;
+      }
+      if (this.hasPendingAuthForServer(name)) {
+        logger.debug(`Skipping reconnect for ${name} while OAuth authorization is pending`);
+        return;
+      }
+      let freshConnection: ServerConnection;
+      try {
+        freshConnection = await this.manager.reconnect(name, definition, connection, signal);
+      } catch (reconnectError) {
+        if (this.stopped || signal?.aborted) return;
+        this.reportConnectionFailure(name, reconnectError, "reconnect", this.manager.getConnection(name));
+        return;
+      }
+      if (this.stopped || signal?.aborted) return;
+      if (freshConnection.status === "needs-auth") {
+        await this.notifyAuthRequired(name);
+        return;
+      }
+      if (freshConnection.status !== "connected") {
+        this.reportConnectionFailure(
+          name,
+          new Error(`MCP server ${name} did not return a connected session`),
+          "reconnect",
+          freshConnection,
+        );
+        return;
+      }
+      logger.debug(`Reconnected stale MCP session for ${name}`);
+      await this.publishConnectedMetadata(name, freshConnection);
+      return;
+    }
+
+    if (refreshResult === "superseded") {
+      await this.handleSupersededConnection(name, definition, connection, signal, retrySuperseded);
+      return;
+    }
+    if (this.retryStates.delete(name)) {
+      await this.onHealthRestored?.(name);
+    }
+  }
+
+  private async handleSupersededConnection(
+    name: string,
+    definition: ServerDefinition,
+    staleConnection: ServerConnection,
+    signal: AbortSignal | undefined,
+    retrySuperseded: boolean,
+  ): Promise<void> {
+    const current = this.manager.getConnection(name);
+    if (current === staleConnection && current.status === "connected") {
+      if (this.retryStates.delete(name)) await this.onHealthRestored?.(name);
+      return;
+    }
+    if (current?.status === "connected") {
+      await this.publishConnectedMetadata(name, current);
+      return;
+    }
+    if (current?.status === "needs-auth") {
+      await this.notifyAuthRequired(name);
+      return;
+    }
+    if (retrySuperseded) {
+      await this.checkKeepAliveConnection(name, definition, signal, false);
+    }
+  }
+
+  private async publishConnectedMetadata(name: string, connection: ServerConnection): Promise<void> {
+    this.pendingMetadataPublications.add(name);
+    try {
+      await this.onReconnect?.(name);
+      this.pendingMetadataPublications.delete(name);
+      this.retryStates.delete(name);
+    } catch (error) {
+      if (this.stopped) return;
+      this.reportConnectionFailure(name, error, "publish", connection);
+    }
+  }
+
+  private async notifyAuthRequired(name: string): Promise<void> {
+    this.pendingMetadataPublications.delete(name);
+    this.retryStates.delete(name);
+    try {
+      await this.onAuthRequired?.(name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: auth-required callback failed for ${name}: ${sanitizeTerminalText(message)}`);
+    }
+  }
+
+  private shouldAttemptConnection(name: string, connection: ServerConnection | undefined): boolean {
+    const retry = this.retryStates.get(name);
+    if (!retry) return true;
+    if (retry.connection !== connection || retry.status !== connection?.status) {
+      this.retryStates.delete(name);
+      return true;
+    }
+    return Date.now() >= retry.nextAttemptAt;
+  }
+
+  private reportConnectionFailure(
+    name: string,
+    error: unknown,
+    action: "refresh" | "reconnect" | "publish",
+    connection: ServerConnection | undefined,
+  ): void {
+    const attempts = (this.retryStates.get(name)?.attempts ?? 0) + 1;
+    const delay = Math.min(
+      KEEP_ALIVE_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 10),
+      KEEP_ALIVE_RETRY_MAX_MS,
+    );
+    this.retryStates.set(name, {
+      attempts,
+      nextAttemptAt: Date.now() + delay,
+      connection,
+      status: connection?.status,
+    });
+    this.onReconnectFailure?.(name, error);
+    const message = error instanceof Error ? error.message : String(error);
+    const target = action === "reconnect"
+      ? `reconnect to ${name}`
+      : action === "publish"
+        ? `publish metadata for ${name}`
+        : `refresh ${name}`;
+    console.error(`MCP: Failed to ${target}: ${sanitizeTerminalText(message)}`);
   }
 
   private getIdleTimeout(name: string): number {
@@ -137,11 +358,23 @@ export class McpLifecycleManager {
     this.removeHealthAbortListener = undefined;
     await this.activeHealthCheck;
     this.activeHealthCheck = undefined;
+    await this.activeConvergence;
+    this.activeConvergence = undefined;
     this.onReconnect = undefined;
     this.onReconnectFailure = undefined;
+    this.onHealthRestored = undefined;
+    this.onAuthRequired = undefined;
     this.onIdleShutdown = undefined;
+    this.retryStates.clear();
+    this.pendingMetadataPublications.clear();
     if (typeof this.manager.closeAll === "function") {
       await this.manager.closeAll();
     }
   }
+}
+
+function shouldReconnectAfterRefresh(error: unknown, hadSessionId: boolean): boolean {
+  if (isTerminatedSession(error, hadSessionId)) return true;
+  return error instanceof SdkError
+    && (error.code === SdkErrorCode.NotConnected || error.code === SdkErrorCode.ConnectionClosed);
 }

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 import {
   Client,
   SdkHttpError,
@@ -7,6 +8,7 @@ import {
   UnauthorizedError,
   type GetPromptResult,
   type ReadResourceResult,
+  type CacheableRequestOptions,
   type RequestOptions,
   type UrlElicitationRequiredError,
   type VersionNegotiationOptions,
@@ -123,6 +125,8 @@ export interface ServerConnection {
   transport: Transport;
   definition: ServerDefinition;
   tools: McpTool[];
+  /** Monotonic guard against older refresh responses replacing newer notifications. */
+  toolsRevision?: number;
   resources: McpResource[];
   prompts: McpPrompt[];
   /** True when prompts were advertised but prompts/list failed. */
@@ -139,6 +143,10 @@ export interface ServerConnection {
 type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void;
 type MetadataListChangedListener = (serverName: string, reason: string) => void;
 
+export type ToolRefreshResult = "updated" | "unchanged" | "superseded";
+
+const KEEP_ALIVE_REFRESH_TIMEOUT_MS = 5_000;
+
 export class McpServerManager {
   private connections = new Map<string, ServerConnection>();
   private connectPromises = new Map<string, Promise<ServerConnection>>();
@@ -146,6 +154,10 @@ export class McpServerManager {
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
   private metadataListChangedListener: MetadataListChangedListener | undefined;
+  private pendingMetadataPublications = new Map<
+    string,
+    { connection: ServerConnection; reason: string }
+  >();
   private elicitationConfig: ServerElicitationConfig | undefined;
   private authStorageOptions: AuthStorageOptions = {};
   private oauthRuntime: McpOAuthRuntime | undefined;
@@ -168,6 +180,25 @@ export class McpServerManager {
 
   setMetadataListChangedListener(listener: MetadataListChangedListener | undefined): void {
     this.metadataListChangedListener = listener;
+  }
+
+  publishMetadataChanged(
+    name: string,
+    expectedConnection: ServerConnection,
+    reason: string,
+  ): boolean {
+    const current = this.connections.get(name);
+    if (current !== expectedConnection || current.status !== "connected") return false;
+    try {
+      this.metadataListChangedListener?.(name, reason);
+      this.pendingMetadataPublications.delete(name);
+      return true;
+    } catch (error) {
+      this.pendingMetadataPublications.set(name, { connection: expectedConnection, reason });
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: metadata publication failed for ${name}; queued for retry: ${message}`);
+      return false;
+    }
   }
 
   setElicitationConfig(config: ServerElicitationConfig | undefined): void {
@@ -301,6 +332,88 @@ export class McpServerManager {
     });
     this.reconnectPromises.set(name, promise);
     return abortable(promise, ownedSignal);
+  }
+
+  /**
+   * Fetch the authoritative tool catalog for a connection that still appears
+   * connected. The SDK response cache is explicitly bypassed so this request
+   * also proves the remote Streamable HTTP session is usable. Results are
+   * identity-guarded: a late response from a replaced connection is ignored.
+   */
+  async refreshTools(
+    name: string,
+    expectedConnection: ServerConnection,
+    signal?: AbortSignal,
+  ): Promise<ToolRefreshResult> {
+    if (this.stopped) throw new Error("MCP server manager is closed");
+    const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
+    throwIfAborted(ownedSignal);
+
+    const current = this.connections.get(name);
+    if (current !== expectedConnection || current.status !== "connected") {
+      return "superseded";
+    }
+
+    const requestOptions = this.buildRequestOptions(expectedConnection.definition, signal);
+    const timeout = Math.min(requestOptions?.timeout ?? KEEP_ALIVE_REFRESH_TIMEOUT_MS, KEEP_ALIVE_REFRESH_TIMEOUT_MS);
+    const healthOptions = {
+      ...requestOptions,
+      timeout,
+    };
+    if (!expectedConnection.client.getServerCapabilities?.()?.tools) {
+      await expectedConnection.client.ping(healthOptions);
+      throwIfAborted(ownedSignal);
+      if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") {
+        return "superseded";
+      }
+      this.retryPendingMetadataPublication(name, expectedConnection);
+      return "unchanged";
+    }
+
+    const toolsRevision = expectedConnection.toolsRevision ?? 0;
+    const refreshSignal = combineAbortSignals(healthOptions.signal, AbortSignal.timeout(timeout));
+    const tools = await this.fetchAllTools(expectedConnection.client, {
+      ...healthOptions,
+      ...(refreshSignal ? { signal: refreshSignal } : {}),
+      cacheMode: "refresh",
+    });
+    throwIfAborted(ownedSignal);
+
+    if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") {
+      return "superseded";
+    }
+    if ((expectedConnection.toolsRevision ?? 0) !== toolsRevision) {
+      return "superseded";
+    }
+
+    if (isDeepStrictEqual(expectedConnection.tools, tools)) {
+      this.retryPendingMetadataPublication(name, expectedConnection);
+      return "unchanged";
+    }
+
+    const previousTools = expectedConnection.tools;
+    expectedConnection.tools = tools;
+    expectedConnection.toolsRevision = toolsRevision + 1;
+    try {
+      await this.metadataListChangedListener?.(name, "keep-alive-refresh");
+      this.pendingMetadataPublications.delete(name);
+    } catch (error) {
+      if (this.connections.get(name) === expectedConnection && expectedConnection.tools === tools) {
+        expectedConnection.tools = previousTools;
+        expectedConnection.toolsRevision = toolsRevision;
+      }
+      throw error;
+    }
+    return "updated";
+  }
+
+  private retryPendingMetadataPublication(name: string, connection: ServerConnection): void {
+    const pendingPublication = this.pendingMetadataPublications.get(name);
+    if (pendingPublication?.connection !== connection) return;
+    this.metadataListChangedListener?.(name, pendingPublication.reason);
+    if (this.pendingMetadataPublications.get(name) === pendingPublication) {
+      this.pendingMetadataPublications.delete(name);
+    }
   }
 
   private async doReconnect(
@@ -440,6 +553,7 @@ export class McpServerManager {
         transport,
         definition,
         tools: [],
+        toolsRevision: 0,
         resources: [],
         prompts: [],
         ...(instructions !== undefined ? { instructions } : {}),
@@ -641,7 +755,9 @@ export class McpServerManager {
     const connection = this.connections.get(serverName);
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.tools = tools;
+    connection.toolsRevision = (connection.toolsRevision ?? 0) + 1;
     this.metadataListChangedListener?.(serverName, "tools-list-changed");
+    this.pendingMetadataPublications.delete(serverName);
   }
 
   private handlePromptsListChanged(
@@ -660,6 +776,7 @@ export class McpServerManager {
     connection.prompts = prompts;
     connection.promptDiscoveryFailed = false;
     this.metadataListChangedListener?.(serverName, "prompts-list-changed");
+    this.pendingMetadataPublications.delete(serverName);
   }
 
   private handleResourcesListChanged(
@@ -677,6 +794,7 @@ export class McpServerManager {
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.resources = resources;
     this.metadataListChangedListener?.(serverName, "resources-list-changed");
+    this.pendingMetadataPublications.delete(serverName);
   }
 
   async handleUrlElicitationRequired(
@@ -851,7 +969,7 @@ export class McpServerManager {
     }
   }
 
-  private async fetchAllTools(client: Client, requestOptions?: RequestOptions): Promise<McpTool[]> {
+  private async fetchAllTools(client: Client, requestOptions?: CacheableRequestOptions): Promise<McpTool[]> {
     const allTools: McpTool[] = [];
     let cursor: string | undefined;
 
@@ -979,6 +1097,7 @@ export class McpServerManager {
   async close(name: string): Promise<void> {
     this.closeGenerations.set(name, (this.closeGenerations.get(name) ?? 0) + 1);
     this.connectAttempts.get(name)?.abort(new Error(`MCP connection ${name} was closed`));
+    this.pendingMetadataPublications.delete(name);
 
     const connection = this.connections.get(name);
     if (!connection) {
@@ -1042,6 +1161,7 @@ export class McpServerManager {
       .filter(error => this.containsCleanupFailure(error));
     this.uiStreamListeners.clear();
     this.acceptedUrlElicitations.clear();
+    this.pendingMetadataPublications.clear();
     this.samplingConfig = undefined;
     this.elicitationConfig = undefined;
     await this.traceWriter?.flush();

--- a/session-recovery.ts
+++ b/session-recovery.ts
@@ -146,6 +146,13 @@ export async function withSessionRecovery<T>(
       throw err;
     }
 
+    try {
+      deps.manager.publishMetadataChanged(serverName, freshConnection, "session-reconnect");
+    } catch (publicationError) {
+      const message = publicationError instanceof Error ? publicationError.message : String(publicationError);
+      logger.debug(`MCP metadata publication after reconnect failed for "${serverName}": ${message}`);
+    }
+    throwIfAborted(deps.signal);
     return fn(freshConnection);
   }
 }


### PR DESCRIPTION
## Problem

A long-lived remote MCP server can be replaced or restarted while its keep-alive connection still appears connected. If tool-list notifications are unavailable or lost, the adapter keeps the old session and stale tool catalog, so Pi can expose tools that no longer exist and miss their replacements.

## Changes

- Force an authoritative, cache-bypassing catalog refresh before user input, before adapter-triggered model turns, and during keep-alive health checks.
- Reconcile changed tools in place, and reconnect only after the server proves the current session is expired or closed.
- Publish replacement metadata before the turn continues or a recovered tool call is replayed.
- Bound polling to 5 seconds per request, 10 concurrent servers, and exponential retry backoff; preserve auth and connection identity/race handling.
- Treat polling as the correctness fallback when the notification stream is unavailable or silently lost—the adapter cannot directly observe a dead GET stream.

## Verification

- `npm run typecheck`
- Focused lifecycle, manager, input-barrier, and recovery tests: 138 passed
- Streamable HTTP wire integration tests: 9 passed
- `npm pack --dry-run`
- Full local suite after building the visualizer: 1150 passed; 2 existing macOS helper-cleanup timing tests failed in the untouched `request-headers-command.test.ts` (GitHub Actions runs on Linux)

Fixes #369
