### PR TITLE
fix(oauth): release idle callback listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
+- Released the OAuth callback listener after idle auth flows and kept MCP pickers hidden while nested OAuth input is active. Thanks to [@trevorleibert-mixpanel](https://github.com/trevorleibert-mixpanel) for PRs #403 and #404.
 - Raised the `ps` `maxBuffer` for request-header command cleanup so the full `ps axeww` process-discovery scan no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures. Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.
 - Kept slow but healthy remote keep-alive servers from being marked failed when a bounded tools/list refresh times out. Thanks to [@brightmeowso](https://github.com/brightmeowso) for #400.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
+  createMcpPanel: vi.fn(),
   removeAuth: vi.fn(),
 }));
 
@@ -9,6 +10,10 @@ vi.mock("../mcp-auth-flow.ts", () => ({
   authenticate: mocks.authenticate,
   removeAuth: mocks.removeAuth,
   supportsOAuth: (definition: { url?: string; auth?: string }) => Boolean(definition.url) && definition.auth !== "bearer",
+}));
+
+vi.mock("../mcp-panel.ts", () => ({
+  createMcpPanel: mocks.createMcpPanel,
 }));
 
 vi.mock("../init.ts", () => ({
@@ -38,6 +43,58 @@ describe("authenticateServer", () => {
 
     expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
     expect(ui.custom).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["openMcpPanel", "success"],
+    ["openMcpAuthPanel", "success"],
+    ["openMcpAuthPanel", "failure"],
+  ] as const)("%s restores the hidden picker after OAuth %s", async (command, outcome) => {
+    let finishAuthentication!: () => void;
+    let markAuthenticationStarted!: () => void;
+    const authenticationStarted = new Promise<void>((resolve) => { markAuthenticationStarted = resolve; });
+    const hidden = vi.fn();
+    const focus = vi.fn();
+    mocks.authenticate.mockImplementationOnce(async () => {
+      expect(hidden).toHaveBeenCalledWith(true);
+      markAuthenticationStarted();
+      await new Promise<void>((resolve) => { finishAuthentication = resolve; });
+      if (outcome === "failure") throw new Error("authentication failed");
+      return "authenticated";
+    });
+    mocks.createMcpPanel.mockImplementationOnce((_config, _cache, _provenance, callbacks, _tui, done) => ({
+      render: () => [],
+      invalidate: () => {},
+      handleInput: () => {
+        void callbacks.authenticate("sentry").then(() => done({ cancelled: true, changes: new Map() }));
+      },
+    }));
+    const ui = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      custom: vi.fn((factory, options) => {
+        const panel = factory({ requestRender: vi.fn() }, undefined, undefined, vi.fn());
+        options.onHandle({ setHidden: hidden, focus });
+        panel.handleInput("\r");
+      }),
+    };
+    const commands = await import("../commands.ts");
+
+    const panel = commands[command]({
+      programmaticConfig: false,
+      config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+      authStorageOptions: {},
+      manager: { getConnection: () => undefined },
+      failureTracker: new Map(),
+      failureMessages: new Map(),
+    } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any);
+
+    await authenticationStarted;
+    finishAuthentication();
+    await panel;
+
+    expect(hidden.mock.calls).toEqual([[true], [false]]);
+    expect(focus).toHaveBeenCalledOnce();
   });
 
   it("interpolates the server URL before OAuth authentication", async () => {
@@ -132,7 +189,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the OAuth URL as one terminal hyperlink and accepts a pasted remote callback", async () => {
+  it("puts the OAuth link in the paste prompt without a confirmation", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
     const inputController = new AbortController();
@@ -166,21 +223,33 @@ describe("authenticateServer", () => {
         onAuthorizationInput: expect.any(Function),
       },
     );
-    expect(ui.notify).toHaveBeenCalledWith(
-      expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
-      "info",
-    );
-    expect(ui.confirm).toHaveBeenCalledWith(
-      "Authorize sentry",
-      expect.stringContaining(authorizationUrl),
-      { signal: inputController.signal },
-    );
+    expect(ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(authorizationUrl), "info");
+    expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
-      "Complete sentry OAuth",
-      "Paste the full callback URL",
+      expect.stringContaining(
+        `\u001B]8;;${authorizationUrl}\u001B\\OPEN AUTHORIZATION PAGE ↗\u001B]8;;\u001B\\\n${authorizationUrl}`,
+      ),
+      undefined,
       { signal: inputController.signal },
     );
-    expect(ui.confirm.mock.invocationCallOrder[0]).toBeLessThan(ui.input.mock.invocationCallOrder[0]);
+  });
+
+  it("does not open paste input when authorization was already cancelled", async () => {
+    const inputController = new AbortController();
+    inputController.abort();
+    mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
+      expect(await options.onAuthorizationInput("https://auth.example.com/authorize", inputController.signal)).toBeUndefined();
+      return "cancelled";
+    });
+    const ui = { notify: vi.fn(), setStatus: vi.fn(), confirm: vi.fn(), input: vi.fn() };
+    const { authenticateServer } = await import("../commands.ts");
+
+    await authenticateServer("sentry", {
+      mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } },
+    }, { hasUI: true, mode: "tui", ui } as any);
+
+    expect(ui.input).not.toHaveBeenCalled();
+    expect(ui.confirm).not.toHaveBeenCalled();
   });
 
   it("blocks bearer token set because the extension UI has no masked secret input", async () => {

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   waitForCallback: vi.fn(),
   cancelPendingCallback: vi.fn(),
   stopCallbackServer: vi.fn(),
+  stopCallbackServerIfIdle: vi.fn(),
   reserveCallbackServer: vi.fn(),
   releaseCallbackServer: vi.fn(),
   open: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock("../mcp-callback-server.ts", () => ({
   waitForCallback: mocks.waitForCallback,
   cancelPendingCallback: mocks.cancelPendingCallback,
   stopCallbackServer: mocks.stopCallbackServer,
+  stopCallbackServerIfIdle: mocks.stopCallbackServerIfIdle,
   reserveCallbackServer: mocks.reserveCallbackServer,
   releaseCallbackServer: mocks.releaseCallbackServer,
 }));
@@ -57,6 +59,7 @@ describe("mcp-auth-flow explicit auth", () => {
     mocks.waitForCallback.mockReset();
     mocks.cancelPendingCallback.mockReset();
     mocks.stopCallbackServer.mockReset();
+    mocks.stopCallbackServerIfIdle.mockReset().mockResolvedValue(false);
     mocks.reserveCallbackServer.mockReset();
     mocks.releaseCallbackServer.mockReset();
     mocks.open.mockReset();
@@ -73,6 +76,28 @@ describe("mcp-auth-flow explicit auth", () => {
     } else {
       process.env.MCP_OAUTH_DIR = originalOAuthDir;
     }
+  });
+
+  it("releases the idle callback server when startAuth is immediately authorized", async () => {
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    await expect(startAuth("cached", "https://api.example.com/mcp", { auth: "oauth" }))
+      .resolves.toEqual({ authorizationUrl: "" });
+
+    expect(mocks.releaseCallbackServer).toHaveBeenCalledOnce();
+    expect(mocks.stopCallbackServerIfIdle).toHaveBeenCalledOnce();
+  });
+
+  it("releases the idle callback server when callback startup fails", async () => {
+    mocks.ensureCallbackServer.mockRejectedValueOnce(new Error("callback bind failed"));
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    await expect(startAuth("bind-failure", "https://api.example.com/mcp", { auth: "oauth" }))
+      .rejects.toThrow("callback bind failed");
+
+    expect(mocks.releaseCallbackServer).toHaveBeenCalledOnce();
+    expect(mocks.stopCallbackServerIfIdle).toHaveBeenCalledOnce();
+    expect(mocks.sdkAuth).not.toHaveBeenCalled();
   });
 
   it("parses manual OAuth redirect URL and code input", async () => {
@@ -218,6 +243,32 @@ describe("mcp-auth-flow explicit auth", () => {
     )).rejects.toThrow("does not match the discovered issuer");
 
     expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the idle callback server when stored-state cleanup fails", async () => {
+    let oauthState = "";
+    mocks.sdkAuth.mockImplementation(async (provider, options) => {
+      if (options.authorizationCode) throw new Error("token exchange failed");
+      oauthState = await provider.state();
+      await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));
+      return "REDIRECT";
+    });
+    const { completeAuthFromInput, startAuth } = await import("../mcp-auth-flow.ts");
+    await startAuth("cleanup-storage-failure", "https://api.example.com/mcp", { auth: "oauth" });
+    mocks.stopCallbackServerIfIdle.mockClear();
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+
+    try {
+      await expect(completeAuthFromInput(
+        "cleanup-storage-failure",
+        `code=auth-code&state=${oauthState}`,
+      )).rejects.toThrow("OAuth completion cleanup failed");
+    } finally {
+      process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "memory";
+    }
+
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(oauthState);
+    expect(mocks.stopCallbackServerIfIdle).toHaveBeenCalledOnce();
   });
 
   it("does not start the callback server during OAuth initialization", async () => {

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -230,6 +230,86 @@ describe("mcp-callback-server", () => {
     expect(mocks.runtime.servers).toHaveLength(2);
   });
 
+  it("waits for idle shutdown before starting a new callback server", async () => {
+    const {
+      ensureCallbackServer,
+      isCallbackServerRunning,
+      stopCallbackServerIfIdle,
+    } = await import("../mcp-callback-server.ts");
+    await ensureCallbackServer();
+    let finishClose: (() => void) | undefined;
+    mocks.runtime.servers[0].close.mockImplementation((callback?: () => void) => {
+      finishClose = callback;
+    });
+
+    const stopping = stopCallbackServerIfIdle();
+    const restarting = ensureCallbackServer({ reserveState: true, oauthState: "new-flow" });
+    expect(mocks.runtime.servers).toHaveLength(1);
+
+    finishClose?.();
+    await stopping;
+    await restarting;
+
+    expect(isCallbackServerRunning()).toBe(true);
+    expect(mocks.runtime.servers).toHaveLength(2);
+    await expect(ensureCallbackServer({ callbackPath: "/other/callback" }))
+      .rejects.toThrow(/cannot be switched while authorizations are pending/);
+  });
+
+  it("forced shutdown revokes a restart waiting on idle shutdown", async () => {
+    const {
+      ensureCallbackServer,
+      isCallbackServerRunning,
+      stopCallbackServer,
+      stopCallbackServerIfIdle,
+    } = await import("../mcp-callback-server.ts");
+    await ensureCallbackServer();
+    let finishClose: (() => void) | undefined;
+    mocks.runtime.servers[0].close.mockImplementation((callback?: () => void) => {
+      finishClose = callback;
+    });
+
+    const idleStopping = stopCallbackServerIfIdle();
+    const restarting = ensureCallbackServer({ reserveState: true, oauthState: "stopped-flow" });
+    const restartResult = expect(restarting).rejects.toThrow("OAuth callback server stopped");
+    const forcedStopping = stopCallbackServer();
+
+    finishClose?.();
+    await Promise.all([idleStopping, forcedStopping]);
+    await restartResult;
+
+    expect(isCallbackServerRunning()).toBe(false);
+    expect(mocks.runtime.servers).toHaveLength(1);
+  });
+
+  it("does not stop while a concurrent bind is reserving callback state", async () => {
+    const {
+      ensureCallbackServer,
+      isCallbackServerRunning,
+      stopCallbackServerIfIdle,
+    } = await import("../mcp-callback-server.ts");
+    await ensureCallbackServer();
+
+    let finishRebind: (() => void) | undefined;
+    mocks.runtime.listenImpl = (_server, _port, _host, onListen) => {
+      finishRebind = onListen;
+    };
+    const rebinding = ensureCallbackServer({
+      strictPort: true,
+      reserveState: true,
+      oauthState: "concurrent-state",
+    });
+
+    await stopCallbackServerIfIdle();
+    finishRebind?.();
+    await rebinding;
+
+    expect(isCallbackServerRunning()).toBe(true);
+    expect(mocks.runtime.servers[1]?.close).not.toHaveBeenCalled();
+    await expect(ensureCallbackServer({ callbackPath: "/other/callback" }))
+      .rejects.toThrow(/cannot be switched while authorizations are pending/);
+  });
+
   it("rebinds to the configured port when strict mode is requested", async () => {
     const { ensureCallbackServer } = await import("../mcp-callback-server.ts");
 
@@ -328,5 +408,31 @@ describe("mcp-callback-server", () => {
 
     cancelPendingCallback("pending-state");
     await expect(pending).rejects.toThrow(/Authorization cancelled/);
+  });
+
+  it("stops only when no pending or reserved auth state remains", async () => {
+    const {
+      ensureCallbackServer,
+      reserveCallbackServer,
+      releaseCallbackServer,
+      waitForCallback,
+      cancelPendingCallback,
+      isCallbackServerRunning,
+      stopCallbackServerIfIdle,
+    } = await import("../mcp-callback-server.ts");
+
+    await ensureCallbackServer();
+    reserveCallbackServer("reserved-state");
+    await stopCallbackServerIfIdle();
+    expect(isCallbackServerRunning()).toBe(true);
+
+    releaseCallbackServer("reserved-state");
+    const pending = waitForCallback("pending-state");
+    await stopCallbackServerIfIdle();
+    expect(isCallbackServerRunning()).toBe(true);
+    cancelPendingCallback("pending-state");
+    await expect(pending).rejects.toThrow(/Authorization cancelled/);
+    await stopCallbackServerIfIdle();
+    expect(isCallbackServerRunning()).toBe(false);
   });
 });

--- a/commands.ts
+++ b/commands.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
 import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCallbacks, type McpPanelResult, type ImportKind } from "./types.ts";
 import {
@@ -288,25 +289,14 @@ export async function authenticateServer(
     const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
     const status = await authenticate(serverName, serverUrl, definition, {
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
-      onAuthorizationUrl: (authorizationUrl) => {
-        ui.notify(
-          `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving, Pi will complete automatically if the browser can reach its localhost callback. " +
-          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi.",
-          "info"
-        );
-      },
+      onAuthorizationUrl: () => {},
       onAuthorizationInput: async (authorizationUrl, inputSignal) => {
-        const readyToPaste = await ui.confirm(
-          `Authorize ${serverName}`,
-          `Open this link in your browser:\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving access, select Yes to paste the callback URL.",
-          { signal: inputSignal },
-        );
-        if (!readyToPaste || inputSignal.aborted) return undefined;
+        if (inputSignal.aborted) return undefined;
         return ui.input(
-          `Complete ${serverName} OAuth`,
-          "Paste the full callback URL",
+          `Complete ${serverName} OAuth\n\n` +
+            `${terminalHyperlink("OPEN AUTHORIZATION PAGE ↗", authorizationUrl)}\n${authorizationUrl}\n\n` +
+            "Approve access, then paste the full localhost callback URL below.",
+          undefined,
           { signal: inputSignal },
         );
       },
@@ -554,6 +544,7 @@ function buildMcpPanelCallbacks(
   state: McpExtensionState,
   config: McpConfig,
   ctx: ExtensionContext,
+  getOverlayHandle?: () => OverlayHandle | undefined,
 ): McpPanelCallbacks {
   // Panel-only diagnostics keep status inspection from mutating connection
   // failure state while allowing the existing panel failure UI to show why the
@@ -566,7 +557,16 @@ function buildMcpPanelCallbacks(
       const definition = config.mcpServers[serverName];
       return definition ? !isServerDisabled(definition) && supportsOAuth(definition) : false;
     },
-    authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
+    authenticate: async (serverName: string) => {
+      const overlay = getOverlayHandle?.();
+      overlay?.setHidden(true);
+      try {
+        return await authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime);
+      } finally {
+        overlay?.setHidden(false);
+        overlay?.focus();
+      }
+    },
     getConnectionStatus: (serverName: string) => {
       authStatusFailures.delete(serverName);
       const definition = config.mcpServers[serverName];
@@ -635,7 +635,8 @@ export async function openMcpPanel(
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
   const { lines: noticeLines, fingerprint } = buildSharedConfigNoticeLines(configPath, ctx.cwd);
 
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
 
   const { createMcpPanel } = await import("./mcp-panel.ts");
   let configChanged = false;
@@ -661,7 +662,11 @@ export async function openMcpPanel(
           });
         }, { noticeLines, keybindings });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 
@@ -700,7 +705,8 @@ export async function openMcpAuthPanel(
   const cache = loadMetadataCache();
   const configPath = pi.getFlag("mcp-config") as string | undefined ?? configOverridePath;
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
   const { createMcpPanel } = await import("./mcp-panel.ts");
 
   await new Promise<void>((resolve) => {
@@ -715,7 +721,11 @@ export async function openMcpAuthPanel(
           noticeLines: ["Select an OAuth MCP server and press Enter or ctrl+a to authenticate."],
         });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -18,6 +18,7 @@ import {
   waitForCallback,
   cancelPendingCallback,
   stopCallbackServer,
+  stopCallbackServerIfIdle,
   releaseCallbackServer,
 } from "./mcp-callback-server.ts"
 import {
@@ -387,7 +388,7 @@ export async function startAuth(
   } catch (error) {
     releaseCallbackServer(oauthState)
     try {
-      await clearOAuthState(serverName, authStorageOptions)
+      await cleanupAndReleaseCallbackServerIfIdle(() => clearOAuthState(serverName, authStorageOptions))
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -429,6 +430,7 @@ export async function startAuth(
       authProvider.deactivate()
       releaseCallbackServer(oauthState)
       await clearOAuthState(serverName, authStorageOptions)
+      await stopCallbackServerIfIdle()
       return { authorizationUrl: "" }
     }
     if (!capturedUrl) {
@@ -439,7 +441,7 @@ export async function startAuth(
   } catch (error) {
     authProvider.deactivate()
     try {
-      await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+      await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -463,7 +465,7 @@ async function setPendingAuth(
   state.pendingAuths.set(key, pendingAuth)
   state.pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+    void clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
       console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
     })
   }, MANUAL_AUTH_TIMEOUT_MS)
@@ -496,6 +498,37 @@ async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oa
       await clearOAuthState(serverName, authStorageOptions)
     }
   }
+}
+
+async function clearPendingAuthAndReleaseIfIdle(
+  runtime: McpOAuthRuntime,
+  serverName: string,
+  oauthState: string | undefined,
+  fallbackStorageOptions: AuthStorageOptions = {},
+): Promise<void> {
+  await cleanupAndReleaseCallbackServerIfIdle(
+    () => clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions),
+  )
+}
+
+async function cleanupAndReleaseCallbackServerIfIdle(cleanup: () => void | Promise<void>): Promise<void> {
+  let cleanupFailure: { error: unknown } | undefined
+  try {
+    await cleanup()
+  } catch (error) {
+    cleanupFailure = { error }
+  }
+
+  try {
+    await stopCallbackServerIfIdle()
+  } catch (releaseError) {
+    if (cleanupFailure) {
+      throw new AggregateError([cleanupFailure.error, releaseError], "OAuth callback cleanup failed")
+    }
+    throw releaseError
+  }
+
+  if (cleanupFailure) throw cleanupFailure.error
 }
 
 function getSearchParamsFromInput(input: string): URLSearchParams | undefined {
@@ -701,7 +734,7 @@ export async function completeAuth(
   } finally {
     if (!keepPendingForRetry) {
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         if (caughtError !== undefined) {
           throw new AggregateError([caughtError, cleanupError], "OAuth completion cleanup failed")
@@ -801,7 +834,7 @@ export async function authenticate(
     } catch (error) {
       if (oauthState) cancelPendingCallback(oauthState)
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         throw new AggregateError([error, cleanupError], "OAuth cancellation cleanup failed")
       }
@@ -922,7 +955,7 @@ export async function removeAuth(serverName: string, options: AuthenticateOption
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+  await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
   throwIfAborted(signal)
   clearAllCredentials(serverName, authStorageOptions)
   await clearOAuthState(serverName, authStorageOptions)

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -180,6 +180,7 @@ interface PendingAuth {
 let server: Server | undefined
 let bindingPromise: Promise<void> | undefined
 let stoppingPromise: Promise<void> | undefined
+let restartableStoppingPromise: Promise<void> | undefined
 let callbackGeneration = 0
 const pendingAuths = new Map<string, PendingAuth>()
 const reservedAuthStates = new Set<string>()
@@ -288,10 +289,16 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
  * If strictPort is false, asks the OS for an available local port.
  */
 export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
-  if (stoppingPromise) {
-    throw new Error("OAuth callback server stopped")
-  }
   const generation = callbackGeneration
+  if (stoppingPromise) {
+    if (!restartableStoppingPromise) {
+      throw new Error("OAuth callback server stopped")
+    }
+    await restartableStoppingPromise
+    if (generation !== callbackGeneration) {
+      throw new Error("OAuth callback server stopped")
+    }
+  }
   while (bindingPromise) {
     await bindingPromise
     if (generation !== callbackGeneration) {
@@ -455,7 +462,11 @@ export function cancelPendingCallback(oauthState: string): void {
  * Stop the callback server and reject all pending authorizations.
  */
 export function stopCallbackServer(): Promise<void> {
-  if (stoppingPromise) return stoppingPromise
+  if (stoppingPromise) {
+    restartableStoppingPromise = undefined
+    callbackGeneration += 1
+    return stoppingPromise
+  }
 
   callbackGeneration += 1
   const cleanup = (async () => {
@@ -492,6 +503,19 @@ export function stopCallbackServer(): Promise<void> {
     if (stoppingPromise === operation) stoppingPromise = undefined
   })
   stoppingPromise = operation
+  return operation
+}
+
+/** Stop the callback server only when no bind or authorization owns it. */
+export function stopCallbackServerIfIdle(): Promise<void> {
+  if (stoppingPromise) return stoppingPromise
+  if (bindingPromise || !server || pendingAuths.size > 0 || reservedAuthStates.size > 0) {
+    return Promise.resolve()
+  }
+  const operation = stopCallbackServer().finally(() => {
+    if (restartableStoppingPromise === operation) restartableStoppingPromise = undefined
+  })
+  restartableStoppingPromise = operation
   return operation
 }
 


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #403 and #404.

It keeps the accepted user-facing behavior from both contributor PRs, with one lifecycle fix added during review:

- release the OAuth callback listener when an auth flow is truly idle
- avoid closing a listener or clearing state owned by a concurrent bind/reservation
- release the listener on immediate `AUTHORIZED` and startup-failure paths
- open remote/headless callback paste input directly with the auth URL in the prompt
- hide `/mcp` and `/mcp-auth` pickers while nested OAuth UI is active, then restore focus

Thanks to [@trevorleibert-mixpanel](https://github.com/trevorleibert-mixpanel) for #403 and #404.

## Validation

- `npm test -- __tests__/commands-auth.test.ts __tests__/mcp-callback-server-unref.test.ts __tests__/mcp-auth-flow-client-credentials.test.ts`
- `PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test --test-concurrency=1 mcp-auth-flow.test.ts mcp-callback-server.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review and targeted follow-up review passed.

Supersedes #403 and #404 after merge.