### PR TITLE
fix: show compact MCP input previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
 - Stopped MCP panel commands from hanging in RPC, JSON, and print modes when terminal-only custom UI is unavailable. Thanks to [@shixin-guo](https://github.com/shixin-guo) for PR #365.
+- Kept compact MCP rows useful by showing a bounded tool-input preview and skipping leading blank output lines in collapsed result previews.
 - Recovered MCP gateway requests nested inside proxy `args` instead of silently showing status, and now rejects invalid nested gateway requests with guidance. Thanks to [@ibrmora](https://github.com/ibrmora) for #363.
 
 ## [2.26.0] - 2026-08-14

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only 
 
 `mcp({ connect: "server-name" })` refreshes an already connected server, so new tools, resources, prompts, and instructions can load without restarting Pi.
 
-MCP proxy and direct-tool results use compact self-rendered rows by default. Collapsed success output shows the call title and the first result line, with a `Ctrl+O to expand` hint when more text is hidden. The full result remains available when expanded and is still returned unchanged to the model. Set `settings.toolResultRendering` to `"boxed"` to restore the legacy boxed Pi row, or set `settings.collapsedResultLines` to `2` or `3` when you want more collapsed text.
+MCP proxy and direct-tool results use compact self-rendered rows by default. Collapsed success output shows the call title, a bounded one-line input preview when arguments exist, and the first result line, with a `Ctrl+O to expand` hint when more text is hidden. The full result remains available when expanded and is still returned unchanged to the model. Set `settings.toolResultRendering` to `"boxed"` to restore the legacy boxed Pi row, or set `settings.collapsedResultLines` to `2` or `3` when you want more collapsed text.
 
 Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are ranked by weighted matches across name, server, description, and any configured `searchKeywords`, then returned one page at a time (`limit` defaults to 12). Use `details.nextOffset` for the next page. Regex search is still available with `regex: true`, but regex results are paginated without ranking.
 

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -160,6 +160,43 @@ describe("MCP tool result renderer", () => {
     expect(output).not.toContain("segment-8");
   });
 
+  it("keeps a bounded input preview in compact final rows", () => {
+    const state: { compactTitle?: string; compactInputPreview?: string } = {};
+    const call = createMcpDirectToolCallRenderer("demo_search")(
+      { query: "alpha", limit: 10 },
+      plainTheme,
+      { isError: false, isPartial: false, expanded: false, state },
+    );
+    const output = renderMcpToolResult(
+      result([{ type: "text", text: "found 10 results" }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false, state },
+    ).render(120).join("\n");
+
+    expect(call.render(120)).toEqual([]);
+    expect(output).toContain("demo_search");
+    expect(output).toContain("query");
+    expect(output).toContain("alpha");
+    expect(output).toContain("found 10 results");
+  });
+
+  it("skips leading blank lines in collapsed previews", () => {
+    const display = formatMcpToolResultLines(result([
+      { type: "text", text: "\n\nuseful\nextra" },
+    ]), false, 1);
+
+    expect(display).toEqual({ lines: ["useful", "…"], truncated: true });
+  });
+
+  it("bounds skipped leading blank lines", () => {
+    const display = formatMcpToolResultLines(result([
+      { type: "text", text: `${"\n".repeat(100)}useful` },
+    ]), false, 1, 50);
+
+    expect(display).toEqual({ lines: ["(leading blank output omitted)", "…"], truncated: true });
+  });
+
   it("bounds a huge single-line collapsed result and shows the expand hint", () => {
     const huge = `head ${"x".repeat(50_000)} tail-marker`;
     const output = renderMcpToolResult(

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -25,6 +25,7 @@ export interface McpProxyToolCallInput {
 
 interface McpToolRenderState {
   compactTitle?: string;
+  compactInputPreview?: string;
 }
 
 interface McpToolRenderContext {
@@ -52,6 +53,7 @@ export interface McpToolResultDisplay {
 }
 
 const DEFAULT_MAX_CALL_INPUT_CHARS = 1500;
+const DEFAULT_MAX_COMPACT_INPUT_CHARS = 240;
 const DEFAULT_BOXED_COLLAPSED_LINES = 3;
 const DEFAULT_COMPACT_COLLAPSED_LINES = 1;
 const DEFAULT_MAX_COLLAPSED_CHARS = 8000;
@@ -70,6 +72,7 @@ class CompactMcpToolResult implements Component {
 
   constructor(
     private readonly title: string,
+    private readonly inputPreview: string,
     private readonly display: McpToolResultDisplay,
     private readonly theme: RenderTheme,
   ) {}
@@ -83,7 +86,7 @@ class CompactMcpToolResult implements Component {
     });
     const lines = resultLines.length > 0 ? resultLines : [""];
     const bodies = lines.map((line, index) => {
-      const prefix = index === 0 && this.title ? `${this.theme.fg("toolTitle", this.title)} → ` : "";
+      const prefix = index === 0 ? this.renderPrefix(safeWidth) : "";
       return `${prefix}${this.theme.fg("toolOutput", line)}`;
     });
     const hiddenText = this.display.truncated || bodies.some((body) => visibleWidth(body) > safeWidth);
@@ -105,6 +108,22 @@ class CompactMcpToolResult implements Component {
 
   invalidate(): void {
     this.rendered = null;
+  }
+
+  private renderPrefix(width: number): string {
+    if (!this.title) return "";
+    const arrow = " → ";
+    if (!this.inputPreview) return `${this.theme.fg("toolTitle", this.title)}${arrow}`;
+
+    const maxPrefixWidth = Math.max(12, Math.floor(width * 0.55));
+    const titleWidth = visibleWidth(this.title);
+    const inputWidth = Math.max(0, maxPrefixWidth - titleWidth - 1);
+    if (inputWidth <= 3) {
+      return `${this.theme.fg("toolTitle", truncateToWidth(this.title, maxPrefixWidth, "…"))}${arrow}`;
+    }
+
+    const input = truncateToWidth(this.inputPreview, inputWidth, "…");
+    return `${this.theme.fg("toolTitle", this.title)} ${this.theme.fg("muted", input)}${arrow}`;
   }
 }
 
@@ -239,6 +258,10 @@ function renderToolCallLines(lines: string[], theme?: RenderTheme) {
   return new Text([styledTitle, ...styledRest].join("\n"), 0, 0);
 }
 
+function formatCompactInputPreview(lines: string[], maxChars = DEFAULT_MAX_COMPACT_INPUT_CHARS): string {
+  return truncateText(lines.slice(1).join(" ").replace(/\s+/g, " ").trim(), maxChars);
+}
+
 export function resolveMcpToolRenderOptions(settings?: McpToolRenderSettings): McpToolRenderOptions {
   const resultRendering = settings?.toolResultRendering === "boxed" ? "boxed" : "compact";
   const collapsedLines = settings?.collapsedResultLines;
@@ -263,7 +286,10 @@ function renderToolCall(
   context: McpToolRenderContext | undefined,
   options: McpToolRenderOptions,
 ) {
-  if (context?.state) context.state.compactTitle = lines[0] ?? "mcp";
+  if (context?.state) {
+    context.state.compactTitle = lines[0] ?? "mcp";
+    context.state.compactInputPreview = formatCompactInputPreview(lines);
+  }
   if (shouldUseCompactFinalRender(options, context)) return new EmptyComponent();
   return renderToolCallLines(lines, theme);
 }
@@ -307,6 +333,19 @@ function collectCollapsedResultLines(
   let truncated = false;
 
   const appendLine = (line: string) => {
+    if (lines.length === 0) {
+      const previewWidth = Math.min(line.length, remainingChars);
+      if (line.slice(0, previewWidth).trim() === "") {
+        if (line.length >= remainingChars) {
+          truncated = true;
+          remainingChars = 0;
+          return false;
+        }
+        remainingChars -= line.length + 1;
+        return true;
+      }
+    }
+
     if (lines.length >= maxLines || remainingChars <= 0) {
       truncated = true;
       return false;
@@ -342,7 +381,7 @@ function collectCollapsedResultLines(
     if (truncated) break;
   }
 
-  if (lines.length === 0) lines.push("");
+  if (lines.length === 0) lines.push(truncated ? "(leading blank output omitted)" : "");
   if (truncated && lines.length >= maxLines) lines.push("…");
   return { lines, truncated };
 }
@@ -393,7 +432,8 @@ export function renderMcpToolResult(
   if (!expanded && renderOptions.resultRendering === "compact") {
     const display = formatMcpToolResultLines(result, false, renderOptions.collapsedResultLines);
     const title = context?.state?.compactTitle ?? formatMcpToolResultIdentity(result.details) ?? "";
-    return new CompactMcpToolResult(title, display, activeTheme);
+    const inputPreview = context?.state?.compactInputPreview ?? "";
+    return new CompactMcpToolResult(title, inputPreview, display, activeTheme);
   }
 
   const display = formatMcpToolResultLines(result, expanded, renderOptions.collapsedResultLines);


### PR DESCRIPTION
## Summary

Compact MCP result rows now keep a bounded one-line argument preview when tool inputs exist, and collapsed result previews skip leading blank output lines so the first visible result is useful.

This keeps the compact rendering mode from #351 while restoring the truncated input/output context users expect.

## Validation

- `npm test -- --run __tests__/tool-result-renderer.test.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- Fresh read-only review: No issues found
