### PR TITLE
fix: reject gateway params nested inside args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.
 - Namespace proxy tools now clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
 - Kept transient HTTP 503 connection failures as availability errors without multiplying gateway retries or misdiagnosing the endpoint as non-MCP. Thanks to [@elkaix](https://github.com/elkaix) for PR #411.

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -921,7 +921,7 @@ describe("mcpAdapter session lifecycle", () => {
     );
   });
 
-  it("dispatches gateway params nested inside proxy args", async () => {
+  it("rejects gateway params nested inside proxy args", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);
     mocks.executeCall.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
@@ -937,18 +937,15 @@ describe("mcpAdapter session lifecycle", () => {
     await Promise.resolve();
 
     const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
-    await proxyTool.execute("call-1", { args: '{"search":"screenshot","limit":3}' });
-    await proxyTool.execute("call-2", { args: { tool: "demo_search", args: { q: "hello" }, server: "demo" } });
-
-    expect(mocks.executeSearch).toHaveBeenCalledWith(state, "screenshot", undefined, undefined, undefined, 3, undefined);
-    expect(mocks.executeCall).toHaveBeenCalledWith(
-      state,
-      "demo_search",
-      { q: "hello" },
-      "demo",
-      expect.any(Function),
-      undefined,
+    await expect(proxyTool.execute("call-1", { args: '{"search":"screenshot","limit":3}' })).rejects.toThrow(
+      "Gateway params were nested inside `args`; pass them top-level",
     );
+    await expect(proxyTool.execute("call-2", { args: { tool: "demo_search", args: { q: "hello" }, server: "demo" } })).rejects.toThrow(
+      "Gateway params were nested inside `args`; pass them top-level",
+    );
+
+    expect(mocks.executeSearch).not.toHaveBeenCalled();
+    expect(mocks.executeCall).not.toHaveBeenCalled();
     expect(mocks.executeStatus).not.toHaveBeenCalled();
   });
 
@@ -969,27 +966,10 @@ describe("mcpAdapter session lifecycle", () => {
     await expect(proxyTool.execute("call-1", { args: '{"query":"screenshot"}' })).rejects.toThrow(
       "Gateway params were nested inside `args`; pass them top-level",
     );
-    expect(mocks.executeStatus).not.toHaveBeenCalled();
-  });
-
-  it("rejects invalid nested gateway param types before dispatch", async () => {
-    const state = createState();
-    mocks.initializeMcp.mockResolvedValue(state);
-
-    const { default: mcpAdapter } = await import("../index.ts");
-    const { api, handlers } = createPi();
-    mcpAdapter(api);
-
-    const sessionStart = handlers.get("session_start");
-    await sessionStart?.({}, {});
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
-    await expect(proxyTool.execute("call-1", { args: { search: 5 } })).rejects.toThrow(
-      "Invalid nested gateway param `search`: expected string, got number",
+    await expect(proxyTool.execute("call-2", { args: "" })).rejects.toThrow(
+      "Gateway params were nested inside `args`; pass them top-level",
     );
-    expect(mocks.executeSearch).not.toHaveBeenCalled();
+    expect(mocks.executeStatus).not.toHaveBeenCalled();
   });
 
   it("routes manual auth actions through the proxy tool", async () => {

--- a/index.ts
+++ b/index.ts
@@ -907,30 +907,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           }
           return args as Record<string, unknown>;
         };
-        const validateNestedGatewayParams = (value: Record<string, unknown>): typeof params => {
-          for (const key of ["tool", "connect", "describe", "instructions", "search", "server", "action"] as const) {
-            if (value[key] !== undefined && typeof value[key] !== "string") {
-              throw new Error(`Invalid nested gateway param \`${key}\`: expected string, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
-            }
-          }
-          for (const key of ["regex", "includeSchemas"] as const) {
-            if (value[key] !== undefined && typeof value[key] !== "boolean") {
-              throw new Error(`Invalid nested gateway param \`${key}\`: expected boolean, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
-            }
-          }
-          for (const key of ["limit", "offset"] as const) {
-            if (value[key] !== undefined && typeof value[key] !== "number") {
-              throw new Error(`Invalid nested gateway param \`${key}\`: expected number, got ${Array.isArray(value[key]) ? "array" : typeof value[key]}`);
-            }
-          }
-          const args = value.args;
-          if (args !== undefined && typeof args !== "string" && (typeof args !== "object" || args === null || Array.isArray(args))) {
-            throw new Error(`Invalid nested gateway param \`args\`: expected JSON object or JSON string, got ${Array.isArray(args) ? "array" : args === null ? "null" : typeof args}`);
-          }
-          return value as typeof params;
-        };
-        let parsedArgs = parseArgs(params.args);
-        let dispatchParams = params;
+        const parsedArgs = parseArgs(params.args);
         const hasGatewayMode = (value: typeof params): boolean =>
           value.tool !== undefined
           || value.connect !== undefined
@@ -939,15 +916,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           || value.search !== undefined
           || value.server !== undefined
           || value.action !== undefined;
-        if (!hasGatewayMode(params) && parsedArgs) {
-          const nestedParams = validateNestedGatewayParams(parsedArgs);
-          if (hasGatewayMode(nestedParams)) {
-            dispatchParams = nestedParams;
-            parsedArgs = parseArgs(nestedParams.args);
-          } else {
-            throw new Error("Gateway params were nested inside `args`; pass them top-level (for example, mcp({ search: \"...\" }) or mcp({ tool: \"...\", args: {} })).");
-          }
-        } else if (!hasGatewayMode(params) && params.args !== undefined) {
+        if (!hasGatewayMode(params) && params.args !== undefined) {
           throw new Error("Gateway params were nested inside `args`; pass them top-level (for example, mcp({ search: \"...\" }) or mcp({ tool: \"...\", args: {} })).");
         }
 
@@ -979,22 +948,22 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         }
         executeOwner?.throwIfInactive();
 
-        if (dispatchParams.action === "ui-messages") {
+        if (params.action === "ui-messages") {
           return executeUiMessages(state);
         }
-        if (dispatchParams.action === "auth-start") {
-          if (!dispatchParams.server) {
+        if (params.action === "auth-start") {
+          if (!params.server) {
             return {
               content: [{ type: "text" as const, text: "auth-start requires `server`. Example: mcp({ action: \"auth-start\", server: \"linear-server\" })" }],
               details: { mode: "auth-start", error: "missing_server" },
             };
           }
           return signal
-            ? executeAuthStart(state, dispatchParams.server, signal)
-            : executeAuthStart(state, dispatchParams.server);
+            ? executeAuthStart(state, params.server, signal)
+            : executeAuthStart(state, params.server);
         }
-        if (dispatchParams.action === "auth-complete") {
-          if (!dispatchParams.server) {
+        if (params.action === "auth-complete") {
+          if (!params.server) {
             return {
               content: [{ type: "text" as const, text: "auth-complete requires `server`." }],
               details: { mode: "auth-complete", error: "missing_server" },
@@ -1008,28 +977,28 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
             };
           }
           return signal
-            ? executeAuthComplete(state, dispatchParams.server, input, signal)
-            : executeAuthComplete(state, dispatchParams.server, input);
+            ? executeAuthComplete(state, params.server, input, signal)
+            : executeAuthComplete(state, params.server, input);
         }
-        if (dispatchParams.tool) {
-          return executeCall(state, dispatchParams.tool, parsedArgs, dispatchParams.server, getPiTools, signal);
+        if (params.tool) {
+          return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, signal);
         }
-        if (dispatchParams.connect) {
-          const result = await executeConnect(state, dispatchParams.connect, signal);
+        if (params.connect) {
+          const result = await executeConnect(state, params.connect, signal);
           syncToolSurface(_ctx as ExtensionContext);
           return result;
         }
-        if (dispatchParams.describe) {
-          return executeDescribe(state, dispatchParams.describe);
+        if (params.describe) {
+          return executeDescribe(state, params.describe);
         }
-        if (dispatchParams.instructions) {
-          return executeInstructions(state, dispatchParams.instructions);
+        if (params.instructions) {
+          return executeInstructions(state, params.instructions);
         }
-        if (dispatchParams.search !== undefined) {
-          return executeSearch(state, dispatchParams.search, dispatchParams.regex, dispatchParams.server, dispatchParams.includeSchemas, dispatchParams.limit, dispatchParams.offset);
+        if (params.search !== undefined) {
+          return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, params.limit, params.offset);
         }
-        if (dispatchParams.server) {
-          return executeList(state, dispatchParams.server);
+        if (params.server) {
+          return executeList(state, params.server);
         }
         return executeStatus(state);
       },


### PR DESCRIPTION
## Problem

The `mcp` proxy tool currently holds **two opposite policies** for gateway params nested inside `args`:

- nested object **has** a gateway key (`tool`/`connect`/`describe`/`instructions`/`search`/`server`/`action`) → **silently unwrapped and executed** (`dispatchParams = nestedParams`);
- nested object **lacks** one → **rejected** with guidance — from two byte-identical throws.

Observed:

| Call | Result |
|---|---|
| `mcp({args: {search: "code flows"}})` | executed the search (silent unwrap) |
| `mcp({args: {args: {search: "..."}}})` | error |
| `mcp({args: {foo: 1}})` | error |
| `mcp({args: ""})` | error (second, byte-identical throw) |

The unwrap and the reject were added in the same change (#363 era), so one of the two was never finished: the error message documents the reject policy while the code also silently accepts the nested form. A model that once sees the silent unwrap succeed will keep nesting params — and hit the reject on the next shape.

## Fix

Pick **one** policy — the documented one: **reject everywhere**. After parsing `args`, any `args` value present without a top-level gateway mode throws the existing guidance error. Deletes the unwrap branch, the `validateNestedGatewayParams` type validator that only existed to type-check the unwrapped params, and the `dispatchParams` indirection (dispatch always uses top-level `params` now). Net −51 lines.

## Tests

- `dispatches gateway params nested inside proxy args` → inverted: nested gateway params (JSON-string and object form) now reject with the guidance message and nothing dispatches;
- added the `args: ""` case to the non-gateway rejection test (it previously hit the second duplicate throw);
- the validator-specific type-error test is gone with the validator — nested objects now get one consistent message.

Typecheck clean; full suite green (only pre-existing `interactive-visualizer` dist-artifact failures remain, unrelated).