### PR TITLE
feat: add pi-mcp command alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `/pi-mcp` as an alias for `/mcp` when a host reserves `/mcp`. Thanks to [@inxeoz](https://github.com/inxeoz) for #391.
 - Added `registerMcpServer(pi, name, definition)` so other extensions can register and dispose session-scoped MCP servers at runtime. Registrations are proxy-tool-only, never persisted, and duplicate names fail closed. Thanks to [@bendavis78](https://github.com/bendavis78) and [@fmoda3](https://github.com/fmoda3) for the runtime API request in #376/#382.
 - Added `pi.mcp` package manifest entries so Pi packages can ship prefixed MCP server definitions without user MCP config edits. Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
 - Added opt-in OS credential-store lookup for static bearer tokens with URL-bound records, using `bearerTokenStore: true`, plus a stdin-only `pi-mcp-adapter token set|status|remove <server>` CLI that never accepts the token as an argument. Thanks to [@AlexanderBartash](https://github.com/AlexanderBartash) for issue #366.

--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 | Command | What it does |
 |---------|--------------|
 | `/mcp` | Interactive panel and first-run onboarding surface |
+| `/pi-mcp` | Alias for `/mcp` when the host reserves `/mcp` |
 | `/mcp setup` | Guided setup for imports, a minimal `.mcp.json`, curated known servers, RepoPrompt quick-add, and config-path inspection |
 | `/mcp tools` | List all tools |
 | `/mcp prompts` | List all MCP prompts registered as slash commands |

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -243,6 +243,17 @@ describe("mcpAdapter session lifecycle", () => {
     }
   });
 
+  it("registers mcp and pi-mcp commands while keeping mcp-auth separate", async () => {
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api } = createPi();
+    mcpAdapter(api);
+
+    const commandNames = api.registerCommand.mock.calls.map((call: any[]) => call[0]);
+    expect(commandNames.filter((name: string) => name === "mcp")).toHaveLength(1);
+    expect(commandNames.filter((name: string) => name === "pi-mcp")).toHaveLength(1);
+    expect(commandNames.filter((name: string) => name === "mcp-auth")).toHaveLength(1);
+  });
+
   it("keeps the proxy tool when direct tools are still missing from cache", async () => {
     mocks.loadMcpConfig.mockReturnValue({
       mcpServers: {

--- a/index.ts
+++ b/index.ts
@@ -538,7 +538,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   // Re-flag returned MCP tool failures so pi registers them as errors (see toolErrorOverride).
   pi.on("tool_result", (event) => toolErrorOverride(event.details));
 
-  pi.registerCommand("mcp", {
+  const registerMcpCommand = (commandName: string) => pi.registerCommand(commandName, {
     description: "Show MCP server status",
     getArgumentCompletions: (prefix: string) => {
       const normalized = prefix.trimStart();
@@ -721,6 +721,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
     },
   });
+  registerMcpCommand("mcp");
+  registerMcpCommand("pi-mcp");
 
   pi.registerCommand("mcp-auth", {
     description: "Authenticate with an MCP server (OAuth)",


### PR DESCRIPTION
## Summary

Adds `/pi-mcp` as an alias for the existing `/mcp` extension command. `/mcp` remains the primary command, and the proxy tool name stays unchanged.

This gives users a conflict-free command when another runtime already owns `/mcp`.

Closes #391.

Thanks to [@inxeoz](https://github.com/inxeoz) for reporting the command conflict.

## Validation

- `npx vitest run __tests__/index-lifecycle.test.ts -t "registers mcp and pi-mcp commands while keeping mcp-auth separate"`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh exact-head review: pass
