### PR TITLE
fix: avoid failing keep-alive on refresh timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Raised the `ps` `maxBuffer` for request-header command cleanup so the full `ps axeww` process-discovery scan no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures. Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.
+- Kept slow but healthy remote keep-alive servers from being marked failed when a bounded tools/list refresh times out. Thanks to [@brightmeowso](https://github.com/brightmeowso) for #400.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.
 - Published the first connected MCP status snapshot only after direct-tool synchronization so status consumers do not see a connected catalog before Pi's model-facing tool surface is current. Thanks to [@dmorn](https://github.com/dmorn) for PR #380.
 - Normalized MCP tool-call arguments before approval and transport so JSON-string arguments keep all fields and embedded quotes. Thanks to [@sebbean](https://github.com/sebbean) for PR #377.

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -316,6 +316,29 @@ describe("lazy-keep-alive lifecycle", () => {
     expect(onHealthRestored).toHaveBeenCalledWith("srv");
   });
 
+  it("backs off tools/list refresh timeouts without marking the connection failed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
+    lifecycle.markKeepAlive("srv", def);
+    fake.setConnection("srv", "connected", "session");
+    vi.spyOn(fake, "refreshTools").mockImplementation(async (name) => {
+      fake.refreshToolsCalls.push(name);
+      return "refresh-timeout" as never;
+    });
+    const onFailure = vi.fn();
+    lifecycle.setReconnectFailureCallback(onFailure);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await lifecycle.ensureConverged();
+    await lifecycle.ensureConverged();
+
+    expect(fake.refreshToolsCalls).toEqual(["srv"]);
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(fake.getConnection("srv")?.status).toBe("connected");
+  });
+
   it("reconnects immediately when a backed-off connection closes in place", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -347,6 +347,22 @@ describe("McpServerManager sampling", () => {
     expect(client.listTools).toHaveBeenCalledTimes(initialListCalls);
   });
 
+  it("marks only tools/list keep-alive timeout errors as refresh timeouts", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const { SdkError, SdkErrorCode } = await import("@modelcontextprotocol/client");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    const timeout = new SdkError(SdkErrorCode.RequestTimeout, "Request timed out");
+    client.listTools.mockRejectedValueOnce(timeout);
+
+    await expect(manager.refreshTools("demo", connection)).resolves.toBe("refresh-timeout");
+
+    client.getServerCapabilities.mockReturnValue({ resources: {} });
+    client.ping = vi.fn(async () => { throw timeout; });
+    await expect(manager.refreshTools("demo", connection)).rejects.toBe(timeout);
+  });
+
   it("retries queued metadata publication after a no-tools ping", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -262,6 +262,10 @@ export class McpLifecycleManager {
       await this.handleSupersededConnection(name, definition, connection, signal, retrySuperseded);
       return;
     }
+    if (refreshResult === "refresh-timeout") {
+      this.deferRefreshTimeout(name, definition, connection);
+      return;
+    }
     if (this.keepAliveServers.get(name) !== definition) return;
     if (this.retryStates.delete(name)) {
       await this.onHealthRestored?.(name);
@@ -350,9 +354,34 @@ export class McpLifecycleManager {
     action: "refresh" | "reconnect" | "publish",
     connection: ServerConnection | undefined,
   ): void {
+    if (!this.recordRetry(name, definition, connection)) return;
+    this.onReconnectFailure?.(name, error);
+    const message = error instanceof Error ? error.message : String(error);
+    const target = action === "reconnect"
+      ? `reconnect to ${name}`
+      : action === "publish"
+        ? `publish metadata for ${name}`
+        : `refresh ${name}`;
+    console.error(`MCP: Failed to ${target}: ${sanitizeTerminalText(message)}`);
+  }
+
+  private deferRefreshTimeout(
+    name: string,
+    definition: ServerDefinition,
+    connection: ServerConnection | undefined,
+  ): void {
+    if (!this.recordRetry(name, definition, connection)) return;
+    logger.debug(`MCP: keep-alive tools/list refresh timed out for ${name}; retrying after backoff`);
+  }
+
+  private recordRetry(
+    name: string,
+    definition: ServerDefinition,
+    connection: ServerConnection | undefined,
+  ): boolean {
     // Do not recreate retry/failure state from a stale convergence pass after
     // disposal or a same-name replacement registration.
-    if (this.keepAliveServers.get(name) !== definition) return;
+    if (this.keepAliveServers.get(name) !== definition) return false;
     const attempts = (this.retryStates.get(name)?.attempts ?? 0) + 1;
     const delay = Math.min(
       KEEP_ALIVE_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 10),
@@ -364,14 +393,7 @@ export class McpLifecycleManager {
       connection,
       status: connection?.status,
     });
-    this.onReconnectFailure?.(name, error);
-    const message = error instanceof Error ? error.message : String(error);
-    const target = action === "reconnect"
-      ? `reconnect to ${name}`
-      : action === "publish"
-        ? `publish metadata for ${name}`
-        : `refresh ${name}`;
-    console.error(`MCP: Failed to ${target}: ${sanitizeTerminalText(message)}`);
+    return true;
   }
 
   private getIdleTimeout(name: string): number {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -2,6 +2,8 @@ import { mkdirSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import {
   Client,
+  SdkError,
+  SdkErrorCode,
   SdkHttpError,
   SSEClientTransport,
   StreamableHTTPClientTransport,
@@ -144,7 +146,7 @@ export interface ServerConnection {
 type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void;
 type MetadataListChangedListener = (serverName: string, reason: string) => void;
 
-export type ToolRefreshResult = "updated" | "unchanged" | "superseded";
+export type ToolRefreshResult = "updated" | "unchanged" | "superseded" | "refresh-timeout";
 
 const KEEP_ALIVE_REFRESH_TIMEOUT_MS = 5_000;
 
@@ -373,11 +375,23 @@ export class McpServerManager {
 
     const toolsRevision = expectedConnection.toolsRevision ?? 0;
     const refreshSignal = combineAbortSignals(healthOptions.signal, AbortSignal.timeout(timeout));
-    const tools = await this.fetchAllTools(expectedConnection.client, {
-      ...healthOptions,
-      ...(refreshSignal ? { signal: refreshSignal } : {}),
-      cacheMode: "refresh",
-    });
+    let tools: McpTool[];
+    try {
+      tools = await this.fetchAllTools(expectedConnection.client, {
+        ...healthOptions,
+        ...(refreshSignal ? { signal: refreshSignal } : {}),
+        cacheMode: "refresh",
+      });
+    } catch (error) {
+      throwIfAborted(ownedSignal);
+      if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") {
+        return "superseded";
+      }
+      if (error instanceof SdkError && error.code === SdkErrorCode.RequestTimeout) {
+        return "refresh-timeout";
+      }
+      throw error;
+    }
     throwIfAborted(ownedSignal);
 
     if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") {


### PR DESCRIPTION
## Summary

Stops slow keep-alive `tools/list` refresh timeouts from marking an otherwise connected server failed or printing repeated `MCP: Failed to refresh ...` TUI errors.

A bounded keep-alive catalog refresh timeout now records retry backoff and leaves the previous connected status/catalog intact. Real liveness failures, no-tools `ping` timeouts, reconnect failures, and non-timeout refresh errors stay on the existing loud failure path.

Closes #400.

Thanks to [@brightmeowso](https://github.com/brightmeowso) for #400.

## Validation

- `npm test -- __tests__/lifecycle-lazy-keep-alive.test.ts __tests__/server-manager-sampling.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: pass
