### PR TITLE
fix: normalize MCP arguments before approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
 - Stopped MCP panel commands from hanging in RPC, JSON, and print modes when terminal-only custom UI is unavailable. Thanks to [@shixin-guo](https://github.com/shixin-guo) for PR #365.
 - Kept compact MCP rows useful by showing a bounded tool-input preview and skipping leading blank output lines in collapsed result previews.

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -267,6 +267,38 @@ describe("tool approval", () => {
     expect(callTool).toHaveBeenCalledOnce();
   });
 
+  it("normalizes JSON-string arguments before proxy and direct approval", async () => {
+    const args = '{"body":"He said \\"hi\\""}';
+    const expected = { body: 'He said "hi"' };
+    for (const origin of ["proxy", "direct"] as const) {
+      const { state, callTool } = createState({
+        approveTools: true,
+        interactive: false,
+        broker: (request) => {
+          expect(request).toMatchObject({ args: expected, origin });
+          expect(request.claim(() => "allow_once")).toBe(true);
+        },
+      });
+
+      if (origin === "proxy") {
+        await executeCall(state, tool.name, args as never);
+      } else {
+        const execute = createDirectToolExecutor(() => state, () => null, {
+          serverName: "demo",
+          originalName: "search-records",
+          prefixedName: "demo_search-records",
+          description: "Search records",
+        });
+        await execute("call-1", args as never, undefined, undefined, {} as never);
+      }
+
+      expect(callTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "search-records", arguments: expected }),
+        undefined,
+      );
+    }
+  });
+
   it("falls back to the built-in prompt when a broker abstains", async () => {
     const { state, select } = createState({
       approveTools: true,

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -631,6 +631,34 @@ describe("UiServer", () => {
       }, requestOptions);
     });
 
+    it("parses JSON-string arguments without dropping quoted fields", async () => {
+      const mockClient = {
+        callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "tool result" }] }),
+      };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [{ name: "some_tool" }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "some_tool", arguments: '{"body":"He said \\"hi\\""}' },
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: "some_tool",
+        arguments: { body: 'He said "hi"' },
+      }, undefined);
+    });
+
     it("executes app-only tools without recording their synthetic call intent", async () => {
       const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "app result" }] });
       const onMessage = vi.fn();

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -429,6 +429,7 @@ export function createDirectToolExecutor(
       };
     }
 
