### PR TITLE
fix(request-headers): validate full cleanup scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Raised the `ps` `maxBuffer` for request-header command cleanup so `ps axeww` (which dumps every process environment) no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures.
+- Switched the per-request process-discovery preflight from the environment-dumping `ps axeww` form to the lightweight `ps -axo pid=,ppid=` snapshot (~KiB instead of MiB), so the preflight run on every outbound request cannot overflow the spawnSync buffer and stays cheap; the full environment scan for descendant cleanup is still exercised lazily by the descendant tracker and cleanup path.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
+- Raised the `ps` `maxBuffer` for request-header command cleanup so `ps axeww` (which dumps every process environment) no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
-- Raised the `ps` `maxBuffer` for request-header command cleanup so `ps axeww` (which dumps every process environment) no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures.
-- Switched the per-request process-discovery preflight from the environment-dumping `ps axeww` form to the lightweight `ps -axo pid=,ppid=` snapshot (~KiB instead of MiB), so the preflight run on every outbound request cannot overflow the spawnSync buffer and stays cheap; the full environment scan for descendant cleanup is still exercised lazily by the descendant tracker and cleanup path.
+- Raised the `ps` `maxBuffer` for request-header command cleanup so the full `ps axeww` process-discovery scan no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures. Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -368,4 +368,30 @@ setTimeout(() => {
       "timeoutMs must be an integer between 1 and 60000",
     );
   });
+
+  it.skipIf(process.platform === "win32")("tolerates ps output exceeding the default spawnSync buffer", async () => {
+    // `ps axeww` dumps every process environment; on busy hosts that exceeds
+    // spawnSync's 1 MiB default maxBuffer, which SIGTERMs `ps` and makes
+    // process discovery fail spuriously. A fake `ps` emitting ~1.7 MiB of
+    // valid lines must not break the request.
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
+    const ps = join(dir, "ps");
+    const line = "1 1 " + "x".repeat(64);
+    const lineCount = 24_000; // ~1.7 MiB, comfortably over 1 MiB
+    // Shell builtins only: the test runs with PATH restricted to this dir, so
+    // external binaries like `yes`/`head` would not be found (exit 127).
+    writeFileSync(ps, `#!/bin/sh\ni=0\nwhile [ "$i" -lt ${lineCount} ]; do\n  echo ${JSON.stringify(line)}\n  i=$((i + 1))\ndone\n`);
+    chmodSync(ps, 0o755);
+    const priorPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      const fetch = createRequestHeadersCommandFetch(
+        { command: "/usr/bin/printf", args: ["{}"] },
+        async () => new Response("ok"),
+      );
+      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
+    } finally {
+      process.env.PATH = priorPath;
+    }
+  });
 });

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -395,30 +395,26 @@ setTimeout(() => {
     }
   });
 
