### PR TITLE
perf(metadata-cache): reduce cache save cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Precomputed normalized MCP tool fields and keyword tokens per catalog to reduce repeated search ranking work.
 - Reduced cold HTTP connect overhead for per-request header commands by collecting process cleanup data in one snapshot per pass.
+- Reduced metadata cache save cost and file size by writing compact JSON while preserving atomic replacement and cross-process merges.
 
 ### Fixed
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.

--- a/__tests__/metadata-cache-instructions.test.ts
+++ b/__tests__/metadata-cache-instructions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadMetadataCache, saveMetadataCache, type ServerCacheEntry } from "../metadata-cache.ts";
@@ -50,5 +50,24 @@ describe("metadata cache instructions", () => {
     saveMetadataCache({ version: 1, servers: { demo: entry } });
 
     expect("instructions" in (loadMetadataCache()?.servers.demo ?? {})).toBe(false);
+  });
+
+  it("writes compact JSON while retaining existing server entries", () => {
+    const entry: ServerCacheEntry = {
+      configHash: "hash",
+      tools: [],
+      resources: [],
+      cachedAt: 1,
+    };
+
+    saveMetadataCache({ version: 1, servers: { first: entry } });
+    saveMetadataCache({ version: 1, servers: { second: { ...entry, cachedAt: 2 } } });
+
+    const raw = readFileSync(join(dir, "mcp-cache.json"), "utf8");
+    expect(raw).not.toContain("\n");
+    expect(JSON.parse(raw).servers).toEqual({
+      first: entry,
+      second: { ...entry, cachedAt: 2 },
+    });
   });
 });

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -75,7 +75,7 @@ export function saveMetadataCache(cache: MetadataCache): void {
   merged.servers = { ...merged.servers, ...cache.servers };
 
   const tmpPath = `${cachePath}.${process.pid}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8");
+  writeFileSync(tmpPath, JSON.stringify(merged), "utf-8");
   renameSync(tmpPath, cachePath);
 }
 


### PR DESCRIPTION
Closes #388.

Writes the generated metadata cache as compact JSON while preserving read/merge/temp-write/rename behavior.

Benchmark evidence:
- Save median -35.91%, p95 -23.26%\n- Cache file size -47.82%

Validation:
- npx vitest run __tests__/metadata-cache-instructions.test.ts\n- npm run typecheck\n- git diff --check
- Fresh read-only review: pass
- Performance impact: disproved regression risk with focused measurements
- Greptile/CI: pending on this PR head

No release is included.