+    const normalizedParams = spec.resourceUri ? params : normalizeToolArguments(params);
     const approval = await ensureToolCallApproved(state, spec.serverName, {
       name: spec.prefixedName,
       originalName: spec.originalName,
@@ -437,7 +438,7 @@ export function createDirectToolExecutor(
       ...(spec.resourceUri !== undefined ? { resourceUri: spec.resourceUri } : {}),
       ...(spec.uiResourceUri !== undefined ? { uiResourceUri: spec.uiResourceUri } : {}),
       ...(spec.uiStreamMode !== undefined ? { uiStreamMode: spec.uiStreamMode } : {}),
-    }, params, ownedSignal, spec.resourceUri ? "resource" : "direct");
+    }, normalizedParams, ownedSignal, spec.resourceUri ? "resource" : "direct");
     if (approval.ok === false) {
       const denied = approval.reason === "denied";
       const message = denied
@@ -509,7 +510,7 @@ export function createDirectToolExecutor(
         ? await maybeStartUiSession(state, {
             serverName: spec.serverName,
             toolName: spec.originalName,
-            toolArgs: params ?? {},
+            toolArgs: normalizedParams,
             uiResourceUri: spec.uiResourceUri!,
             ...(spec.uiStreamMode !== undefined ? { streamMode: spec.uiStreamMode } : {}),
             ...(signal ? { signal } : {}),
@@ -527,7 +528,7 @@ export function createDirectToolExecutor(
         spec.serverName,
         (conn) => abortable(conn.client.callTool({
           name: spec.originalName,
-          arguments: normalizeToolArguments(params),
+          arguments: normalizedParams,
           _meta: uiSession?.requestMeta,
         }, requestOptions), ownedSignal),
       );

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -15,7 +15,7 @@ import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
@@ -527,7 +527,7 @@ export function createDirectToolExecutor(
         spec.serverName,
         (conn) => abortable(conn.client.callTool({
           name: spec.originalName,
-          arguments: params ?? {},
+          arguments: normalizeToolArguments(params),
           _meta: uiSession?.requestMeta,
         }, requestOptions), ownedSignal),
       );

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -13,7 +13,7 @@ import { reconstructPromptMetadata } from "./metadata-cache.ts";
 import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatAuthRequiredMessage, formatMcpStatus, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, formatMcpStatus, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
 import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
@@ -1235,7 +1235,7 @@ export async function executeCall(
       serverName,
       (conn) => abortable(conn.client.callTool({
         name: toolMeta.originalName,
-        arguments: args ?? {},
+        arguments: normalizeToolArguments(args),
         _meta: uiSession?.requestMeta,
       }, requestOptions), ownedSignal),
     );

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1136,11 +1136,12 @@ export async function executeCall(
     return disabledCallResult(serverName, toolMeta);
   }
 
+  const normalizedArgs = toolMeta.resourceUri ? args ?? {} : normalizeToolArguments(args);
   const approval = await ensureToolCallApproved(
     state,
     serverName,
     toolMeta,
-    args,
+    normalizedArgs,
     ownedSignal,
     origin ?? (toolMeta.resourceUri ? "resource" : "proxy"),
   );
@@ -1217,7 +1218,7 @@ export async function executeCall(
       ? await maybeStartUiSession(state, {
           serverName,
           toolName: toolMeta.originalName,
-          toolArgs: args ?? {},
+          toolArgs: normalizedArgs,
           uiResourceUri: toolMeta.uiResourceUri,
           ...(toolMeta.uiStreamMode !== undefined ? { streamMode: toolMeta.uiStreamMode } : {}),
           ...(signal ? { signal } : {}),
@@ -1235,7 +1236,7 @@ export async function executeCall(
       serverName,
       (conn) => abortable(conn.client.callTool({
         name: toolMeta.originalName,
-        arguments: normalizeToolArguments(args),
+        arguments: normalizedArgs,
         _meta: uiSession?.requestMeta,
       }, requestOptions), ownedSignal),
     );

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -10,7 +10,7 @@ import {
 import { ContentBlockSchema } from "@modelcontextprotocol/core";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
-import { formatAuthRequiredMessage } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments } from "./utils.ts";
 import { buildHostHtmlTemplate, buildCspMetaContent } from "./host-html-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
@@ -440,10 +440,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
         const callArgs = {
           name: callParams.name,
-          arguments:
-            callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
-              ? callParams.arguments
-              : {},
+          arguments: normalizeToolArguments(callParams.arguments, `tool "${callParams.name}" arguments`),
         };
         const toolMeta = {
           name: callParams.name,

--- a/utils.ts
+++ b/utils.ts
@@ -282,6 +282,51 @@ export function normalizeDirectToolInputSchema(schema: unknown): Record<string, 
   return normalized;
 }
 
+export function normalizeToolArguments(
+  value: unknown,
+  context = "tool arguments",
+): Record<string, unknown> {
+  if (value === undefined || value === null || value === "") return {};
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return {};
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(
+        `${context}: invalid args JSON (${error instanceof SyntaxError ? error.message : String(error)}); ` +
+        `pass args as a JSON object, or as a valid JSON string encoding one`,
+        { cause: error },
+      );
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        `${context}: expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`,
+      );
+    }
+    return parsed as Record<string, unknown>;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `${context}: expected a JSON object, got ${Array.isArray(value) ? "array" : typeof value}`,
+    );
+  }
+
+  // JSON round-trip: keep only JSON-serializable plain data so embedded quotes
+  // are escaped at transport by JSON.stringify, never string-interpolated.
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `${context}: value is not JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
 export function formatAuthRequiredMessage(
   config: Pick<McpConfig, "settings">,
   serverName: string,


### PR DESCRIPTION
This is a maintainer replacement for #377.

It keeps the contributor fix for string-typed MCP tool arguments, then also normalizes direct and proxy arguments before approval so the approval preview, session approval key, UI session args, and MCP transport all use the same object.

Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

Validation:
- `npm test -- --run __tests__/tool-approval.test.ts __tests__/ui-server.test.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`
- Fresh review: no issues found
