### PR TITLE
fix(oauth): recover fresh Linux keyrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
+- Recovered missing, expired, and rejected Linux session keyrings through the existing `keyctl` helper, preserved actionable secure-store startup errors during OAuth cleanup, and stopped labeling Bearer-challenged 401 endpoints as non-MCP.
 - Raised the `ps` `maxBuffer` for request-header command cleanup so the full `ps axeww` process-discovery scan no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures. Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.
 - Kept slow but healthy remote keep-alive servers from being marked failed when a bounded tools/list refresh times out. Thanks to [@brightmeowso](https://github.com/brightmeowso) for #400.
 - Reused one selector candidate index while reconstructing filtered cached metadata, avoiding repeated scans of large cached catalogs at startup.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ If Pi is running on a remote server, `/mcp-auth <server>` shows a clickable auth
 
 The same flow is available through the proxy tool for non-interactive clients. Persistent OAuth still requires an available OS credential store; on headless Linux that usually means an unlocked Secret Service/libsecret keyring. The adapter fails closed instead of falling back to plaintext credentials when the secure store is unavailable.
 
-On Linux, if credential access fails because Pi inherited a revoked session keyring, the adapter uses a best-effort recovery path through `keyctl session - node <packaged helper>` so explicit re-authentication can write fresh credentials without killing a long-lived tmux server. This path requires `keyctl` and `node` on `PATH`; missing, locked, or otherwise unavailable credential stores still fail closed.
+On Linux, if credential access fails because Pi inherited a missing, expired, rejected, or revoked session keyring, the adapter uses a best-effort recovery path through `keyctl session - node <packaged helper>` so explicit re-authentication can write fresh credentials without killing a long-lived tmux server. This path requires `keyctl` (provided by the `keyutils` package) and `node` on `PATH`; locked or otherwise unavailable credential stores still fail closed.
 
 ```js
 mcp({ action: "auth-start", server: "linear-server" })

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -189,7 +189,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the OAuth URL as a terminal hyperlink in the notify, then opens the paste input directly (no redundant confirm)", async () => {
+  it("puts the OAuth link at the top of the paste prompt instead of the chat transcript", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
     const inputController = new AbortController();
@@ -223,17 +223,13 @@ describe("authenticateServer", () => {
         onAuthorizationInput: expect.any(Function),
       },
     );
-    expect(ui.notify).toHaveBeenCalledWith(
-      expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
-      "info",
-    );
-    // The pre-existing Yes/No confirm was redundant: onAuthorizationUrl
-    // already surfaced the clickable link. Skipping it lets the user paste
-    // and press Enter in one step.
+    expect(ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(authorizationUrl), "info");
     expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
-      "Complete sentry OAuth",
-      "Paste the full callback URL from your browser",
+      expect.stringContaining(
+        `\u001B]8;;${authorizationUrl}\u001B\\OPEN AUTHORIZATION PAGE ↗\u001B]8;;\u001B\\\n${authorizationUrl}`,
+      ),
+      undefined,
       { signal: inputController.signal },
     );
   });

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
+  createMcpPanel: vi.fn(),
   removeAuth: vi.fn(),
 }));
 
@@ -9,6 +10,10 @@ vi.mock("../mcp-auth-flow.ts", () => ({
   authenticate: mocks.authenticate,
   removeAuth: mocks.removeAuth,
   supportsOAuth: (definition: { url?: string; auth?: string }) => Boolean(definition.url) && definition.auth !== "bearer",
+}));
+
+vi.mock("../mcp-panel.ts", () => ({
+  createMcpPanel: mocks.createMcpPanel,
 }));
 
 vi.mock("../init.ts", () => ({
@@ -39,6 +44,58 @@ describe("authenticateServer", () => {
     expect(ui.notify).toHaveBeenCalledWith("No OAuth-capable MCP servers are configured.", "warning");
     expect(ui.custom).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["openMcpPanel", "success"],
+    ["openMcpAuthPanel", "success"],
+    ["openMcpAuthPanel", "failure"],
+  ] as const)(
+    "%s restores the hidden picker after OAuth %s",
+    async (command, outcome) => {
+      let finishAuthentication!: () => void;
+      const hidden = vi.fn();
+      const focus = vi.fn();
+      mocks.authenticate.mockImplementationOnce(async () => {
+        expect(hidden).toHaveBeenCalledWith(true);
+        await new Promise<void>((resolve) => { finishAuthentication = resolve; });
+        if (outcome === "failure") throw new Error("authentication failed");
+        return "authenticated";
+      });
+      mocks.createMcpPanel.mockImplementationOnce((_config, _cache, _provenance, callbacks, _tui, done) => ({
+        render: () => [],
+        invalidate: () => {},
+        handleInput: () => {
+          void callbacks.authenticate("sentry").then(() => done({ cancelled: true, changes: new Map() }));
+        },
+      }));
+      const ui = {
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+        custom: vi.fn((factory, options) => {
+          const panel = factory({ requestRender: vi.fn() }, undefined, undefined, vi.fn());
+          options.onHandle({ setHidden: hidden, focus });
+          panel.handleInput("\r");
+        }),
+      };
+      const commands = await import("../commands.ts");
+
+      const panel = commands[command]({
+        programmaticConfig: false,
+        config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+        authStorageOptions: {},
+        manager: { getConnection: () => undefined },
+        failureTracker: new Map(),
+        failureMessages: new Map(),
+      } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any);
+
+      await vi.waitFor(() => expect(hidden).toHaveBeenCalledWith(true));
+      finishAuthentication();
+      await panel;
+
+      expect(hidden.mock.calls).toEqual([[true], [false]]);
+      expect(focus).toHaveBeenCalledOnce();
+    },
+  );
 
   it("interpolates the server URL before OAuth authentication", async () => {
     const originalUrl = process.env.MCP_AUTH_URL;

--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -132,7 +132,7 @@ describe("authenticateServer", () => {
     );
   });
 
-  it("surfaces the OAuth URL as one terminal hyperlink and accepts a pasted remote callback", async () => {
+  it("surfaces the OAuth URL as a terminal hyperlink in the notify, then opens the paste input directly (no redundant confirm)", async () => {
     const authorizationUrl = "https://auth.example.com/authorize?resource=https%3A%2F%2Fmcp.sentry.dev%2Fmcp";
     const callbackUrl = "http://localhost:3118/callback?code=code&state=state";
     const inputController = new AbortController();
@@ -170,17 +170,42 @@ describe("authenticateServer", () => {
       expect.stringContaining(`\u001B]8;;${authorizationUrl}\u001B\\${authorizationUrl}\u001B]8;;\u001B\\`),
       "info",
     );
-    expect(ui.confirm).toHaveBeenCalledWith(
-      "Authorize sentry",
-      expect.stringContaining(authorizationUrl),
-      { signal: inputController.signal },
-    );
+    // The pre-existing Yes/No confirm was redundant: onAuthorizationUrl
+    // already surfaced the clickable link. Skipping it lets the user paste
+    // and press Enter in one step.
+    expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
       "Complete sentry OAuth",
-      "Paste the full callback URL",
+      "Paste the full callback URL from your browser",
       { signal: inputController.signal },
     );
-    expect(ui.confirm.mock.invocationCallOrder[0]).toBeLessThan(ui.input.mock.invocationCallOrder[0]);
+  });
+
+  it("skips the paste input entirely when the auth flow was aborted before onAuthorizationInput fired", async () => {
+    const authorizationUrl = "https://auth.example.com/authorize";
+    const inputController = new AbortController();
+    inputController.abort();
+    mocks.authenticate.mockImplementationOnce(async (_name, _url, _definition, options) => {
+      const input = await options.onAuthorizationInput(authorizationUrl, inputController.signal);
+      expect(input).toBeUndefined();
+      return "cancelled";
+    });
+    const ui = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      confirm: vi.fn(),
+      input: vi.fn(),
+    };
+    const { authenticateServer } = await import("../commands.ts");
+
+    await authenticateServer("sentry", {
+      mcpServers: {
+        sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" },
+      },
+    }, { hasUI: true, mode: "tui", ui } as any);
+
+    expect(ui.input).not.toHaveBeenCalled();
+    expect(ui.confirm).not.toHaveBeenCalled();
   });
 
   it("blocks bearer token set because the extension UI has no masked secret input", async () => {

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   stopCallbackServer: vi.fn(),
   reserveCallbackServer: vi.fn(),
   releaseCallbackServer: vi.fn(),
+  isCallbackServerRunning: vi.fn(() => false),
+  isCallbackServerIdle: vi.fn(() => true),
   open: vi.fn(),
   sdkAuth: vi.fn(),
   fetch: vi.fn(),
@@ -39,6 +41,8 @@ vi.mock("../mcp-callback-server.ts", () => ({
   stopCallbackServer: mocks.stopCallbackServer,
   reserveCallbackServer: mocks.reserveCallbackServer,
   releaseCallbackServer: mocks.releaseCallbackServer,
+  isCallbackServerRunning: mocks.isCallbackServerRunning,
+  isCallbackServerIdle: mocks.isCallbackServerIdle,
 }));
 
 vi.mock("open", () => ({
@@ -59,6 +63,11 @@ describe("mcp-auth-flow explicit auth", () => {
     mocks.stopCallbackServer.mockReset();
     mocks.reserveCallbackServer.mockReset();
     mocks.releaseCallbackServer.mockReset();
+    // Default the callback server to "not bound" so the release-on-idle path
+    // is a no-op in tests that predate that path. Tests that want to exercise
+    // release-on-idle set these to true explicitly.
+    mocks.isCallbackServerRunning.mockReset().mockReturnValue(false);
+    mocks.isCallbackServerIdle.mockReset().mockReturnValue(false);
     mocks.open.mockReset();
     mocks.sdkAuth.mockReset().mockResolvedValue("AUTHORIZED");
     mocks.fetch.mockReset().mockResolvedValue(new Response(null));
@@ -1104,5 +1113,49 @@ describe("mcp-auth-flow explicit auth", () => {
     }));
     expect(mocks.reserveCallbackServer).not.toHaveBeenCalled();
     expect(mocks.open).not.toHaveBeenCalled();
+  });
+
+  it("releases the callback server after a completed auth when no other auths are pending", async () => {
+    // Simulate: server is currently bound, and once the completed auth's
+    // pending record clears, isCallbackServerIdle flips to true.
+    mocks.isCallbackServerRunning.mockReturnValue(true);
+    mocks.isCallbackServerIdle.mockReturnValue(true);
+    let oauthState: string | undefined;
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      oauthState = await provider.state();
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${oauthState}`));
+      return "REDIRECT";
+    });
+    const { startAuth, completeAuthFromInput } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("solo", "https://api.example.com/mcp", { auth: "oauth" });
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
+
+    await expect(completeAuthFromInput("solo", `code=deadbeef&state=${oauthState}`)).resolves.toBe("authenticated");
+
+    // The pilot behavior: callback port released so other Pi processes can
+    // reclaim it for their own /mcp-auth flows.
+    expect(mocks.stopCallbackServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not release the callback server after an auth completes while other auths are still pending", async () => {
+    // isCallbackServerRunning is true (bound), but isCallbackServerIdle is
+    // false because a second pending auth exists.
+    mocks.isCallbackServerRunning.mockReturnValue(true);
+    mocks.isCallbackServerIdle.mockReturnValue(false);
+    let oauthState: string | undefined;
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      oauthState = await provider.state();
+      await provider.redirectToAuthorization(new URL(`https://auth.example.com/authorize?state=${oauthState}`));
+      return "REDIRECT";
+    });
+    const { startAuth, completeAuthFromInput } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("first", "https://api.example.com/mcp", { auth: "oauth" });
+    await expect(completeAuthFromInput("first", `code=deadbeef&state=${oauthState}`)).resolves.toBe("authenticated");
+
+    // Not idle -> release-on-idle skipped so the still-pending second auth's
+    // callback listener stays alive.
+    expect(mocks.stopCallbackServer).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -1115,6 +1115,28 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.open).not.toHaveBeenCalled();
   });
 
