### PR TITLE
fix: harden MCP boundary validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `/pi-mcp` as an alias for `/mcp` when a host reserves `/mcp`. Thanks to [@inxeoz](https://github.com/inxeoz) for #391.
-- Added `registerMcpServer(pi, name, definition)` so other extensions can register and dispose session-scoped MCP servers at runtime. Registrations are proxy-tool-only, never persisted, and duplicate names fail closed. Thanks to [@bendavis78](https://github.com/bendavis78) and [@fmoda3](https://github.com/fmoda3) for the runtime API request in #376/#382.
+- Added `registerMcpServer({ pi, name, definition })` so other extensions can register and dispose session-scoped MCP servers at runtime. Registrations are proxy-tool-only, never persisted, and duplicate names fail closed. Thanks to [@bendavis78](https://github.com/bendavis78) and [@fmoda3](https://github.com/fmoda3) for the runtime API request in #376/#382.
 - Added `pi.mcp` package manifest entries so Pi packages can ship prefixed MCP server definitions without user MCP config edits. Thanks to [@bendavis78](https://github.com/bendavis78) for #376 and [@fmoda3](https://github.com/fmoda3) for the manifest design.
 - Added opt-in OS credential-store lookup for static bearer tokens with URL-bound records, using `bearerTokenStore: true`, plus a stdin-only `pi-mcp-adapter token set|status|remove <server>` CLI that never accepts the token as an argument. Thanks to [@AlexanderBartash](https://github.com/AlexanderBartash) for issue #366.
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ An extension can register MCP servers with the installed adapter at runtime, for
 import { registerMcpServer } from "pi-mcp-adapter";
 
 export default function pluginHost(pi) {
-  const registration = registerMcpServer(pi, "acme__docs", {
-    url: "https://mcp.example.com/mcp",
+  const registration = registerMcpServer({
+    pi,
+    name: "acme__docs",
+    definition: {
+      url: "https://mcp.example.com/mcp",
+    },
   });
   // Later, when the plugin is uninstalled:
   await registration.dispose();

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -8,6 +8,11 @@ function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
 }
 
+function writeText(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value, "utf-8");
+}
+
 describe("config discovery", () => {
   const originalHome = process.env.HOME;
   const originalPackageDir = process.env.PI_PACKAGE_DIR;
@@ -75,6 +80,31 @@ describe("config discovery", () => {
     expect(config.mcpServers.acme_tools__tools_db).toEqual({ command: "first" });
     expect(warning).toHaveBeenCalledWith(expect.stringContaining("duplicate normalized MCP server acme_tools__tools_db"));
     warning.mockRestore();
+  });
+
+  it("fails loudly on malformed package settings JSON", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-settings-invalid-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-settings-invalid-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    writeText(join(home, ".pi", "agent", "settings.json"), "{ not json");
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(() => loadMcpConfig()).toThrow("user Pi settings");
+  });
+
+  it("fails loudly on malformed package MCP JSON", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-package-mcp-invalid-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-package-mcp-invalid-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    const packageRoot = join(home, ".pi", "agent", "npm", "node_modules", "acme-tools");
+    writeJson(join(home, ".pi", "agent", "settings.json"), { packages: ["npm:acme-tools"] });
+    writeJson(join(packageRoot, "package.json"), { name: "acme-tools", pi: { mcp: "./mcp.json" } });
+    writeText(join(packageRoot, "mcp.json"), "{ not json");
+
+    const { loadMcpConfig } = await import("../config.ts");
+    expect(() => loadMcpConfig()).toThrow("Pi package acme-tools MCP config");
   });
 
   it("drops incompatible package transport fields when a normal override changes transport", async () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -1123,6 +1123,10 @@ describe("excludeTools filtering", () => {
     const { executeCall } = await import("../proxy-modes.ts");
     await expect(executeCall(state, "my-server_search-records", {})).resolves.toMatchObject({ details: { server: "my-server", tool: "search-records" } });
     expect(callTool).toHaveBeenCalledOnce();
+    await expect(executeCall(state, "my-server_search-records", { token: undefined })).rejects.toThrow(
+      "tool arguments: value at token is not JSON-serializable",
+    );
+    expect(callTool).toHaveBeenCalledOnce();
   });
 
   it("does not apply live legacy exclusions to another server's current tool name", () => {

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -952,6 +952,26 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.executeStatus).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid nested gateway param types before dispatch", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    const sessionStart = handlers.get("session_start");
+    await sessionStart?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    await expect(proxyTool.execute("call-1", { args: { search: 5 } })).rejects.toThrow(
+      "Invalid nested gateway param `search`: expected string, got number",
+    );
+    expect(mocks.executeSearch).not.toHaveBeenCalled();
+  });
+
   it("routes manual auth actions through the proxy tool", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);

--- a/__tests__/lifecycle-lazy-keep-alive.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive.test.ts
@@ -7,6 +7,7 @@ import { lazyConnect } from "../init.ts";
 import { McpLifecycleManager } from "../lifecycle.ts";
 import { executeCall } from "../proxy-modes.ts";
 import { reconnectServers } from "../commands.ts";
+import type { ToolRefreshResult } from "../server-manager.ts";
 import type { ServerDefinition } from "../types.ts";
 
 interface FakeConnection {
@@ -23,6 +24,7 @@ class FakeManager {
   idleResponses = new Map<string, boolean>();
   connectError: Error | undefined;
   refreshToolsError: Error | undefined;
+  refreshToolsResult: ToolRefreshResult = "unchanged";
   reconnectError: Error | undefined;
   reconnectStatus: FakeConnection["status"] = "connected";
 
@@ -49,10 +51,10 @@ class FakeManager {
     return connection;
   }
 
-  async refreshTools(name: string): Promise<"unchanged"> {
+  async refreshTools(name: string): Promise<ToolRefreshResult> {
     this.refreshToolsCalls.push(name);
     if (this.refreshToolsError) throw this.refreshToolsError;
-    return "unchanged";
+    return this.refreshToolsResult;
   }
 
   async reconnect(name: string, _definition: ServerDefinition, staleConnection: FakeConnection): Promise<FakeConnection> {
@@ -221,7 +223,7 @@ describe("lazy-keep-alive lifecycle", () => {
     };
     vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
       fake.connections.set("srv", freshConnection);
-      return "superseded" as never;
+      return "superseded";
     });
     const onReconnect = vi.fn();
     lifecycle.setReconnectCallback(onReconnect);
@@ -237,7 +239,7 @@ describe("lazy-keep-alive lifecycle", () => {
     const connection = fake.setConnection("srv", "connected", "stale-session")!;
     vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
       connection.status = "closed";
-      return "superseded" as never;
+      return "superseded";
     });
 
     await lifecycle.ensureConverged();
@@ -277,7 +279,7 @@ describe("lazy-keep-alive lifecycle", () => {
     };
     vi.spyOn(fake, "refreshTools").mockImplementation(async () => {
       fake.connections.set("srv", freshConnection);
-      return "superseded" as never;
+      return "superseded";
     });
     const onReconnect = vi.fn()
       .mockRejectedValueOnce(new Error("metadata cache unavailable"))
@@ -322,10 +324,7 @@ describe("lazy-keep-alive lifecycle", () => {
     const def: ServerDefinition = { url: "https://example.test/mcp", lifecycle: "keep-alive" };
     lifecycle.markKeepAlive("srv", def);
     fake.setConnection("srv", "connected", "session");
-    vi.spyOn(fake, "refreshTools").mockImplementation(async (name) => {
-      fake.refreshToolsCalls.push(name);
-      return "refresh-timeout" as never;
-    });
+    fake.refreshToolsResult = "refresh-timeout";
     const onFailure = vi.fn();
     lifecycle.setReconnectFailureCallback(onFailure);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -181,7 +181,7 @@ describe("runtime MCP server registration", () => {
 
   it("throws when no adapter is installed for the Pi instance", async () => {
     const { registerMcpServer } = await import("../index.ts");
-    expect(() => registerMcpServer({} as any, "plugin", { url: "https://example.test/mcp" }))
+    expect(() => registerMcpServer({ pi: {} as any, name: "plugin", definition: { url: "https://example.test/mcp" } }))
       .toThrow("pi-mcp-adapter is not installed for this Pi instance");
   });
 
@@ -194,7 +194,7 @@ describe("runtime MCP server registration", () => {
     await handlers.get("session_start")?.({}, {});
     await settle();
 
-    const registration = registerMcpServer(api, "plugin-a", { url: "https://example.test/mcp" });
+    const registration = registerMcpServer({ pi: api, name: "plugin-a", definition: { url: "https://example.test/mcp" } });
     expect(state.config.mcpServers["plugin-a"]).toMatchObject({
       url: "https://example.test/mcp",
       directTools: false,
@@ -228,10 +228,10 @@ describe("runtime MCP server registration", () => {
     await handlers.get("session_start")?.({}, {});
     await settle();
 
-    expect(() => registerMcpServer(api, "configured", { url: "https://other.test/mcp" }))
+    expect(() => registerMcpServer({ pi: api, name: "configured", definition: { url: "https://other.test/mcp" } }))
       .toThrow('MCP server "configured" is already registered');
-    registerMcpServer(api, "plugin-a", { url: "https://a.test/mcp" });
-    expect(() => registerMcpServer(api, "plugin-a", { url: "https://b.test/mcp" }))
+    registerMcpServer({ pi: api, name: "plugin-a", definition: { url: "https://a.test/mcp" } });
+    expect(() => registerMcpServer({ pi: api, name: "plugin-a", definition: { url: "https://b.test/mcp" } }))
       .toThrow('MCP server "plugin-a" is already registered');
   });
 
@@ -242,7 +242,7 @@ describe("runtime MCP server registration", () => {
     const { api, handlers } = createPi();
     mcpAdapter(api);
 
-    registerMcpServer(api, "early-plugin", { url: "https://early.test/mcp" });
+    registerMcpServer({ pi: api, name: "early-plugin", definition: { url: "https://early.test/mcp" } });
     await handlers.get("session_start")?.({}, {});
     await settle();
 
@@ -263,8 +263,8 @@ describe("runtime MCP server registration", () => {
     await handlers.get("session_start")?.({}, {});
     await settle();
 
-    registerMcpServer(api, "plugin-a", { url: "https://plugin.test/mcp" });
-    registerMcpServer(api, "plugin-b", { url: "https://plugin-b.test/mcp" });
+    registerMcpServer({ pi: api, name: "plugin-a", definition: { url: "https://plugin.test/mcp" } });
+    registerMcpServer({ pi: api, name: "plugin-b", definition: { url: "https://plugin-b.test/mcp" } });
 
     await handlers.get("session_start")?.({}, {});
     await settle();

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -659,6 +659,30 @@ describe("UiServer", () => {
       }, undefined);
     });
 
+    it("rejects invalid app tool arguments as a boundary error", async () => {
+      const mockClient = { callTool: vi.fn() };
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: mockClient,
+          tools: [{ name: "some_tool" }],
+        }),
+      });
+      handle = await startUiServer(createServerOptions({ manager }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "some_tool", arguments: [] },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ ok: false, error: 'tool "some_tool" arguments: expected a JSON object, got array' });
+      expect(mockClient.callTool).not.toHaveBeenCalled();
+    });
+
     it("executes app-only tools without recording their synthetic call intent", async () => {
       const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "app result" }] });
       const onMessage = vi.fn();

--- a/index.ts
+++ b/index.ts
@@ -887,6 +887,28 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           }
           return args as Record<string, unknown>;
         };
+        const validateNestedGatewayParams = (value: Record<string, unknown>): typeof params => {
+          for (const key of ["tool", "connect", "describe", "instructions", "search", "server", "action"] as const) {
+            if (value[key] !== undefined && typeof value[key] !== "string") {
+              throw new Error(`Invalid nested gateway param \`${key}\`: expected string, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
+            }
+          }
+          for (const key of ["regex", "includeSchemas"] as const) {
+            if (value[key] !== undefined && typeof value[key] !== "boolean") {
+              throw new Error(`Invalid nested gateway param \`${key}\`: expected boolean, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
+            }
+          }
+          for (const key of ["limit", "offset"] as const) {
+            if (value[key] !== undefined && typeof value[key] !== "number") {
+              throw new Error(`Invalid nested gateway param \`${key}\`: expected number, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
+            }
+          }
+          const args = value.args;
+          if (args !== undefined && typeof args !== "string" && (typeof args !== "object" || args === null || Array.isArray(args))) {
+            throw new Error(`Invalid nested gateway param \`args\`: expected JSON object or JSON string, got ${Array.isArray(args) ? "array" : args === null ? "null" : typeof args}`);
+          }
+          return value as typeof params;
+        };
         let parsedArgs = parseArgs(params.args);
         let dispatchParams = params;
         const hasGatewayMode = (value: typeof params): boolean =>
@@ -898,7 +920,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           || value.server !== undefined
           || value.action !== undefined;
         if (!hasGatewayMode(params) && parsedArgs) {
-          const nestedParams = parsedArgs as typeof params;
+          const nestedParams = validateNestedGatewayParams(parsedArgs);
           if (hasGatewayMode(nestedParams)) {
             dispatchParams = nestedParams;
             parsedArgs = parseArgs(nestedParams.args);
@@ -1051,7 +1073,8 @@ export function createMcpAdapter(options: McpAdapterOptions = {}) {
  * become visible at the next tool sync. To change a definition, dispose the
  * registration and register again.
  */
-export function registerMcpServer(pi: ExtensionAPI, name: string, definition: ServerEntry): McpServerRegistration {
+export function registerMcpServer(options: { pi: ExtensionAPI; name: string; definition: ServerEntry }): McpServerRegistration {
+  const { pi, name, definition } = options;
   const register = runtimeRegistrars.get(pi);
   if (!register) {
     throw new Error("pi-mcp-adapter is not installed for this Pi instance");

--- a/package-mcp-loader.ts
+++ b/package-mcp-loader.ts
@@ -56,15 +56,21 @@ function getConfiguredPackageRoots(cwd: string): string[] {
     [join(cwd, getConfigDirName(), "settings.json"), "project"],
     [join(getAgentDir(), "settings.json"), "user"],
   ] as const) {
-    const settings = readJson(settingsPath) as { packages?: unknown } | null;
-    if (!Array.isArray(settings?.packages)) continue;
-    for (const entry of settings.packages) {
+    const settings = readOptionalJson(settingsPath, `${scope} Pi settings`);
+    if (settings === undefined) continue;
+    if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+      throw new Error(`${scope} Pi settings ${settingsPath} must be a JSON object`);
+    }
+    const packages = (settings as { packages?: unknown }).packages;
+    if (packages === undefined) continue;
+    if (!Array.isArray(packages)) throw new Error(`${scope} Pi settings ${settingsPath} packages must be an array`);
+    for (const entry of packages) {
       const source = typeof entry === "string"
         ? entry
         : entry && typeof entry === "object" && !Array.isArray(entry) && typeof (entry as PackageSetting).source === "string"
           ? (entry as PackageSetting).source
           : undefined;
-      if (!source) continue;
+      if (!source) throw new Error(`${scope} Pi settings ${settingsPath} package entries must be strings or objects with a string source`);
       const root = resolvePackageRoot(source, scope, cwd);
       if (root && !roots.includes(root)) roots.push(root);
     }
@@ -93,7 +99,7 @@ function resolvePackageRoot(source: string, scope: "user" | "project", cwd: stri
 }
 
 function readPackageManifest(packageRoot: string): PackageManifest | null {
-  const manifest = readJson(join(packageRoot, "package.json"));
+  const manifest = readOptionalJson(join(packageRoot, "package.json"), `Pi package manifest ${packageRoot}`);
   return manifest && typeof manifest === "object" && !Array.isArray(manifest) ? manifest as PackageManifest : null;
 }
 
@@ -104,28 +110,35 @@ function getManifestMcpPaths(value: unknown, packageName: string): string[] | nu
 }
 
 function readMcpConfig(path: string, packageName: string): McpConfig | null {
-  const config = readJson(path);
+  const config = readRequiredJson(path, `Pi package ${packageName} MCP config`);
   if (!config || typeof config !== "object" || Array.isArray(config)) {
-    console.warn(`Pi package ${packageName} skips invalid MCP config ${path}`);
-    return null;
+    throw new Error(`Pi package ${packageName} MCP config ${path} must be a JSON object`);
   }
   const servers = (config as { mcpServers?: unknown }).mcpServers;
-  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return { mcpServers: {} };
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    throw new Error(`Pi package ${packageName} MCP config ${path} must contain a JSON object mcpServers field`);
+  }
   const mcpServers: Record<string, ServerEntry> = {};
   for (const [name, server] of Object.entries(servers)) {
-    if (server && typeof server === "object" && !Array.isArray(server)) {
-      mcpServers[name] = server as ServerEntry;
+    if (!server || typeof server !== "object" || Array.isArray(server)) {
+      throw new Error(`Pi package ${packageName} MCP config ${path} server ${name} must be a JSON object`);
     }
+    mcpServers[name] = server as ServerEntry;
   }
   return { mcpServers };
 }
 
-function readJson(path: string): unknown | null {
+function readRequiredJson(path: string, description: string): unknown {
   try {
     return JSON.parse(stripJsonComments(readFileSync(path, "utf8"), { trailingCommas: true }));
-  } catch {
-    return null;
+  } catch (error) {
+    throw new Error(`${description} ${path} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
   }
+}
+
+function readOptionalJson(path: string, description: string): unknown | undefined {
+  if (!existsSync(path)) return undefined;
+  return readRequiredJson(path, description);
 }
 
 function resolveContainedPath(root: string, path: string): string | null {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -8,15 +8,9 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const USE_PROCESS_GROUP = process.platform !== "win32";
 const CLEANUP_TOKEN_ENV = "PI_MCP_REQUEST_HEADERS_CLEANUP_TOKEN";
-// `ps axeww` dumps the full environment of every process on the host. On busy
-// machines that output exceeds spawnSync's default 1 MiB maxBuffer, which causes
-// Node to SIGTERM `ps` and report status === null. Raise the cap so process
-// discovery keeps working without spurious cleanup failures. Observed output
-// is ~1 MiB on a loaded dev machine (1000+ procs at ~1 KiB each); 8 MiB gives
-// ~8x headroom and covers a machine ~8x busier (or ~4x with heavy envs), which
-// is a realistic worst-case dev box. maxBuffer is a cap, not a pre-allocation:
-// Node grows the buffer to the actual output, so this costs ~0 unless `ps`
-// really emits that much.
+// Busy hosts can exceed spawnSync's 1 MiB default when `ps axeww` dumps each
+// process environment. Keep discovery below a bounded cap instead of letting
+// `ps` get SIGTERM'd and reporting a false cleanup failure.
 const PS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 function isNoSuchProcessError(error: unknown): boolean {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -436,9 +436,16 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           return;
         }
 
+        let normalizedArguments: Record<string, unknown>;
+        try {
+          normalizedArguments = normalizeToolArguments(callParams.arguments, `tool "${callParams.name}" arguments`);
+        } catch (error) {
+          sendJson(res, 400, { ok: false, error: error instanceof Error ? error.message : String(error) });
+          return;
+        }
         const callArgs = {
           name: callParams.name,
-          arguments: normalizeToolArguments(callParams.arguments, `tool "${callParams.name}" arguments`),
+          arguments: normalizedArguments,
         };
         const toolMeta = {
           name: callParams.name,

--- a/utils.ts
+++ b/utils.ts
@@ -315,8 +315,7 @@ export function normalizeToolArguments(
     );
   }
 
-  // JSON round-trip: keep only JSON-serializable plain data so embedded quotes
-  // are escaped at transport by JSON.stringify, never string-interpolated.
+  assertJsonSerializable(value, context);
   try {
     return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
   } catch (error) {
@@ -325,6 +324,32 @@ export function normalizeToolArguments(
       { cause: error },
     );
   }
+}
+
+function assertJsonSerializable(value: unknown, context: string, path = ""): void {
+  if (value === null) return;
+  if (typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${context}: value at ${path || "root"} is not a finite number`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) assertJsonSerializable(item, context, `${path}[${index}]`);
+    return;
+  }
+  if (typeof value === "object") {
+    if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+      throw new Error(`${context}: value at ${path || "root"} is not a plain JSON object`);
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new Error(`${context}: value at ${path || "root"} has symbol keys`);
+    }
+    for (const [key, item] of Object.entries(value)) {
+      assertJsonSerializable(item, context, path ? `${path}.${key}` : key);
+    }
+    return;
+  }
+  throw new Error(`${context}: value at ${path || "root"} is not JSON-serializable`);
 }
 
 export function formatAuthRequiredMessage(


### PR DESCRIPTION
## Summary

This hardens the unreleased MCP adapter boundary changes found during the deslop and TypeScript quality audit.

It changes the unreleased runtime registration API to object parameters, validates nested gateway arguments before dispatch, fails loudly for malformed package MCP config, rejects lossy tool argument normalization, and maps UI tool argument validation failures to HTTP 400.

## Validation

- `npm test -- __tests__/config.test.ts __tests__/index-lifecycle.test.ts __tests__/runtime-register.test.ts __tests__/lifecycle-lazy-keep-alive.test.ts __tests__/server-manager-sampling.test.ts __tests__/request-headers-command.test.ts __tests__/direct-tools.test.ts __tests__/ui-server.test.ts`
- `npm run typecheck`
- `git diff --check && git diff --cached --check`
- Fresh review passed with no findings.