### PR TITLE
fix: clarify ambiguous HTTP probe responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.

--- a/__tests__/mcp-probe.test.ts
+++ b/__tests__/mcp-probe.test.ts
@@ -64,6 +64,38 @@ describe("MCP endpoint shape probe", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("reports an accepted response without claiming the URL is not MCP", async () => {
+    mockFetch(new Response("Accepted", {
+      status: 202,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const result = await probeMcpEndpoint("https://example.test/mcp");
+
+    expect(result).toMatchObject({
+      isMcp: false,
+      classification: "endpoint returned application/json (202) — MCP endpoint shape could not be determined",
+    });
+    expect(result.classification).not.toContain("does not appear to speak MCP");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unauthenticated response without claiming the URL is not MCP", async () => {
+    mockFetch(
+      new Response("Unauthorized", { status: 401, headers: { "content-type": "application/json" } }),
+      new Response("Unauthorized", { status: 401, headers: { "content-type": "application/json" } }),
+    );
+
+    const result = await probeMcpEndpoint("https://example.test/mcp");
+
+    expect(result).toMatchObject({
+      isMcp: false,
+      classification: "endpoint returned application/json (401) — authentication may be required; MCP endpoint shape could not be determined",
+    });
+    expect(result.classification).not.toContain("does not appear to speak MCP");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("recognizes a modern stateless server/discover response", async () => {
     mockFetch(new Response(JSON.stringify({
       jsonrpc: "2.0", id: 1, result: { protocolVersion: "2026-07-28" },

--- a/mcp-probe.ts
+++ b/mcp-probe.ts
@@ -168,7 +168,11 @@ function notMcp(response: Response): McpProbeResult {
     isMcp: false,
     classification: response.status === 503
       ? `${responseDescription} — server is temporarily unavailable; MCP endpoint shape could not be determined`
-      : `${responseDescription} — this URL does not appear to speak MCP`,
+      : response.status === 202
+        ? `${responseDescription} — MCP endpoint shape could not be determined`
+      : response.status === 401
+        ? `${responseDescription} — authentication may be required; MCP endpoint shape could not be determined`
+        : `${responseDescription} — this URL does not appear to speak MCP`,
   };
 }
 


### PR DESCRIPTION
## Summary

Clarifies endpoint probe diagnostics for ambiguous HTTP 202 and unauthenticated HTTP 401 responses. The probe no longer claims these ambiguous responses mean the URL does not speak MCP.

This is diagnostic-only. It does not change OAuth, token storage, reconnect lifecycle, transport selection, SDK behavior, or SSE fallback rules. It does not claim to fix the Atlassian reconnect issue.

Refs #415.

Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.

## Validation

- `npm test -- --run __tests__/mcp-probe.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`