### PR TITLE
fix: publish connected status after tool sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added opt-in OS credential-store lookup for static bearer tokens with URL-bound records, using `bearerTokenStore: true`, plus a stdin-only `pi-mcp-adapter token set|status|remove <server>` CLI that never accepts the token as an argument. Thanks to [@AlexanderBartash](https://github.com/AlexanderBartash) for issue #366.
 
 ### Fixed
+- Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.
 - Stopped MCP panel commands from hanging in RPC, JSON, and print modes when terminal-only custom UI is unavailable. Thanks to [@shixin-guo](https://github.com/shixin-guo) for PR #365.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ pi.events.on(MCP_STATUS_EVENT, (snapshot) => {
 });
 ```
 
-The snapshot is read-only machine-readable data with copied per-server entries. It includes `totalTools`, `totalResources`, `connectedCount`, and `disabledCount`; each server includes `name`, `status`, `toolCount`, and `disabled`, with `resourceCount` when known and `failedAgoSeconds` only for an active failure. Reading status never connects a lazy server, starts authentication, or exposes SDK clients, transports, credentials, or server definitions. An initial snapshot is emitted after initialization, updates are emitted for status and metadata changes, and an empty snapshot is emitted when the session shuts down.
+The snapshot is read-only machine-readable data with copied per-server entries. It includes `totalTools`, `totalResources`, `connectedCount`, and `disabledCount`; each server includes `name`, `status`, `toolCount`, and `disabled`, with `resourceCount` when known and `failedAgoSeconds` only for an active failure. Reading status never connects a lazy server, starts authentication, or exposes SDK clients, transports, credentials, or server definitions. An initial snapshot is emitted after initialization, updates are emitted for status and metadata changes, and an empty snapshot is emitted when the session shuts down. Initialization withholds that first snapshot until authoritative metadata has been reconciled into Pi's active direct-tool registry. A `connected` snapshot therefore follows model-facing tool-surface synchronization, including removal of stale cached tools when the authoritative catalog is empty.
 
 In the configuration examples below, `30000` is illustrative only. If `requestTimeoutMs` is omitted or set to `<= 0`, the MCP SDK default timeout is used.
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_STATUS_EVENT } from "../types.ts";
 
 const mocks = vi.hoisted(() => ({
   initializeMcp: vi.fn(),
@@ -155,6 +156,52 @@ function createPi(options: { unregisterTool?: false | ((name: string) => boolean
         activeTools = nextActiveTools;
       }),
     } as any,
+  };
+}
+
+function createStatusObservingPi() {
+  const { api, handlers } = createPi();
+  let activeTools = ["bash"];
+  const connectedSurfaces: string[][] = [];
+
+  api.registerTool.mockImplementation((tool: { name: string }) => {
+    if (!activeTools.includes(tool.name)) activeTools.push(tool.name);
+  });
+  api.unregisterTool.mockImplementation((toolName: string) => {
+    const previousLength = activeTools.length;
+    activeTools = activeTools.filter((name) => name !== toolName);
+    return activeTools.length !== previousLength;
+  });
+  api.getActiveTools.mockImplementation(() => [...activeTools]);
+  api.setActiveTools.mockImplementation((nextActiveTools: string[]) => {
+    activeTools = [...nextActiveTools];
+  });
+  api.events = {
+    emit: vi.fn((channel: string, payload: { connectedCount?: number }) => {
+      if (channel !== MCP_STATUS_EVENT || payload.connectedCount !== 1) return;
+      connectedSurfaces.push(activeTools
+        .filter((name) => name === "mcp" || name.startsWith("demo_"))
+        .sort());
+    }),
+  };
+
+  return { api, handlers, connectedSurfaces };
+}
+
+function connectedStatusSnapshot(toolCount: number) {
+  return {
+    version: 1,
+    servers: [{
+      name: "demo",
+      status: "connected",
+      toolCount,
+      resourceCount: 0,
+      disabled: false,
+    }],
+    totalTools: toolCount,
+    totalResources: 0,
+    connectedCount: 1,
+    disabledCount: 0,
   };
 }
 
@@ -598,6 +645,87 @@ describe("mcpAdapter session lifecycle", () => {
     await Promise.resolve();
 
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
+  });
+
+  it("publishes connected status only after replacing stale cached direct tools", async () => {
+    const config = {
+      settings: { disableProxyTool: true },
+      mcpServers: {
+        demo: { command: "demo-server", lifecycle: "keep-alive", directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({ version: 1, servers: { demo: {} } });
+    mocks.resolveDirectTools
+      .mockReturnValueOnce([{
+        serverName: "demo",
+        originalName: "stale",
+        prefixedName: "demo_stale",
+        description: "Cached stale tool",
+      }])
+      .mockReturnValue([{
+        serverName: "demo",
+        originalName: "current",
+        prefixedName: "demo_current",
+        description: "Authoritative current tool",
+      }]);
+    mocks.initializeMcp.mockImplementation(async (_pi, _ctx, _owner, options) => {
+      state.statusEvents = options.statusEvents;
+      state.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(1));
+      return state;
+    });
+    mocks.updateStatusBar.mockImplementation((currentState) => {
+      currentState.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(1));
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers, connectedSurfaces } = createStatusObservingPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(connectedSurfaces).toEqual([["demo_current"]]);
+  });
+
+  it("publishes an authoritative empty catalog only after removing stale cached direct tools", async () => {
+    const config = {
+      settings: { disableProxyTool: true },
+      mcpServers: {
+        demo: { command: "demo-server", lifecycle: "keep-alive", directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({ version: 1, servers: { demo: {} } });
+    mocks.resolveDirectTools
+      .mockReturnValueOnce([{
+        serverName: "demo",
+        originalName: "stale",
+        prefixedName: "demo_stale",
+        description: "Cached stale tool",
+      }])
+      .mockReturnValue([]);
+    mocks.initializeMcp.mockImplementation(async (_pi, _ctx, _owner, options) => {
+      state.statusEvents = options.statusEvents;
+      state.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(0));
+      return state;
+    });
+    mocks.updateStatusBar.mockImplementation((currentState) => {
+      currentState.statusEvents?.emit(MCP_STATUS_EVENT, connectedStatusSnapshot(0));
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers, connectedSurfaces } = createStatusObservingPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(connectedSurfaces).toEqual([["mcp"]]);
   });
 
   it("removes stale direct tools and registers the proxy after metadata refresh", async () => {

--- a/index.ts
+++ b/index.ts
@@ -360,7 +360,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           }
         : {}),
       oauthRuntime,
-      statusEvents: pi.events,
     });
     initPromise = promise;
 
@@ -394,6 +393,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       };
       syncPromptCommands();
       syncToolSurface(ctx);
+      // A connected snapshot is readiness-like external state. Publish it only
+      // after Pi's model-facing direct-tool surface reflects live metadata.
+      nextState.statusEvents = pi.events;
       updateStatusBar(nextState);
       initPromise = null;
       if (earlyConfig.settings?.freezeDirectTools === true) {


### PR DESCRIPTION
## Summary

This is a current-main replacement for #380. It preserves @dmorn's two commits, adds the required changelog credit, and keeps the same behavior:

- withhold the first connected MCP status snapshot during initialization
- publish that first connected snapshot only after direct-tool synchronization
- document the status snapshot readiness contract

## Validation

- `npm test -- __tests__/index-lifecycle.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: no issues found

Supersedes #380. Thanks to [@dmorn](https://github.com/dmorn) for the implementation.
