### PR TITLE
fix(request-headers): survive ps axeww overflow on busy hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Raised the `ps` `maxBuffer` for request-header command cleanup so `ps axeww` (which dumps every process environment) no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures.
+- Switched the per-request process-discovery preflight from the environment-dumping `ps axeww` form to the lightweight `ps -axo pid=,ppid=` snapshot (~KiB instead of MiB), so the preflight run on every outbound request cannot overflow the spawnSync buffer and stays cheap; the full environment scan for descendant cleanup is still exercised lazily by the descendant tracker and cleanup path.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
+- Raised the `ps` `maxBuffer` for request-header command cleanup so `ps axeww` (which dumps every process environment) no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -368,4 +368,30 @@ setTimeout(() => {
       "timeoutMs must be an integer between 1 and 60000",
     );
   });
+
+  it.skipIf(process.platform === "win32")("tolerates ps output exceeding the default spawnSync buffer", async () => {
+    // `ps axeww` dumps every process environment; on busy hosts that exceeds
+    // spawnSync's 1 MiB default maxBuffer, which SIGTERMs `ps` and makes
+    // process discovery fail spuriously. A fake `ps` emitting ~1.7 MiB of
+    // valid lines must not break the request.
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
+    const ps = join(dir, "ps");
+    const line = "1 1 " + "x".repeat(64);
+    const lineCount = 24_000; // ~1.7 MiB, comfortably over 1 MiB
+    // Shell builtins only: the test runs with PATH restricted to this dir, so
+    // external binaries like `yes`/`head` would not be found (exit 127).
+    writeFileSync(ps, `#!/bin/sh\ni=0\nwhile [ "$i" -lt ${lineCount} ]; do\n  echo ${JSON.stringify(line)}\n  i=$((i + 1))\ndone\n`);
+    chmodSync(ps, 0o755);
+    const priorPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      const fetch = createRequestHeadersCommandFetch(
+        { command: "/usr/bin/printf", args: ["{}"] },
+        async () => new Response("ok"),
+      );
+      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
+    } finally {
+      process.env.PATH = priorPath;
+    }
+  });
 });

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -394,4 +394,33 @@ setTimeout(() => {
       process.env.PATH = priorPath;
     }
   });
