### PR TITLE
perf: cache prepared search ranking fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `pi.mcp` package manifest entries so Pi packages can ship prefixed MCP server definitions without user MCP config edits. Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
 - Added opt-in OS credential-store lookup for static bearer tokens with URL-bound records, using `bearerTokenStore: true`, plus a stdin-only `pi-mcp-adapter token set|status|remove <server>` CLI that never accepts the token as an argument. Thanks to [@AlexanderBartash](https://github.com/AlexanderBartash) for issue #366.
 
+### Changed
+- Precomputed normalized MCP tool fields and keyword tokens per catalog to reduce repeated search ranking work.
+
 ### Fixed
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/__tests__/search-ranking.test.ts
+++ b/__tests__/search-ranking.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { paginate, resolveSearchKeywords, scoreToolMatch } from "../search-ranking.ts";
-import type { ServerEntry } from "../types.ts";
+import { paginate, rankToolMatches, resolveSearchKeywords, scoreToolMatch } from "../search-ranking.ts";
+import type { McpExtensionState } from "../state.ts";
+import type { ServerEntry, ToolMetadata } from "../types.ts";
 
 const tool = (name: string, description: string) => ({
   name,
@@ -64,6 +65,22 @@ describe("search ranking", () => {
     const advanced = tool("search_records_advanced", "Advanced record search");
 
     expect(scoreToolMatch(advanced, "demo", "advanced", [])).toEqual(scoreToolMatch(advanced, "demo", "advanced"));
+  });
+
+  it("refreshes prepared fields when catalog or keyword references change", () => {
+    const state = {
+      toolMetadata: new Map([["demo", [tool("search_records", "Find records")]]]),
+      config: { mcpServers: { demo: { command: "demo", searchKeywords: { search_records: ["fuzzy"] } } } },
+    } as unknown as McpExtensionState;
+
+    expect(rankToolMatches(state, "fuzzy")).toHaveLength(1);
+    state.config.mcpServers.demo!.searchKeywords = { search_records: ["semantic"] };
+    expect(rankToolMatches(state, "fuzzy")).toHaveLength(0);
+    expect(rankToolMatches(state, "semantic")).toHaveLength(1);
+
+    state.toolMetadata.set("demo", [tool("create_record", "Create a record")] as ToolMetadata[]);
+    expect(rankToolMatches(state, "search")).toHaveLength(0);
+    expect(rankToolMatches(state, "create")).toHaveLength(1);
   });
 
   it("paginates including offsets beyond the result set", () => {

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -23,6 +23,26 @@ export interface RankedToolMatch {
   score: number;
 }
 
+type SearchField = Exclude<keyof typeof FIELD_WEIGHTS, "keywords">;
+
+interface PreparedToolSearch {
+  tool: ToolMetadata;
+  fields: Array<[SearchField, string, string[]]>;
+  nameTokens: string[];
+  keywordPhrases: string[];
+  keywordTokens: string[];
+}
+
+interface CachedServerSearch {
+  metadata: ToolMetadata[];
+  searchKeywords: ServerEntry["searchKeywords"];
+  toolPrefix: ReturnType<typeof resolveToolPrefix>;
+  withKeywords?: PreparedToolSearch[];
+  withoutKeywords?: PreparedToolSearch[];
+}
+
+const searchCache = new WeakMap<McpExtensionState, Map<string, CachedServerSearch>>();
+
 /**
  * Resolve the configured searchKeywords entries that apply to a tool.
  * Keys match by original name, prefixed name, or glob — the same candidate
@@ -64,25 +84,37 @@ export function tokenize(value: string): string[] {
   return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean);
 }
 
-export function scoreToolMatch(tool: ToolMetadata, server: string, query: string, keywords?: string[]): number | null {
-  const normalizedQuery = normalizeSearchText(query).trim();
-  const queryTokens = tokenize(query);
-  if (queryTokens.length === 0) return null;
-
+function prepareToolSearch(tool: ToolMetadata, server: string, keywords?: string[]): PreparedToolSearch {
   const fields = {
     name: normalizeSearchText(tool.name),
     originalName: normalizeSearchText(tool.originalName),
     server: normalizeSearchText(server),
     description: normalizeSearchText(tool.description),
   };
+  const preparedFields = (Object.entries(fields) as Array<[SearchField, string]>)
+    .map(([field, value]): [SearchField, string, string[]] => [field, value, tokenize(value)]);
+  const keywordPhrases = keywords?.map(keyword => normalizeSearchText(keyword).trim()).filter(Boolean) ?? [];
+  return {
+    tool,
+    fields: preparedFields,
+    nameTokens: preparedFields[0]![2],
+    keywordPhrases,
+    keywordTokens: keywordPhrases.flatMap(tokenize),
+  };
+}
+
+function scorePreparedToolMatch(
+  prepared: PreparedToolSearch,
+  normalizedQuery: string,
+  queryTokens: string[],
+): number | null {
   let score = 0;
   let phraseMatched = false;
   let wholeFieldExact = false;
   const matchedTokens = new Set<string>();
 
-  for (const [field, value] of Object.entries(fields) as Array<[keyof typeof FIELD_WEIGHTS, string]>) {
+  for (const [field, value, fieldTokens] of prepared.fields) {
     const weight = FIELD_WEIGHTS[field];
-    const fieldTokens = tokenize(value);
     if (value === normalizedQuery) {
       score += weight * 14;
       phraseMatched = true;
@@ -112,11 +144,10 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
   // Configured keywords are discrete phrases, so the phrase-level bonus is
   // computed per phrase (best match wins) rather than on a joined string,
   // which would phrase-match queries spanning two unrelated keywords.
-  if (keywords !== undefined && keywords.length > 0) {
+  if (prepared.keywordPhrases.length > 0) {
     const weight = FIELD_WEIGHTS.keywords;
-    const phrases = keywords.map(keyword => normalizeSearchText(keyword).trim()).filter(Boolean);
     let phraseScore = 0;
-    for (const phrase of phrases) {
+    for (const phrase of prepared.keywordPhrases) {
       if (phrase === normalizedQuery) {
         phraseScore = Math.max(phraseScore, weight * 14);
         phraseMatched = true;
@@ -131,15 +162,14 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
     }
     score += phraseScore;
 
-    const keywordTokens = phrases.flatMap(tokenize);
     for (const token of queryTokens) {
-      if (keywordTokens.includes(token)) {
+      if (prepared.keywordTokens.includes(token)) {
         score += weight * 4;
         matchedTokens.add(token);
-      } else if (keywordTokens.some(keywordToken => keywordToken.startsWith(token) || (keywordToken.length >= MIN_STEM_LENGTH && token.startsWith(keywordToken)))) {
+      } else if (prepared.keywordTokens.some(keywordToken => keywordToken.startsWith(token) || (keywordToken.length >= MIN_STEM_LENGTH && token.startsWith(keywordToken)))) {
         score += weight * 2;
         matchedTokens.add(token);
-      } else if (phrases.some(phrase => phrase.includes(token))) {
+      } else if (prepared.keywordPhrases.some(phrase => phrase.includes(token))) {
         score += weight;
         matchedTokens.add(token);
       }
@@ -151,9 +181,50 @@ export function scoreToolMatch(tool: ToolMetadata, server: string, query: string
 
   score += coverage === 1 ? 25 : Math.round(coverage * 10);
   const firstQueryToken = queryTokens[0];
-  if (firstQueryToken !== undefined && tokenize(fields.name).includes(firstQueryToken)) score += 8;
+  if (firstQueryToken !== undefined && prepared.nameTokens.includes(firstQueryToken)) score += 8;
   if (wholeFieldExact) score += 20;
   return score;
+}
+
+export function scoreToolMatch(tool: ToolMetadata, server: string, query: string, keywords?: string[]): number | null {
+  const normalizedQuery = normalizeSearchText(query).trim();
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return null;
+  return scorePreparedToolMatch(prepareToolSearch(tool, server, keywords), normalizedQuery, queryTokens);
+}
+
+function getPreparedTools(
+  state: McpExtensionState,
+  serverName: string,
+  metadata: ToolMetadata[],
+  definition: ServerEntry | undefined,
+  globalPrefix: ToolPrefix,
+  includeKeywords: boolean,
+): PreparedToolSearch[] {
+  let stateCache = searchCache.get(state);
+  if (!stateCache) {
+    stateCache = new Map();
+    searchCache.set(state, stateCache);
+  }
+  const toolPrefix = resolveToolPrefix(definition, globalPrefix);
+  let cached = stateCache.get(serverName);
+  if (cached?.metadata !== metadata || cached.searchKeywords !== definition?.searchKeywords || cached.toolPrefix !== toolPrefix) {
+    cached = { metadata, searchKeywords: definition?.searchKeywords, toolPrefix };
+    stateCache.set(serverName, cached);
+  }
+  const cacheKey = includeKeywords ? "withKeywords" : "withoutKeywords";
+  let prepared = cached[cacheKey];
+  if (!prepared) {
+    prepared = metadata.map(tool => prepareToolSearch(
+      tool,
+      serverName,
+      includeKeywords && definition?.searchKeywords !== undefined
+        ? resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix)
+        : undefined,
+    ));
+    cached[cacheKey] = prepared;
+  }
+  return prepared;
 }
 
 export function rankToolMatches(
@@ -163,18 +234,17 @@ export function rankToolMatches(
   includeKeywords = true,
 ): RankedToolMatch[] {
   const matches: RankedToolMatch[] = [];
+  const normalizedQuery = normalizeSearchText(query).trim();
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return matches;
   const globalPrefix = state.config.settings?.toolPrefix ?? "server";
   for (const [serverName, metadata] of state.toolMetadata.entries()) {
     if (server && serverName !== server) continue;
     const definition = state.config.mcpServers[serverName];
     if (isServerDisabled(definition)) continue;
-    const hasKeywords = includeKeywords && definition?.searchKeywords !== undefined;
-    for (const tool of metadata) {
-      const keywords = hasKeywords
-        ? resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix)
-        : undefined;
-      const score = scoreToolMatch(tool, serverName, query, keywords);
-      if (score !== null) matches.push({ server: serverName, tool, score });
+    for (const prepared of getPreparedTools(state, serverName, metadata, definition, globalPrefix, includeKeywords)) {
+      const score = scorePreparedToolMatch(prepared, normalizedQuery, queryTokens);
+      if (score !== null) matches.push({ server: serverName, tool: prepared.tool, score });
     }
   }
   return matches.sort((a, b) => b.score - a.score || a.tool.name.localeCompare(b.tool.name));


### PR DESCRIPTION
Closes #385.

Caches prepared MCP search ranking fields so large-catalog searches do less repeated normalization and tokenization.

Benchmark evidence:
- All-server median -95.2%, p95 -90.9%\n- Typing sequence median -96.5%, p95 -96.8%\n- Top-25 identities, exact scores, and order matched baseline

Validation:
- npx vitest run __tests__/search-ranking.test.ts __tests__/proxy-modes-discovery.test.ts\n- npm run typecheck\n- git diff --check
- Fresh read-only review: pass
- Performance impact: disproved regression risk with focused measurements
- Greptile/CI: pending on this PR head

No release is included.