+  it("preserves an unavailable credential-store error during startup cleanup", async () => {
+    const previousStore = process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+    const { OAuthCredentialStoreError } = await import("../mcp-auth.ts");
+
+    try {
+      await startAuth("fresh-user", "https://api.example.com/mcp", { auth: "oauth" });
+      throw new Error("expected startAuth to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OAuthCredentialStoreError);
+      expect(error).not.toBeInstanceOf(AggregateError);
+      expect((error as Error).message).toContain("Failed to read OAuth credentials for fresh-user");
+    } finally {
+      if (previousStore === undefined) delete process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE;
+      else process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = previousStore;
+    }
+
+    expect(mocks.cancelPendingCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.sdkAuth).not.toHaveBeenCalled();
+  });
+
   it("releases the callback server after a completed auth when no other auths are pending", async () => {
     // Simulate: server is currently bound, and once the completed auth's
     // pending record clears, isCallbackServerIdle flips to true.

--- a/__tests__/mcp-auth-storage.test.ts
+++ b/__tests__/mcp-auth-storage.test.ts
@@ -240,7 +240,7 @@ describe("mcp-auth storage paths", () => {
     expect(entries[0][0]).not.toContain(".chunk.");
   });
 
-  it("routes revoked Linux keyring operations through the recovery helper", () => {
+  it.each(["keyrevoked", "keyringmissing"])("routes recoverable Linux %s operations through the recovery helper", (storeFailure) => {
     const harnessDir = mkdtempSync(join(tmpdir(), "pi-mcp-keyring-recovery-"));
     const keyctlPath = join(harnessDir, "keyctl");
     const helperPath = join(harnessDir, "helper.cjs");
@@ -273,7 +273,7 @@ if (input.operation === 'read') {
 }
 `);
 
-    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "keyrevoked";
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = storeFailure;
     process.env.PI_MCP_ADAPTER_TEST_LINUX_KEYRING_RECOVERY = "1";
     process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_KEYCTL = keyctlPath;
     process.env.PI_MCP_ADAPTER_KEYRING_RECOVERY_NODE = process.execPath;

--- a/__tests__/mcp-callback-server-unref.test.ts
+++ b/__tests__/mcp-callback-server-unref.test.ts
@@ -329,4 +329,42 @@ describe("mcp-callback-server", () => {
     cancelPendingCallback("pending-state");
     await expect(pending).rejects.toThrow(/Authorization cancelled/);
   });
+
+  it("reports idle only when no pending or reserved auth state remains", async () => {
+    const {
+      ensureCallbackServer,
+      reserveCallbackServer,
+      releaseCallbackServer,
+      waitForCallback,
+      cancelPendingCallback,
+      getPendingAuthCount,
+      getReservedAuthStateCount,
+      isCallbackServerIdle,
+    } = await import("../mcp-callback-server.ts");
+
+    // Freshly-bound server with nothing in flight is idle so callers can
+    // release the port immediately after their auth flow tears down.
+    await ensureCallbackServer();
+    expect(getPendingAuthCount()).toBe(0);
+    expect(getReservedAuthStateCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(true);
+
+    // Reserved states (booked before the pending map fills) block idle.
+    reserveCallbackServer("reserved-a");
+    expect(getReservedAuthStateCount()).toBe(1);
+    expect(isCallbackServerIdle()).toBe(false);
+
+    // Pending callbacks also block idle even when nothing is reserved.
+    releaseCallbackServer("reserved-a");
+    const pending = waitForCallback("pending-a");
+    expect(getPendingAuthCount()).toBe(1);
+    expect(getReservedAuthStateCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(false);
+
+    // Both cleared -> idle again.
+    cancelPendingCallback("pending-a");
+    await expect(pending).rejects.toThrow(/Authorization cancelled/);
+    expect(getPendingAuthCount()).toBe(0);
+    expect(isCallbackServerIdle()).toBe(true);
+  });
 });

--- a/__tests__/mcp-probe.test.ts
+++ b/__tests__/mcp-probe.test.ts
@@ -81,6 +81,25 @@ describe("MCP endpoint shape probe", () => {
     });
   });
 
+  it.each([
+    ["application/json", JSON.stringify({ error: "invalid_token" })],
+    ["text/plain", "Unauthorized"],
+  ])("treats a Bearer-challenged 401 %s response as auth-required", async (contentType, body) => {
+    mockFetch(new Response(body, {
+      status: 401,
+      headers: {
+        "content-type": contentType,
+        "www-authenticate": 'Bearer resource_metadata="https://example.test/.well-known/oauth-protected-resource"',
+      },
+    }));
+
+    await expect(probeMcpEndpoint("https://example.test/mcp")).resolves.toEqual({
+      isMcp: true,
+      classification: "endpoint requires Bearer authentication (401); MCP protocol shape cannot be verified without credentials",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to legacy when server/discover returns method not found", async () => {
     mockFetch(
       new Response(JSON.stringify({

--- a/commands.ts
+++ b/commands.ts
@@ -289,23 +289,16 @@ export async function authenticateServer(
     const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
     const status = await authenticate(serverName, serverUrl, definition, {
       ...(authStorageOptions.baseDir ? { authStorageOptions } : {}),
-      onAuthorizationUrl: (authorizationUrl) => {
-        ui.notify(
-          `Open this URL to authenticate ${serverName}:\n\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving, Pi will complete automatically if the browser can reach its localhost callback. " +
-          "On a remote machine, copy the full localhost URL from the browser address bar and paste it into Pi.",
-          "info"
-        );
-      },
-      onAuthorizationInput: async (_authorizationUrl, inputSignal) => {
-        // The authorization URL was already announced via the notify above
-        // (a clickable terminal hyperlink users can open before pasting).
-        // Skip a redundant Yes/No confirm and open the paste input directly,
-        // so hitting Enter after pasting the callback URL just works.
+      // Keep the authorization URL with the paste prompt instead of adding it
+      // to the chat transcript.
+      onAuthorizationUrl: () => {},
+      onAuthorizationInput: async (authorizationUrl, inputSignal) => {
         if (inputSignal.aborted) return undefined;
         return ui.input(
-          `Complete ${serverName} OAuth`,
-          "Paste the full callback URL from your browser",
+          `Complete ${serverName} OAuth\n\n` +
+            `${terminalHyperlink("OPEN AUTHORIZATION PAGE ↗", authorizationUrl)}\n${authorizationUrl}\n\n` +
+            "Approve access, then paste the full localhost callback URL below.",
+          undefined,
           { signal: inputSignal },
         );
       },

--- a/commands.ts
+++ b/commands.ts
@@ -296,17 +296,15 @@ export async function authenticateServer(
           "info"
         );
       },
-      onAuthorizationInput: async (authorizationUrl, inputSignal) => {
-        const readyToPaste = await ui.confirm(
-          `Authorize ${serverName}`,
-          `Open this link in your browser:\n${terminalHyperlink(authorizationUrl, authorizationUrl)}\n\n` +
-          "After approving access, select Yes to paste the callback URL.",
-          { signal: inputSignal },
-        );
-        if (!readyToPaste || inputSignal.aborted) return undefined;
+      onAuthorizationInput: async (_authorizationUrl, inputSignal) => {
+        // The authorization URL was already announced via the notify above
+        // (a clickable terminal hyperlink users can open before pasting).
+        // Skip a redundant Yes/No confirm and open the paste input directly,
+        // so hitting Enter after pasting the callback URL just works.
+        if (inputSignal.aborted) return undefined;
         return ui.input(
           `Complete ${serverName} OAuth`,
-          "Paste the full callback URL",
+          "Paste the full callback URL from your browser",
           { signal: inputSignal },
         );
       },

--- a/commands.ts
+++ b/commands.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
 import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCallbacks, type McpPanelResult, type ImportKind } from "./types.ts";
 import {
@@ -554,6 +555,7 @@ function buildMcpPanelCallbacks(
   state: McpExtensionState,
   config: McpConfig,
   ctx: ExtensionContext,
+  getOverlayHandle?: () => OverlayHandle | undefined,
 ): McpPanelCallbacks {
   // Panel-only diagnostics keep status inspection from mutating connection
   // failure state while allowing the existing panel failure UI to show why the
@@ -566,7 +568,16 @@ function buildMcpPanelCallbacks(
       const definition = config.mcpServers[serverName];
       return definition ? !isServerDisabled(definition) && supportsOAuth(definition) : false;
     },
-    authenticate: (serverName: string) => authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime),
+    authenticate: async (serverName: string) => {
+      const overlay = getOverlayHandle?.();
+      overlay?.setHidden(true);
+      try {
+        return await authenticateServer(serverName, config, ctx, state.owner?.signal, state.oauthRuntime);
+      } finally {
+        overlay?.setHidden(false);
+        overlay?.focus();
+      }
+    },
     getConnectionStatus: (serverName: string) => {
       authStatusFailures.delete(serverName);
       const definition = config.mcpServers[serverName];
@@ -635,7 +646,8 @@ export async function openMcpPanel(
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
   const { lines: noticeLines, fingerprint } = buildSharedConfigNoticeLines(configPath, ctx.cwd);
 
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
 
   const { createMcpPanel } = await import("./mcp-panel.ts");
   let configChanged = false;
@@ -661,7 +673,11 @@ export async function openMcpPanel(
           });
         }, { noticeLines, keybindings });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 
@@ -700,7 +716,8 @@ export async function openMcpAuthPanel(
   const cache = loadMetadataCache();
   const configPath = pi.getFlag("mcp-config") as string | undefined ?? configOverridePath;
   const provenanceMap = getServerProvenance(configPath, ctx.cwd);
-  const callbacks = buildMcpPanelCallbacks(state, config, ctx);
+  let overlayHandle: OverlayHandle | undefined;
+  const callbacks = buildMcpPanelCallbacks(state, config, ctx, () => overlayHandle);
   const { createMcpPanel } = await import("./mcp-panel.ts");
 
   await new Promise<void>((resolve) => {
@@ -715,7 +732,11 @@ export async function openMcpAuthPanel(
           noticeLines: ["Select an OAuth MCP server and press Enter or ctrl+a to authenticate."],
         });
       },
-      { overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: 82 },
+        onHandle: (handle) => { overlayHandle = handle; },
+      },
     );
   });
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -389,7 +389,7 @@ export async function startAuth(
   } catch (error) {
     releaseCallbackServer(oauthState)
     try {
-      await clearOAuthState(serverName, authStorageOptions)
+      await releaseCallbackServerIfIdle()
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -441,7 +441,7 @@ export async function startAuth(
   } catch (error) {
     authProvider.deactivate()
     try {
-      await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
+      await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions, false)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -473,7 +473,7 @@ async function setPendingAuth(
   state.pendingAuthCleanupTimers.set(key, cleanupTimer)
 }
 
-async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}): Promise<void> {
+async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}, clearStoredState = true): Promise<void> {
   const state = getRuntimeState(runtime)
   const key = getPendingAuthKey(serverName, fallbackStorageOptions)
   const pendingAuth = state.pendingAuths.get(key)
@@ -493,9 +493,11 @@ async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oa
   const stateToRelease = pendingState ?? oauthState
   if (stateToRelease) {
     cancelPendingCallback(stateToRelease)
-    const storedState = await getOAuthState(serverName, authStorageOptions)
-    if (storedState === stateToRelease) {
-      await clearOAuthState(serverName, authStorageOptions)
+    if (clearStoredState) {
+      const storedState = await getOAuthState(serverName, authStorageOptions)
+      if (storedState === stateToRelease) {
+        await clearOAuthState(serverName, authStorageOptions)
+      }
     }
   }
 }
@@ -528,8 +530,9 @@ async function clearPendingAuthAndReleaseIfIdle(
   serverName: string,
   oauthState: string | undefined,
   fallbackStorageOptions: AuthStorageOptions = {},
+  clearStoredState = true,
 ): Promise<void> {
-  await clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions)
+  await clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions, clearStoredState)
   await releaseCallbackServerIfIdle()
 }
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -19,6 +19,8 @@ import {
   cancelPendingCallback,
   stopCallbackServer,
   releaseCallbackServer,
+  isCallbackServerRunning,
+  isCallbackServerIdle,
 } from "./mcp-callback-server.ts"
 import {
   getAuthForUrl,
@@ -439,7 +441,7 @@ export async function startAuth(
   } catch (error) {
     authProvider.deactivate()
     try {
-      await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+      await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
     } catch (cleanupError) {
       throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
     }
@@ -463,7 +465,7 @@ async function setPendingAuth(
   state.pendingAuths.set(key, pendingAuth)
   state.pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuth(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+    void clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
       console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
     })
   }, MANUAL_AUTH_TIMEOUT_MS)
@@ -496,6 +498,39 @@ async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oa
       await clearOAuthState(serverName, authStorageOptions)
     }
   }
