### PR TITLE
perf: cache MCP panel derived counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced cold HTTP connect overhead for per-request header commands by collecting process cleanup data in one snapshot per pass.
 - Reduced metadata cache save cost and file size by writing compact JSON while preserving atomic replacement and cross-process merges.
 - Reduced high-frequency UI stream event-log pruning cost by tracking the latest checkpoint event ID instead of rescanning retained patches.
+- Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -142,6 +142,90 @@ describe("mcp-panel rendering", () => {
     expect(createFailedPanel("idle", "should not appear", 60)).not.toContain("should not appear");
   });
 
+  it("updates direct counts and token totals after each toggle", () => {
+    const config: McpConfig = {
+      mcpServers: {
+        example: { command: "mock", directTools: ["alpha"] },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        example: {
+          configHash: computeServerHash(config.mcpServers.example),
+          cachedAt: Date.now(),
+          tools: [{ name: "alpha" }, { name: "beta" }],
+          resources: [],
+        },
+      },
+    };
+    const panel = createMcpPanel(config, cache, new Map(), createCallbacks(), { requestRender: () => {} }, () => {});
+
+    expect(stripAnsi(panel.render(100).join("\n"))).toContain("1 direct  ~12 tokens");
+    panel.handleInput("\r");
+    panel.handleInput("\x1b[B");
+    panel.handleInput("\r");
+    expect(stripAnsi(panel.render(100).join("\n"))).toContain("no direct tools");
+
+    panel.handleInput("\x1b[B");
+    panel.handleInput(" ");
+    expect(stripAnsi(panel.render(100).join("\n"))).toContain("1 direct  ~12 tokens");
+
+    panel.handleInput("\x1b[A");
+    panel.handleInput("\x1b[A");
+    panel.handleInput(" ");
+    const allDirect = stripAnsi(panel.render(100).join("\n"));
+    expect(allDirect).toContain("2/2  ~24");
+    expect(allDirect).toContain("2 direct  ~24 tokens");
+    panel.dispose();
+  });
+
+  it("rebuilds derived totals before requesting a render after reconnect", async () => {
+    const config: McpConfig = {
+      mcpServers: {
+        example: { command: "mock", directTools: ["alpha"] },
+      },
+    };
+    const initialCache: MetadataCache = {
+      version: 1,
+      servers: {
+        example: {
+          configHash: computeServerHash(config.mcpServers.example),
+          cachedAt: Date.now(),
+          tools: [{ name: "alpha" }],
+          resources: [],
+        },
+      },
+    };
+    let status: "idle" | "connected" = "idle";
+    const callbacks: McpPanelCallbacks = {
+      ...createCallbacks(),
+      reconnect: async () => {
+        status = "connected";
+        return true;
+      },
+      getConnectionStatus: () => status,
+      refreshCacheAfterReconnect: () => ({
+        configHash: computeServerHash(config.mcpServers.example),
+        cachedAt: Date.now(),
+        tools: [{ name: "alpha", description: "Expanded alpha description" }, { name: "beta" }],
+        resources: [],
+      }),
+    };
+    const snapshots: string[] = [];
+    let panel!: ReturnType<typeof createMcpPanel>;
+    panel = createMcpPanel(config, initialCache, new Map(), callbacks, {
+      requestRender: () => snapshots.push(stripAnsi(panel.render(100).join("\n"))),
+    }, () => {});
+
+    panel.handleInput("\x12");
+    await Promise.resolve();
+
+    expect(snapshots.at(-1)).toContain("1/2  ~19");
+    expect(snapshots.at(-1)).toContain("1 direct  ~19 tokens");
+    panel.dispose();
+  });
+
   it("keeps dirty changes and closes when Keep & Close is confirmed", () => {
     const config = createConfig();
     const done = vi.fn<(result: McpPanelResult) => void>();

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -137,6 +137,8 @@ interface ServerState {
   connectionStatus: ConnectionStatus;
   failureMessage?: string | null;
   tools: ToolState[];
+  directCount: number;
+  directTokens: number;
   hasCachedData: boolean;
 }
 
@@ -241,7 +243,13 @@ class McpPanel {
 
       const status = callbacks.getConnectionStatus(serverName);
       const failureMessage = callbacks.getFailureMessage?.(serverName) ?? null;
-
+      let directCount = 0;
+      let directTokens = 0;
+      for (const tool of tools) {
+        if (!tool.isDirect) continue;
+        directCount++;
+        directTokens += tool.estimatedTokens;
+      }
       this.servers.push({
         name: serverName,
         expanded: false,
@@ -253,6 +261,8 @@ class McpPanel {
         connectionStatus: status,
         failureMessage,
         tools,
+        directCount,
+        directTokens,
         hasCachedData: !!serverCache,
       });
     }
@@ -444,7 +454,7 @@ class McpPanel {
       } else if (item.toolIndex !== undefined) {
         const tool = server.tools[item.toolIndex];
         if (!tool) return;
-        tool.isDirect = !tool.isDirect;
+        this.toggleToolDirect(server, tool);
         if (tool.isDirect && server.source === "import") {
           this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
         }
@@ -595,16 +605,28 @@ class McpPanel {
       if (server.source === "import" && newState) {
         this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
       }
-      for (const t of server.tools) t.isDirect = newState;
+      let directTokens = 0;
+      for (const tool of server.tools) {
+        tool.isDirect = newState;
+        if (newState) directTokens += tool.estimatedTokens;
+      }
+      server.directCount = newState ? server.tools.length : 0;
+      server.directTokens = directTokens;
     } else if (item.toolIndex !== undefined) {
       const tool = server.tools[item.toolIndex];
       if (!tool) return;
-      tool.isDirect = !tool.isDirect;
+      this.toggleToolDirect(server, tool);
       if (tool.isDirect && server.source === "import") {
         this.importNotice = `Imported from ${sanitizeDisplayText(server.importKind ?? "external")} — will copy to user config on save`;
       }
     }
     this.updateDirty();
+  }
+
+  private toggleToolDirect(server: ServerState, tool: ToolState): void {
+    tool.isDirect = !tool.isDirect;
+    server.directCount += tool.isDirect ? 1 : -1;
+    server.directTokens += tool.isDirect ? tool.estimatedTokens : -tool.estimatedTokens;
   }
 
   private handleDiscardInput(data: string): void {
@@ -717,6 +739,13 @@ class McpPanel {
     }
 
     server.tools = newTools;
+    server.directCount = 0;
+    server.directTokens = 0;
+    for (const tool of newTools) {
+      if (!tool.isDirect) continue;
+      server.directCount++;
+      server.directTokens += tool.estimatedTokens;
+    }
     this.rebuildVisibleItems();
     this.updateDirty();
   }
@@ -826,13 +855,14 @@ class McpPanel {
       if (this.authOnly) {
         lines.push(row(fg(t.description, "select a server to authenticate")));
       } else {
-        const directCount = this.servers.reduce((sum, s) => sum + s.tools.filter((t) => t.isDirect).length, 0);
-        const totalTokens = this.servers.reduce(
-          (sum, s) => sum + s.tools.filter((t) => t.isDirect).reduce((ts, t) => ts + t.estimatedTokens, 0),
-          0,
-        );
+        let directCount = 0;
+        let directTokens = 0;
+        for (const server of this.servers) {
+          directCount += server.directCount;
+          directTokens += server.directTokens;
+        }
         const stats =
-          directCount > 0 ? `${directCount} direct  ~${totalTokens.toLocaleString()} tokens` : "no direct tools";
+          directCount > 0 ? `${directCount} direct  ~${directTokens.toLocaleString()} tokens` : "no direct tools";
         lines.push(row(fg(t.description, stats + (this.dirty ? fg(t.needsAuth, "  (unsaved)") : ""))));
       }
     }
@@ -900,7 +930,7 @@ class McpPanel {
       return `${prefix}   ${nameStr}${importLabel}  ${fg(t.description, "(not cached)")}${statusLabel}`;
     }
 
-    const directCount = server.tools.filter((t) => t.isDirect).length;
+    const directCount = server.directCount;
     const totalCount = server.tools.length;
     let toggleIcon = fg(t.description, "○");
     if (directCount === totalCount && totalCount > 0) {
@@ -913,8 +943,7 @@ class McpPanel {
     if (totalCount > 0) {
       toolInfo = `${directCount}/${totalCount}`;
       if (directCount > 0) {
-        const tokens = server.tools.filter((t) => t.isDirect).reduce((s, t) => s + t.estimatedTokens, 0);
-        toolInfo += `  ~${tokens.toLocaleString()}`;
+        toolInfo += `  ~${server.directTokens.toLocaleString()}`;
       }
       toolInfo = fg(t.description, toolInfo);
     }


### PR DESCRIPTION
Closes #390.

Caches MCP panel per-server derived counts and reuses them during render.

Benchmark evidence:
- Large cached panel render median -10.97%, p95 -9.74%\n- Render checksum stayed identical

Validation:
- npx vitest run __tests__/mcp-panel-*.test.ts\n- npm run typecheck\n- git diff --check
- Fresh read-only review: pass
- Performance impact: disproved regression risk with focused measurements
- Greptile/CI: pending on this PR head

No release is included.
