### PR TITLE
perf: reduce request header cleanup scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Precomputed normalized MCP tool fields and keyword tokens per catalog to reduce repeated search ranking work.
+- Reduced cold HTTP connect overhead for per-request header commands by collecting process cleanup data in one snapshot per pass.
 
 ### Fixed
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -69,6 +69,27 @@ describe("per-request HTTP header commands", () => {
     await fetch("https://mcp.example.test/mcp", { method: "POST", body: "one" });
     await fetch("https://mcp.example.test/mcp", { method: "POST", body: "two" });
     expect(bodies).toEqual(["one", "two"]);
+  });
+
+  it.skipIf(process.platform === "win32")("uses one cleanup process snapshot per stabilization pass", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
+    const calls = join(dir, "calls");
+    const ps = join(dir, "ps");
+    writeFileSync(ps, `#!/bin/sh\nprintf 'scan\\n' >> ${JSON.stringify(calls)}\n`);
+    chmodSync(ps, 0o755);
+    const priorPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      const fetch = createRequestHeadersCommandFetch(
+        { command: "/usr/bin/printf", args: ["{}"] },
+        async () => new Response("ok"),
+      );
+      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
+      const snapshots = readFileSync(calls, "utf8").trim().split("\n");
+      expect(snapshots.length).toBeGreaterThanOrEqual(3);
+    } finally {
+      process.env.PATH = priorPath;
+    }
   });
 
   it("fails closed when the command exits unsuccessfully", async () => {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -18,54 +18,38 @@ function runPosixPs(args: string[]): { status: number | null; stdout: string } {
   return spawnSync("ps", args, { encoding: "utf8" });
 }
 
-function collectPosixDescendantPids(rootPid: number): number[] {
-  const result = runPosixPs(["-axo", "pid=,ppid="]);
+function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number[] {
+  const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
     throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
   }
 
   const childrenByParent = new Map<number, number[]>();
+  const processPids = new Set<number>();
+  const needle = cleanupToken ? `${CLEANUP_TOKEN_ENV}=${cleanupToken}` : undefined;
   for (const line of result.stdout.split("\n")) {
-    const [pidText, ppidText] = line.trim().split(/\s+/, 2);
-    const pid = Number(pidText);
-    const ppid = Number(ppidText);
+    const match = /^\s*(\d+)\s+(\d+)(?:\s+(.*))?$/.exec(line);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const ppid = Number(match[2]);
     if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
     const children = childrenByParent.get(ppid);
     if (children) children.push(pid);
     else childrenByParent.set(ppid, [pid]);
+    if (needle && pid !== process.pid && match[3]?.includes(needle)) processPids.add(pid);
   }
 
-  const descendants: number[] = [];
   const stack = [...(childrenByParent.get(rootPid) ?? [])];
   while (stack.length > 0) {
     const pid = stack.pop()!;
-    descendants.push(pid);
+    processPids.add(pid);
     stack.push(...(childrenByParent.get(pid) ?? []));
   }
-  return descendants;
-}
-
-function collectPosixCleanupTokenPids(cleanupToken: string): number[] {
-  const result = runPosixPs(["axeww", "-o", "pid=,command="]);
-  if (result.status !== 0) {
-    throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
-  }
-
-  const needle = `${CLEANUP_TOKEN_ENV}=${cleanupToken}`;
-  const pids: number[] = [];
-  for (const line of result.stdout.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed.includes(needle)) continue;
-    const [pidText] = trimmed.split(/\s+/, 1);
-    const pid = Number(pidText);
-    if (Number.isInteger(pid) && pid !== process.pid) pids.push(pid);
-  }
-  return pids;
+  return [...processPids];
 }
 
 function assertPosixProcessDiscoveryAvailable(): void {
-  collectPosixDescendantPids(process.pid);
-  collectPosixCleanupTokenPids(`${process.pid}-preflight`);
+  collectPosixProcessPids(process.pid, `${process.pid}-preflight`);
 }
 
 function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {
@@ -109,10 +93,7 @@ function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPi
       }
       let stablePasses = 0;
       for (let pass = 0; pass < 16; pass++) {
-        const candidates = [
-          ...collectPosixDescendantPids(child.pid),
-          ...(cleanupToken ? collectPosixCleanupTokenPids(cleanupToken) : []),
-        ];
+        const candidates = collectPosixProcessPids(child.pid, cleanupToken);
         const newPids = candidates.filter(pid => !frozenPids.has(pid));
         if (newPids.length === 0) {
           stablePasses++;
@@ -212,8 +193,7 @@ async function invokeRequestHeadersCommand(
     const trackPosixDescendants = () => {
       if (!USE_PROCESS_GROUP || child.pid === undefined || settled || trackingError) return;
       try {
-        for (const pid of collectPosixDescendantPids(child.pid)) trackedPosixDescendantPids.add(pid);
-        for (const pid of collectPosixCleanupTokenPids(cleanupToken)) trackedPosixDescendantPids.add(pid);
+        for (const pid of collectPosixProcessPids(child.pid, cleanupToken)) trackedPosixDescendantPids.add(pid);
       } catch (error) {
         trackingError = error instanceof Error ? error : new Error(String(error));
       }


### PR DESCRIPTION
Closes #387.

Combines request-header cleanup process discovery into one process-table snapshot per pass.

Benchmark evidence:
- Cold local connect median -39.3%, p95 -49.9%\n- Request count and header command count unchanged

Validation:
- npx vitest run __tests__/request-headers-command.test.ts __tests__/server-manager-streamable-http.test.ts __tests__/server-manager-http-auth.test.ts __tests__/mcp-probe.test.ts __tests__/server-manager-stderr-capture.test.ts\n- npm run typecheck\n- git diff --check
- Fresh read-only review: pass
- Performance impact: disproved regression risk with focused measurements
- Greptile/CI: pending on this PR head

No release is included.
