### PR TITLE
fix: show mcpScript call input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.
 - Namespace proxy tools now clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.

--- a/__tests__/tool-result-renderer.test.ts
+++ b/__tests__/tool-result-renderer.test.ts
@@ -2,8 +2,10 @@ import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/p
 import { describe, expect, it } from "vitest";
 import {
   createMcpDirectToolCallRenderer,
+  createMcpScriptToolCallRenderer,
   resolveMcpToolRenderOptions,
   formatMcpDirectToolCallLines,
+  formatMcpScriptToolCallLines,
   formatMcpProxyToolCallLines,
   formatMcpToolResultIdentity,
   formatMcpToolResultLines,
@@ -74,6 +76,16 @@ describe("MCP tool call renderer", () => {
 
   it("omits empty direct tool arguments", () => {
     expect(formatMcpDirectToolCallLines("cf-portal_status", {})).toEqual(["cf-portal_status"]);
+  });
+
+  it("shows bounded mcpScript code", () => {
+    const display = formatMcpScriptToolCallLines({
+      code: `await tools.search({ query: "${"x".repeat(1_600)}" });`,
+    });
+
+    expect(display[0]).toBe("mcpScript");
+    expect(display[1]).toHaveLength(1_500);
+    expect(display[1]?.endsWith("…")).toBe(true);
   });
 });
 
@@ -179,6 +191,26 @@ describe("MCP tool result renderer", () => {
     expect(output).toContain("query");
     expect(output).toContain("alpha");
     expect(output).toContain("found 10 results");
+  });
+
+  it("does not copy mcpScript code into compact final rows", () => {
+    const state: { compactTitle?: string; compactInputPreview?: string } = {};
+    const code = 'emit("secret-script-code");';
+    const call = createMcpScriptToolCallRenderer()(
+      { code },
+      plainTheme,
+      { isError: false, isPartial: false, expanded: false, state },
+    );
+    const output = renderMcpToolResult(
+      result([{ type: "text", text: "done" }]),
+      collapsedOptions,
+      plainTheme,
+      { isError: false, state },
+    ).render(120).join("\n");
+
+    expect(call.render(120)).toEqual([]);
+    expect(state.compactInputPreview).toBeUndefined();
+    expect(output).not.toContain(code);
   });
 
   it("skips leading blank lines in collapsed previews", () => {
@@ -358,5 +390,15 @@ describe("MCP tool call renderers without a theme", () => {
   it("renders direct calls without a theme", () => {
     const output = createMcpDirectToolCallRenderer("test_tool")({ key: "value" }).render(80).join("\n");
     expect(output).toContain("test_tool");
+  });
+
+  it("renders mcpScript calls without a theme", () => {
+    const output = createMcpScriptToolCallRenderer()(
+      { code: 'emit("visible");' },
+      undefined,
+      { isError: false, expanded: true },
+    ).render(80).join("\n");
+    expect(output).toContain("mcpScript");
+    expect(output).toContain('emit("visible");');
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ import { logger } from "./logger.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
 import { formatTerminalError, getConfigPathFromArgv, normalizeDirectToolInputSchema, truncateAtWord } from "./utils.ts";
 import { createOAuthRuntime, shutdownOAuth } from "./mcp-auth-flow.ts";
-import { createMcpDirectToolCallRenderer, createMcpProxyToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions } from "./tool-result-renderer.ts";
+import { createMcpDirectToolCallRenderer, createMcpProxyToolCallRenderer, createMcpScriptToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions } from "./tool-result-renderer.ts";
 import { toolErrorOverride } from "./error-signal.ts";
 import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwner } from "./runtime-owner.ts";
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
@@ -806,6 +806,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         code: Type.String({ description: "Trusted JavaScript MCP script. Use tools.<prefixedToolName>(args) and emit(value)." }),
         timeoutMs: optionalNumber({ minimum: 1, description: "Execution timeout in milliseconds (default: 30000)" }),
       }),
+      renderCall: createMcpScriptToolCallRenderer(toolRenderOptions),
       renderResult: renderMcpToolResult,
       async execute(_toolCallId: string, params: { code: string; timeoutMs?: number }, signal: AbortSignal | undefined) {
         const executeOwner = currentOwner;

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -250,6 +250,13 @@ export function formatMcpDirectToolCallLines(
   return [displayName, formatJsonish(args, maxInputChars)];
 }
 
+export function formatMcpScriptToolCallLines(
+  args: { code: string },
+  maxInputChars = DEFAULT_MAX_CALL_INPUT_CHARS,
+): string[] {
+  return ["mcpScript", truncateText(args.code, maxInputChars)];
+}
+
 function renderToolCallLines(lines: string[], theme?: RenderTheme) {
   const activeTheme = theme ?? plainTheme;
   const [title = "mcp", ...rest] = lines;
@@ -311,6 +318,13 @@ export function createMcpProxyToolCallRenderer(options: McpToolRenderOptions) {
 export function createMcpDirectToolCallRenderer(displayName: string, options = resolveMcpToolRenderOptions()) {
   return (args: Record<string, unknown>, theme?: RenderTheme, context?: McpToolRenderContext) => {
     return renderToolCall(formatMcpDirectToolCallLines(displayName, args), theme, context, options);
+  };
+}
+
+export function createMcpScriptToolCallRenderer(options = resolveMcpToolRenderOptions()) {
+  return (args: { code: string }, theme?: RenderTheme, context?: McpToolRenderContext) => {
+    if (shouldUseCompactFinalRender(options, context)) return new EmptyComponent();
+    return renderToolCallLines(formatMcpScriptToolCallLines(args), theme);
   };
 }
 


### PR DESCRIPTION
## Summary

Shows bounded `mcpScript` submitted code in the expanded tool-call view so users can inspect what ran. The code stays out of compact result previews and result details.

Closes #413.

Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.

## Validation

- `npm test -- --run __tests__/tool-result-renderer.test.ts __tests__/index-lifecycle.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`