+}
+
+/**
+ * Release the OAuth callback listener when nothing else needs it, so other
+ * processes can reclaim the (potentially pre-registered) port. Called from
+ * auth completion / cancellation sites; NOT from the sweep-before-set path
+ * in setPendingAuth (that path is about to add a fresh record) or from
+ * shutdownOAuth (which handles server teardown itself).
+ *
+ * The next auth flow in this process rebinds on demand via
+ * ensureCallbackServer, so releasing eagerly is safe.
+ */
+async function releaseCallbackServerIfIdle(): Promise<void> {
+  if (isCallbackServerRunning() && isCallbackServerIdle()) {
+    await stopCallbackServer()
+  }
+}
+
+/**
+ * Clear the per-server pending-auth record and, when no other auths remain
+ * anywhere, release the OAuth callback port so peer processes can bind it
+ * for their own /mcp-auth flows. Use this at true completion sites
+ * (successful auth, cancellation, removeAuth); use clearPendingAuth alone
+ * from setPendingAuth's sweep-before-set and from shutdown paths.
+ */
+async function clearPendingAuthAndReleaseIfIdle(
+  runtime: McpOAuthRuntime,
+  serverName: string,
+  oauthState: string | undefined,
+  fallbackStorageOptions: AuthStorageOptions = {},
+): Promise<void> {
+  await clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions)
+  await releaseCallbackServerIfIdle()
 }
 
 function getSearchParamsFromInput(input: string): URLSearchParams | undefined {
@@ -701,7 +736,7 @@ export async function completeAuth(
   } finally {
     if (!keepPendingForRetry) {
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         if (caughtError !== undefined) {
           throw new AggregateError([caughtError, cleanupError], "OAuth completion cleanup failed")
@@ -801,7 +836,7 @@ export async function authenticate(
     } catch (error) {
       if (oauthState) cancelPendingCallback(oauthState)
       try {
-        await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+        await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
       } catch (cleanupError) {
         throw new AggregateError([error, cleanupError], "OAuth cancellation cleanup failed")
       }
@@ -922,7 +957,7 @@ export async function removeAuth(serverName: string, options: AuthenticateOption
   if (oauthState) {
     cancelPendingCallback(oauthState)
   }
-  await clearPendingAuth(runtime, serverName, oauthState, authStorageOptions)
+  await clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, authStorageOptions)
   throwIfAborted(signal)
   clearAllCredentials(serverName, authStorageOptions)
   await clearOAuthState(serverName, authStorageOptions)

--- a/mcp-auth.ts
+++ b/mcp-auth.ts
@@ -215,20 +215,33 @@ const unavailableAuthSecretStore: AuthSecretStore = {
   },
 };
 
-function createKeyRevokedTestError(): Error {
-  return new Error("Couldn't access platform storage: KeyRevoked", { cause: new Error('KeyRevoked') });
+function createKeyringTestError(code: 'KeyRevoked' | 'KeyringDoesNotExist'): Error {
+  return new Error(`Couldn't access platform storage: ${code}`, { cause: new Error(code) });
 }
 
 const keyRevokedAuthSecretStore: AuthSecretStore = {
   read() {
     testAuthSecretStoreReadCount++;
-    throw createKeyRevokedTestError();
+    throw createKeyringTestError('KeyRevoked');
   },
   write() {
-    throw createKeyRevokedTestError();
+    throw createKeyringTestError('KeyRevoked');
   },
   remove() {
-    throw createKeyRevokedTestError();
+    throw createKeyringTestError('KeyRevoked');
+  },
+};
+
+const missingKeyringAuthSecretStore: AuthSecretStore = {
+  read() {
+    testAuthSecretStoreReadCount++;
+    throw createKeyringTestError('KeyringDoesNotExist');
+  },
+  write() {
+    throw createKeyringTestError('KeyringDoesNotExist');
+  },
+  remove() {
+    throw createKeyringTestError('KeyringDoesNotExist');
   },
 };
 
@@ -259,6 +272,7 @@ function getAuthSecretStore(): AuthSecretStore {
   if (process.env[TEST_AUTH_STORE_ENV] === 'sizelimited') return sizeLimitedAuthSecretStore;
   if (process.env[TEST_AUTH_STORE_ENV] === 'unavailable') return unavailableAuthSecretStore;
   if (process.env[TEST_AUTH_STORE_ENV] === 'keyrevoked') return keyRevokedAuthSecretStore;
+  if (process.env[TEST_AUTH_STORE_ENV] === 'keyringmissing') return missingKeyringAuthSecretStore;
   return keyringAuthSecretStore;
 }
 
@@ -348,7 +362,7 @@ function isLinuxKeyringRecoveryEnabled(): boolean {
 
 function shouldAttemptLinuxKeyringRecovery(error: unknown): boolean {
   return isLinuxKeyringRecoveryEnabled()
-    && causeChainContains(error, /key\s*(?:has been\s*)?revoked|keyrevoked/i);
+    && causeChainContains(error, /key\s*(?:has been\s*)?(?:expired|rejected|revoked)|key(?:ring)?\s*(?:does\s*not\s*exist|expired|rejected|revoked)/i);
 }
 
 function runLinuxKeyringRecoveryOperation(operation: KeyringRecoveryOperation, account: string, payload?: string): KeyringRecoveryResponse {

--- a/mcp-callback-server.ts
+++ b/mcp-callback-server.ts
@@ -508,3 +508,20 @@ export function isCallbackServerRunning(): boolean {
 export function getPendingAuthCount(): number {
   return pendingAuths.size
 }
+
+/**
+ * Get the number of reserved authorization states (bookings for auth flows
+ * that have not yet reached the waitForCallback phase).
+ */
+export function getReservedAuthStateCount(): number {
+  return reservedAuthStates.size
+}
+
+/**
+ * True if the callback server currently has no reason to remain bound.
+ * A caller that just finished cleaning up its own auth state can consult
+ * this to decide whether to release the port for other processes.
+ */
+export function isCallbackServerIdle(): boolean {
+  return pendingAuths.size === 0 && reservedAuthStates.size === 0
+}

--- a/mcp-probe.ts
+++ b/mcp-probe.ts
@@ -139,14 +139,16 @@ async function classifyResponse(response: Response, strategy: ProbeStrategy): Pr
       },
     };
   }
-  if (response.status === 401 && isBearerChallenge(response) && envelope) {
+  if (response.status === 401 && isBearerChallenge(response)) {
     return {
       kind: "mcp",
       result: {
         isMcp: true,
-        classification: strategy.kind === "modern"
-          ? `endpoint requires Bearer authentication during MCP ${MODERN_PROTOCOL_VERSION} server/discover probing`
-          : "endpoint requires Bearer authentication and responded with a JSON-RPC 2.0 error",
+        classification: envelope
+          ? strategy.kind === "modern"
+            ? `endpoint requires Bearer authentication during MCP ${MODERN_PROTOCOL_VERSION} server/discover probing`
+            : "endpoint requires Bearer authentication and responded with a JSON-RPC 2.0 error"
+          : "endpoint requires Bearer authentication (401); MCP protocol shape cannot be verified without credentials",
       },
     };
   }


### PR DESCRIPTION
## Summary

- recover missing, expired, rejected, and revoked Linux session keyrings through the existing `keyctl` helper
- preserve the original secure credential-store error when OAuth startup fails instead of masking it with `OAuth startup cleanup failed`
- treat Bearer-challenged HTTP 401 responses as authentication-required MCP endpoints even when the unauthenticated body is not JSON-RPC

## Context

Fresh/headless Linux sessions can inherit an unavailable session keyring, especially through long-lived shells or tmux. Several valid hosted MCP endpoints also return plain JSON or text 401 bodies before authentication. Together these failures made first-time authentication fail with either an aggregate cleanup error or the misleading `this URL does not appear to speak MCP` diagnostic.

Credential handling remains fail-closed. Recovery is limited to concrete session-keyring lifecycle failures and still requires `keyctl` plus `node` on `PATH`; the adapter never falls back to plaintext credentials.

This is stacked on #404 for the remote authentication UI changes. #403 is already on `main`.

## Validation

- `npm run typecheck`
- `npm run test:oauth` — 137 passed
- `npm test` — 1,223 passed after building the interactive visualizer fixture
- focused Vitest suite — 69 passed
- live unauthenticated probes against Linear, Notion, Chronosphere, and Mixpanel classify each Bearer-challenged 401 as authentication-required
