### PR TITLE
feat: load MCP servers from Pi package manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `pi.mcp` package manifest entries so Pi packages can ship prefixed MCP server definitions without user MCP config edits. Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
+
 ### Fixed
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ Each directory must contain a valid Agent Plugins 1.0 `plugin.json`. If it also 
 
 Agent Plugins is a portable package format. Native Pi MCP config remains `.mcp.json`, `~/.config/mcp/mcp.json`, and Pi-owned overrides.
 
+### Pi package manifests
+
+A Pi package can ship MCP servers for the installed adapter without requiring a separate MCP config file. Declare a package-relative config in its `package.json`:
+
+```json
+{
+  "pi": {
+    "mcp": "./mcp.json"
+  }
+}
+```
+
+`pi.mcp` can also be an array of package-relative paths. Each file uses the normal `mcpServers` object shape, but package manifests load only server entries: package `settings` and `imports` are ignored. Server names are prefixed with the sanitized package name, such as `acme_tools__docs`, and user/global/project MCP config has higher precedence. The adapter loads only Pi packages listed in Pi settings; it does not scan `node_modules`.
+
 ### SDK configuration
 
 Use `createMcpAdapter` when an SDK or server integration already owns its MCP configuration:

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -25,6 +25,251 @@ describe("config discovery", () => {
       process.env.PI_PACKAGE_DIR = originalPackageDir;
     }
     process.chdir(originalCwd);
+  });
+
+  it("loads package manifest MCP servers below user config without package settings or imports", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const packageRoot = join(home, ".pi", "agent", "npm", "node_modules", "@acme", "tools");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["npm:@acme/tools@1.0.0"] });
+    writeJson(join(packageRoot, "package.json"), { name: "@acme/tools", pi: { mcp: ["./mcp.json", "./extra.json"] } });
+    writeJson(join(packageRoot, "mcp.json"), {
+      settings: { directTools: true },
+      imports: ["vscode"],
+      mcpServers: {
+        tools: { command: "package-command", args: ["--package"], env: { PACKAGE: "1" } },
+        full: { command: "package-full", args: ["--package-full"], env: { PACKAGE: "1" } },
+        "tools.db": { command: "first" },
+      },
+    });
+    writeJson(join(packageRoot, "extra.json"), {
+      mcpServers: {
+        tools_db: { command: "duplicate" },
+      },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      settings: { directTools: false },
+      mcpServers: {
+        acme_tools__tools: { command: "user-command" },
+        acme_tools__full: { command: "user-full", args: ["--user-full"], env: { USER: "1" } },
+      },
+    });
+
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadMcpConfig } = await import("../config.ts");
+    const config = loadMcpConfig();
+    expect(config.settings).toEqual({ directTools: false });
+    expect(config.mcpServers.acme_tools__tools).toEqual({
+      command: "user-command",
+      args: ["--package"],
+      env: { PACKAGE: "1" },
+    });
+    expect(config.mcpServers.acme_tools__full).toEqual({
+      command: "user-full",
+      args: ["--user-full"],
+      env: { USER: "1" },
+    });
+    expect(config.mcpServers.acme_tools__tools_db).toEqual({ command: "first" });
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("duplicate normalized MCP server acme_tools__tools_db"));
+    warning.mockRestore();
+  });
+
+  it("drops incompatible package transport fields when a normal override changes transport", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-transport-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-transport-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const packageRoot = join(home, ".pi", "agent", "npm", "node_modules", "acme-tools");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["npm:acme-tools"] });
+    writeJson(join(packageRoot, "package.json"), { name: "acme-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(packageRoot, "mcp.json"), {
+      mcpServers: {
+        http: {
+          url: "https://package.test/mcp",
+          headers: { Authorization: "Bearer package" },
+          bearerTokenEnv: "PACKAGE_TOKEN",
+          requestHeadersCommand: "headers",
+          httpTransport: "sse",
+        },
+        stdio: {
+          command: "package-command",
+          args: ["--package"],
+          env: { PACKAGE: "1" },
+          cwd: "/package",
+          pluginDataDir: "/package/data",
+          literalEnv: true,
+        },
+        socket: {
+          url: "https://package.test/socket",
+          headers: { Authorization: "Bearer package" },
+          bearerTokenEnv: "PACKAGE_TOKEN",
+          requestHeadersCommand: "headers",
+          httpTransport: "sse",
+        },
+      },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      mcpServers: {
+        "acme-tools__http": { command: "local-command" },
+        "acme-tools__stdio": { url: "https://project.test/mcp" },
+        "acme-tools__socket": { socket: "/tmp/project.sock" },
+      },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toMatchObject({
+      "acme-tools__http": { command: "local-command" },
+      "acme-tools__stdio": { url: "https://project.test/mcp" },
+      "acme-tools__socket": { socket: "/tmp/project.sock" },
+    });
+    expect(loadMcpConfig().mcpServers["acme-tools__http"]).toEqual({ command: "local-command" });
+    expect(loadMcpConfig().mcpServers["acme-tools__stdio"]).toEqual({ url: "https://project.test/mcp" });
+    expect(loadMcpConfig().mcpServers["acme-tools__socket"]).toEqual({ socket: "/tmp/project.sock" });
+  });
+
+  it("does not load a package source that escapes Pi's managed git directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-escape-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-escape-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const escapedPackage = join(home, ".pi", "outside-package");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["git:../../outside-package"] });
+    writeJson(join(escapedPackage, "package.json"), { name: "outside-package", pi: { mcp: "./mcp.json" } });
+    writeJson(join(escapedPackage, "mcp.json"), { mcpServers: { unsafe: { command: "unsafe" } } });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toEqual({});
+  });
+
+  it("loads raw HTTPS and SSH package sources from Pi's managed git directory", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-git-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-git-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const gitRoot = join(home, ".pi", "agent", "git", "github.com", "acme");
+    writeJson(join(home, ".pi", "agent", "settings.json"), {
+      packages: ["https://github.com/acme/http-tools", "ssh://git@github.com/acme/ssh-tools", "git@github.com:acme/scp-tools.git"],
+    });
+    writeJson(join(gitRoot, "http-tools", "package.json"), { name: "http-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(gitRoot, "http-tools", "mcp.json"), { mcpServers: { http: { command: "http" } } });
+    writeJson(join(gitRoot, "ssh-tools", "package.json"), { name: "ssh-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(gitRoot, "ssh-tools", "mcp.json"), { mcpServers: { ssh: { command: "ssh" } } });
+    writeJson(join(gitRoot, "scp-tools", "package.json"), { name: "scp-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(gitRoot, "scp-tools", "mcp.json"), { mcpServers: { scp: { command: "scp" } } });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toEqual({
+      "http-tools__http": { command: "http" },
+      "ssh-tools__ssh": { command: "ssh" },
+      "scp-tools__scp": { command: "scp" },
+    });
+  });
+
+  it("skips a package MCP symlink that resolves outside its package root", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-symlink-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-symlink-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const packageRoot = join(home, ".pi", "agent", "npm", "node_modules", "acme-tools");
+    const outsideConfig = join(project, "outside-mcp.json");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["npm:acme-tools"] });
+    writeJson(join(packageRoot, "package.json"), { name: "acme-tools", pi: { mcp: "./linked-mcp.json" } });
+    writeJson(outsideConfig, { mcpServers: { outside: { command: "unsafe" } } });
+    symlinkSync(outsideConfig, join(packageRoot, "linked-mcp.json"));
+
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toEqual({});
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("file must stay inside the package"));
+    warning.mockRestore();
+  });
+
+  it("gives project package settings precedence over matching user package settings", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-precedence-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-precedence-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const globalPackage = join(home, ".pi", "agent", "global-package");
+    const projectPackage = join(project, ".pi", "project-package");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["./global-package"] });
+    writeJson(join(project, ".pi", "settings.json"), { packages: ["./project-package"] });
+    writeJson(join(globalPackage, "package.json"), { name: "acme-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(globalPackage, "mcp.json"), { mcpServers: { docs: { command: "global" } } });
+    writeJson(join(projectPackage, "package.json"), { name: "acme-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(projectPackage, "mcp.json"), { mcpServers: { docs: { command: "project" } } });
+
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers).toEqual({ "acme-tools__docs": { command: "project" } });
+    warning.mockRestore();
+  });
+
+  it("keeps unspecified Agent Plugin fields when normal config overrides a plugin server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-plugin-override-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-plugin-override-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const plugin = join(project, "plugins", "acme-tools");
+    writeJson(join(plugin, "plugin.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "acme.tools",
+    });
+    writeJson(join(plugin, "mcp.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: { local: { type: "stdio", command: "node", args: ["plugin.js"] } },
+    });
+    writeJson(join(project, ".mcp.json"), {
+      settings: { agentPluginPaths: ["./plugins/acme-tools"] },
+      mcpServers: { acme_tools__local: { command: "override-node" } },
+    });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers.acme_tools__local).toMatchObject({
+      command: "override-node",
+      args: ["plugin.js"],
+      cwd: realpathSync(plugin),
+      env: { PLUGIN_ROOT: realpathSync(plugin) },
+    });
+  });
+
+  it("suppresses a package server that collides with an Agent Plugin server", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-plugin-collision-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-plugin-collision-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    const packageRoot = join(home, ".pi", "agent", "npm", "node_modules", "acme-tools");
+    const plugin = join(project, "plugins", "acme-tools");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["npm:acme-tools"] });
+    writeJson(join(packageRoot, "package.json"), { name: "acme-tools", pi: { mcp: "./mcp.json" } });
+    writeJson(join(packageRoot, "mcp.json"), {
+      mcpServers: { local: { command: "package", args: ["--package"], env: { PACKAGE: "1" } } },
+    });
+    writeJson(join(plugin, "plugin.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "acme.tools",
+    });
+    writeJson(join(plugin, "mcp.json"), {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: { local: { type: "stdio", command: "node", args: ["plugin.js"] } },
+    });
+    writeJson(join(project, ".mcp.json"), { settings: { agentPluginPaths: ["./plugins/acme-tools"] } });
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(loadMcpConfig().mcpServers.acme_tools__local).toMatchObject({
+      command: "node",
+      args: ["plugin.js"],
+    });
+    expect(loadMcpConfig().mcpServers.acme_tools__local).not.toHaveProperty("env.PACKAGE");
   });
 
   it("drops malformed server entries at the config boundary", async () => {

--- a/config.ts
+++ b/config.ts
@@ -6,6 +6,7 @@ import { parse as parseToml } from "smol-toml";
 import stripJsonComments from "strip-json-comments";
 import { getAgentPath, getConfigDirName } from "./agent-dir.ts";
 import { getAgentPluginSummaries, loadAgentPluginConfigs, type AgentPluginSummary } from "./agent-plugin-loader.ts";
+import { loadPackageMcpConfigs } from "./package-mcp-loader.ts";
 import { isServerDisabled, type HostConfigDiscovery, type McpConfig, type ServerEntry, type McpSettings, type ImportKind, type ServerProvenance } from "./types.ts";
 import { toStringRecord } from "./utils.ts";
 
@@ -306,8 +307,12 @@ export function loadMcpConfig(overridePath?: string, cwd = process.cwd()): McpCo
     config = mergeConfigs(config, expandImports(loaded, cwd));
   }
 
+  const packageConfig = loadPackageMcpConfigs(cwd);
   const pluginConfig = loadAgentPluginConfigs(config.settings?.agentPluginPaths, cwd);
-  return mergeConfigs(pluginConfig, config);
+  const packageServers = Object.fromEntries(
+    Object.entries(packageConfig.mcpServers).filter(([name]) => !Object.hasOwn(pluginConfig.mcpServers, name)),
+  );
+  return mergeConfigs({ mcpServers: packageServers }, mergeConfigs(pluginConfig, config));
 }
 
 function getMergedSettings(overridePath?: string, cwd = process.cwd()): McpSettings | undefined {
@@ -491,17 +496,30 @@ function mergeServerMaps(
     // applies (it is spread last). Behaviour is unchanged when the url is
     // identical or the override omits `url` (partial overrides still inherit).
     let baseEntry: ServerEntry = existing ?? {};
-    if (existing && typeof definition.socket === "string") {
+    if (existing && typeof definition.command === "string") {
       baseEntry = { ...existing };
       for (const field of [
-        "command", "args", "env", "cwd", "url", "headers", "auth",
-        "bearerToken", "bearerTokenEnv", "oauth",
+        "url", "headers", "requestHeadersCommand", "auth", "bearerToken",
+        "bearerTokenEnv", "oauth", "httpTransport", "socket",
       ] as const) {
         delete baseEntry[field];
       }
-    } else if (existing?.socket && (typeof definition.command === "string" || typeof definition.url === "string")) {
+    } else if (existing && typeof definition.url === "string") {
       baseEntry = { ...existing };
-      delete baseEntry.socket;
+      for (const field of [
+        "command", "args", "env", "cwd", "pluginDataDir", "literalEnv", "socket",
+      ] as const) {
+        delete baseEntry[field];
+      }
+    } else if (existing && typeof definition.socket === "string") {
+      baseEntry = { ...existing };
+      for (const field of [
+        "command", "args", "env", "cwd", "pluginDataDir", "literalEnv", "url",
+        "headers", "requestHeadersCommand", "auth", "bearerToken", "bearerTokenEnv",
+        "oauth", "httpTransport",
+      ] as const) {
+        delete baseEntry[field];
+      }
     }
     if (existing && typeof definition.url === "string" && definition.url !== existing.url) {
       if (baseEntry === existing) baseEntry = { ...existing };

--- a/package-mcp-loader.ts
+++ b/package-mcp-loader.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import stripJsonComments from "strip-json-comments";
+import { getAgentDir, getConfigDirName } from "./agent-dir.ts";
+import type { McpConfig, ServerEntry } from "./types.ts";
+
+interface PackageSetting {
+  source: string;
+}
+
+interface PackageManifest {
+  name?: unknown;
+  pi?: { mcp?: unknown };
+}
+
+export function loadPackageMcpConfigs(cwd = process.cwd()): McpConfig {
+  const mcpServers: Record<string, ServerEntry> = {};
+  const seen = new Set<string>();
+
+  for (const packageRoot of getConfiguredPackageRoots(cwd)) {
+    const manifest = readPackageManifest(packageRoot);
+    if (!manifest || typeof manifest.name !== "string" || !manifest.name) continue;
+    const paths = getManifestMcpPaths(manifest.pi?.mcp, manifest.name);
+    if (!paths) continue;
+
+    const packagePrefix = formatPackageName(manifest.name);
+    const packageServers = new Set<string>();
+    for (const path of paths) {
+      const configPath = resolvePackageConfigPath(packageRoot, path);
+      if (!configPath) {
+        console.warn(`Pi package ${manifest.name} skips MCP config ${path}: file must stay inside the package`);
+        continue;
+      }
+
+      const config = readMcpConfig(configPath, manifest.name);
+      if (!config) continue;
+      for (const [serverName, server] of Object.entries(config.mcpServers)) {
+        const normalizedName = `${packagePrefix}__${formatServerName(serverName)}`;
+        if (packageServers.has(normalizedName) || seen.has(normalizedName)) {
+          console.warn(`Pi package ${manifest.name} skips duplicate normalized MCP server ${normalizedName}`);
+          continue;
+        }
+        packageServers.add(normalizedName);
+        seen.add(normalizedName);
+        mcpServers[normalizedName] = server;
+      }
+    }
+  }
+
+  return { mcpServers };
+}
+
+function getConfiguredPackageRoots(cwd: string): string[] {
+  const roots: string[] = [];
+  for (const [settingsPath, scope] of [
+    [join(cwd, getConfigDirName(), "settings.json"), "project"],
+    [join(getAgentDir(), "settings.json"), "user"],
+  ] as const) {
+    const settings = readJson(settingsPath) as { packages?: unknown } | null;
+    if (!Array.isArray(settings?.packages)) continue;
+    for (const entry of settings.packages) {
+      const source = typeof entry === "string"
+        ? entry
+        : entry && typeof entry === "object" && !Array.isArray(entry) && typeof (entry as PackageSetting).source === "string"
+          ? (entry as PackageSetting).source
+          : undefined;
+      if (!source) continue;
+      const root = resolvePackageRoot(source, scope, cwd);
+      if (root && !roots.includes(root)) roots.push(root);
+    }
+  }
+  return roots;
+}
+
+function resolvePackageRoot(source: string, scope: "user" | "project", cwd: string): string | null {
+  const baseDir = scope === "user" ? getAgentDir() : join(cwd, getConfigDirName());
+  if (source.startsWith("npm:")) {
+    const name = source.slice(4).trim().match(/^(@?[^@]+(?:\/[^@]+)?)/)?.[1];
+    return name ? resolveContainedPath(join(baseDir, "npm", "node_modules"), name) : null;
+  }
+  const gitSource = source.startsWith("git:")
+    ? source.slice(4).trim()
+    : /^(?:(?:https?|ssh):\/\/|git@[^:]+:)/.test(source) ? source : null;
+  if (gitSource) {
+    const value = gitSource
+      .replace(/^ssh:\/\/git@/, "")
+      .replace(/^git@([^:]+):/, "$1/")
+      .replace(/^[a-z]+:\/\//i, "");
+    const path = value.replace(/@[^/]+$/, "").replace(/\.git$/, "");
+    return path && !path.startsWith("/") ? resolveContainedPath(join(baseDir, "git"), path) : null;
+  }
+  return isAbsolute(source) ? resolve(source) : resolve(baseDir, source);
+}
+
+function readPackageManifest(packageRoot: string): PackageManifest | null {
+  const manifest = readJson(join(packageRoot, "package.json"));
+  return manifest && typeof manifest === "object" && !Array.isArray(manifest) ? manifest as PackageManifest : null;
+}
+
+function getManifestMcpPaths(value: unknown, packageName: string): string[] | null {
+  const paths = typeof value === "string" ? [value] : Array.isArray(value) && value.every((path): path is string => typeof path === "string") ? value : null;
+  if (value !== undefined && !paths) console.warn(`Pi package ${packageName} ignores invalid pi.mcp manifest entry`);
+  return paths;
+}
+
+function readMcpConfig(path: string, packageName: string): McpConfig | null {
+  const config = readJson(path);
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    console.warn(`Pi package ${packageName} skips invalid MCP config ${path}`);
+    return null;
+  }
+  const servers = (config as { mcpServers?: unknown }).mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return { mcpServers: {} };
+  const mcpServers: Record<string, ServerEntry> = {};
+  for (const [name, server] of Object.entries(servers)) {
+    if (server && typeof server === "object" && !Array.isArray(server)) {
+      mcpServers[name] = server as ServerEntry;
+    }
+  }
+  return { mcpServers };
+}
+
+function readJson(path: string): unknown | null {
+  try {
+    return JSON.parse(stripJsonComments(readFileSync(path, "utf8"), { trailingCommas: true }));
+  } catch {
+    return null;
+  }
+}
+
+function resolveContainedPath(root: string, path: string): string | null {
+  const resolved = resolve(root, path);
+  const rel = relative(root, resolved);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(sep) && !isAbsolute(rel)) ? resolved : null;
+}
+
+function resolvePackageConfigPath(packageRoot: string, path: string): string | null {
+  const lexicalPath = resolveContainedPath(packageRoot, path);
+  if (!lexicalPath || !existsSync(lexicalPath) || !statSync(lexicalPath).isFile()) return null;
+  try {
+    const realPackageRoot = realpathSync(packageRoot);
+    const realConfigPath = realpathSync(lexicalPath);
+    return resolveContainedPath(realPackageRoot, realConfigPath);
+  } catch {
+    return null;
+  }
+}
+
+function formatPackageName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || "package";
+}
+
+function formatServerName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || "server";
+}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "ui-tool-visibility.ts",
     "ui-app-bridge-helpers.ts",
     "config.ts",
+    "package-mcp-loader.ts",
     "server-manager.ts",
     "request-headers-command.ts",
     "unix-socket-transport.ts",


### PR DESCRIPTION
## Summary

This implements the manifest-declared MCP package path selected for #376. Pi packages can now declare `{"pi":{"mcp":"./mcp.json"}}`, and the installed adapter loads those server definitions without requiring users to edit their own MCP config.

Package MCP files are server-only. The adapter ignores package `settings` and `imports`, prefixes server names with the sanitized package name, reads only configured Pi packages, and keeps normal user/global/project MCP config higher priority.

Closes #376.

## Validation

- `npm test -- __tests__/config.test.ts __tests__/package-manifest.test.ts`
- `npm run typecheck`
- `git diff origin/main...HEAD --check`

Fresh review found the first-pass precedence and Git-source issues. The fixes passed a targeted fresh review with no issues found.

Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
