### PR TITLE
fix(oauth): hide MCP picker during nested auth UI

### DIFF
--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -189,7 +189,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the OAuth URL as a terminal hyperlink in the notify, then opens the paste input directly (no redundant confirm)", async () => {
+  it("puts the OAuth link at the top of the paste prompt instead of the chat transcript", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
     const inputController = new AbortController();
@@ -223,17 +223,13 @@ describe("authenticateServer", () => {
         onAuthorizationInput: expect.any(Function),
       },
     );
-    expect(ui.notify).toHaveBeenCalledWith(
-      expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
-      "info",
-    );
-    // The pre-existing Yes/No confirm was redundant: onAuthorizationUrl
-    // already surfaced the clickable link. Skipping it lets the user paste
-    // and press Enter in one step.
+    expect(ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(authorizationUrl), "info");
     expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
-      "Complete sentry OAuth",
-      "Paste the full callback URL from your browser",
+      expect.stringContaining(
+        `\u001B]8;;${authorizationUrl}\u001B\\OPEN AUTHORIZATION PAGE ↗\u001B]8;;\u001B\\\n${authorizationUrl}`,
+      ),
+      undefined,
       { signal: inputController.signal },
     );
   });

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
+  createMcpPanel: vi.fn(),
   removeAuth: vi.fn(),
 }));
 
