### PR TITLE
feat: add runtime MCP server registration API for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `registerMcpServer(pi, name, definition)` so other extensions can register and dispose session-scoped MCP servers at runtime. Registrations are proxy-tool-only, never persisted, and duplicate names fail closed. Thanks to [@bendavis78](https://github.com/bendavis78) and [@fmoda3](https://github.com/fmoda3) for the runtime API request in #376/#382.
 - Added `pi.mcp` package manifest entries so Pi packages can ship prefixed MCP server definitions without user MCP config edits. Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
 - Added opt-in OS credential-store lookup for static bearer tokens with URL-bound records, using `bearerTokenStore: true`, plus a stdin-only `pi-mcp-adapter token set|status|remove <server>` CLI that never accepts the token as an argument. Thanks to [@AlexanderBartash](https://github.com/AlexanderBartash) for issue #366.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ A Pi package can ship MCP servers for the installed adapter without requiring a 
 
 `pi.mcp` can also be an array of package-relative paths. Each file uses the normal `mcpServers` object shape, but package manifests load only server entries: package `settings` and `imports` are ignored. Server names are prefixed with the sanitized package name, such as `acme_tools__docs`, and user/global/project MCP config has higher precedence. The adapter loads only Pi packages listed in Pi settings; it does not scan `node_modules`.
 
+### Runtime registration from other extensions
+
+An extension can register MCP servers with the installed adapter at runtime, for example a plugin host that discovers plugins after load:
+
+```ts
+import { registerMcpServer } from "pi-mcp-adapter";
+
+export default function pluginHost(pi) {
+  const registration = registerMcpServer(pi, "acme__docs", {
+    url: "https://mcp.example.com/mcp",
+  });
+  // Later, when the plugin is uninstalled:
+  await registration.dispose();
+}
+```
+
+Runtime registrations are session scoped and never written to config files. Duplicate server names fail closed against configured servers and other registrations. Registered servers use the normal lazy connection, OAuth, approval, and shutdown behavior, but they are proxy-tool-only and their tools become visible at the next tool sync. To change a definition, dispose the registration and register again. Registration throws when no adapter is installed for the given Pi instance.
+
 ### SDK configuration
 
 Use `createMcpAdapter` when an SDK or server integration already owns its MCP configuration:

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -545,4 +545,61 @@ describe("lazy-keep-alive lifecycle", () => {
 
     expect(manager.connect).toHaveBeenCalledTimes(2);
   });
+
+  it("closes a keep-alive connection when the server is unregistered mid-connect", async () => {
+    const def = makeDefinition("keep-alive");
+    lifecycle.registerServer("srv", def);
+    lifecycle.markKeepAlive("srv", def);
+
+    let resolveConnect!: (connection: FakeConnection) => void;
+    fake.connect = vi.fn((name: string) => {
+      fake.connectCalls.push(name);
+      return new Promise<FakeConnection>((resolve) => {
+        resolveConnect = (connection) => {
+          fake.connections.set(name, connection);
+          resolve(connection);
+        };
+      });
+    }) as never;
+
+    const convergence = lifecycle.ensureConverged();
+    await Promise.resolve();
+    expect(fake.connectCalls).toContain("srv");
+
+    lifecycle.unregisterServer("srv");
+    resolveConnect({ status: "connected" });
+    await convergence;
+
+    expect(fake.closeCalls).toContain("srv");
+    expect(fake.connections.has("srv")).toBe(false);
+  });
+
+  it("does not record retry state from a stale pass against a same-name replacement", async () => {
+    const def = makeDefinition("keep-alive");
+    lifecycle.registerServer("srv", def);
+    lifecycle.markKeepAlive("srv", def);
+
+    let rejectConnect!: (error: Error) => void;
+    fake.connect = vi.fn((name: string) => {
+      fake.connectCalls.push(name);
+      return new Promise<FakeConnection>((_resolve, reject) => {
+        rejectConnect = reject;
+      });
+    }) as never;
+
+    const convergence = lifecycle.ensureConverged();
+    await Promise.resolve();
+    expect(fake.connectCalls).toContain("srv");
+
+    // Dispose, then immediately register a replacement under the same name.
+    lifecycle.unregisterServer("srv");
+    const replacement = makeDefinition("keep-alive");
+    lifecycle.registerServer("srv", replacement);
+    lifecycle.markKeepAlive("srv", replacement);
+
+    rejectConnect(new Error("connection closed during dispose"));
+    await convergence;
+
+    expect((lifecycle as any).retryStates.has("srv")).toBe(false);
+  });
 });

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initializeMcp: vi.fn(),
+  updateStatusBar: vi.fn(),
+  flushMetadataCache: vi.fn(),
+  notifyToolMetadataUpdated: vi.fn(),
+  initializeOAuth: vi.fn().mockResolvedValue(undefined),
+  createOAuthRuntime: vi.fn((signal: AbortSignal) => ({ signal })),
+  shutdownOAuth: vi.fn().mockResolvedValue(undefined),
+  loadMcpConfig: vi.fn(() => ({ mcpServers: {} })),
+  cloneMcpConfig: vi.fn((config: unknown) => structuredClone(config)),
+  loadMetadataCache: vi.fn(() => null),
+  buildProxyDescription: vi.fn(() => "MCP gateway"),
+  createDirectToolExecutor: vi.fn(() => vi.fn()),
+  getMissingConfiguredDirectToolServers: vi.fn(() => []),
+  resolveDirectTools: vi.fn(() => []),
+  showStatus: vi.fn(),
+  showTools: vi.fn(),
+  showPrompts: vi.fn(),
+  reconnectServer: vi.fn(),
+  reconnectServers: vi.fn(),
+  authenticateServer: vi.fn(),
+  logoutServer: vi.fn(),
+  manageBearerToken: vi.fn(),
+  openMcpAuthPanel: vi.fn(),
+  openMcpPanel: vi.fn(),
+  openMcpSetup: vi.fn(),
+  writeProjectServerDisabledOverride: vi.fn(() => ({ path: "/tmp/project/.pi/mcp.json", changed: true })),
+  executeAuthComplete: vi.fn(),
+  executeAuthStart: vi.fn(),
+  executeCall: vi.fn(),
+  executeConnect: vi.fn(),
+  executeDescribe: vi.fn(),
+  executeInstructions: vi.fn(),
+  executeList: vi.fn(),
+  executeSearch: vi.fn(),
+  executeStatus: vi.fn(),
+  executeUiMessages: vi.fn(),
+  getConfigPathFromArgv: vi.fn(() => undefined),
+  normalizeDirectToolInputSchema: vi.fn((schema: unknown) => schema),
+  truncateAtWord: vi.fn((text: string) => text),
+}));
+
+vi.mock("../init.ts", () => ({
+  initializeMcp: mocks.initializeMcp,
+  updateStatusBar: mocks.updateStatusBar,
+  flushMetadataCache: mocks.flushMetadataCache,
+  notifyToolMetadataUpdated: mocks.notifyToolMetadataUpdated,
+}));
+
+vi.mock("../mcp-auth-flow.ts", () => ({
+  initializeOAuth: mocks.initializeOAuth,
+  createOAuthRuntime: mocks.createOAuthRuntime,
+  shutdownOAuth: mocks.shutdownOAuth,
+}));
+
+vi.mock("../config.ts", () => ({
+  loadMcpConfig: mocks.loadMcpConfig,
+  cloneMcpConfig: mocks.cloneMcpConfig,
+  writeProjectServerDisabledOverride: mocks.writeProjectServerDisabledOverride,
+}));
+
+vi.mock("../metadata-cache.ts", () => ({
+  loadMetadataCache: mocks.loadMetadataCache,
+}));
+
+vi.mock("../direct-tools.ts", () => ({
+  buildProxyDescription: mocks.buildProxyDescription,
+  createDirectToolExecutor: mocks.createDirectToolExecutor,
+  getMissingConfiguredDirectToolServers: mocks.getMissingConfiguredDirectToolServers,
+  resolveDirectTools: mocks.resolveDirectTools,
+}));
+
+vi.mock("../commands.ts", () => ({
+  showStatus: mocks.showStatus,
+  showTools: mocks.showTools,
+  showPrompts: mocks.showPrompts,
+  reconnectServer: mocks.reconnectServer,
+  reconnectServers: mocks.reconnectServers,
+  authenticateServer: mocks.authenticateServer,
+  logoutServer: mocks.logoutServer,
+  manageBearerToken: mocks.manageBearerToken,
+  openMcpAuthPanel: mocks.openMcpAuthPanel,
+  openMcpPanel: mocks.openMcpPanel,
+  openMcpSetup: mocks.openMcpSetup,
+}));
+
+vi.mock("../proxy-modes.ts", () => ({
+  executeAuthComplete: mocks.executeAuthComplete,
+  executeAuthStart: mocks.executeAuthStart,
+  executeCall: mocks.executeCall,
+  executeConnect: mocks.executeConnect,
+  executeDescribe: mocks.executeDescribe,
+  executeInstructions: mocks.executeInstructions,
+  executeList: mocks.executeList,
+  executeSearch: mocks.executeSearch,
+  executeStatus: mocks.executeStatus,
+  executeUiMessages: mocks.executeUiMessages,
+}));
+
+vi.mock("../utils.ts", () => ({
+  formatTerminalError: (error: unknown) => error instanceof Error ? error.message : String(error),
+  getConfigPathFromArgv: mocks.getConfigPathFromArgv,
+  normalizeDirectToolInputSchema: mocks.normalizeDirectToolInputSchema,
+  sanitizeTerminalText: (text: string) => text,
+  truncateAtWord: mocks.truncateAtWord,
+}));
+
+function createState() {
+  return {
+    manager: {
+      getAllConnections: () => new Map(),
+      close: vi.fn().mockResolvedValue(undefined),
+    },
+    lifecycle: {
+      gracefulShutdown: vi.fn().mockResolvedValue(undefined),
+      ensureConverged: vi.fn().mockResolvedValue(undefined),
+      registerServer: vi.fn(),
+      markKeepAlive: vi.fn(),
+      unregisterServer: vi.fn(),
+    },
+    toolMetadata: new Map(),
+    config: { mcpServers: {} } as { mcpServers: Record<string, unknown> },
+    oauthRuntime: { signal: new AbortController().signal },
+    failureTracker: new Map(),
+    uiResourceHandler: {},
+    consentManager: {},
+    uiServer: null,
+    completedUiSessions: [],
+    openBrowser: vi.fn(),
+  } as any;
+}
+
+function createPi() {
+  const handlers = new Map<string, (...args: any[]) => unknown>();
+  let activeTools = ["bash", "mcp"];
+  return {
+    handlers,
+    api: {
+      registerTool: vi.fn(),
+      unregisterTool: vi.fn(() => true),
+      registerFlag: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
+        handlers.set(event, handler);
+      }),
+      getAllTools: vi.fn(() => []),
+      getActiveTools: vi.fn(() => activeTools),
+      setActiveTools: vi.fn((nextActiveTools: string[]) => {
+        activeTools = nextActiveTools;
+      }),
+    } as any,
+  };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("runtime MCP server registration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const value of Object.values(mocks)) {
+      if (typeof value === "function" && "mockReset" in value) value.mockReset();
+    }
+    mocks.initializeOAuth.mockResolvedValue(undefined);
+    mocks.createOAuthRuntime.mockImplementation((signal: AbortSignal) => ({ signal }));
+    mocks.shutdownOAuth.mockResolvedValue(undefined);
+    mocks.loadMcpConfig.mockReturnValue({ mcpServers: {} });
+    mocks.cloneMcpConfig.mockImplementation((config: unknown) => structuredClone(config));
+    mocks.loadMetadataCache.mockReturnValue(null);
+    mocks.buildProxyDescription.mockReturnValue("MCP gateway");
+    mocks.createDirectToolExecutor.mockReturnValue(vi.fn());
+    mocks.getMissingConfiguredDirectToolServers.mockReturnValue([]);
+    mocks.resolveDirectTools.mockReturnValue([]);
+    mocks.getConfigPathFromArgv.mockReturnValue(undefined);
+    mocks.truncateAtWord.mockImplementation((text: string) => text);
+  });
+
+  it("throws when no adapter is installed for the Pi instance", async () => {
+    const { registerMcpServer } = await import("../index.ts");
+    expect(() => registerMcpServer({} as any, "plugin", { url: "https://example.test/mcp" }))
+      .toThrow("pi-mcp-adapter is not installed for this Pi instance");
+  });
+
+  it("registers after init, exposes the server in state, and disposes cleanly", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    const registration = registerMcpServer(api, "plugin-a", { url: "https://example.test/mcp" });
+    expect(state.config.mcpServers["plugin-a"]).toMatchObject({
+      url: "https://example.test/mcp",
+      directTools: false,
+    });
+    expect(state.lifecycle.registerServer).toHaveBeenCalledWith(
+      "plugin-a",
+      expect.objectContaining({ url: "https://example.test/mcp" }),
+      undefined,
+    );
+
+    await registration.dispose();
+    expect(state.config.mcpServers["plugin-a"]).toBeUndefined();
+    expect(state.lifecycle.unregisterServer).toHaveBeenCalledWith("plugin-a");
+    expect(state.manager.close).toHaveBeenCalledWith("plugin-a");
+
+    // Dispose is idempotent.
+    await registration.dispose();
+    expect(state.manager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on duplicate names against config and other registrations", async () => {
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: { configured: { url: "https://configured.test/mcp" } },
+    });
+    const state = createState();
+    state.config.mcpServers = { configured: { url: "https://configured.test/mcp" } };
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    expect(() => registerMcpServer(api, "configured", { url: "https://other.test/mcp" }))
+      .toThrow('MCP server "configured" is already registered');
+    registerMcpServer(api, "plugin-a", { url: "https://a.test/mcp" });
+    expect(() => registerMcpServer(api, "plugin-a", { url: "https://b.test/mcp" }))
+      .toThrow('MCP server "plugin-a" is already registered');
+  });
+
+  it("queues pre-init registrations and drains them when init completes", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    registerMcpServer(api, "early-plugin", { url: "https://early.test/mcp" });
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    expect(state.config.mcpServers["early-plugin"]).toMatchObject({
+      url: "https://early.test/mcp",
+      directTools: false,
+    });
+  });
+
+  it("reapplies registrations across session restarts and keeps configured servers on collision", async () => {
+    const firstState = createState();
+    const secondState = createState();
+    secondState.config.mcpServers = { "plugin-a": { url: "https://now-configured.test/mcp" } };
+    mocks.initializeMcp.mockResolvedValueOnce(firstState).mockResolvedValueOnce(secondState);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    registerMcpServer(api, "plugin-a", { url: "https://plugin.test/mcp" });
+    registerMcpServer(api, "plugin-b", { url: "https://plugin-b.test/mcp" });
+
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    // Collision after restart: the configured server wins, fail closed.
+    expect(secondState.config.mcpServers["plugin-a"]).toMatchObject({ url: "https://now-configured.test/mcp" });
+    expect(secondState.config.mcpServers["plugin-b"]).toMatchObject({ url: "https://plugin-b.test/mcp" });
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import type { AgentToolUpdateCallback, ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata } from "./types.ts";
+import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata, ServerEntry } from "./types.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
 import type { TSchema } from "typebox";
@@ -22,6 +22,7 @@ import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
+export type { ServerEntry } from "./types.ts";
 export {
   MCP_STATUS_EVENT,
   MCP_STATUS_SNAPSHOT_VERSION,
@@ -37,6 +38,14 @@ export {
 
 const INIT_WAIT_TIMEOUT_MS = 30_000;
 const INIT_WAIT_TIMED_OUT: unique symbol = Symbol("init-wait-timed-out");
+
+export interface McpServerRegistration {
+  dispose(): Promise<void>;
+}
+
+// Routes runtime registrations to the adapter installed for a specific Pi
+// instance, so a process with several adapters cannot cross-register.
+const runtimeRegistrars = new WeakMap<ExtensionAPI, (name: string, definition: ServerEntry) => McpServerRegistration>();
 
 async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof INIT_WAIT_TIMED_OUT> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -130,6 +139,19 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   let proxyToolRegistered = false;
   let proxyToolDescription: string | null = null;
   let directToolsFrozen = false;
+  // Session/runtime scoped server registrations from other extensions. They
+  // survive session restarts within this install and die with the process.
+  const runtimeServers = new Map<string, ServerEntry>();
+
+  // Mirrors init's per-server lifecycle registration so runtime servers get
+  // idle cleanup and keep-alive health recovery like configured servers.
+  function attachRuntimeServerLifecycle(targetState: McpExtensionState, name: string, definition: ServerEntry): void {
+    const lifecycleMode = definition.lifecycle ?? "lazy";
+    const persistsAfterFirstSpawn = lifecycleMode === "eager" || lifecycleMode === "lazy-keep-alive";
+    const idleOverride = definition.idleTimeout ?? (persistsAfterFirstSpawn ? 0 : undefined);
+    targetState.lifecycle.registerServer(name, definition, idleOverride !== undefined ? { idleTimeout: idleOverride } : undefined);
+    if (lifecycleMode === "keep-alive") targetState.lifecycle.markKeepAlive(name, definition);
+  }
 
   // OMP remaps `typebox` to a host shim that historically lacked Type.Unsafe.
   // Prefer Unsafe when present (real TypeBox / fixed OMP shim); otherwise pass
@@ -282,6 +304,45 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   registerPromptCommands(resolveCachedPrompts(earlyConfig));
 
+  runtimeRegistrars.set(pi, (name: string, definition: ServerEntry): McpServerRegistration => {
+    if (typeof name !== "string" || name.trim() === "") {
+      throw new Error("MCP server name must be a non-empty string");
+    }
+    if (typeof definition !== "object" || definition === null || Array.isArray(definition)) {
+      throw new Error(`MCP server definition for "${name}" must be an object`);
+    }
+    const effective = state?.config ?? earlyConfig;
+    if (runtimeServers.has(name) || Object.hasOwn(effective.mcpServers, name)) {
+      throw new Error(`MCP server "${name}" is already registered`);
+    }
+    // Runtime-registered servers are proxy-tool-only: direct tools are frozen
+    // at startup and must not be rebuilt for late registrations.
+    const entry: ServerEntry = { ...structuredClone(definition), directTools: false };
+    runtimeServers.set(name, entry);
+    const registeredState = state;
+    if (registeredState) {
+      registeredState.config.mcpServers[name] = entry;
+      attachRuntimeServerLifecycle(registeredState, name, entry);
+      syncToolSurface();
+      updateStatusBar(registeredState);
+    }
+    let disposed = false;
+    return {
+      dispose: async (): Promise<void> => {
+        if (disposed) return;
+        disposed = true;
+        runtimeServers.delete(name);
+        const currentState = state;
+        if (!currentState || currentState.config.mcpServers[name] !== entry) return;
+        delete currentState.config.mcpServers[name];
+        currentState.lifecycle.unregisterServer(name);
+        await currentState.manager.close(name);
+        syncToolSurface();
+        updateStatusBar(currentState);
+      },
+    };
+  });
+
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
 
   pi.registerFlag("mcp-config", {
@@ -314,6 +375,14 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
 
       state = nextState;
+      for (const [name, definition] of runtimeServers) {
+        if (Object.hasOwn(nextState.config.mcpServers, name)) {
+          console.error(`MCP: runtime-registered server "${name}" now collides with a configured server; keeping the configured server`);
+          continue;
+        }
+        nextState.config.mcpServers[name] = definition;
+        attachRuntimeServerLifecycle(nextState, name, definition);
+      }
       nextState.onToolMetadataUpdated = (_serverName, _reason) => {
         if (state !== nextState || !owner.isActive()) return;
         syncPromptCommands();
@@ -969,6 +1038,21 @@ export function createMcpAdapter(options: McpAdapterOptions = {}) {
       ...(factoryConfig !== undefined ? { config: cloneMcpConfig(factoryConfig) } : {}),
     });
   };
+}
+
+/**
+ * Register an MCP server with the adapter installed for this Pi instance.
+ * Registrations are session/runtime scoped and never persisted. Duplicate
+ * names fail closed. Registered servers are proxy-tool-only; their tools
+ * become visible at the next tool sync. To change a definition, dispose the
+ * registration and register again.
+ */
+export function registerMcpServer(pi: ExtensionAPI, name: string, definition: ServerEntry): McpServerRegistration {
+  const register = runtimeRegistrars.get(pi);
+  if (!register) {
+    throw new Error("pi-mcp-adapter is not installed for this Pi instance");
+  }
+  return register(name, definition);
 }
 
 export default createMcpAdapter();

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -73,6 +73,14 @@ export class McpLifecycleManager {
     if (settings?.idleTimeout !== undefined) this.serverSettings.set(name, settings);
   }
 
+  unregisterServer(name: string): void {
+    this.allServers.delete(name);
+    this.keepAliveServers.delete(name);
+    this.serverSettings.delete(name);
+    this.retryStates.delete(name);
+    this.pendingMetadataPublications.delete(name);
+  }
+
   setGlobalIdleTimeout(minutes: number): void {
     this.globalIdleTimeout = minutes * 60 * 1000;
   }
@@ -155,6 +163,10 @@ export class McpLifecycleManager {
     retrySuperseded = true,
   ): Promise<void> {
     if (isServerDisabled(definition) || this.stopped || signal?.aborted) return;
+    // Fence against unregisterServer racing an in-flight convergence pass.
+    // Identity comparison also rejects stale passes after a same-name
+    // replacement registration, which a name check would wrongly accept.
+    if (this.keepAliveServers.get(name) !== definition) return;
     const connection = this.manager.getConnection(name);
     if (connection?.status === "needs-auth") {
       this.pendingMetadataPublications.delete(name);
@@ -171,17 +183,18 @@ export class McpLifecycleManager {
         freshConnection = await this.manager.connect(name, definition, signal);
       } catch (error) {
         if (this.stopped || signal?.aborted) return;
-        this.reportConnectionFailure(name, error, "reconnect", this.manager.getConnection(name));
+        this.reportConnectionFailure(name, definition, error, "reconnect", this.manager.getConnection(name));
         return;
       }
       if (this.stopped || signal?.aborted) return;
       if (freshConnection.status === "needs-auth") {
-        await this.notifyAuthRequired(name);
+        await this.notifyAuthRequired(name, definition, freshConnection);
         return;
       }
       if (freshConnection.status !== "connected") {
         this.reportConnectionFailure(
           name,
+          definition,
           new Error(`MCP server ${name} did not return a connected session`),
           "reconnect",
           freshConnection,
@@ -189,12 +202,12 @@ export class McpLifecycleManager {
         return;
       }
       logger.debug(`Reconnected to ${name}`);
-      await this.publishConnectedMetadata(name, freshConnection);
+      await this.publishConnectedMetadata(name, definition, freshConnection);
       return;
     }
 
     if (this.pendingMetadataPublications.has(name)) {
-      await this.publishConnectedMetadata(name, connection);
+      await this.publishConnectedMetadata(name, definition, connection);
       return;
     }
     if (!definition.url) return;
@@ -210,7 +223,7 @@ export class McpLifecycleManager {
         return;
       }
       if (!shouldReconnectAfterRefresh(error, hadSessionId)) {
-        this.reportConnectionFailure(name, error, "refresh", connection);
+        this.reportConnectionFailure(name, definition, error, "refresh", connection);
         return;
       }
       if (this.hasPendingAuthForServer(name)) {
@@ -222,17 +235,18 @@ export class McpLifecycleManager {
         freshConnection = await this.manager.reconnect(name, definition, connection, signal);
       } catch (reconnectError) {
         if (this.stopped || signal?.aborted) return;
-        this.reportConnectionFailure(name, reconnectError, "reconnect", this.manager.getConnection(name));
+        this.reportConnectionFailure(name, definition, reconnectError, "reconnect", this.manager.getConnection(name));
         return;
       }
       if (this.stopped || signal?.aborted) return;
       if (freshConnection.status === "needs-auth") {
-        await this.notifyAuthRequired(name);
+        await this.notifyAuthRequired(name, definition, freshConnection);
         return;
       }
       if (freshConnection.status !== "connected") {
         this.reportConnectionFailure(
           name,
+          definition,
           new Error(`MCP server ${name} did not return a connected session`),
           "reconnect",
           freshConnection,
@@ -240,7 +254,7 @@ export class McpLifecycleManager {
         return;
       }
       logger.debug(`Reconnected stale MCP session for ${name}`);
-      await this.publishConnectedMetadata(name, freshConnection);
+      await this.publishConnectedMetadata(name, definition, freshConnection);
       return;
     }
 
@@ -248,6 +262,7 @@ export class McpLifecycleManager {
       await this.handleSupersededConnection(name, definition, connection, signal, retrySuperseded);
       return;
     }
+    if (this.keepAliveServers.get(name) !== definition) return;
     if (this.retryStates.delete(name)) {
       await this.onHealthRestored?.(name);
     }
@@ -261,16 +276,17 @@ export class McpLifecycleManager {
     retrySuperseded: boolean,
   ): Promise<void> {
     const current = this.manager.getConnection(name);
+    if (this.keepAliveServers.get(name) !== definition) return;
     if (current === staleConnection && current.status === "connected") {
       if (this.retryStates.delete(name)) await this.onHealthRestored?.(name);
       return;
     }
     if (current?.status === "connected") {
-      await this.publishConnectedMetadata(name, current);
+      await this.publishConnectedMetadata(name, definition, current);
       return;
     }
     if (current?.status === "needs-auth") {
-      await this.notifyAuthRequired(name);
+      await this.notifyAuthRequired(name, definition, current);
       return;
     }
     if (retrySuperseded) {
@@ -278,7 +294,15 @@ export class McpLifecycleManager {
     }
   }
 
-  private async publishConnectedMetadata(name: string, connection: ServerConnection): Promise<void> {
+  private async publishConnectedMetadata(name: string, definition: ServerDefinition, connection: ServerConnection): Promise<void> {
+    // Fence stale convergence passes by definition identity so disposal, and
+    // disposal followed by a same-name replacement, never re-track this
+    // server. Close the pass's own connection only when it is still current,
+    // so a replacement's connection is never touched.
+    if (this.keepAliveServers.get(name) !== definition) {
+      if (this.manager.getConnection(name) === connection) await this.manager.close(name);
+      return;
+    }
     this.pendingMetadataPublications.add(name);
     try {
       await this.onReconnect?.(name);
@@ -286,11 +310,19 @@ export class McpLifecycleManager {
       this.retryStates.delete(name);
     } catch (error) {
       if (this.stopped) return;
-      this.reportConnectionFailure(name, error, "publish", connection);
+      this.reportConnectionFailure(name, definition, error, "publish", connection);
     }
   }
 
-  private async notifyAuthRequired(name: string): Promise<void> {
+  private async notifyAuthRequired(name: string, definition: ServerDefinition, connection: ServerConnection): Promise<void> {
+    // Fence stale convergence passes by definition identity. Close the
+    // leftover needs-auth connection only while it is still the manager's
+    // current entry, so a replacement's connection is never touched and the
+    // stale client/transport cannot leak when a replacement connects later.
+    if (this.keepAliveServers.get(name) !== definition) {
+      if (this.manager.getConnection(name) === connection) await this.manager.close(name);
+      return;
+    }
     this.pendingMetadataPublications.delete(name);
     this.retryStates.delete(name);
     try {
@@ -313,10 +345,14 @@ export class McpLifecycleManager {
 
   private reportConnectionFailure(
     name: string,
+    definition: ServerDefinition,
     error: unknown,
     action: "refresh" | "reconnect" | "publish",
     connection: ServerConnection | undefined,
   ): void {
+    // Do not recreate retry/failure state from a stale convergence pass after
+    // disposal or a same-name replacement registration.
+    if (this.keepAliveServers.get(name) !== definition) return;
     const attempts = (this.retryStates.get(name)?.attempts ?? 0) + 1;
     const delay = Math.min(
       KEEP_ALIVE_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 10),


### PR DESCRIPTION
Closes #382, the runtime half of #376.

Adds `registerMcpServer(pi, name, definition)` exported from the package. Other extensions — such as [@bendavis78](https://github.com/bendavis78)'s [Agent Plugins](https://agent-plugins.org/) host — can register MCP servers after the adapter has loaded and dispose them on plugin uninstall. [@fmoda3](https://github.com/fmoda3) also asked for this in addition to the `pi.mcp` manifest path that shipped in #379.

Contract:

- Returns `{ dispose(): Promise<void> }`. Dispose closes the connection, removes the entry, and refreshes the tool surface. It is idempotent.
- Session/runtime scoped, never persisted to config files. Registrations are reapplied across session restarts within the same install and die with the process.
- Duplicate names fail closed against the effective config (user, manifest, agent-plugin) and other runtime registrations. If a session restart introduces a configured server with the same name, the configured server wins and the runtime entry is skipped with an error log.
- Proxy-tool-only: registered definitions are forced to `directTools: false`, so the frozen direct-tool surface is untouched. Tools become visible at the next tool sync.
- No in-place redefinition: dispose, then register again.
- Routing is Pi-instance scoped via a `WeakMap` keyed by the extension API object, so a process with the default adapter plus a `createMcpAdapter(...)` instance cannot cross-register. Registration throws when no adapter is installed for the given Pi instance.
- Registrations made before init completes queue and drain when the session state is built.

Lazy connection, OAuth, metadata cache, approval, and shutdown stay owned by the installed adapter, unchanged — the server manager already resolves definitions per call from session state, so registration is a state insert plus tool-surface sync.

Tests cover: post-init register/dispose (including idempotent dispose and `manager.close` call), duplicate-name fail-closed against config and registrations, pre-init queueing, restart reapplication, and the collision-after-restart case.
