### PR TITLE
perf: reuse cached metadata selector index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Precomputed normalized MCP tool fields and keyword tokens per catalog to reduce repeated search ranking work.
 
 ### Fixed
+- Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.
 - Scoped session tool approvals to the approved argument payload instead of every later call to the same tool. Thanks to [@spaceshipmike](https://github.com/spaceshipmike) for #367.

--- a/__tests__/collision-scan-lazy.test.ts
+++ b/__tests__/collision-scan-lazy.test.ts
@@ -7,7 +7,7 @@ import {
   type ServerEntry,
 } from "../types.ts";
 import { buildProxyDescription, resolveDirectTools } from "../direct-tools.ts";
-import { computeServerHash, reconstructToolMetadata } from "../metadata-cache.ts";
+import { computeServerHash, createCachedToolSelectorCandidateIndex, reconstructToolMetadata } from "../metadata-cache.ts";
 import { buildToolMetadata } from "../tool-metadata.ts";
 
 // Intercept the only function the cross-server collision scan calls. Because
@@ -112,6 +112,23 @@ describe("cross-server collision scan is skipped without tool filters", () => {
   it("reconstructToolMetadata builds filtered candidates once", () => {
     const { config, cache } = makeLargeFilteredConfig(40);
     reconstructToolMetadata("a", cache.servers.a, "server", config.mcpServers.a, config.mcpServers, cache);
+    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
+  });
+
+  it("reuses cached candidates across filtered server reconstruction", () => {
+    const a = makeServer("a", { includeTools: ["*"] });
+    const b = makeServer("b", { includeTools: ["*"] });
+    const tools = Array.from({ length: 20 }, (_, index) => ({ name: `tool_${index}`, description: `Tool ${index}` }));
+    const config: McpConfig = { mcpServers: { a, b } };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: { a: makeCacheEntry(a, tools), b: makeCacheEntry(b, tools) },
+    };
+    const selectorCandidateIndex = createCachedToolSelectorCandidateIndex(config.mcpServers, cache, "server");
+
+    reconstructToolMetadata("a", cache.servers.a, "server", a, config.mcpServers, cache, selectorCandidateIndex);
+    reconstructToolMetadata("b", cache.servers.b, "server", b, config.mcpServers, cache, selectorCandidateIndex);
+
     expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   cache: null as { version: 1; servers: Record<string, unknown> } | null,
   config: { settings: {}, mcpServers: {} } as any,
   manager: undefined as any,
+  createCachedToolSelectorCandidateIndex: vi.fn(() => undefined),
   getMissingConfiguredDirectToolServers: vi.fn(() => [] as string[]),
   isServerCacheValid: vi.fn(() => false),
   buildToolMetadata: vi.fn(() => ({ metadata: [], failedTools: [] })),
@@ -25,6 +26,7 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../metadata-cache.ts", () => ({
   computeServerHash: vi.fn(() => "hash"),
+  createCachedToolSelectorCandidateIndex: mocks.createCachedToolSelectorCandidateIndex,
   getMetadataCachePath: vi.fn(() => mocks.cachePath),
   getMissingConfiguredDirectToolServers: mocks.getMissingConfiguredDirectToolServers,
   isServerCacheValid: mocks.isServerCacheValid,
@@ -103,6 +105,7 @@ describe("lazy-keep-alive initializeMcp integration", () => {
     };
     mocks.manager = createManager();
     mocks.getMissingConfiguredDirectToolServers.mockReset().mockReturnValue([]);
+    mocks.createCachedToolSelectorCandidateIndex.mockClear();
     mocks.isServerCacheValid.mockReset().mockReturnValue(false);
     mocks.buildToolMetadata.mockClear();
   });
@@ -191,6 +194,29 @@ describe("lazy-keep-alive initializeMcp integration", () => {
     expect(knownMetadata.get("my-server")?.map(tool => tool.originalName)).toEqual(["do_thing"]);
     expect(knownMetadata.has("my_server")).toBe(false);
     expect(mocks.buildToolMetadata.mock.calls[0]?.[7]).toBe(true);
+  });
+
+  it("does not index cached candidates when filtered metadata is invalid", async () => {
+    writeFileSync(mocks.cachePath, JSON.stringify({ version: 1, servers: {} }));
+    mocks.cache = {
+      version: 1,
+      servers: {
+        srv: { configHash: "stale", cachedAt: Date.now(), tools: [], resources: [] },
+      },
+    };
+    mocks.config = {
+      settings: { toolPrefix: "server" },
+      mcpServers: { srv: { command: "demo", includeTools: ["*"] } },
+    };
+    const { initializeMcp } = await import("../init.ts");
+
+    await initializeMcp({ getFlag: vi.fn(() => undefined) } as any, {
+      cwd: tempDir,
+      hasUI: false,
+      mode: "headless",
+    } as any);
+
+    expect(mocks.createCachedToolSelectorCandidateIndex).not.toHaveBeenCalled();
   });
 
   it("marks no-cache bootstrap spawns for health-check reconnects", async () => {

--- a/init.ts
+++ b/init.ts
@@ -1,12 +1,13 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { McpExtensionState } from "./state.ts";
-import { formatToolName, isServerDisabled, resolveToolPrefix, type McpAdapterOptions, type PromptMetadata, type ToolMetadata } from "./types.ts";
+import { formatToolName, isServerDisabled, resolveToolPrefix, type McpAdapterOptions, type PromptMetadata, type ToolMetadata, type ToolSelectorCandidateIndex } from "./types.ts";
 import { existsSync } from "node:fs";
 import { cloneMcpConfig, loadMcpConfig } from "./config.ts";
 import { ConsentManager } from "./consent-manager.ts";
 import { McpLifecycleManager } from "./lifecycle.ts";
 import {
   computeServerHash,
+  createCachedToolSelectorCandidateIndex,
   getMetadataCachePath,
   getMissingConfiguredDirectToolServers,
   isServerCacheValid,
@@ -239,6 +240,7 @@ export async function initializeMcp(
   }
 
   const prefix = config.settings?.toolPrefix ?? "server";
+  let cachedSelectorCandidateIndex: ToolSelectorCandidateIndex | undefined;
 
   for (const [name, definition] of serverEntries) {
     const lifecycleMode = definition.lifecycle ?? "lazy";
@@ -255,7 +257,13 @@ export async function initializeMcp(
 
     const cachedEntry = cache?.servers?.[name];
     if (cachedEntry && isServerCacheValid(cachedEntry, definition)) {
-      const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition, config.mcpServers, cache ?? undefined);
+      const hasToolFilters =
+        (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
+        (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
+      if (hasToolFilters && !cachedSelectorCandidateIndex && cache) {
+        cachedSelectorCandidateIndex = createCachedToolSelectorCandidateIndex(config.mcpServers, cache, prefix);
+      }
+      const metadata = reconstructToolMetadata(name, cachedEntry, prefix, definition, config.mcpServers, cache ?? undefined, cachedSelectorCandidateIndex);
       toolMetadata.set(name, metadata);
       if (Array.isArray(cachedEntry.resources)) {
         resourceCounts.set(name, cachedEntry.resources.length);

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -19,7 +19,7 @@ import type {
   ToolMetadata,
   PromptMetadata,
 } from "./types.ts";
-import { createToolSelectorCandidateIndex, formatPromptCommandName, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix } from "./types.ts";
+import { createToolSelectorCandidateIndex, formatPromptCommandName, formatToolName, getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix, type ToolPrefix, type ToolSelectorCandidateIndex } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import {
   extractToolUiStreamMode,
@@ -189,6 +189,7 @@ export function reconstructToolMetadata(
   definition: Pick<ServerEntry, "exposeResources" | "includeTools" | "excludeTools" | "toolPrefix">,
   configuredServers?: Record<string, ServerEntry>,
   cache?: MetadataCache,
+  sharedSelectorCandidateIndex?: ToolSelectorCandidateIndex,
 ): ToolMetadata[] {
   const metadata: ToolMetadata[] = [];
   const seenNames = new Set<string>();
@@ -196,25 +197,11 @@ export function reconstructToolMetadata(
   const hasToolFilters =
     (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
     (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-  const selectorCandidateIndex = hasToolFilters && configuredServers && cache ? (() => {
-    const candidates = new Set<string>();
-    for (const [otherServerName, otherDefinition] of Object.entries(configuredServers)) {
-      const otherEntry = cache.servers[otherServerName];
-      if (!otherEntry || !isServerCacheValid(otherEntry, otherDefinition) || isServerDisabled(otherDefinition)) continue;
-      const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
-      for (const otherTool of otherEntry.tools ?? []) {
-        if (!isUiToolVisibleToModel(otherTool.uiVisibility)) continue;
-        for (const candidate of getToolNameCandidates(otherTool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
-      }
-      if (otherDefinition.exposeResources !== false) {
-        for (const resource of otherEntry.resources ?? []) {
-          const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
-        }
-      }
-    }
-    return createToolSelectorCandidateIndex(candidates);
-  })() : undefined;
+  const selectorCandidateIndex = hasToolFilters
+    ? sharedSelectorCandidateIndex ?? (configuredServers && cache
+      ? createCachedToolSelectorCandidateIndex(configuredServers, cache, prefix)
+      : undefined)
+    : undefined;
 
   for (const tool of entry.tools ?? []) {
     if (!tool?.name) continue;
@@ -266,6 +253,30 @@ export function reconstructToolMetadata(
   }
 
   return metadata;
+}
+
+export function createCachedToolSelectorCandidateIndex(
+  configuredServers: Record<string, ServerEntry>,
+  cache: MetadataCache,
+  prefix: ToolPrefix,
+): ToolSelectorCandidateIndex {
+  const candidates = new Set<string>();
+  for (const [serverName, definition] of Object.entries(configuredServers)) {
+    const entry = cache.servers[serverName];
+    if (!entry || !isServerCacheValid(entry, definition) || isServerDisabled(definition)) continue;
+    const effectivePrefix = resolveToolPrefix(definition, prefix);
+    for (const tool of entry.tools ?? []) {
+      if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+      for (const candidate of getToolNameCandidates(tool.name, serverName, effectivePrefix, false)) candidates.add(candidate);
+    }
+    if (definition.exposeResources !== false) {
+      for (const resource of entry.resources ?? []) {
+        const baseName = `read_${resourceNameToToolName(resource.name)}`;
+        for (const candidate of getToolNameCandidates(baseName, serverName, effectivePrefix, false)) candidates.add(candidate);
+      }
+    }
+  }
+  return createToolSelectorCandidateIndex(candidates);
 }
 
 export function serializeTools(tools: McpTool[]): CachedTool[] {


### PR DESCRIPTION
Closes #386.

Reuses one cached selector index during filtered cached metadata reconstruction.

Benchmark evidence:
- Median -93.6%, p95 -93.6%\n- Reconstructed catalog output stayed at 9,900 tools

Validation:
- npx vitest run __tests__/collision-scan-lazy.test.ts __tests__/direct-tools.test.ts __tests__/ui-tool-visibility.test.ts __tests__/lifecycle-lazy-keep-alive-init.test.ts __tests__/index-lifecycle.test.ts\n- npm run typecheck\n- git diff --check
- Fresh read-only review: pass
- Performance impact: disproved regression risk with focused measurements
- Greptile/CI: pending on this PR head

No release is included.
