### PR TITLE
fix: publish connected status after tool synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ pi.events.on(MCP_STATUS_EVENT, (snapshot) => {
 });
 ```
 
-The snapshot is read-only machine-readable data with copied per-server entries. It includes `totalTools`, `totalResources`, `connectedCount`, and `disabledCount`; each server includes `name`, `status`, `toolCount`, and `disabled`, with `resourceCount` when known and `failedAgoSeconds` only for an active failure. Reading status never connects a lazy server, starts authentication, or exposes SDK clients, transports, credentials, or server definitions. An initial snapshot is emitted after initialization, updates are emitted for status and metadata changes, and an empty snapshot is emitted when the session shuts down.
+The snapshot is read-only machine-readable data with copied per-server entries. It includes `totalTools`, `totalResources`, `connectedCount`, and `disabledCount`; each server includes `name`, `status`, `toolCount`, and `disabled`, with `resourceCount` when known and `failedAgoSeconds` only for an active failure. Reading status never connects a lazy server, starts authentication, or exposes SDK clients, transports, credentials, or server definitions. An initial snapshot is emitted after initialization, updates are emitted for status and metadata changes, and an empty snapshot is emitted when the session shuts down. Initialization withholds that first snapshot until authoritative metadata has been reconciled into Pi's active direct-tool registry. A `connected` snapshot therefore follows model-facing tool-surface synchronization, including removal of stale cached tools when the authoritative catalog is empty.
 
 In the configuration examples below, `30000` is illustrative only. If `requestTimeoutMs` is omitted or set to `<= 0`, the MCP SDK default timeout is used.
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_STATUS_EVENT } from "../types.ts";
 
 const mocks = vi.hoisted(() => ({
   initializeMcp: vi.fn(),
@@ -155,6 +156,52 @@ function createPi(options: { unregisterTool?: false | ((name: string) => boolean
         activeTools = nextActiveTools;
       }),
     } as any,
+  };
+}
+
+function createStatusObservingPi() {
+  const { api, handlers } = createPi();
+  let activeTools = ["bash"];
+  const connectedSurfaces: string[][] = [];
+
+  api.registerTool.mockImplementation((tool: { name: string }) => {
+    if (!activeTools.includes(tool.name)) activeTools.push(tool.name);
+  });
+  api.unregisterTool.mockImplementation((toolName: string) => {
+    const previousLength = activeTools.length;
+    activeTools = activeTools.filter((name) => name !== toolName);
+    return activeTools.length !== previousLength;
+  });
+  api.getActiveTools.mockImplementation(() => [...activeTools]);
+  api.setActiveTools.mockImplementation((nextActiveTools: string[]) => {
+    activeTools = [...nextActiveTools];
+  });
+  api.events = {
+    emit: vi.fn((channel: string, payload: { connectedCount?: number }) => {
+      if (channel !== MCP_STATUS_EVENT || payload.connectedCount !== 1) return;
+      connectedSurfaces.push(activeTools
+        .filter((name) => name === "mcp" || name.startsWith("demo_"))
+        .sort());
+    }),
+  };
+
+  return { api, handlers, connectedSurfaces };
+}
+
+function connectedStatusSnapshot(toolCount: number) {
+  return {
+    version: 1,
+    servers: [{
+      name: "demo",
+      status: "connected",
+      toolCount,
+      resourceCount: 0,
+      disabled: false,
+    }],
+    totalTools: toolCount,
+    totalResources: 0,
+    connectedCount: 1,
+    disabledCount: 0,
   };
 }
 
@@ -598,6 +645,87 @@ describe("mcpAdapter session lifecycle", () => {
     await Promise.resolve();
 
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
+  });
+
+  it("publishes connected status only after replacing stale cached direct tools", async () => {
+    const config = {
+      settings: { disableProxyTool: true },
+      mcpServers: {
+        demo: { command: "demo-server", lifecycle: "keep-alive", directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({ version: 1, servers: { demo: {} } });
+    mocks.resolveDirectTools
+      .mockReturnValueOnce([{
+        serverName: "demo",
+        originalName: "stale",
+        prefixedName: "demo_stale",
+        description: "Cached stale tool",
+      }])
+      .mockReturnValue([{
+        serverName: "demo",
+        originalName: "current",
+        prefixedName: "demo_current",
+        description: "Authoritative current tool",
+      }]);
+    mocks.initializeMcp.mockImplementation(async (_pi, _ctx, _owner, options) => {
+      state.statusEvents = options.statusEvents;
+      state.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(1));
+      return state;
+    });
+    mocks.updateStatusBar.mockImplementation((currentState) => {
+      currentState.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(1));
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers, connectedSurfaces } = createStatusObservingPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(connectedSurfaces).toEqual([["demo_current"]]);
+  });
+
+  it("publishes an authoritative empty catalog only after removing stale cached direct tools", async () => {
+    const config = {
+      settings: { disableProxyTool: true },
+      mcpServers: {
+        demo: { command: "demo-server", lifecycle: "keep-alive", directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({ version: 1, servers: { demo: {} } });
+    mocks.resolveDirectTools
+      .mockReturnValueOnce([{
+        serverName: "demo",
+        originalName: "stale",
+        prefixedName: "demo_stale",
+        description: "Cached stale tool",
+      }])
+      .mockReturnValue([]);
+    mocks.initializeMcp.mockImplementation(async (_pi, _ctx, _owner, options) => {
+      state.statusEvents = options.statusEvents;
+      state.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(0));
+      return state;
+    });
+    mocks.updateStatusBar.mockImplementation((currentState) => {
+      currentState.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(0));
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers, connectedSurfaces } = createStatusObservingPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(connectedSurfaces).toEqual([["mcp"]]);
   });
 
   it("removes stale direct tools and registers the proxy after metadata refresh", async () => {

--- a/index.ts
+++ b/index.ts
@@ -299,7 +299,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           }
         : {}),
       oauthRuntime,
-      statusEvents: pi.events,
     });
     initPromise = promise;
 
@@ -325,6 +324,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       };
       syncPromptCommands();
       syncToolSurface(ctx);
+      // A connected snapshot is readiness-like external state. Publish it only
+      // after Pi's model-facing direct-tool surface reflects live metadata.
+      nextState.statusEvents = pi.events;
       updateStatusBar(nextState);
       initPromise = null;
       if (earlyConfig.settings?.freezeDirectTools === true) {


### PR DESCRIPTION
## Summary

- withhold MCP status publication during initialization
- publish the first connected snapshot only after Pi's direct-tool surface has synchronized
- document connected status as an authoritative model-facing surface contract

## Why

PR #374 fixed keep-alive reconnection and catalog refresh. During initial startup, however, `initializeMcp()` can still emit a connected status snapshot before `syncToolSurface()` has replaced cached direct tools. Consumers that use the public status event as readiness evidence can therefore observe a connected catalog while Pi still exposes stale tools.

This follow-up delays the event bus until tool synchronization completes, including the authoritative-empty-catalog case.

## Validation

- `npm test -- __tests__/index-lifecycle.test.ts` — 51 passed
- `npm run typecheck` — passed
- `npm test` — 1,169 passed; two unrelated child-process cleanup timing tests failed identically on untouched upstream `main`

Follow-up to #374 and the original report in #369 / draft PR #370.
