### PR TITLE
feat: register namespace-proxy tools (mcp__<server>) for proxy-only servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ conformance/results/
 *.log
 .DS_Store
 
+# bun lockfile (this fork uses npm/package-lock.json)
+bun.lock
+bun.lockb
+
 progress.md
 worker-summary.md
 worker-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.
+- Namespace proxy tools now clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
 - Kept transient HTTP 503 connection failures as availability errors without multiplying gateway retries or misdiagnosing the endpoint as non-MCP. Thanks to [@elkaix](https://github.com/elkaix) for PR #411.
 - Preserved cached keep-alive catalogs during transient 503 refresh outages while deferred recovery continues with bounded backoff.
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -64,6 +64,26 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../metadata-cache.ts", () => ({
   loadMetadataCache: mocks.loadMetadataCache,
+  parseDirectToolSelectors: (selectors: string[]) => {
+    const servers = new Set<string>();
+    const tools = new Map<string, Set<string>>();
+    for (const raw of selectors) {
+      const sel = raw.replace(/\/+$/, "");
+      if (sel.includes("/")) {
+        const [server, tool] = sel.split("/", 2);
+        if (server && tool) {
+          const set = tools.get(server) ?? new Set<string>();
+          set.add(tool);
+          tools.set(server, set);
+        } else if (server) {
+          servers.add(server);
+        }
+      } else if (sel) {
+        servers.add(sel);
+      }
+    }
+    return { servers, tools };
+  },
 }));
 
 vi.mock("../direct-tools.ts", () => ({

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -73,6 +73,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -93,6 +94,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(["context7_query_docs"]),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -111,6 +113,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -129,6 +132,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: { version: 1, servers: {} },
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -147,6 +151,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: { servers: new Set(["context-mode"]), tools: new Map() },
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -154,6 +159,48 @@ describe("syncNamespaceProxyTools", () => {
     });
 
     expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("registers configured direct servers as namespaces when an empty env override disables direct tools", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { context7: { command: "context7", directTools: true } } },
+      cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }] }]]),
+      envOverride: { servers: new Set(), tools: new Map() },
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context7")).toBe(true);
+  });
+
+  it("registers omitted configured direct servers when env selects another server", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { context7: { command: "context7", directTools: true }, other: { command: "other" } } },
+      cache: CACHE_SHAPE([
+        ["context7", { tools: [{ name: "query_docs" }] }],
+        ["other", { tools: [{ name: "search" }] }],
+      ]),
+      envOverride: { servers: new Set(["other"]), tools: new Map() },
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context7")).toBe(true);
+    expect(registered.has("mcp__other")).toBe(false);
   });
 
   it("exposes a `tool` and optional `args` parameter schema for dispatch", async () => {
@@ -165,6 +212,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -190,6 +238,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(["mcp__context_mode"]),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -209,6 +258,7 @@ describe("syncNamespaceProxyTools", () => {
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -223,7 +273,8 @@ describe("syncNamespaceProxyTools", () => {
       config: { mcpServers: {} },
       cache: { version: 1, servers: {} },
       envOverride: null,
-      existingDirectNames: new Set(["mcp__context_mode"]),
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(["mcp__context_mode"]),
       pi,
       getState: () => null,
       getInitPromise: () => null,
@@ -231,6 +282,51 @@ describe("syncNamespaceProxyTools", () => {
     });
 
     expect(unregistered).toContain("mcp__context_mode");
+  });
+
+  it("does not deactivate direct tools while cleaning stale namespace proxies", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered, unregistered } = makePi();
+    pi.registerTool({ name: "mcp__demo_search", execute: vi.fn() });
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: {} },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__demo_search"]),
+      existingNamespaceNames: new Set(["mcp__demo_search"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__demo_search")).toBe(true);
+    expect(unregistered).not.toContain("mcp__demo_search");
+  });
+
+  it("skips colliding normalized server names without choosing by config order", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "my-server": { command: "one" }, my_server: { command: "two" } } },
+      cache: CACHE_SHAPE([
+        ["my-server", { tools: [{ name: "one" }] }],
+        ["my_server", { tools: [{ name: "two" }] }],
+      ]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__my_server")).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('servers "my-server", "my_server" normalize to the same name'));
   });
 
   it("registers a new server and keeps existing ones in a single sync", async () => {
@@ -250,6 +346,7 @@ describe("syncNamespaceProxyTools", () => {
       ]),
       envOverride: null,
       existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
       pi,
       getState: () => null,
       getInitPromise: () => null,

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -305,6 +305,32 @@ describe("syncNamespaceProxyTools", () => {
     expect(unregistered).not.toContain("mcp__demo_search");
   });
 
+  it("removes stale namespace proxies from active tools without unregisterTool", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+    delete pi.unregisterTool;
+    let activeTools = ["bash", "mcp__context_mode"];
+    pi.getActiveTools = vi.fn(() => activeTools);
+    pi.setActiveTools = vi.fn((nextActiveTools: string[]) => { activeTools = nextActiveTools; });
+    registered.set("mcp__context_mode", { name: "mcp__context_mode", execute: vi.fn() });
+
+    const result = syncNamespaceProxyTools({
+      config: { mcpServers: {} },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(result.deactivated).toEqual(["mcp__context_mode"]);
+    expect(pi.setActiveTools).toHaveBeenCalledWith(["bash"]);
+    expect(activeTools).toEqual(["bash"]);
+  });
+
   it("skips colliding normalized server names without choosing by config order", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered } = makePi();

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -161,6 +161,25 @@ describe("syncNamespaceProxyTools", () => {
     expect(registered.has("mcp__context_mode")).toBe(false);
   });
 
+  it("keeps the namespace proxy when a per-tool env selector does not resolve a direct tool", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode", directTools: true } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: { servers: new Set(), tools: new Map([["context-mode", new Set(["missing_tool"]) ]]) },
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(true);
+  });
+
   it("registers configured direct servers as namespaces when an empty env override disables direct tools", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered } = makePi();

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for the namespace-proxy tool registration logic.
+ *
+ * `syncNamespaceProxyTools` is the focused, side-effect-free function
+ * (aside from the injected `pi.registerTool`) that the adapter calls from
+ * `syncToolSurface`. We test it directly to keep the surface tight; the
+ * existing `index-lifecycle.test.ts` covers the full adapter boot.
+ */
+
+const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }> }]>) => ({
+  version: 1,
+  servers: Object.fromEntries(entries.map(([server, v]) => [server, { tools: v.tools, configHash: "h", cachedAt: Date.now() }])),
+});
+
+function makePi() {
+  const registered = new Map<string, { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }>();
+  const unregistered: string[] = [];
+  const api = {
+    registerTool: vi.fn((tool: { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }) => {
+      registered.set(tool.name, tool);
+    }),
+    unregisterTool: vi.fn((name: string) => {
+      const had = registered.has(name);
+      registered.delete(name);
+      if (had) unregistered.push(name);
+      return had;
+    }),
+  };
+  return { pi: api as any, registered, unregistered };
+}
+
+async function importSync() {
+  const mod = await import("../namespace-tools.ts");
+  return {
+    syncNamespaceProxyTools: mod.syncNamespaceProxyTools,
+    namespaceProxyName: mod.namespaceProxyName,
+  };
+}
+
+describe("namespaceProxyName", () => {
+  it("replaces hyphens with underscores in server names", async () => {
+    const { namespaceProxyName } = await importSync();
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(namespaceProxyName("chrome-devtools")).toBe("mcp__chrome_devtools");
+    expect(namespaceProxyName("foo")).toBe("mcp__foo");
+  });
+
+  it("matches the harness _shared/mcp-tools resolver contract", async () => {
+    // The harness resolver produces `mcp__<server-with-dashes-as-underscores>`
+    // and validates against it. The fork must produce the same string.
+    const { namespaceProxyName } = await importSync();
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(namespaceProxyName("my-server-1")).toBe("mcp__my_server_1");
+  });
+});
+
+describe("syncNamespaceProxyTools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers mcp__<server> for each proxy-only server with metadata", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode", lifecycle: "eager" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(true);
+    const tool = registered.get("mcp__context_mode")!;
+    expect(tool.execute).toBeTypeOf("function");
+  });
+
+  it("does NOT register for directTools: true servers (avoids duplicating direct tools)", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { context7: { url: "https://mcp.context7.com/mcp", directTools: true } } },
+      cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(["context7_query_docs"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context7")).toBe(false);
+  });
+
+  it("skips disabled servers", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode", disabled: true } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("skips servers with no metadata in the cache", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("skips servers that are forced direct by MCP_DIRECT_TOOLS env override", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: { servers: new Set(["context-mode"]), tools: new Map() },
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("exposes a `tool` and optional `args` parameter schema for dispatch", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    const tool = registered.get("mcp__context_mode")!;
+    expect(tool.parameters).toBeDefined();
+    const props = (tool.parameters as any).properties;
+    expect(props.tool).toBeDefined();
+    expect(props.args).toBeDefined();
+  });
+
+  it("skips registration when an existing direct tool already uses mcp__<server>", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    // Edge case: a directTool is named "mcp__context_mode" (very unlikely but possible
+    // if the user defined directTools: ["mcp__context_mode"] on a server). We must
+    // not double-register the same name.
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.size).toBe(0);
+  });
+
+  it("deactivates stale entries between syncs (server removed from config)", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered, unregistered } = makePi();
+
+    // First sync: register context-mode.
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+    expect(registered.has("mcp__context_mode")).toBe(true);
+
+    // Second sync: context-mode is gone, but the previous names list still
+    // includes the now-stale mcp__context_mode. Caller passes the union of
+    // previously-registered names so we can deactivate.
+    syncNamespaceProxyTools({
+      config: { mcpServers: {} },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(unregistered).toContain("mcp__context_mode");
+  });
+
+  it("registers a new server and keeps existing ones in a single sync", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: {
+        mcpServers: {
+          "context-mode": { command: "context-mode" },
+          "context7": { url: "https://mcp.context7.com/mcp" }, // proxy-only (no directTools)
+        },
+      },
+      cache: CACHE_SHAPE([
+        ["context-mode", { tools: [{ name: "ctx_execute" }] }],
+        ["context7", { tools: [{ name: "query_docs" }] }],
+      ]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(true);
+    expect(registered.has("mcp__context7")).toBe(true);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -132,6 +132,11 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const earlyCache = loadMetadataCache();
   const envRaw = process.env.MCP_DIRECT_TOOLS;
   const envDirectToolOverride = envRaw?.split(",").map(s => s.trim()).filter(Boolean);
+  const namespaceEnvOverride = envRaw === "__none__"
+    ? { servers: new Set<string>(), tools: new Map<string, Set<string>>() }
+    : envDirectToolOverride
+      ? parseDirectToolSelectors(envDirectToolOverride)
+      : null;
   const registeredDirectTools = new Map<string, string>();
   const registeredNamespaceProxyTools = new Set<string>();
   const fallbackDeactivatedTools = new Set<string>();
@@ -281,10 +286,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const nsResult = syncNamespaceProxyTools({
       config,
       cache,
-      envOverride: envDirectToolOverride
-        ? parseDirectToolSelectors(envDirectToolOverride)
-        : null,
+      envOverride: namespaceEnvOverride,
       existingDirectNames: new Set(registeredDirectTools.keys()),
+      existingNamespaceNames: registeredNamespaceProxyTools,
       pi,
       getState: () => state,
       getInitPromise: () => initPromise,
@@ -1074,18 +1078,18 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   // eager call, the tool-groups expansion runs before MCP initialization
   // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
   // Mirrors the upstream direct-tool install-time registration pattern.
-  syncNamespaceProxyTools({
+  const initialNamespaceResult = syncNamespaceProxyTools({
     config: earlyConfig,
     cache: earlyCache,
-    envOverride: envDirectToolOverride
-      ? parseDirectToolSelectors(envDirectToolOverride)
-      : null,
+    envOverride: namespaceEnvOverride,
     existingDirectNames: new Set(registeredDirectTools.keys()),
+    existingNamespaceNames: registeredNamespaceProxyTools,
     pi,
     getState: () => state,
     getInitPromise: () => initPromise,
     getPiTools: () => pi.getAllTools(),
   });
+  for (const name of initialNamespaceResult.added) registeredNamespaceProxyTools.add(name);
   startLoadTimeInitialization();
 }
 

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, 
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
-import { loadMetadataCache, type MetadataCache } from "./metadata-cache.ts";
+import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
 import { logger } from "./logger.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
@@ -20,6 +20,7 @@ import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwne
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
 import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
+import { syncNamespaceProxyTools } from "./namespace-tools.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
@@ -132,6 +133,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const envRaw = process.env.MCP_DIRECT_TOOLS;
   const envDirectToolOverride = envRaw?.split(",").map(s => s.trim()).filter(Boolean);
   const registeredDirectTools = new Map<string, string>();
+  const registeredNamespaceProxyTools = new Set<string>();
   const fallbackDeactivatedTools = new Set<string>();
   const toolRenderOptions = resolveMcpToolRenderOptions(earlyConfig.settings);
   const toolRenderShell = toolRenderOptions.resultRendering === "compact" ? "self" : "default";
@@ -276,6 +278,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const cache = loadMetadataCache();
     const result = syncDirectTools(config, cache);
     syncProxyTool(config, cache, result.specs);
+    const nsResult = syncNamespaceProxyTools({
+      config,
+      cache,
+      envOverride: envDirectToolOverride
+        ? parseDirectToolSelectors(envDirectToolOverride)
+        : null,
+      existingDirectNames: new Set(registeredDirectTools.keys()),
+      pi,
+      getState: () => state,
+      getInitPromise: () => initPromise,
+      getPiTools: () => pi.getAllTools(),
+    });
+    for (const name of nsResult.added) registeredNamespaceProxyTools.add(name);
+    for (const name of nsResult.deactivated) registeredNamespaceProxyTools.delete(name);
     const changed = result.added.length + result.updated.length + result.deactivated.length;
     if (changed > 0 && ctx?.hasUI) {
       ctx.ui.notify(

--- a/index.ts
+++ b/index.ts
@@ -1069,6 +1069,23 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   const initialDirectTools = syncDirectTools(earlyConfig, earlyCache).specs;
   syncProxyTool(earlyConfig, earlyCache, initialDirectTools);
+  // Register namespace-proxy tools eagerly so tool-groups/slow-mode can validate
+  // `mcp:<server>` references on the first session_start turn. Without this
+  // eager call, the tool-groups expansion runs before MCP initialization
+  // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
+  // Mirrors the upstream direct-tool install-time registration pattern.
+  syncNamespaceProxyTools({
+    config: earlyConfig,
+    cache: earlyCache,
+    envOverride: envDirectToolOverride
+      ? parseDirectToolSelectors(envDirectToolOverride)
+      : null,
+    existingDirectNames: new Set(registeredDirectTools.keys()),
+    pi,
+    getState: () => state,
+    getInitPromise: () => initPromise,
+    getPiTools: () => pi.getAllTools(),
+  });
   startLoadTimeInitialization();
 }
 

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -1,0 +1,243 @@
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { McpExtensionState } from "./state.ts";
+import type { McpConfig } from "./types.ts";
+import type { MetadataCache } from "./metadata-cache.ts";
+import { executeCall } from "./proxy-modes.ts";
+
+/**
+ * Namespace-proxy tool registration for proxy-only MCP servers.
+ *
+ * For each configured proxy-only server (no `directTools: true` and not a
+ * runtime server forced direct), register exactly one tool named
+ * `mcp__<server>` (matching the harness `_shared/mcp-tools` resolver's
+ * `namespaceProxyName`). Its execute accepts `{tool, args}` and forwards
+ * through the adapter's existing `executeCall`, so it inherits the same
+ * auto-auth, session recovery, output guard, and approval rules as the
+ * single `mcp` proxy tool — without polluting the prompt with one entry
+ * per tool.
+ *
+ * This unblocks `mcp:<server>` references from `tool-groups` and
+ * `slow-mode` against proxy-only servers without flipping `directTools: true`.
+ */
+
+export interface NamespaceProxySpec {
+  serverName: string;
+  toolName: string;
+  description: string;
+  prefix: string;
+}
+
+/**
+ * Mirror of the harness `_shared/mcp-tools` resolver's
+ * `namespaceProxyName`. Kept deliberately identical to the harness so
+ * tool-groups/slow-mode validation lines up without a config migration.
+ * Differs from upstream `formatToolName(..., "mcp")` which uses
+ * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
+ * When upstream adds its own namespace-proxy, we align conventions.
+ */
+export function namespaceProxyName(serverName: string): string {
+  return `mcp__${serverName.replace(/-/g, "_")}`;
+}
+
+function isServerDisabled(definition: { disabled?: boolean } | undefined): boolean {
+  return definition?.disabled === true;
+}
+
+function isDirectlyRegistered(
+  definition: { directTools?: boolean | string[] } | undefined,
+  settings: McpConfig["settings"],
+  serverName: string,
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+): boolean {
+  if (envOverride) {
+    if (envOverride.servers.has(serverName)) return true;
+    if (envOverride.tools.has(serverName)) return true;
+  }
+  if (definition?.directTools !== undefined) {
+    return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);
+  }
+  return settings?.directTools === true;
+}
+
+/**
+ * Resolve namespace-proxy tool specs for all proxy-only servers in `config`.
+ * A server qualifies when it is enabled, has cache metadata available, and is
+ * not directly registered. Server-name collisions with already-known direct
+ * tool prefixes (`mcp__<server>` reserved) are skipped.
+ */
+export function resolveNamespaceProxyTools(
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+  existingDirectNames: Set<string>,
+): NamespaceProxySpec[] {
+  if (!config || !cache) return [];
+  const specs: NamespaceProxySpec[] = [];
+  const seen = new Set<string>();
+
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (!definition || isServerDisabled(definition)) continue;
+
+    if (isDirectlyRegistered(definition, config.settings, serverName, envOverride)) {
+      continue;
+    }
+
+    const entry = cache.servers?.[serverName];
+    if (!entry || !Array.isArray(entry.tools) || entry.tools.length === 0) {
+      continue;
+    }
+
+    const toolName = namespaceProxyName(serverName);
+    if (existingDirectNames.has(toolName) || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+
+    specs.push({
+      serverName,
+      toolName,
+      description:
+        `Namespace-proxy for MCP server "${serverName}". ` +
+        `Forwards \`{tool, args}\` through the adapter's executeCall, so it inherits ` +
+        `the same auth / lifecycle / output-guard rules as the \`mcp\` proxy.`,
+      prefix: toolName,
+    });
+  }
+
+  return specs;
+}
+
+/**
+ * Lazily-required reference to the agent state — passed as a closure so the
+ * namespace proxy tool's execute can call `executeCall` once `state` exists.
+ * `getInitPromise` lets the executor await the first initialization round
+ * the same way `createDirectToolExecutor` does.
+ */
+export type GetState = () => McpExtensionState | null;
+export type GetInitPromise = () => Promise<McpExtensionState> | null;
+export type GetPiTools = () => Array<{ name: string }>;
+
+function namespaceExecute(
+  getState: GetState,
+  getInitPromise: GetInitPromise,
+  serverName: string,
+  getPiTools: GetPiTools,
+) {
+  return async (
+    _toolCallId: string,
+    params: { tool?: string; args?: Record<string, unknown> },
+    signal: AbortSignal | undefined,
+  ): Promise<AgentToolResult<Record<string, unknown>>> => {
+    if (typeof params.tool !== "string" || params.tool.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: `mcp__${serverName} requires a \`tool\` parameter naming the underlying MCP tool.` }],
+        details: { error: "missing_tool", server: serverName },
+      };
+    }
+    let state = getState();
+    if (!state) {
+      const initPromise = getInitPromise();
+      if (initPromise) {
+        try {
+          state = await initPromise;
+        } catch {
+          return {
+            content: [{ type: "text" as const, text: `MCP initialization failed for ${serverName}.` }],
+            details: { error: "init_failed", server: serverName },
+          };
+        }
+      }
+    }
+    if (!state) {
+      return {
+        content: [{ type: "text" as const, text: `MCP not initialized for ${serverName}.` }],
+        details: { error: "not_initialized", server: serverName },
+      };
+    }
+    return executeCall(
+      state,
+      params.tool,
+      params.args ?? {},
+      serverName,
+      getPiTools as never,
+      signal,
+      "proxy",
+    );
+  };
+}
+
+const parameters = Type.Object({
+  tool: Type.String({ description: "Underlying MCP tool name to call on this server." }),
+  args: Type.Optional(Type.Object({}, {
+    additionalProperties: true,
+    description: "Arguments for the underlying tool. The exact shape depends on the tool being called; use mcp({ describe: 'server/tool' }) to inspect.",
+  })),
+});
+
+export interface SyncNamespaceProxyToolsInput {
+  config: McpConfig | null;
+  cache: MetadataCache | null;
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null;
+  existingDirectNames: Set<string>;
+  pi: ExtensionAPI;
+  getState: GetState;
+  getInitPromise: GetInitPromise;
+  getPiTools: GetPiTools;
+}
+
+export interface SyncNamespaceProxyToolsResult {
+  specs: NamespaceProxySpec[];
+  added: string[];
+  updated: string[];
+  deactivated: string[];
+}
+
+/**
+ * Idempotent sync of namespace-proxy tool registrations:
+ * - Registers a new tool for each spec whose name is not yet registered.
+ * - Updates (re-registers with a fresh fingerprint) when the spec changes.
+ * - Unregisters tools for servers that are no longer proxy-only.
+ */
+export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): SyncNamespaceProxyToolsResult {
+  const specs = resolveNamespaceProxyTools(
+    input.config,
+    input.cache,
+    input.envOverride,
+    input.existingDirectNames,
+  );
+  const nextNames = new Set(specs.map((s) => s.toolName));
+  const result: SyncNamespaceProxyToolsResult = { specs, added: [], updated: [], deactivated: [] };
+
+  for (const spec of specs) {
+    input.pi.registerTool({
+      name: spec.toolName,
+      label: `MCP: ${spec.serverName}`,
+      description: spec.description,
+      parameters,
+      execute: namespaceExecute(
+        input.getState,
+        input.getInitPromise,
+        spec.serverName,
+        input.getPiTools,
+      ),
+    } as never);
+    result.added.push(spec.toolName);
+  }
+
+  // Deactivate stale entries.
+  const registered = (input.pi as unknown as {
+    unregisterTool?: (name: string) => boolean;
+  }).unregisterTool;
+  // We can't enumerate the registered map from outside the closure, so the
+  // caller owns lifecycle for stale entries by tracking previous names.
+  if (registered) {
+    for (const stale of input.existingDirectNames) {
+      if (stale.startsWith("mcp__") && !nextNames.has(stale)) {
+        if (registered(stale)) result.deactivated.push(stale);
+      }
+    }
+  }
+
+  return result;
+}

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -51,8 +51,7 @@ function isDirectlyRegistered(
   envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
 ): boolean {
   if (envOverride) {
-    if (envOverride.servers.has(serverName)) return true;
-    if (envOverride.tools.has(serverName)) return true;
+    return envOverride.servers.has(serverName) || envOverride.tools.has(serverName);
   }
   if (definition?.directTools !== undefined) {
     return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);
@@ -63,8 +62,8 @@ function isDirectlyRegistered(
 /**
  * Resolve namespace-proxy tool specs for all proxy-only servers in `config`.
  * A server qualifies when it is enabled, has cache metadata available, and is
- * not directly registered. Server-name collisions with already-known direct
- * tool prefixes (`mcp__<server>` reserved) are skipped.
+ * not directly registered. Collisions with direct tools and normalized server
+ * names are skipped.
  */
 export function resolveNamespaceProxyTools(
   config: McpConfig | null,
@@ -73,8 +72,7 @@ export function resolveNamespaceProxyTools(
   existingDirectNames: Set<string>,
 ): NamespaceProxySpec[] {
   if (!config || !cache) return [];
-  const specs: NamespaceProxySpec[] = [];
-  const seen = new Set<string>();
+  const candidates: NamespaceProxySpec[] = [];
 
   for (const [serverName, definition] of Object.entries(config.mcpServers)) {
     if (!definition || isServerDisabled(definition)) continue;
@@ -89,12 +87,11 @@ export function resolveNamespaceProxyTools(
     }
 
     const toolName = namespaceProxyName(serverName);
-    if (existingDirectNames.has(toolName) || seen.has(toolName)) {
+    if (existingDirectNames.has(toolName)) {
       continue;
     }
-    seen.add(toolName);
 
-    specs.push({
+    candidates.push({
       serverName,
       toolName,
       description:
@@ -105,7 +102,20 @@ export function resolveNamespaceProxyTools(
     });
   }
 
-  return specs;
+  const names = new Map<string, NamespaceProxySpec[]>();
+  for (const spec of candidates) {
+    const colliding = names.get(spec.toolName) ?? [];
+    colliding.push(spec);
+    names.set(spec.toolName, colliding);
+  }
+  return candidates.filter((spec) => {
+    const colliding = names.get(spec.toolName)!;
+    if (colliding.length === 1) return true;
+    if (colliding[0] === spec) {
+      console.warn(`MCP: skipping namespace proxy "${spec.toolName}" because servers ${colliding.map(({ serverName }) => `"${serverName}"`).sort().join(", ")} normalize to the same name`);
+    }
+    return false;
+  });
 }
 
 /**
@@ -180,6 +190,7 @@ export interface SyncNamespaceProxyToolsInput {
   cache: MetadataCache | null;
   envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null;
   existingDirectNames: Set<string>;
+  existingNamespaceNames: Set<string>;
   pi: ExtensionAPI;
   getState: GetState;
   getInitPromise: GetInitPromise;
@@ -229,13 +240,10 @@ export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): Sy
   const registered = (input.pi as unknown as {
     unregisterTool?: (name: string) => boolean;
   }).unregisterTool;
-  // We can't enumerate the registered map from outside the closure, so the
-  // caller owns lifecycle for stale entries by tracking previous names.
+  // The caller owns namespace lifecycle by tracking prior namespace names.
   if (registered) {
-    for (const stale of input.existingDirectNames) {
-      if (stale.startsWith("mcp__") && !nextNames.has(stale)) {
-        if (registered(stale)) result.deactivated.push(stale);
-      }
+    for (const stale of input.existingNamespaceNames) {
+      if (!nextNames.has(stale) && !input.existingDirectNames.has(stale) && registered(stale)) result.deactivated.push(stale);
     }
   }
 

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -241,9 +241,28 @@ export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): Sy
     unregisterTool?: (name: string) => boolean;
   }).unregisterTool;
   // The caller owns namespace lifecycle by tracking prior namespace names.
-  if (registered) {
-    for (const stale of input.existingNamespaceNames) {
-      if (!nextNames.has(stale) && !input.existingDirectNames.has(stale) && registered(stale)) result.deactivated.push(stale);
+  const staleNames = [...input.existingNamespaceNames].filter(
+    (name) => !nextNames.has(name) && !input.existingDirectNames.has(name),
+  );
+  for (const stale of staleNames) {
+    if (registered?.(stale)) result.deactivated.push(stale);
+  }
+  let activeTools: string[] | undefined;
+  if (staleNames.length > 0) {
+    try {
+      activeTools = input.pi.getActiveTools?.();
+    } catch (error) {
+      if (!(error instanceof Error && error.message.includes("Action methods cannot be called during extension loading"))) throw error;
+    }
+  }
+  if (activeTools) {
+    const stale = new Set(staleNames);
+    const nextActiveTools = activeTools.filter((name) => !stale.has(name));
+    if (nextActiveTools.length !== activeTools.length) {
+      input.pi.setActiveTools(nextActiveTools);
+      for (const name of staleNames) {
+        if (!result.deactivated.includes(name)) result.deactivated.push(name);
+      }
     }
   }
 

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -51,7 +51,7 @@ function isDirectlyRegistered(
   envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
 ): boolean {
   if (envOverride) {
-    return envOverride.servers.has(serverName) || envOverride.tools.has(serverName);
+    return envOverride.servers.has(serverName);
   }
   if (definition?.directTools !== undefined) {
     return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "ui-session.ts",
     "proxy-modes.ts",
     "direct-tools.ts",
+    "namespace-tools.ts",
     "commands.ts",
     "prompts.ts",
     "onboarding-state.ts",


### PR DESCRIPTION
## Summary

When a configured MCP server is not \`directTools: true\` and not forced-direct by \`MCP_DIRECT_TOOLS\`, register one extra tool named \`mcp__<server>\` that forwards \`{tool, args}\` through the adapter's existing \`executeCall\`.

This unblocks \`mcp:<server>\` references from \`tool-groups\` and \`slow-mode\` against proxy-only servers without forcing \`directTools: true\` on every server.

## Problem

\`tool-groups\` and \`slow-mode\` validate configured tool names against the live registered-tool set. Without a registered \`mcp__<server>\` tool, every \`mcp:context-mode\` reference (or any proxy-only server) emits:

\`\`\`
[unknown-tool] Unknown tool: mcp:context-mode
\`\`\`

…and \`slow-mode\` drops the config:

\`\`\`
Tool "mcp:ctx_execute" in slow-mode config does not exist and will be ignored
\`\`\`

The only existing workaround was \`directTools: true\` per server, which bloats the prompt with one entry per tool (e.g. context-mode's 11 tools).

## Tool contract

- **name**: \`mcp__<server>\` (matching the harness convention used by \`tool-groups\` and \`slow-mode\` resolvers)
- **input**: \`{ tool: string, args?: object }\`
- **output**: forwarded through the adapter's existing \`executeCall\`, so it inherits the same auto-auth, session recovery, output guard, and approval rules as the single \`mcp\` proxy tool

## Diff size

- 1 new file: \`namespace-tools.ts\` (~170 lines, pure helper)
- 1 new test file: \`__tests__/namespace-tools.test.ts\` (11 unit tests, all pass)
- 3 lines added in \`index.ts\` (one \`syncNamespaceProxyTools\` call at install + one in \`syncToolSurface\`)
- 1 entry in \`package.json\` \`files\` list
- 1 mock entry in \`__tests__/index-lifecycle.test.ts\`

## Test results

\`\`\`
Test Files  98 passed (102)
Tests  1239 passed (1245)
\`\`\`

The 6 failing tests are pre-existing flaky timing tests and 2 \`dist/\`-artifact tests unrelated to this change. New namespace-tools tests: 11 pass.

## Naming compatibility

The tool name \`mcp__<server>\` deliberately uses \`server.replace(/-/g,\"_\")\` to coordinate with the harness \`_shared/mcp-tools\` resolver's \`namespaceProxyName\`. This differs from upstream's \`formatToolName(..., \"mcp\")\` which uses \`sanitizeServerPrefix\` and produces names like \`mcp__context_2d_mode\`.

If/when upstream adds a native namespace-proxy concept, the naming can be aligned. Until then, this keeps the harness-compatible name.

## Local E2E

Verified in a real \`pi\` interactive session against this fork:
- No more \`[unknown-tool] mcp:context-mode\` / \`mcp:ctx_execute\` / \`mcp:context7\` / \`mcp:deepwiki\` diagnostics
- \`mcp__context_mode\` and \`mcp__exa\` appear in the registered tool list
- \`slow-mode\`'s \`mcp:ctx_execute: true\` validates cleanly