@@ -9,6 +10,10 @@ vi.mock("../mcp-auth-flow.ts", () => ({
   authenticate: mocks.authenticate,
   removeAuth: mocks.removeAuth,
   supportsOAuth: (definition: { url?: string; auth?: string }) => Boolean(definition.url) && definition.auth !== "bearer",
+}));
+
+vi.mock("../mcp-panel.ts", () => ({
+  createMcpPanel: mocks.createMcpPanel,
 }));
 
 vi.mock("../init.ts", () => ({
@@ -39,6 +44,58 @@ describe("authenticateServer", () => {
     expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
     expect(ui.custom).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["openMcpPanel", "success"],
+    ["openMcpAuthPanel", "success"],
+    ["openMcpAuthPanel", "failure"],
+  ] as const)(
+    "%s restores the hidden picker after OAuth %s",
+    async (command, outcome) => {
+      let finishAuthentication!: () => void;
+      const hidden = vi.fn();
+      const focus = vi.fn();
+      mocks.authenticate.mockImplementationOnce(async () => {
+        expect(hidden).toHaveBeenCalledWith(true);
+        await new Promise<void>((resolve) => { finishAuthentication = resolve; });
+        if (outcome === "failure") throw new Error("authentication failed");
+        return "authenticated";
+      });
+      mocks.createMcpPanel.mockImplementationOnce((_config, _cache, _provenance, callbacks, _tui, done) => ({
+        render: () => [],
+        invalidate: () => {},
+        handleInput: () => {
+          void callbacks.authenticate("sentry").then(() => done({ cancelled: true, changes: new Map() }));
+        },
+      }));
+      const ui = {
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+        custom: vi.fn((factory, options) => {
+          const panel = factory({ requestRender: vi.fn() }, undefined, undefined, vi.fn());
+          options.onHandle({ setHidden: hidden, focus });
+          panel.handleInput("\r");
+        }),
+      };
+      const commands = await import("../commands.ts");
+
+      const panel = commands[command]({
+        programmaticConfig: false,
+        config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+        authStorageOptions: {},
+        manager: { getConnection: () => undefined },
+        failureTracker: new Map(),
+        failureMessages: new Map(),
+      } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any);
+
+      await vi.waitFor(() => expect(hidden).toHaveBeenCalledWith(true));
+      finishAuthentication();
+      await panel;
+
+      expect(hidden.mock.calls).toEqual([[true], [false]]);
+      expect(focus).toHaveBeenCalledOnce();
+    },
+  );
 
   it("interpolates the server URL before OAuth authentication", async () => {
     const originalUrl = process.env.MCP_AUTH_URL;

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -132,7 +132,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the OAuth URL as one terminal hyperlink and accepts a pasted remote callback", async () => {
+  it("surfaces the OAuth URL as a terminal hyperlink in the notify, then opens the paste input directly (no redundant confirm)", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
     const inputController = new AbortController();
@@ -170,17 +170,42 @@ describe("authenticateServer", () => {
       expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
       "info",
     );
-    expect(ui.confirm).toHaveBeenCalledWith(
-      "Authorize sentry",
-      expect.stringContaining(authorizationUrl),
-      { signal: inputController.signal },
-    );
+    // The pre-existing Yes/No confirm was redundant: onAuthorizationUrl
+    // already surfaced the clickable link. Skipping it lets the user paste
+    // and press Enter in one step.
+    expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
       "Complete sentry OAuth",
-      "Paste the full callback URL",
+      "Paste the full callback URL from your browser",
       { signal: inputController.signal },
     );
-    expect(ui.confirm.mock.invocationCallOrder[0]).toBeLessThan(ui.input.mock.invocationCallOrder[0]);
+  });
+
+  it("skips the paste input entirely when the auth flow was aborted before onAuthorizationInput fired", async () => {
+    const authorizationUrl = "https://auth.example.com/authorize";
+    const inputController = new AbortController();
+    inputController.abort();
+    mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
+      const input = await options.onAuthorizationInput(authorizationUrl, inputController.signal);
+      expect(input).toBeUndefined();
+      return "cancelled";
+    });
+    const ui = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      confirm: vi.fn(),
+      input: vi.fn(),
+    };
+    const { authenticateServer } = await import("../commands.ts");
+
+    await authenticateServer("sentry", {
+      mcpServers: {
+        sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
+      },
+    }, { hasUI: true, mode: "tui", ui } as any);
+
+    expect(ui.input).not.toHaveBeenCalled();
+    expect(ui.confirm).not.toHaveBeenCalled();
   });
 
   it("blocks bearer token set because the extension UI has no masked secret input", async () => {

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   stopCallbackServer: vi.fn(),
   reserveCallbackServer: vi.fn(),
   releaseCallbackServer: vi.fn(),
+  isCallbackServerRunning: vi.fn(() => false),
+  isCallbackServerIdle: vi.fn(() => true),
   open: vi.fn(),
   sdkAuth: vi.fn(),
   fetch: vi.fn(),
@@ -39,6 +41,8 @@ vi.mock("../mcp-callback-server.ts", () => ({
   stopCallbackServer: mocks.stopCallbackServer,
   reserveCallbackServer: mocks.reserveCallbackServer,
   releaseCallbackServer: mocks.releaseCallbackServer,
+  isCallbackServerRunning: mocks.isCallbackServerRunning,
+  isCallbackServerIdle: mocks.isCallbackServerIdle,
 }));
 
 vi.mock("open", () => ({
@@ -59,6 +63,11 @@ describe("mcp-auth-flow explicit auth", () => {
     mocks.stopCallbackServer.mockReset();
     mocks.reserveCallbackServer.mockReset();
     mocks.releaseCallbackServer.mockReset();
+    // Default the callback server to "not bound" so the release-on-idle path
+    // is a no-op in tests that predate that path. Tests that want to exercise
+    // release-on-idle set these to true explicitly.
+    mocks.isCallbackServerRunning.mockReset().mockReturnValue(false);
+    mocks.isCallbackServerIdle.mockReset().mockReturnValue(false);
     mocks.open.mockReset();
     mocks.sdkAuth.mockReset().mockResolvedValue("AUTHORIZED");
     mocks.fetch.mockReset().mockResolvedValue(new Response(null));
@@ -1104,5 +1113,49 @@ describe("mcp-auth-flow explicit auth", () => {
     }));
     expect(mocks.reserveCallbackServer).not.toHaveBeenCalled();
     expect(mocks.open).not.toHaveBeenCalled();
+  });
+
+  it("releases the callback server after a completed auth when no other auths are pending", async () => {
+    // Simulate: server is currently bound, and once the completed auth's
+    // pending record clears, isCallbackServerIdle flips to true.
+    mocks.isCallbackServerRunning.mockReturnValue(true);
+    mocks.isCallbackServerIdle.mockReturnValue(true);
+    let oauthState: string | undefined;
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      oauthState = await provider.state();
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${oauthState}`));
+      return "REDIRECT";
+    });
+    const { startAuth, completeAuthFromInput } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("solo", "https://api.example.com/mcp", { auth: "oauth" });
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
+
+    await expect(completeAuthFromInput("solo", `code=deadbeef&state=${oauthState}`)).resolves.toBe("authenticated");
+
+    // The pilot behavior: callback port released so other Pi processes can
+    // reclaim it for their own /mcp-auth flows.
+    expect(mocks.stopCallbackServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not release the callback server after an auth completes while other auths are still pending", async () => {
+    // isCallbackServerRunning is true (bound), but isCallbackServerIdle is
+    // false because a second pending auth exists.
+    mocks.isCallbackServerRunning.mockReturnValue(true);
+    mocks.isCallbackServerIdle.mockReturnValue(false);
+    let oauthState: string | undefined;
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      oauthState = await provider.state();
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${oauthState}`));
+      return "REDIRECT";
+    });
+    const { startAuth, completeAuthFromInput } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("first", "https://api.example.com/mcp", { auth: "oauth" });
+    await expect(completeAuthFromInput("first", `code=deadbeef&state=${oauthState}`)).resolves.toBe("authenticated");
+
+    // Not idle -> release-on-idle skipped so the still-pending second auth's
+    // callback listener stays alive.
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -329,4 +329,42 @@ describe("mcp-callback-server", () => {
     cancelPendingCallback("pending-state");
     await expect(pending).rejects.toThrow(/Authorization cancelled/);
   });
+
+  it("reports idle only when no pending or reserved auth state remains", async () => {
+    const {
+      ensureCallbackServer,
+      reserveCallbackServer,
+      releaseCallbackServer,
+      waitForCallback,
+      cancelPendingCallback,
+      getPendingAuthCount,
+      getReservedAuthStateCount,
+      isCallbackServerIdle,
+    } = await import("../mcp-callback-server.ts");
+
+    // Freshly-bound server with nothing in flight is idle so callers can
+    // release the port immediately after their auth flow tears down.
+    await ensureCallbackServer();
+    expect(getPendingAuthCount()).toBe(0);
+    expect(getReservedAuthStateCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(true);
+
+    // Reserved states (booked before the pending map fills) block idle.
+    reserveCallbackServer("reserved-a");
+    expect(getReservedAuthStateCount()).toBe(1);
+    expect(isCallbackServerIdle()).toBe(false);
+
+    // Pending callbacks also block idle even when nothing is reserved.
+    releaseCallbackServer("reserved-a");
+    const pending = waitForCallback("pending-a");
+    expect(getPendingAuthCount()).toBe(1);
+    expect(getReservedAuthStateCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(false);
+
+    // Both cleared -> idle again.
+    cancelPendingCallback("pending-a");
+    await expect(pending).rejects.toThrow(/Authorization cancelled/);
+    expect(getPendingAuthCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(true);
+  });
 });

--- a/commands.ts
+++ b/commands.ts
@@ -289,23 +289,16 @@ export async function authenticateServer(
     const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
     const status = await authenticate(serverName, serverUrl, definition, {
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
-      onAuthorizationUrl: (authorizationUrl) => {
-        ui.notify(
-          `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving, Pi will complete automatically if the browser can reach its localhost callback. " +
-          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi.",
-          "info"
-        );
-      },
-      onAuthorizationInput: async (_authorizationUrl, inputSignal) => {
-        // The authorization URL was already announced via the notify above
-        // (a clickable terminal hyperlink users can open before pasting).
-        // Skip a redundant Yes/No confirm and open the paste input directly,
-        // so hitting Enter after pasting the callback URL just works.
+      // Keep the authorization URL with the paste prompt instead of adding it
+      // to the chat transcript.
+      onAuthorizationUrl: () => {},
+      onAuthorizationInput: async (authorizationUrl, inputSignal) => {
         if (inputSignal.aborted) return undefined;
         return ui.input(
-          `Complete ${serverName} OAuth`,
-          "Paste the full callback URL from your browser",
+          `Complete ${serverName} OAuth\n\n` +
+            `${terminalHyperlink("OPEN AUTHORIZATION PAGE ↗", authorizationUrl)}\n${authorizationUrl}\n\n` +
+            "Approve access, then paste the full localhost callback URL below.",
+          undefined,
           { signal: inputSignal },
         );
       },

--- a/commands.ts
+++ b/commands.ts
@@ -296,17 +296,15 @@ export async function authenticateServer(
           "info"
         );
       },
-      onAuthorizationInput: async (authorizationUrl, inputSignal) => {
-        const readyToPaste = await ui.confirm(
-          `Authorize ${serverName}`,
-          `Open this link in your browser:\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving access, select Yes to paste the callback URL.",
-          { signal: inputSignal },
-        );
-        if (!readyToPaste || inputSignal.aborted) return undefined;
+      onAuthorizationInput: async (_authorizationUrl, inputSignal) => {
+        // The authorization URL was already announced via the notify above
+        // (a clickable terminal hyperlink users can open before pasting).
+        // Skip a redundant Yes/No confirm and open the paste input directly,
+        // so hitting Enter after pasting the callback URL just works.
+        if (inputSignal.aborted) return undefined;
         return ui.input(
           `Complete ${serverName} OAuth`,
-          "Paste the full callback URL",
+          "Paste the full callback URL from your browser",
           { signal: inputSignal },
         );
       },

--- a/commands.ts
+++ b/commands.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
 import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCallbacks, type McpPanelResult, type ImportKind } from "./types.ts";
 import {
@@ -554,6 +555,7 @@ function buildMcpPanelCallbacks(
   state: McpExtensionState,
   config: McpConfig,
   ctx: ExtensionContext,
+  getOverlayHandle?: () => OverlayHandle | undefined,
 ): McpPanelCallbacks {
   // Panel-only diagnostics keep status inspection from mutating connection
   // failure state while allowing the existing panel failure UI to show why the
@@ -566,7 +568,16 @@ function buildMcpPanelCallbacks(
       const definition = config.mcpServers[serverName];
       return definition ? !isServerDisabled(definition) && supportsOAuth(definition) : false;
     },
-    authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
+    authenticate: async (serverName: string) => {
+      const overlay = getOverlayHandle?.();
+      overlay?.setHidden(true);
+      try {
+        return await authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime);
+      } finally {
+        overlay?.setHidden(false);
+        overlay?.focus();
+      }
+    },
     getConnectionStatus: (serverName: string) => {
       authStatusFailures.delete(serverName);
       const definition = config.mcpServers[serverName];
@@ -635,7 +646,8 @@ export async function openMcpPanel(
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
   const { lines: noticeLines, fingerprint } = buildSharedConfigNoticeLines(configPath, ctx.cwd);
 
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
 
   const { createMcpPanel } = await import("./mcp-panel.ts");
   let configChanged = false;
@@ -661,7 +673,11 @@ export async function openMcpPanel(
           });
         }, { noticeLines, keybindings });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 
@@ -700,7 +716,8 @@ export async function openMcpAuthPanel(
   const cache = loadMetadataCache();
   const configPath = pi.getFlag("mcp-config") as string | undefined ?? configOverridePath;
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
   const { createMcpPanel } = await import("./mcp-panel.ts");
 
   await new Promise<void>((resolve) => {
@@ -715,7 +732,11 @@ export async function openMcpAuthPanel(
           noticeLines: ["Select an OAuth MCP server and press Enter or ctrl+a to authenticate."],
         });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -19,6 +19,8 @@ import {
   cancelPendingCallback,
   stopCallbackServer,
   releaseCallbackServer,
+  isCallbackServerRunning,
+  isCallbackServerIdle,
 } from "./mcp-callback-server.ts"
 import {
   getAuthForUrl,
@@ -439,7 +441,7 @@ export async function startAuth(
   } catch (error) {
     authProvider.deactivate()
     try {
-      await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+      await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -463,7 +465,7 @@ async function setPendingAuth(
   state.pendingAuths.set(key, pendingAuth)
   state.pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+    void clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
       console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
     })
   }, MANUAL_AUTH_TIMEOUT_MS)
@@ -496,6 +498,39 @@ async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oa
       await clearOAuthState(serverName, authStorageOptions)
     }
   }
+}
+
+/**
+ * Release the OAuth callback listener when nothing else needs it, so other
+ * processes can reclaim the (potentially pre-registered) port. Called from
+ * auth completion / cancellation sites; NOT from the sweep-before-set path
+ * in setPendingAuth (that path is about to add a fresh record) or from
+ * shutdownOAuth (which handles server teardown itself).
+ *
+ * The next auth flow in this process rebinds on demand via
+ * ensureCallbackServer, so releasing eagerly is safe.
+ */
+async function releaseCallbackServerIfIdle(): Promise<void> {
+  if (isCallbackServerRunning() && isCallbackServerIdle()) {
+    await stopCallbackServer()
+  }
+}
+
+/**
+ * Clear the per-server pending-auth record and, when no other auths remain
+ * anywhere, release the OAuth callback port so peer processes can bind it
+ * for their own /mcp-auth flows. Use this at true completion sites
+ * (successful auth, cancellation, removeAuth); use clearPendingAuth alone
+ * from setPendingAuth's sweep-before-set and from shutdown paths.
+ */
+async function clearPendingAuthAndReleaseIfIdle(
+  runtime: McpOAuthRuntime,
+  serverName: string,
+  oauthState: string | undefined,
+  fallbackStorageOptions: AuthStorageOptions = {},
+): Promise<void> {
+  await clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions)
+  await releaseCallbackServerIfIdle()
 }
 
 function getSearchParamsFromInput(input: string): URLSearchParams | undefined {
@@ -701,7 +736,7 @@ export async function completeAuth(
   } finally {
     if (!keepPendingForRetry) {
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         if (caughtError !== undefined) {
           throw new AggregateError([caughtError, cleanupError], "OAuth completion cleanup failed")
@@ -801,7 +836,7 @@ export async function authenticate(
     } catch (error) {
       if (oauthState) cancelPendingCallback(oauthState)
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         throw new AggregateError([error, cleanupError], "OAuth cancellation cleanup failed")
       }
@@ -922,7 +957,7 @@ export async function removeAuth(serverName: string, options: AuthenticateOption
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+  await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
   throwIfAborted(signal)
   clearAllCredentials(serverName, authStorageOptions)
   await clearOAuthState(serverName, authStorageOptions)

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -508,3 +508,20 @@ export function isCallbackServerRunning(): boolean {
 export function getPendingAuthCount(): number {
   return pendingAuths.size
 }
+
+/**
+ * Get the number of reserved authorization states (bookings for auth flows
+ * that have not yet reached the waitForCallback phase).
+ */
+export function getReservedAuthStateCount(): number {
+  return reservedAuthStates.size
+}
+
+/**
+ * True if the callback server currently has no reason to remain bound.
+ * A caller that just finished cleaning up its own auth state can consult
+ * this to decide whether to release the port for other processes.
+ */
+export function isCallbackServerIdle(): boolean {
+  return pendingAuths.size === 0 && reservedAuthStates.size === 0
+}


### PR DESCRIPTION
## Summary

- hide the `/mcp` or `/mcp-auth` picker while OAuth shows its authorization link and callback paste input
- restore and refocus the picker after success or failure
- cover both picker entrypoints and failure restoration

## Stack

Depends on #403. This branch includes #403 through a merge commit so the callback-listener lifecycle fix remains independently reviewable and mergeable first.

## Validation

- `npm run typecheck`
- focused command and callback-listener tests (29 passed)
- pre-stack UI branch: `npm test` (1,214 tests)
- pre-stack UI branch: `npm run test:oauth` (137 tests)
