### PR TITLE
fix: suppress Node 24 mcpScript FD warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,17 @@ jobs:
       - run: npm run test:oauth
       - run: npm run test:conformance
       - run: npm pack --dry-run
+
+  node24-worker-fds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+      - run: npm test -- --run __tests__/mcp-code.test.ts

--- a/__tests__/fixtures/mcp-code-fd-runner.ts
+++ b/__tests__/fixtures/mcp-code-fd-runner.ts
@@ -1,0 +1,17 @@
+import { runMcpScript } from "../../mcp-code.ts";
+import type { McpExtensionState } from "../../state.ts";
+
+const state = {
+  owner: undefined,
+  toolMetadata: new Map(),
+  config: { settings: {} },
+} as unknown as McpExtensionState;
+
+for (let index = 0; index < 32; index += 1) {
+  const result = await runMcpScript(state, 'emit("ok")', 5_000);
+  if (result.details.error) {
+    throw new Error(`mcpScript failed: ${JSON.stringify(result.details)}`);
+  }
+}
+
+process.stdout.write("completed 32 mcpScript workers\n");

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -1,3 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { createMcpAdapter } from "../index.ts";
@@ -6,7 +8,9 @@ import { McpServerManager } from "../server-manager.ts";
 import type { McpExtensionState } from "../state.ts";
 import { MCP_TOOL_APPROVAL_REQUEST_EVENT, type McpToolApprovalRequest } from "../types.ts";
 
+const execFileAsync = promisify(execFile);
 const fixture = fileURLToPath(new URL("./fixtures/mcp-code-server.mjs", import.meta.url));
+const fdRunner = fileURLToPath(new URL("./fixtures/mcp-code-fd-runner.ts", import.meta.url));
 const definition = { command: process.execPath, args: [fixture] };
 let manager: McpServerManager;
 let state: McpExtensionState;
@@ -49,6 +53,24 @@ describe("runMcpScript", () => {
     expect(registerTool).toHaveBeenCalled();
     expect(registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcpScript" }));
   });
+
+  it.runIf(Number.parseInt(process.versions.node, 10) >= 24)(
+    "does not emit unmanaged file descriptor warnings",
+    async () => {
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", fdRunner],
+        {
+          env: { ...process.env, NODE_OPTIONS: "--trace-warnings" },
+          maxBuffer: 1024 * 1024,
+        },
+      );
+
+      expect(stdout).toContain("completed 32 mcpScript workers");
+      expect(stderr).not.toMatch(/File descriptor \d+ (?:closed but not opened|opened .* twice) in unmanaged mode/);
+    },
+    30_000,
+  );
 
   beforeAll(async () => {
     manager = new McpServerManager();

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -249,6 +249,10 @@ export async function runMcpScript(
     worker = new Worker(new URL("./mcp-script-worker.mjs", import.meta.url), {
       workerData: { code },
       env: {},
+      // The sandbox cannot open files, and the host always terminates this worker.
+      // Disable Node's unmanaged FD bookkeeping, which emits false warnings when
+      // short-lived workers are terminated on Node 24.
+      trackUnmanagedFds: false,
     });
     const activeWorker = worker;
     const execution = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Why

On Node 24, repeatedly running `mcpScript` emits warnings such as:

```
Warning: File descriptor 22 closed but not opened in unmanaged mode
Warning: File descriptor 22 opened in unmanaged mode twice
```

Each script runs in a short-lived worker. Node's unmanaged file descriptor bookkeeping races with worker termination, even though the worker sandbox cannot open files through `process`, `require`, or other host globals.

## What changed

- Disable unmanaged file descriptor tracking for the `mcpScript` worker. The host still explicitly terminates every worker.
- Add a Node 24 regression test that runs 32 workers in a subprocess and rejects unmanaged file descriptor warnings on stderr.
- Run the focused worker test under Node 24 in CI. The existing CI job remains on Node 22.

Without the worker option, the new regression test consistently fails on Node 24.16.0. With it, the focused test and the full 1,217-test suite pass without the warnings.