+
+  it.skipIf(process.platform === "win32")("preflight uses a lightweight ps snapshot without the environment dump", async () => {
+    // The per-request preflight must not invoke the environment-dumping
+    // `axeww` form; it should use the small `ps -axo pid=,ppid=` snapshot so
+    // it stays small and cannot overflow the spawnSync buffer on busy hosts.
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
+    const ps = join(dir, "ps");
+    const argsLog = join(dir, "args");
+    // Record the args of every ps invocation, one per line, then exit 0.
+    writeFileSync(ps, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}\nexit 0\n`);
+    chmodSync(ps, 0o755);
+    const priorPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      const fetch = createRequestHeadersCommandFetch(
+        { command: "/usr/bin/printf", args: ["{}"] },
+        async () => new Response("ok"),
+      );
+      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
+      const calls = readFileSync(argsLog, "utf8").trim().split("\n");
+      expect(calls.length).toBeGreaterThan(0);
+      // The preflight is the first ps call (synchronous, before spawn). It
+      // must not use the environment-dumping `axeww` form.
+      expect(calls[0]).not.toContain("axeww");
+      expect(calls[0]).toContain("pid=,ppid=");
+    } finally {
+      process.env.PATH = priorPath;
+    }
+  });
 });

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -8,20 +8,29 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const USE_PROCESS_GROUP = process.platform !== "win32";
 const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
+// `ps axeww` dumps the full environment of every process on the host. On busy
+// machines that output exceeds spawnSync's default 1 MiB maxBuffer, which causes
+// Node to SIGTERM `ps` and report status === null. Raise the cap so process
+// discovery keeps working without spurious cleanup failures.
+const PS_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";
 }
 
-function runPosixPs(args: string[]): { status: number | null; stdout: string } {
-  if (process.env.PI_MCP_ADAPTER_TEST_FAIL_PS === "1") return { status: 1, stdout: "" };
-  return spawnSync("ps", args, { encoding: "utf8" });
+function runPosixPs(args: string[]): { status: number | null; signal: NodeJS.Signals | null; stdout: string } {
+  if (process.env.PI_MCP_ADAPTER_TEST_FAIL_PS === "1") return { status: 1, signal: null, stdout: "" };
+  const result = spawnSync("ps", args, { encoding: "utf8", maxBuffer: PS_MAX_BUFFER_BYTES });
+  return { status: result.status, signal: result.signal, stdout: result.stdout };
 }
 
 function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number[] {
   const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
-    throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
+    const reason = result.status === null
+      ? `ps was killed by signal ${result.signal ?? "unknown"}`
+      : `ps exited with code ${result.status}`;
+    throw new Error(`HTTP request headers command cleanup failed: ${reason}`);
   }
 
   const childrenByParent = new Map<number, number[]>();

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -11,8 +11,13 @@ const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
 // `ps axeww` dumps the full environment of every process on the host. On busy
 // machines that output exceeds spawnSync's default 1 MiB maxBuffer, which causes
 // Node to SIGTERM `ps` and report status === null. Raise the cap so process
-// discovery keeps working without spurious cleanup failures.
-const PS_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+// discovery keeps working without spurious cleanup failures. Observed output
+// is ~1 MiB on a loaded dev machine (1000+ procs at ~1 KiB each); 8 MiB gives
+// ~8x headroom and covers a machine ~8x busier (or ~4x with heavy envs), which
+// is a realistic worst-case dev box. maxBuffer is a cap, not a pre-allocation:
+// Node grows the buffer to the actual output, so this costs ~0 unless `ps`
+// really emits that much.
+const PS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -24,13 +24,16 @@ function runPosixPs(args: string[]): { status: number | null; signal: NodeJS.Sig
   return { status: result.status, signal: result.signal, stdout: result.stdout };
 }
 
+function psFailureReason(result: { status: number | null; signal: NodeJS.Signals | null }): string {
+  return result.status === null
+    ? `ps was killed by signal ${result.signal ?? "unknown"}`
+    : `ps exited with code ${result.status}`;
+}
+
 function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number[] {
   const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
-    const reason = result.status === null
-      ? `ps was killed by signal ${result.signal ?? "unknown"}`
-      : `ps exited with code ${result.status}`;
-    throw new Error(`HTTP request headers command cleanup failed: ${reason}`);
+    throw new Error(`HTTP request headers command cleanup failed: ${psFailureReason(result)}`);
   }
 
   const childrenByParent = new Map<number, number[]>();
@@ -58,7 +61,15 @@ function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number
 }
 
 function assertPosixProcessDiscoveryAvailable(): void {
-  collectPosixProcessPids(process.pid, `${process.pid}-preflight`);
+  // Use the lightweight column form (`ps -axo pid=,ppid=`) instead of the
+  // environment dump (`axeww`) so this per-request preflight stays small
+  // (~KiB, not MiB) and cannot overflow the spawnSync buffer on busy hosts.
+  // The full environment scan used for descendant cleanup is exercised lazily
+  // by the descendant tracker and the cleanup path.
+  const result = runPosixPs(["-axo", "pid=,ppid="]);
+  if (result.status !== 0) {
+    throw new Error(`HTTP request headers command cleanup failed: ${psFailureReason(result)}`);
+  }
 }
 
 function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {


### PR DESCRIPTION
## 🎥 Demonstration

Repro on a busy macOS dev machine (1000+ processes, Chrome/IDE/Docker envs):

```bash
# ps axeww dumps every process environment; on busy hosts it exceeds
# spawnSync's 1 MiB default, so Node SIGTERMs ps and reports status === null.
node -e 'const {spawnSync}=require("child_process");
const r=spawnSync("ps",["axeww","-o","pid=,ppid=,command="],{encoding:"utf8"});
console.log("status="+r.status,"signal="+r.signal,"err="+(r.error?r.error.code:"none"),"bytes="+Buffer.byteLength(r.stdout||""))'
```

Observed locally during the incident: `status=null signal=SIGTERM err=ENOBUFS bytes=1114112`
(~1.19 MiB, 141 KB over the 1 MiB default). That null status surfaced as
`MCP: Failed to refresh datadog-gmail: HTTP request headers command cleanup
failed: ps exited with code unknown` on every keep-alive refresh.

## 🎯 Motivation

Servers configured with `requestHeadersCommand` (e.g. `mcp-auth token <server>`)
spawn a trusted command per outbound HTTP request. While it runs, the adapter
calls `ps` to discover descendant processes to kill, so orphaned helpers cannot
escape. On busy hosts `ps axeww` (full environment of every process) overflows
`spawnSync`'s 1 MiB default `maxBuffer`, Node SIGTERMs `ps`, and the adapter
treats the null status as a non-zero exit and throws, failing the whole request.

The chosen bet is to keep the existing synchronous, atomic cleanup design
(SIGSTOP the group, discover, SIGKILL, without yielding the event loop so
descendants cannot fork/setsid away between freeze and kill) and just remove
the spurious buffer overflow. Full async streaming was rejected because it
would require async-ifying that sync-atomic cleanup loop, widening the
orphan-escape window that the `kills descendants that move into another
process group` / `reparent before timeout` tests exist to guard.

## 📋 Summary

### Raise the ps maxBuffer cap

`runPosixPs` now passes `maxBuffer: 8 MiB` to `spawnSync`. Measured `ps axeww`
output is ~1 MiB on a loaded dev machine (1000+ procs at ~1 KiB each); the cap
only needs to clear the 1 MiB default that was causing the SIGTERM. 8 MiB gives
~8x headroom and covers a machine ~8x busier, or ~4x with heavy envs. The only
scenario that exceeds 8 MiB is ~8000 procs with heavy envs (~15 MiB), an
extreme CI/server rather than a dev laptop. `maxBuffer` is a cap, not a
pre-allocation: Node grows the buffer to the actual output, so this costs ~0
unless `ps` really emits that much.

[`request-headers-command.ts:20`](https://github.com/rtfpessoa/pi-mcp-adapter/blob/e7066ca007ffd83658eeb8d73c656553a125f380/request-headers-command.ts#L20)

> [!IMPORTANT]
> Genuine `ps` failures (binary missing, non-zero exit, OOM signal-kill) still
> return a non-zero status or signal and still throw, so the fail-closed
> contract is preserved. The existing `PI_MCP_ADAPTER_TEST_FAIL_PS` tests still
> pass unchanged.

### Lightweight preflight without the environment dump

The per-request preflight (`assertPosixProcessDiscoveryAvailable`) ran the
full `ps axeww` form just to verify `ps` is available. That ~1 MiB dump on
every outbound request was the most frequent overflow trigger, since a single
overflow fails every keep-alive refresh. It now uses the lightweight
`ps -axo pid=,ppid=` snapshot (~KiB, never overflows) and only validates that
`ps` exits 0. The full environment scan that finds token-bearing orphan
descendants is still exercised lazily by the 50ms descendant tracker and the
cleanup path, both of which rely on the raised maxBuffer above.

[`request-headers-command.ts:68`](https://github.com/rtfpessoa/pi-mcp-adapter/blob/e7066ca007ffd83658eeb8d73c656553a125f380/request-headers-command.ts#L68)

### Clearer failure message

A signal-killed `ps` (`status === null`) is now reported as
`ps was killed by signal <sig>` instead of the misleading
`ps exited with code unknown`. A shared `psFailureReason` helper keeps the
preflight and the cleanup scan producing the same message.

### Tests

- `tolerates ps output exceeding the default spawnSync buffer`: a fake `ps` on
  PATH emits ~1.7 MiB of valid lines; the request must succeed. Verified to fail
  without the maxBuffer fix (`ps was killed by signal SIGTERM`) and pass with it.
- `preflight uses a lightweight ps snapshot without the environment dump`:
  records every `ps` invocation's args and asserts the first (preflight) call
  contains `pid=,ppid=` and not `axeww`. Verified to fail when the preflight
  still uses `axeww`.

## 🔎 Expert review questions

- The preflight no longer validates the `axeww` token scan at startup; it only
  checks that `ps` runs. Is lazy validation by the 50ms tracker and cleanup
  path sufficient, or should the first request still preflight the full
  environment scan?
- Is 8 MiB the right fixed cap for the cleanup/tracker `axeww` path, or should
  it scale (e.g. derived from process count) to avoid a future overflow on an
  unusually large host?

## ↪️ Known deviations

No deviation evidence available.

## 🚧 Non-goals

- Did not async-stream the `ps` output. The sync-atomic cleanup loop
  (SIGSTOP, discover, SIGKILL without yielding) is intentionally preserved to
  keep the orphan-escape window closed; streaming would require async-ifying
  that loop.
- Did not change the `console.error` diagnostics in `lifecycle.ts` /
  `init.ts` that surface these failures. Main has tests deliberately enforcing
  those `console.error` calls (including clipboard-injection sanitization), so
  routing them through the leveled logger is out of scope for this fix.