### PR TITLE
fix: scope session tool approvals to arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
 - Recovered MCP gateway requests nested inside proxy `args` instead of silently showing status, and now rejects invalid nested gateway requests with guidance. Thanks to [@ibrmora](https://github.com/ibrmora) for #363.
 
 ## [2.26.0] - 2026-08-14

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -197,10 +197,11 @@ describe("tool approval", () => {
 
   it("caches only Allow for session decisions", async () => {
     const session = createState({ approveTools: true, decision: "Allow for session" });
-    await ensureToolCallApproved(session.state, "demo", tool, {}, undefined);
-    await ensureToolCallApproved(session.state, "demo", tool, {}, undefined);
-    expect(session.select).toHaveBeenCalledTimes(1);
-    expect(session.state.approvedToolCalls.has("demo\u0000search-records")).toBe(true);
+    await ensureToolCallApproved(session.state, "demo", tool, { record: { id: "safe", type: "demo" } }, undefined);
+    await ensureToolCallApproved(session.state, "demo", tool, { record: { type: "demo", id: "safe" } }, undefined);
+    await ensureToolCallApproved(session.state, "demo", tool, { record: { id: "other", type: "demo" } }, undefined);
+    expect(session.select).toHaveBeenCalledTimes(2);
+    expect(session.state.approvedToolCalls.size).toBe(2);
 
     const once = createState({ approveTools: true, decision: "Allow once" });
     await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
@@ -279,7 +280,7 @@ describe("tool approval", () => {
     expect(select).toHaveBeenCalledOnce();
   });
 
-  it("uses broker allow_for_session decisions for the existing session cache", async () => {
+  it("scopes broker allow_for_session decisions to their arguments", async () => {
     const broker = vi.fn((request: McpToolApprovalRequest) => {
       expect(request.claim(() => "allow_for_session")).toBe(true);
     });
@@ -287,9 +288,10 @@ describe("tool approval", () => {
 
     await ensureToolCallApproved(state, "demo", tool, {}, undefined);
     await ensureToolCallApproved(state, "demo", tool, {}, undefined);
+    await ensureToolCallApproved(state, "demo", tool, { query: "other" }, undefined);
 
-    expect(broker).toHaveBeenCalledOnce();
-    expect(state.approvedToolCalls.has("demo\u0000search-records")).toBe(true);
+    expect(broker).toHaveBeenCalledTimes(2);
+    expect(state.approvedToolCalls.size).toBe(2);
   });
 
   it("requires brokers to claim synchronously", async () => {

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { abortable } from "./abort.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import type { McpExtensionState } from "./state.ts";
@@ -19,6 +19,18 @@ import { sanitizeTerminalText } from "./utils.ts";
 export type ToolCallApprovalResult =
   | { ok: true }
   | { ok: false; reason: "denied" | "approval_required_headless" };
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined || typeof value !== "object") {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? "undefined" : serialized;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(item => stableStringify(item)).join(",")}]`;
+  }
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map(key => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
+}
 
 export function isToolCallApprovalRequired(
   config: McpConfig,
@@ -136,7 +148,8 @@ export async function ensureToolCallApproved(
   origin: McpToolApprovalOrigin = toolMeta.resourceUri ? "resource" : "proxy",
   approvalMetadata?: ReadonlyMap<string, readonly ToolMetadata[]>,
 ): Promise<ToolCallApprovalResult> {
-  const cacheKey = `${serverName}\u0000${toolMeta.originalName}`;
+  const argsHash = createHash("sha256").update(stableStringify(args ?? {})).digest("hex");
+  const cacheKey = `${serverName}\u0000${toolMeta.originalName}\u0000${argsHash}`;
   const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
   if (approvedToolCalls.has(cacheKey)) {
     return { ok: true };


### PR DESCRIPTION
## Summary

Fixes #367 by scoping `allow_for_session` approvals to the exact effective tool-call arguments as well as the server and original tool name.

The cache stores a SHA-256 digest of deterministic argument serialization, not raw argument text. Calls with reordered equivalent object keys share approval, while changed argument payloads require a new approval.

## Validation

- `npx vitest run __tests__/tool-approval.test.ts`
- `npm run typecheck`
- `git diff --check`

## Credit

Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
