### PR TITLE
fix: suppress Node 24 mcpScript FD warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,17 @@ jobs:
       - run: npm run test:oauth
       - run: npm run test:conformance
       - run: npm pack --dry-run
+
+  node24-worker-fds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+      - run: npm test -- --run __tests__/mcp-code.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused MCP panel direct-tool counts and token totals across renders while keeping toggle and reconnect updates immediate.
 
 ### Fixed
+- Suppressed false Node 24 unmanaged file-descriptor warnings for short-lived `mcpScript` workers. Thanks to [@blalor](https://github.com/blalor) for PR #407.
 - Released the OAuth callback listener after idle auth flows and kept MCP pickers hidden while nested OAuth input is active. Thanks to [@trevorleibert-mixpanel](https://github.com/trevorleibert-mixpanel) for PRs #403 and #404.
 - Raised the `ps` `maxBuffer` for request-header command cleanup so the full `ps axeww` process-discovery scan no longer overflows spawnSync's 1 MiB default on busy hosts, which had SIGTERM'd `ps` and surfaced as spurious `HTTP request headers command cleanup failed: ps exited with code unknown` refresh failures. Thanks to [@rtfpessoa](https://github.com/rtfpessoa) for PR #399.
 - Kept slow but healthy remote keep-alive servers from being marked failed when a bounded tools/list refresh times out. Thanks to [@brightmeowso](https://github.com/brightmeowso) for #400.

--- a/__tests__/fixtures/mcp-code-fd-runner.ts
+++ b/__tests__/fixtures/mcp-code-fd-runner.ts
@@ -1,0 +1,17 @@
+import { runMcpScript } from "../../mcp-code.ts";
+import type { McpExtensionState } from "../../state.ts";
+
+const state = {
+  owner: undefined,
+  toolMetadata: new Map(),
+  config: { settings: {} },
+} as unknown as McpExtensionState;
+
+for (let index = 0; index < 32; index += 1) {
+  const result = await runMcpScript(state, 'emit("ok")', 5_000);
+  if (result.details.error) {
+    throw new Error(`mcpScript failed: ${JSON.stringify(result.details)}`);
+  }
+}
+
+process.stdout.write("completed 32 mcpScript workers\n");

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -1,3 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { createMcpAdapter } from "../index.ts";
@@ -6,7 +8,9 @@ import { McpServerManager } from "../server-manager.ts";
 import type { McpExtensionState } from "../state.ts";
 import { MCP_TOOL_APPROVAL_REQUEST_EVENT, type McpToolApprovalRequest } from "../types.ts";
 
+const execFileAsync = promisify(execFile);
 const fixture = fileURLToPath(new URL("./fixtures/mcp-code-server.mjs", import.meta.url));
+const fdRunner = fileURLToPath(new URL("./fixtures/mcp-code-fd-runner.ts", import.meta.url));
 const definition = { command: process.execPath, args: [fixture] };
 let manager: McpServerManager;
 let state: McpExtensionState;
@@ -49,6 +53,24 @@ describe("runMcpScript", () => {
     expect(registerTool).toHaveBeenCalled();
     expect(registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcpScript" }));
   });
+
+  it.runIf(Number.parseInt(process.versions.node, 10) >= 24)(
+    "does not emit unmanaged file descriptor warnings",
+    async () => {
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", fdRunner],
+        {
+          env: { ...process.env, NODE_OPTIONS: "--trace-warnings" },
+          maxBuffer: 1024 * 1024,
+        },
+      );
+
+      expect(stdout).toContain("completed 32 mcpScript workers");
+      expect(stderr).not.toMatch(/File descriptor \d+ (?:closed but not opened in unmanaged mode|opened in unmanaged mode twice)/);
+    },
+    30_000,
+  );
 
   beforeAll(async () => {
     manager = new McpServerManager();

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -249,6 +249,10 @@ export async function runMcpScript(
     worker = new Worker(new URL("./mcp-script-worker.mjs", import.meta.url), {
       workerData: { code },
       env: {},
+      // The sandbox cannot open files, and the host always terminates this worker.
+      // Disable Node's unmanaged FD bookkeeping, which emits false warnings when
+      // short-lived workers are terminated on Node 24.
+      trackUnmanagedFds: false,
     });
     const activeWorker = worker;
     const execution = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Why

This is a maintainer replacement for #407. It preserves Brian Lalor's Node 24 worker fix and adds the review fix needed before landing.

Repeated short-lived `mcpScript` workers can produce Node 24 unmanaged file descriptor warnings even though the sandbox does not expose host file APIs. The host still explicitly terminates workers on completion.

## What changed

- Disable unmanaged FD tracking for the sandboxed `mcpScript` worker.
- Add a subprocess regression that rejects both unmanaged FD warning forms:
  - `closed but not opened in unmanaged mode`
  - `opened in unmanaged mode twice`
- Add a focused Node 24 CI job for `__tests__/mcp-code.test.ts`.
- Credit [@blalor](https://github.com/blalor) in the changelog for #407.

## Validation

- `npm test -- --run __tests__/mcp-code.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh read-only review passed: `/tmp/pi-mcp-adapter-pr407-replacement-report.fresh-review.md`

Co-authored-by: Brian Lalor <blalor@bravo5.org>