### PR TITLE
fix: normalize tool-call arguments before transport (embedded-quote serialization)

### DIFF
--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -15,7 +15,7 @@ import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
@@ -527,7 +527,7 @@ export function createDirectToolExecutor(
         spec.serverName,
         (conn) => abortable(conn.client.callTool({
           name: spec.originalName,
-          arguments: params ?? {},
+          arguments: normalizeToolArguments(params),
           _meta: uiSession?.requestMeta,
         }, requestOptions), ownedSignal),
       );

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -13,7 +13,7 @@ import { reconstructPromptMetadata } from "./metadata-cache.ts";
 import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, formatMcpStatus, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
@@ -1235,7 +1235,7 @@ export async function executeCall(
       serverName,
       (conn) => abortable(conn.client.callTool({
         name: toolMeta.originalName,
-        arguments: args ?? {},
+        arguments: normalizeToolArguments(args),
         _meta: uiSession?.requestMeta,
       }, requestOptions), ownedSignal),
     );

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -10,7 +10,7 @@ import {
 import { ContentBlockSchema } from "@modelcontextprotocol/core";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
-import { formatAuthRequiredMessage } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments } from "./utils.ts";
 import { buildHostHtmlTemplate, buildCspMetaContent } from "./host-html-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
@@ -440,10 +440,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
         const callArgs = {
           name: callParams.name,
-          arguments:
-            callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
-              ? callParams.arguments
-              : {},
+          arguments: normalizeToolArguments(callParams.arguments, `tool "${callParams.name}" arguments`),
         };
         const toolMeta = {
           name: callParams.name,

--- a/utils.ts
+++ b/utils.ts
@@ -282,6 +282,51 @@ export function normalizeDirectToolInputSchema(schema: unknown): Record<string, 
   return normalized;
 }
 
+export function normalizeToolArguments(
+  value: unknown,
+  context = "tool arguments",
+): Record<string, unknown> {
+  if (value === undefined || value === null || value === "") return {};
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return {};
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(
+        `${context}: invalid args JSON (${error instanceof SyntaxError ? error.message : String(error)}); ` +
+        `pass args as a JSON object, or as a valid JSON string encoding one`,
+        { cause: error },
+      );
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        `${context}: expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`,
+      );
+    }
+    return parsed as Record<string, unknown>;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `${context}: expected a JSON object, got ${Array.isArray(value) ? "array" : typeof value}`,
+    );
+  }
+
+  // JSON round-trip: keep only JSON-serializable plain data so embedded quotes
+  // are escaped at transport by JSON.stringify, never string-interpolated.
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `${context}: value is not JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
 export function formatAuthRequiredMessage(
   config: Pick<McpConfig, "settings">,
   serverName: string,


### PR DESCRIPTION
## Problem

Tool-call args containing literal double-quotes in free-text fields (e.g. a mailbox message body with a quoted phrase) could corrupt agent→MCP serialization:

- **proxy-modes.ts / direct-tools.ts** passed `arguments` straight to the SDK `callTool`. An object is JSON.stringify'd correctly, but a **string-typed `arguments` slipped through un-normalized**, breaking serialization and dropping sibling fields (server-side `Required` errors).
- **ui-server.ts** **silently collapsed** string-typed `arguments` to `{}` — losing every field including required ones.

## Fix

Add `normalizeToolArguments` to `utils.ts` and apply it at every `callTool` transport boundary:

- Parses JSON **strings once** into an object (never re-stringifies/concatenates).
- JSON round-trips object args so embedded quotes are always escaped by `JSON.stringify` at transport, never string-interpolated.
- Rejects arrays/primitives with descriptive errors, so the server always receives a plain object map.

## Behavior

- `normalizeToolArguments(undefined | '' | null)` → `{}`
- `normalizeToolArguments('{"a":1}')'` → `{ a: 1 }`
- `normalizeToolArguments({ body: 'He said "hi"' })` → round-trips intact (quotes preserved as data)
- `normalizeToolArguments([1,2])` → throws descriptive error
- malformed JSON string → throws descriptive error

No API change; server contract unchanged.