-  it.skipIf(process.platform === "win32")("preflight uses a lightweight ps snapshot without the environment dump", async () => {
-    // The per-request preflight must not invoke the environment-dumping
-    // `axeww` form; it should use the small `ps -axo pid=,ppid=` snapshot so
-    // it stays small and cannot overflow the spawnSync buffer on busy hosts.
+  it.skipIf(process.platform === "win32")("fails closed before spawning when the full cleanup scan fails after a lightweight scan would pass", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
     const ps = join(dir, "ps");
-    const argsLog = join(dir, "args");
-    // Record the args of every ps invocation, one per line, then exit 0.
-    writeFileSync(ps, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}\nexit 0\n`);
+    const marker = join(dir, "marker");
+    writeFileSync(ps, `#!/bin/sh\ncase "$*" in\n  *axeww*) exit 1 ;;\n  *) exit 0 ;;\nesac\n`);
     chmodSync(ps, 0o755);
+    const script = commandScript(`
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(marker)}, "spawned");
+process.stdout.write(JSON.stringify({ "x-derived": "ok" }));
+`);
     const priorPath = process.env.PATH;
     process.env.PATH = dir;
     try {
-      const fetch = createRequestHeadersCommandFetch(
-        { command: "/usr/bin/printf", args: ["{}"] },
-        async () => new Response("ok"),
+      const fetch = createRequestHeadersCommandFetch({ command: process.execPath, args: [script] });
+
+      await expect(fetch("https://mcp.example.test/mcp")).rejects.toThrow(
+        "HTTP request headers command cleanup failed: ps exited with code 1",
       );
-      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
-      const calls = readFileSync(argsLog, "utf8").trim().split("\n");
-      expect(calls.length).toBeGreaterThan(0);
-      // The preflight is the first ps call (synchronous, before spawn). It
-      // must not use the environment-dumping `axeww` form.
-      expect(calls[0]).not.toContain("axeww");
-      expect(calls[0]).toContain("pid=,ppid=");
+      expect(existsSync(marker)).toBe(false);
     } finally {
       process.env.PATH = priorPath;
     }

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -394,4 +394,33 @@ setTimeout(() => {
       process.env.PATH = priorPath;
     }
   });
+
+  it.skipIf(process.platform === "win32")("preflight uses a lightweight ps snapshot without the environment dump", async () => {
+    // The per-request preflight must not invoke the environment-dumping
+    // `axeww` form; it should use the small `ps -axo pid=,ppid=` snapshot so
+    // it stays small and cannot overflow the spawnSync buffer on busy hosts.
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-ps-"));
+    const ps = join(dir, "ps");
+    const argsLog = join(dir, "args");
+    // Record the args of every ps invocation, one per line, then exit 0.
+    writeFileSync(ps, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}\nexit 0\n`);
+    chmodSync(ps, 0o755);
+    const priorPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      const fetch = createRequestHeadersCommandFetch(
+        { command: "/usr/bin/printf", args: ["{}"] },
+        async () => new Response("ok"),
+      );
+      await expect(fetch("https://mcp.example.test/mcp")).resolves.toBeInstanceOf(Response);
+      const calls = readFileSync(argsLog, "utf8").trim().split("\n");
+      expect(calls.length).toBeGreaterThan(0);
+      // The preflight is the first ps call (synchronous, before spawn). It
+      // must not use the environment-dumping `axeww` form.
+      expect(calls[0]).not.toContain("axeww");
+      expect(calls[0]).toContain("pid=,ppid=");
+    } finally {
+      process.env.PATH = priorPath;
+    }
+  });
 });

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -8,20 +8,29 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const USE_PROCESS_GROUP = process.platform !== "win32";
 const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
+// `ps axeww` dumps the full environment of every process on the host. On busy
+// machines that output exceeds spawnSync's default 1 MiB maxBuffer, which causes
+// Node to SIGTERM `ps` and report status === null. Raise the cap so process
+// discovery keeps working without spurious cleanup failures.
+const PS_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";
 }
 
-function runPosixPs(args: string[]): { status: number | null; stdout: string } {
-  if (process.env.PI_MCP_ADAPTER_TEST_FAIL_PS === "1") return { status: 1, stdout: "" };
-  return spawnSync("ps", args, { encoding: "utf8" });
+function runPosixPs(args: string[]): { status: number | null; signal: NodeJS.Signals | null; stdout: string } {
+  if (process.env.PI_MCP_ADAPTER_TEST_FAIL_PS === "1") return { status: 1, signal: null, stdout: "" };
+  const result = spawnSync("ps", args, { encoding: "utf8", maxBuffer: PS_MAX_BUFFER_BYTES });
+  return { status: result.status, signal: result.signal, stdout: result.stdout };
 }
 
 function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number[] {
   const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
-    throw new Error(`HTTP request headers command cleanup failed: ps exited with code ${result.status ?? "unknown"}`);
+    const reason = result.status === null
+      ? `ps was killed by signal ${result.signal ?? "unknown"}`
+      : `ps exited with code ${result.status}`;
+    throw new Error(`HTTP request headers command cleanup failed: ${reason}`);
   }
 
   const childrenByParent = new Map<number, number[]>();

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -11,8 +11,13 @@ const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
 // `ps axeww` dumps the full environment of every process on the host. On busy
 // machines that output exceeds spawnSync's default 1 MiB maxBuffer, which causes
 // Node to SIGTERM `ps` and report status === null. Raise the cap so process
-// discovery keeps working without spurious cleanup failures.
-const PS_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+// discovery keeps working without spurious cleanup failures. Observed output
+// is ~1 MiB on a loaded dev machine (1000+ procs at ~1 KiB each); 8 MiB gives
+// ~8x headroom and covers a machine ~8x busier (or ~4x with heavy envs), which
+// is a realistic worst-case dev box. maxBuffer is a cap, not a pre-allocation:
+// Node grows the buffer to the actual output, so this costs ~0 unless `ps`
+// really emits that much.
+const PS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as NodeJS.ErrnoException).code === "ESRCH";

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -24,13 +24,16 @@ function runPosixPs(args: string[]): { status: number | null; signal: NodeJS.Sig
   return { status: result.status, signal: result.signal, stdout: result.stdout };
 }
 
+function psFailureReason(result: { status: number | null; signal: NodeJS.Signals | null }): string {
+  return result.status === null
+    ? `ps was killed by signal ${result.signal ?? "unknown"}`
+    : `ps exited with code ${result.status}`;
+}
+
 function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number[] {
   const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
-    const reason = result.status === null
-      ? `ps was killed by signal ${result.signal ?? "unknown"}`
-      : `ps exited with code ${result.status}`;
-    throw new Error(`HTTP request headers command cleanup failed: ${reason}`);
+    throw new Error(`HTTP request headers command cleanup failed: ${psFailureReason(result)}`);
   }
 
   const childrenByParent = new Map<number, number[]>();
@@ -58,7 +61,15 @@ function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number
 }
 
 function assertPosixProcessDiscoveryAvailable(): void {
-  collectPosixProcessPids(process.pid, `${process.pid}-preflight`);
+  // Use the lightweight column form (`ps -axo pid=,ppid=`) instead of the
+  // environment dump (`axeww`) so this per-request preflight stays small
+  // (~KiB, not MiB) and cannot overflow the spawnSync buffer on busy hosts.
+  // The full environment scan used for descendant cleanup is exercised lazily
+  // by the descendant tracker and the cleanup path.
+  const result = runPosixPs(["-axo", "pid=,ppid="]);
+  if (result.status !== 0) {
+    throw new Error(`HTTP request headers command cleanup failed: ${psFailureReason(result)}`);
+  }
 }
 
 function isTaskkillNoSuchProcess(result: ReturnType<typeof spawnSync>): boolean {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -66,12 +66,7 @@ function collectPosixProcessPids(rootPid: number, cleanupToken?: string): number
 }
 
 function assertPosixProcessDiscoveryAvailable(): void {
-  // Use the lightweight column form (`ps -axo pid=,ppid=`) instead of the
-  // environment dump (`axeww`) so this per-request preflight stays small
-  // (~KiB, not MiB) and cannot overflow the spawnSync buffer on busy hosts.
-  // The full environment scan used for descendant cleanup is exercised lazily
-  // by the descendant tracker and the cleanup path.
-  const result = runPosixPs(["-axo", "pid=,ppid="]);
+  const result = runPosixPs(["axeww", "-o", "pid=,ppid=,command="]);
   if (result.status !== 0) {
     throw new Error(`HTTP request headers command cleanup failed: ${psFailureReason(result)}`);
   }


### PR DESCRIPTION
## Summary

Replaces #399 while preserving the useful contributor fix.

This keeps the raised `ps axeww` `maxBuffer`, but removes the lightweight preflight that could let a request-header helper spawn before the real cleanup scan was known to work. The preflight now validates the same full process-discovery scan used by cleanup before spawning the header command.

Supersedes #399.

Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.

## Validation

- `npm test -- __tests__/request-headers-command.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: pass
