### PR TITLE
fix: don't hang MCP panels outside TUI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
+- Stopped MCP panel commands from hanging in RPC, JSON, and print modes when terminal-only custom UI is unavailable. Thanks to [@shixin-guo](https://github.com/shixin-guo) for PR #365.
 - Recovered MCP gateway requests nested inside proxy `args` instead of silently showing status, and now rejects invalid nested gateway requests with guidance. Thanks to [@ibrmora](https://github.com/ibrmora) for #363.
 
 ## [2.26.0] - 2026-08-14

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -27,7 +27,7 @@ describe("authenticateServer", () => {
     await openMcpAuthPanel({
       programmaticConfig: false,
       config: { mcpServers: { disabled: { url: "https://example.test/mcp", auth: "oauth", disabled: true } } },
-    } as any, { getFlag: vi.fn() } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
     expect(ui.custom).not.toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe("authenticateServer", () => {
       const definition = { url: "${MCP_AUTH_URL}", auth: "oauth" as const };
       const result = await authenticateServer("sentry", {
         mcpServers: { sentry: definition },
-      }, { hasUI: true, ui } as any);
+      }, { hasUI: true, mode: "tui", ui } as any);
 
       expect(result.ok).toBe(true);
       expect(mocks.authenticate).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe("authenticateServer", () => {
     try {
       const result = await authenticateServer("sentry", {
         mcpServers: { sentry: { url: "https://${MCP_AUTH_URL}/mcp", auth: "oauth" } },
-      }, { hasUI: true, ui } as any);
+      }, { hasUI: true, mode: "tui", ui } as any);
 
       expect(result.ok).toBe(false);
       expect(result.message).toBe("Missing environment variable in MCP server URL: MCP_AUTH_URL");
@@ -97,7 +97,7 @@ describe("authenticateServer", () => {
       config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
       authStorageOptions: {},
       manager: { close },
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result).toEqual({ ok: false, message: "simulated secure credential store unavailable" });
     expect(close).not.toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe("authenticateServer", () => {
       config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
       authStorageOptions: {},
       manager: { close: vi.fn(async () => { throw new Error("close failed"); }) },
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result).toEqual({ ok: false, message: "close failed" });
     expect(ui.notify).toHaveBeenCalledWith(
@@ -147,7 +147,7 @@ describe("authenticateServer", () => {
       mcpServers: {
         sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
       },
-    }, { hasUI: true, ui } as any);
+    }, { hasUI: true, mode: "tui", ui } as any);
 
     expect(result.ok).toBe(true);
     expect(mocks.authenticate).toHaveBeenCalledWith(

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -66,7 +66,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(mocks.createMcpSetupPanel).toHaveBeenCalled();
     expect(mocks.createMcpPanel).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     expect(mocks.createMcpPanel).toHaveBeenCalled();
     const options = mocks.createMcpPanel.mock.calls[0]?.[6];
@@ -124,7 +124,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
 
     expect(mocks.createMcpPanel).toHaveBeenCalled();
     expect(warning).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui, cwd: process.cwd() } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
 
     expect(mocks.createMcpSetupPanel).toHaveBeenCalled();
     const discovery = mocks.createMcpSetupPanel.mock.calls[0]?.[0];
@@ -177,7 +177,7 @@ describe("commands onboarding", () => {
       manager: { close },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { hasUI: true, ui } as any);
+    } as any, { hasUI: true, mode: "tui", ui } as any);
 
     await pendingCallbackRejection;
     expect(result.ok).toBe(true);
@@ -205,7 +205,7 @@ describe("commands onboarding", () => {
       manager: { getConnection: () => null },
       toolMetadata: new Map(),
       failureTracker: new Map(),
-    } as any, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     const callbacks = mocks.createMcpPanel.mock.calls[0]?.[3];
     expect(callbacks.getConnectionStatus("legacy")).toBe("needs-auth");
@@ -244,7 +244,7 @@ describe("commands onboarding", () => {
     } as any;
     const { openMcpPanel } = await import("../commands.ts");
 
-    await openMcpPanel(state, { getFlag: () => undefined } as any, { hasUI: true, ui } as any);
+    await openMcpPanel(state, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui } as any);
 
     const callbacks = mocks.createMcpPanel.mock.calls[0]?.[3];
     await expect(callbacks.reconnect("notion")).resolves.toBe(true);

--- a/__tests__/commands-panel-auth-storage.test.ts
+++ b/__tests__/commands-panel-auth-storage.test.ts
@@ -51,7 +51,7 @@ describe("MCP panels with unavailable OAuth credential storage", () => {
     await expect(openPanel(
       createState(),
       { getFlag: () => undefined } as any,
-      { hasUI: true, cwd: "/tmp", ui } as any,
+      { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any,
     )).resolves.toEqual({ configChanged: false });
 
     expect(getRendered()).toContain("failed");

--- a/__tests__/commands-panel-non-tui.test.ts
+++ b/__tests__/commands-panel-non-tui.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../init.ts", () => ({
+  getFailureAgeSeconds: vi.fn(() => null),
+  getFailureMessage: vi.fn(() => undefined),
+  clearFailure: vi.fn(),
+  lazyConnect: vi.fn(),
+  markKeepAliveAfterConnect: vi.fn(),
+  recordFailure: vi.fn(),
+  updateMetadataCache: vi.fn(),
+  notifyToolMetadataUpdated: vi.fn(),
+  updateStatusBar: vi.fn(),
+}));
+
+const state = () =>
+  ({
+    config: { mcpServers: { demo: { command: "node" } } },
+    manager: { getConnection: () => undefined },
+    toolMetadata: new Map(),
+    promptMetadata: new Map(),
+    failureTracker: new Map(),
+  }) as any;
+
+// In rpc/print mode `ctx.ui.custom()` is a headless stub: it resolves without
+// invoking the factory, so anything that awaits `done` never settles. These
+// tests pin the text fallbacks that keep `/mcp` from hanging in those modes.
+// Failing them looks like a hung command, not a failed assertion, so the stub
+// mirrors the real behaviour: it never calls back.
+const nonTuiUi = () => {
+  const notify = vi.fn();
+  const custom = vi.fn(() => new Promise<never>(() => {}));
+  return { notify, custom, ui: { notify, custom } };
+};
+
+const withTimeout = <T>(promise: Promise<T>, label: string) =>
+  Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`${label} hung waiting for a custom UI panel`)), 1000),
+    ),
+  ]);
+
+describe("MCP panels outside the terminal UI", () => {
+  it("/mcp falls back to the text status instead of hanging on an overlay", async () => {
+    const { openMcpPanel } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpPanel(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpPanel",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("MCP Server Status:"), "info");
+  });
+
+  it("/mcp setup explains where the panel is available", async () => {
+    const { openMcpSetup } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpSetup(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpSetup",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("terminal UI"), "info");
+  });
+
+  it("/mcp-auth points at the per-server command", async () => {
+    const { openMcpAuthPanel } = await import("../commands.ts");
+    const { ui, notify, custom } = nonTuiUi();
+
+    const result = await withTimeout(
+      openMcpAuthPanel(state(), {} as any, { hasUI: true, mode: "rpc", cwd: "/repo", ui } as any),
+      "openMcpAuthPanel",
+    );
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(result).toEqual({ configChanged: false });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/mcp-auth <server>"), "info");
+  });
+
+  it("still renders the overlay in the terminal UI", async () => {
+    const { openMcpSetup } = await import("../commands.ts");
+    const { ui, custom } = nonTuiUi();
+
+    // `custom` never settles, so poll for the call rather than awaiting the
+    // panel or racing a fixed delay against the dynamic panel import.
+    void openMcpSetup(state(), {} as any, { hasUI: true, mode: "tui", cwd: "/repo", ui } as any);
+    const deadline = Date.now() + 5000;
+    while (custom.mock.calls.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(custom).toHaveBeenCalled();
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -28,6 +28,19 @@ function terminalHyperlink(label: string, url: string): string {
   return `\u001B]8;;${sanitizeTerminalText(url)}\u001B\\${sanitizeTerminalText(label)}\u001B]8;;\u001B\\`;
 }
 
+/**
+ * True when this run mode can display a `ctx.ui.custom()` overlay.
+ *
+ * `ctx.hasUI` only reports that *some* UI context is bound. In rpc/print mode
+ * that context is a headless stub whose `custom()` returns immediately without
+ * ever invoking the factory or the `done` callback, so a panel awaited through
+ * `new Promise(resolve => ctx.ui.custom(...))` never settles and the command
+ * hangs. Overlay panels therefore additionally require `ctx.mode === "tui"`.
+ */
+function canRenderPanel(ctx: ExtensionContext): boolean {
+  return ctx.hasUI && ctx.mode === "tui";
+}
+
 export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
   if (!ctx.hasUI) return;
 
@@ -399,6 +412,10 @@ export async function openMcpSetup(
   options: { includeHostConfigs?: boolean } = {},
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (!canRenderPanel(ctx)) {
+    ctx.ui.notify(`The interactive MCP setup panel is only available in the terminal UI (current mode: ${ctx.mode}). Edit .mcp.json directly, or run /mcp status to review servers.`, "info");
+    return { configChanged: false };
+  }
   if (state.programmaticConfig) {
     ctx.ui.notify("MCP setup is unavailable when config is supplied by createMcpAdapter().", "info");
     return { configChanged: false };
@@ -533,6 +550,11 @@ export async function openMcpPanel(
     }
     return { configChanged: false };
   }
+  if (!canRenderPanel(ctx)) {
+    // No overlay here, but the same information is available as text.
+    await showStatus(state, ctx);
+    return { configChanged: false };
+  }
   if (Object.keys(state.config.mcpServers).length === 0) {
     return openMcpSetup(state, pi, ctx, configOverridePath, "empty", { includeHostConfigs: false });
   }
@@ -587,6 +609,10 @@ export async function openMcpAuthPanel(
   configOverridePath?: string,
 ): Promise<PanelFlowResult> {
   if (!ctx.hasUI) return { configChanged: false };
+  if (!canRenderPanel(ctx)) {
+    ctx.ui.notify(`The interactive MCP auth panel is only available in the terminal UI (current mode: ${ctx.mode}). Use /mcp-auth <server> to authenticate a specific server.`, "info");
+    return { configChanged: false };
+  }
   if (state.programmaticConfig) {
     ctx.ui.notify("Use /mcp-auth <server> to authenticate a server from the in-memory SDK config.", "info");
     return { configChanged: false };


### PR DESCRIPTION
## Summary

Replacement for #365 with the same reviewed code plus the required changelog credit.

This keeps `/mcp`, `/mcp status`, `/mcp setup`, and MCP auth panel commands from hanging in RPC, JSON, and print modes when `ctx.hasUI` is true but terminal custom UI is unavailable.

## Validation

Source review and focused checks passed on #365 at `88a1b1ce47386f818993dfbabc3e424911a9b56b`:

- `npm run typecheck`
- `npx vitest run __tests__/commands-panel-non-tui.test.ts __tests__/commands-auth.test.ts __tests__/commands-onboarding.test.ts __tests__/commands-panel-auth-storage.test.ts`
- `git diff --check`

This replacement adds only changelog credit on top of that reviewed head. The exact-head CI gate must still pass before merge.

## Credit

Thanks to [@shixin-guo](https://github.com/shixin-guo) for PR #365.
