### PR TITLE
style: clean up OAuth prompt and panel test

### DIFF
--- a/__tests__/commands-auth.test.ts
+++ b/__tests__/commands-auth.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle } from "@earendil-works/pi-tui";
+import type { openMcpAuthPanel, openMcpPanel } from "../commands.ts";
+import type { createMcpPanel } from "../mcp-panel.ts";
 
 const mocks = vi.hoisted(() => ({
   authenticate: vi.fn(),
   createMcpPanel: vi.fn(),
   removeAuth: vi.fn(),
 }));
+
+type PanelState = Parameters<typeof openMcpPanel>[0];
+type PanelApi = Parameters<typeof openMcpPanel>[1];
+type PanelContext = Parameters<typeof openMcpPanel>[2];
+type CustomArgs = Parameters<ExtensionContext["ui"]["custom"]>;
 
 vi.mock("../mcp-auth-flow.ts", () => ({
   authenticate: mocks.authenticate,
@@ -62,32 +71,41 @@ describe("authenticateServer", () => {
       if (outcome === "failure") throw new Error("authentication failed");
       return "authenticated";
     });
-    mocks.createMcpPanel.mockImplementationOnce((_config, _cache, _provenance, callbacks, _tui, done) => ({
-      render: () => [],
-      invalidate: () => {},
-      handleInput: () => {
-        void callbacks.authenticate("sentry").then(() => done({ cancelled: true, changes: new Map() }));
-      },
-    }));
+    mocks.createMcpPanel.mockImplementationOnce((...args: Parameters<typeof createMcpPanel>) => {
+      const callbacks = args[3];
+      const done = args[5];
+      return {
+        render: () => [],
+        invalidate: () => {},
+        handleInput: () => {
+          void callbacks.authenticate("sentry").then(() => done({ cancelled: true, changes: new Map() }));
+        },
+      };
+    });
     const ui = {
       notify: vi.fn(),
       setStatus: vi.fn(),
-      custom: vi.fn((factory, options) => {
+      custom: vi.fn((factory: CustomArgs[0], options: NonNullable<CustomArgs[1]>) => {
         const panel = factory({ requestRender: vi.fn() }, undefined, undefined, vi.fn());
-        options.onHandle({ setHidden: hidden, focus });
+        options.onHandle?.({ setHidden: hidden, focus } as OverlayHandle);
         panel.handleInput("\r");
       }),
     };
     const commands = await import("../commands.ts");
-
-    const panel = commands[command]({
+    const state = {
       programmaticConfig: false,
       config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
       authStorageOptions: {},
       manager: { getConnection: () => undefined },
       failureTracker: new Map(),
       failureMessages: new Map(),
-    } as any, { getFlag: vi.fn() } as any, { hasUI: true, mode: "tui", cwd: "/tmp", ui } as any);
+    } as PanelState;
+    const pi = { getFlag: vi.fn() } as PanelApi;
+    const ctx = { hasUI: true, mode: "tui", cwd: "/tmp", ui } as PanelContext;
+
+    const panel = command === "openMcpPanel"
+      ? commands.openMcpPanel(state, pi, ctx)
+      : commands.openMcpAuthPanel(state, pi, ctx);
 
     await authenticationStarted;
     finishAuthentication();
@@ -227,7 +245,7 @@ describe("authenticateServer", () => {
     expect(ui.confirm).not.toHaveBeenCalled();
     expect(ui.input).toHaveBeenCalledWith(
       expect.stringContaining(
-        `\u001B]8;;${authorizationUrl}\u001B\\OPEN AUTHORIZATION PAGE ↗\u001B]8;;\u001B\\\n${authorizationUrl}`,
+        `\u001B]8;;${authorizationUrl}\u001B\\Open authorization page\u001B]8;;\u001B\\\n${authorizationUrl}`,
       ),
       undefined,
       { signal: inputController.signal },

--- a/commands.ts
+++ b/commands.ts
@@ -294,7 +294,7 @@ export async function authenticateServer(
         if (inputSignal.aborted) return undefined;
         return ui.input(
           `Complete ${serverName} OAuth\n\n` +
-            `${terminalHyperlink("OPEN AUTHORIZATION PAGE ↗", authorizationUrl)}\n${authorizationUrl}\n\n` +
+            `${terminalHyperlink("Open authorization page", authorizationUrl)}\n${authorizationUrl}\n\n` +
             "Approve access, then paste the full localhost callback URL below.",
           undefined,
           { signal: inputSignal },


### PR DESCRIPTION
## Why

Follow-up deslop pass for the OAuth prompt work from #406 and #409.

## What changed

- Use sentence-case text for the OAuth authorization link in the terminal prompt.
- Keep the panel overlay regression test tied to the real command and panel contracts instead of broad `as any` casts.

## Validation

- `git diff --check`
- `npm test -- --run __tests__/commands-auth.test.ts`
- `npm run typecheck`
- Fallow audit: 0 introduced findings
- slop-scan delta: 0 added/worsened findings
- Fresh cleanup review: no findings