### PR TITLE
feat: native `mcp:` reference resolution + public export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ conformance/results/
 *.log
 .DS_Store
 
+# bun lockfile (this fork uses npm/package-lock.json)
+bun.lock
+bun.lockb
+
 progress.md
 worker-summary.md
 worker-*.md

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -64,6 +64,26 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../metadata-cache.ts", () => ({
   loadMetadataCache: mocks.loadMetadataCache,
+  parseDirectToolSelectors: (selectors: string[]) => {
+    const servers = new Set<string>();
+    const tools = new Map<string, Set<string>>();
+    for (const raw of selectors) {
+      const sel = raw.replace(/\/+$/, "");
+      if (sel.includes("/")) {
+        const [server, tool] = sel.split("/", 2);
+        if (server && tool) {
+          const set = tools.get(server) ?? new Set<string>();
+          set.add(tool);
+          tools.set(server, set);
+        } else if (server) {
+          servers.add(server);
+        }
+      } else if (sel) {
+        servers.add(sel);
+      }
+    }
+    return { servers, tools };
+  },
 }));
 
 vi.mock("../direct-tools.ts", () => ({

--- a/__tests__/mcp-references.test.ts
+++ b/__tests__/mcp-references.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveMcpToolReferences,
+  parseMcpReference,
+  isProxyOnlyServer,
+  namespaceProxyName,
+  createMcpRefResolver,
+  type McpConfig,
+  type MetadataCache,
+} from "../mcp-references.ts";
+
+function makeCache(): MetadataCache {
+  return {
+    version: 1,
+    servers: {
+      context7: {
+        configHash: "h",
+        cachedAt: Date.now(),
+        tools: [{ name: "resolve_library_id" }, { name: "query_docs" }],
+        resources: [],
+      },
+      deepwiki: {
+        configHash: "h",
+        cachedAt: Date.now(),
+        tools: [{ name: "ask_question" }, { name: "read_wiki_contents" }],
+        resources: [],
+      },
+      "context-mode": {
+        configHash: "h",
+        cachedAt: Date.now(),
+        tools: [{ name: "ctx_execute" }, { name: "ctx_search" }],
+        resources: [],
+      },
+    },
+  };
+}
+
+function makeConfig(): McpConfig {
+  return {
+    mcpServers: {
+      context7: { url: "https://mcp.context7.com/mcp", directTools: true },
+      deepwiki: { url: "https://mcp.deepwiki.com/mcp", directTools: true },
+      "context-mode": { command: "context-mode", lifecycle: "eager" },
+    },
+  };
+}
+
+describe("parseMcpReference", () => {
+  it("returns empty for a bare mcp: with no server", () => {
+    expect(parseMcpReference("mcp:")).toEqual({ raw: "mcp:" });
+  });
+
+  it("parses server-level reference", () => {
+    expect(parseMcpReference("mcp:context7")).toEqual({ raw: "mcp:context7", server: "context7" });
+  });
+
+  it("parses server/tool reference", () => {
+    expect(parseMcpReference("mcp:context7/query_docs")).toEqual({
+      raw: "mcp:context7/query_docs",
+      server: "context7",
+      tool: "query_docs",
+    });
+  });
+
+  it("does not treat a non-mcp reference as mcp", () => {
+    expect(parseMcpReference("read")).toEqual({ raw: "read" });
+  });
+});
+
+describe("isProxyOnlyServer", () => {
+  it("is false for directTools: true", () => {
+    expect(isProxyOnlyServer("context7", { directTools: true }, undefined)).toBe(false);
+  });
+
+  it("is true when directTools is unset and no global directTools", () => {
+    expect(isProxyOnlyServer("context-mode", {}, undefined)).toBe(true);
+  });
+
+  it("is false when global directTools is true", () => {
+    expect(isProxyOnlyServer("context-mode", {}, { directTools: true })).toBe(false);
+  });
+
+  it("is false when envOverride marks the server direct (D5)", () => {
+    const env = { servers: new Set(["context-mode"]), tools: new Map() };
+    expect(isProxyOnlyServer("context-mode", {}, undefined, env)).toBe(false);
+  });
+
+  it("is true when envOverride does not mention the server", () => {
+    const env = { servers: new Set(["other-server"]), tools: new Map() };
+    expect(isProxyOnlyServer("context-mode", {}, undefined, env)).toBe(true);
+  });
+});
+
+describe("namespaceProxyName", () => {
+  it("formats server name with mcp__ prefix and simple underscores (D4)", () => {
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(namespaceProxyName("my-server-1")).toBe("mcp__my_server_1");
+    expect(namespaceProxyName("context7")).toBe("mcp__context7");
+  });
+});
+
+describe("resolveMcpToolReferences", () => {
+  const cache = makeCache();
+  const config = makeConfig();
+
+  it("expands a server-level reference to all its tools", () => {
+    const r = resolveMcpToolReferences(["mcp:context7"], config, cache);
+    expect(r.names).toEqual(["context7_resolve_library_id", "context7_query_docs"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("resolves a specific server/tool reference", () => {
+    const r = resolveMcpToolReferences(["mcp:context7/query_docs"], config, cache);
+    expect(r.names).toEqual(["context7_query_docs"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("resolves a bare tool reference to its owning direct server tool", () => {
+    const r = resolveMcpToolReferences(["mcp:ask_question"], config, cache);
+    expect(r.names).toEqual(["deepwiki_ask_question"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("resolves a bare tool on a proxy-only server to the namespace-proxy name", () => {
+    const r = resolveMcpToolReferences(["mcp:ctx_execute"], config, cache);
+    expect(r.names).toEqual(["mcp__context_mode"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("resolves a server-level reference on a proxy-only server to its namespace-proxy name", () => {
+    const r = resolveMcpToolReferences(["mcp:context-mode"], config, cache);
+    expect(r.names).toEqual(["mcp__context_mode"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("passes non-mcp references through unchanged", () => {
+    const r = resolveMcpToolReferences(["read", "grep"], config, cache);
+    expect(r.names).toEqual(["read", "grep"]);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("deduplicates across references", () => {
+    const r = resolveMcpToolReferences(["mcp:context7", "mcp:context7/query_docs"], config, cache);
+    expect(r.names).toEqual(["context7_resolve_library_id", "context7_query_docs"]);
+  });
+
+  it("emits a diagnostic for an unknown server", () => {
+    const r = resolveMcpToolReferences(["mcp:does-not-exist"], config, cache);
+    expect(r.names).toEqual([]);
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("emits a diagnostic for an unknown tool on a known server", () => {
+    const r = resolveMcpToolReferences(["mcp:context7/nope"], config, cache);
+    expect(r.names).toEqual([]);
+    expect(r.diagnostics.join(" ")).toContain("unknown tool");
+  });
+
+  it("returns a diagnostic when config is missing", () => {
+    const r = resolveMcpToolReferences(["mcp:context7"], null, cache);
+    expect(r.names).toEqual([]);
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("emits a diagnostic when a server has no cache metadata", () => {
+    const r = resolveMcpToolReferences(["mcp:context7"], config, { version: 1, servers: {} });
+    expect(r.names).toEqual([]);
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("expands directTools with the native toolPrefix name for dashed servers (D4)", () => {
+    const cfg: McpConfig = {
+      mcpServers: {
+        "context-mode": { command: "context-mode", directTools: true, toolPrefix: "mcp" },
+      },
+      settings: {},
+    };
+    const c: MetadataCache = {
+      version: 1,
+      servers: {
+        "context-mode": {
+          configHash: "h",
+          cachedAt: Date.now(),
+          tools: [{ name: "ctx_execute" }],
+          resources: [],
+        },
+      },
+    };
+    // The adapter registers direct tools as formatToolName(tool, server, "mcp")
+    // which KEEPS hyphens in dashed server names → mcp__context-mode_ctx_execute
+    // (the native sanitizeServerPrefix preserves `-`; NOT _2d_ encoding, and not
+    // the old harness copy which replaced `-` with `_`).
+    const r = resolveMcpToolReferences(["mcp:context-mode"], cfg, c);
+    expect(r.names).toEqual(["mcp__context-mode_ctx_execute"]);
+  });
+
+  it("resolves direct names instead of the proxy name when envOverride marks the server direct (D5)", () => {
+    const env = { servers: new Set(["context-mode"]), tools: new Map() };
+    const r = resolveMcpToolReferences(["mcp:context-mode"], config, cache, env);
+    // context-mode is proxy-only in config but forced direct by env; the
+    // resolver must expand its cache tools like a direct server (native
+    // formatToolName keeps the dash), NOT return mcp__context_mode.
+    expect(r.names).toEqual(["context-mode_ctx_execute", "context-mode_ctx_search"]);
+    expect(r.names).not.toContain("mcp__context_mode");
+    expect(r.diagnostics).toEqual([]);
+  });
+});
+
+describe("createMcpRefResolver", () => {
+  function makeDeps(config: McpConfig | null, cache: MetadataCache | null) {
+    return {
+      loadConfig: vi.fn(() => config),
+      loadCache: vi.fn(() => cache),
+      envDirectTools: undefined,
+    };
+  }
+
+  it("returns [] for mcp: references when config is null", () => {
+    const deps = makeDeps(null, makeCache());
+    const resolve = createMcpRefResolver(undefined, deps);
+    expect(resolve("mcp:context7")).toEqual([]);
+  });
+
+  it("passes non-mcp references through unchanged", () => {
+    const deps = makeDeps(makeConfig(), makeCache());
+    const resolve = createMcpRefResolver(undefined, deps);
+    expect(resolve("read")).toEqual(["read"]);
+    expect(resolve("grep")).toEqual(["grep"]);
+  });
+
+  it("memoizes config/cache loading across calls", () => {
+    const deps = makeDeps(makeConfig(), makeCache());
+    const resolve = createMcpRefResolver(undefined, deps);
+    resolve("mcp:context7");
+    resolve("mcp:context7");
+    expect(deps.loadConfig).toHaveBeenCalledTimes(1);
+    expect(deps.loadCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] when config load throws and retries on next call", () => {
+    const loadConfig = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("boom");
+      })
+      .mockImplementationOnce(() => makeConfig());
+    const deps = makeDeps(makeConfig(), makeCache());
+    deps.loadConfig = loadConfig;
+    const resolve = createMcpRefResolver(undefined, deps);
+    expect(resolve("mcp:context7")).toEqual([]);
+    // Next call retries (no negative memoization of exceptions).
+    expect(resolve("mcp:context7")).toEqual(["context7_resolve_library_id", "context7_query_docs"]);
+    expect(loadConfig).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("public export smoke (index.ts)", () => {
+  it("re-exports the resolution API from the package entrypoint", async () => {
+    const mod = await import("../index.ts");
+    expect(typeof mod.resolveMcpToolReferences).toBe("function");
+    expect(typeof mod.createMcpRefResolver).toBe("function");
+    expect(typeof mod.namespaceProxyName).toBe("function");
+    expect(typeof mod.parseMcpReference).toBe("function");
+    expect(typeof mod.isProxyOnlyServer).toBe("function");
+    expect(typeof mod.loadMcpConfig).toBe("function");
+    expect(typeof mod.loadMetadataCache).toBe("function");
+  });
+});

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for the namespace-proxy tool registration logic.
+ *
+ * `syncNamespaceProxyTools` is the focused, side-effect-free function
+ * (aside from the injected `pi.registerTool`) that the adapter calls from
+ * `syncToolSurface`. We test it directly to keep the surface tight; the
+ * existing `index-lifecycle.test.ts` covers the full adapter boot.
+ */
+
+const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }> }]>) => ({
+  version: 1,
+  servers: Object.fromEntries(entries.map(([server, v]) => [server, { tools: v.tools, configHash: "h", cachedAt: Date.now() }])),
+});
+
+function makePi() {
+  const registered = new Map<string, { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }>();
+  const unregistered: string[] = [];
+  const api = {
+    registerTool: vi.fn((tool: { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }) => {
+      registered.set(tool.name, tool);
+    }),
+    unregisterTool: vi.fn((name: string) => {
+      const had = registered.has(name);
+      registered.delete(name);
+      if (had) unregistered.push(name);
+      return had;
+    }),
+  };
+  return { pi: api as any, registered, unregistered };
+}
+
+async function importSync() {
+  const mod = await import("../namespace-tools.ts");
+  return {
+    syncNamespaceProxyTools: mod.syncNamespaceProxyTools,
+    namespaceProxyName: mod.namespaceProxyName,
+  };
+}
+
+describe("namespaceProxyName", () => {
+  it("replaces hyphens with underscores in server names", async () => {
+    const { namespaceProxyName } = await importSync();
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(namespaceProxyName("chrome-devtools")).toBe("mcp__chrome_devtools");
+    expect(namespaceProxyName("foo")).toBe("mcp__foo");
+  });
+
+  it("matches the harness _shared/mcp-tools resolver contract", async () => {
+    // The harness resolver produces `mcp__<server-with-dashes-as-underscores>`
+    // and validates against it. The fork must produce the same string.
+    const { namespaceProxyName } = await importSync();
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(namespaceProxyName("my-server-1")).toBe("mcp__my_server_1");
+  });
+});
+
+describe("syncNamespaceProxyTools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers mcp__<server> for each proxy-only server with metadata", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode", lifecycle: "eager" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(true);
+    const tool = registered.get("mcp__context_mode")!;
+    expect(tool.execute).toBeTypeOf("function");
+  });
+
+  it("does NOT register for directTools: true servers (avoids duplicating direct tools)", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { context7: { url: "https://mcp.context7.com/mcp", directTools: true } } },
+      cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(["context7_query_docs"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context7")).toBe(false);
+  });
+
+  it("skips disabled servers", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode", disabled: true } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("skips servers with no metadata in the cache", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("skips servers that are forced direct by MCP_DIRECT_TOOLS env override", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: { servers: new Set(["context-mode"]), tools: new Map() },
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("exposes a `tool` and optional `args` parameter schema for dispatch", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    const tool = registered.get("mcp__context_mode")!;
+    expect(tool.parameters).toBeDefined();
+    const props = (tool.parameters as any).properties;
+    expect(props.tool).toBeDefined();
+    expect(props.args).toBeDefined();
+  });
+
+  it("skips registration when an existing direct tool already uses mcp__<server>", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    // Edge case: a directTool is named "mcp__context_mode" (very unlikely but possible
+    // if the user defined directTools: ["mcp__context_mode"] on a server). We must
+    // not double-register the same name.
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.size).toBe(0);
+  });
+
+  it("deactivates stale entries between syncs (server removed from config)", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered, unregistered } = makePi();
+
+    // First sync: register context-mode.
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+    expect(registered.has("mcp__context_mode")).toBe(true);
+
+    // Second sync: context-mode is gone, but the previous names list still
+    // includes the now-stale mcp__context_mode. Caller passes the union of
+    // previously-registered names so we can deactivate.
+    syncNamespaceProxyTools({
+      config: { mcpServers: {} },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(unregistered).toContain("mcp__context_mode");
+  });
+
+  it("registers a new server and keeps existing ones in a single sync", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: {
+        mcpServers: {
+          "context-mode": { command: "context-mode" },
+          "context7": { url: "https://mcp.context7.com/mcp" }, // proxy-only (no directTools)
+        },
+      },
+      cache: CACHE_SHAPE([
+        ["context-mode", { tools: [{ name: "ctx_execute" }] }],
+        ["context7", { tools: [{ name: "query_docs" }] }],
+      ]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(true);
+    expect(registered.has("mcp__context7")).toBe(true);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, 
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
-import { loadMetadataCache, type MetadataCache } from "./metadata-cache.ts";
+import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
 import { logger } from "./logger.ts";
 import { executeAuthComplete, executeAuthStart, executeCall, executeConnect, executeDescribe, executeInstructions, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
@@ -20,6 +20,7 @@ import { createMcpRuntimeOwner, createOwnedUi, isAbortError, type McpRuntimeOwne
 import { publishMcpStatusShutdown } from "./mcp-status.ts";
 import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
+import { syncNamespaceProxyTools } from "./namespace-tools.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
@@ -132,6 +133,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const envRaw = process.env.MCP_DIRECT_TOOLS;
   const envDirectToolOverride = envRaw?.split(",").map(s => s.trim()).filter(Boolean);
   const registeredDirectTools = new Map<string, string>();
+  const registeredNamespaceProxyTools = new Set<string>();
   const fallbackDeactivatedTools = new Set<string>();
   const toolRenderOptions = resolveMcpToolRenderOptions(earlyConfig.settings);
   const toolRenderShell = toolRenderOptions.resultRendering === "compact" ? "self" : "default";
@@ -276,6 +278,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const cache = loadMetadataCache();
     const result = syncDirectTools(config, cache);
     syncProxyTool(config, cache, result.specs);
+    const nsResult = syncNamespaceProxyTools({
+      config,
+      cache,
+      envOverride: envDirectToolOverride
+        ? parseDirectToolSelectors(envDirectToolOverride)
+        : null,
+      existingDirectNames: new Set(registeredDirectTools.keys()),
+      pi,
+      getState: () => state,
+      getInitPromise: () => initPromise,
+      getPiTools: () => pi.getAllTools(),
+    });
+    for (const name of nsResult.added) registeredNamespaceProxyTools.add(name);
+    for (const name of nsResult.deactivated) registeredNamespaceProxyTools.delete(name);
     const changed = result.added.length + result.updated.length + result.deactivated.length;
     if (changed > 0 && ctx?.hasUI) {
       ctx.ui.notify(

--- a/index.ts
+++ b/index.ts
@@ -1069,6 +1069,23 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   const initialDirectTools = syncDirectTools(earlyConfig, earlyCache).specs;
   syncProxyTool(earlyConfig, earlyCache, initialDirectTools);
+  // Register namespace-proxy tools eagerly so tool-groups/slow-mode can validate
+  // `mcp:<server>` references on the first session_start turn. Without this
+  // eager call, the tool-groups expansion runs before MCP initialization
+  // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
+  // Mirrors the upstream direct-tool install-time registration pattern.
+  syncNamespaceProxyTools({
+    config: earlyConfig,
+    cache: earlyCache,
+    envOverride: envDirectToolOverride
+      ? parseDirectToolSelectors(envDirectToolOverride)
+      : null,
+    existingDirectNames: new Set(registeredDirectTools.keys()),
+    pi,
+    getState: () => state,
+    getInitPromise: () => initPromise,
+    getPiTools: () => pi.getAllTools(),
+  });
   startLoadTimeInitialization();
 }
 

--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,23 @@ export {
   type McpToolApprovalRequest,
 } from "./types.ts";
 
+// Native `mcp:` reference resolution API (see mcp-references.ts). Consumers
+// like tool-groups / slow-mode import these from the package instead of
+// duplicating the resolver in their own tree.
+export {
+  parseMcpReference,
+  isProxyOnlyServer,
+  namespaceProxyName,
+  resolveMcpToolReferences,
+  createMcpRefResolver,
+  type McpToolReference,
+  type McpToolResolution,
+  type McpRefResolver,
+  type McpDirectOverride,
+} from "./mcp-references.ts";
+export { loadMcpConfig } from "./config.ts";
+export { loadMetadataCache, parseDirectToolSelectors } from "./metadata-cache.ts";
+
 const INIT_WAIT_TIMEOUT_MS = 30_000;
 const INIT_WAIT_TIMED_OUT: unique symbol = Symbol("init-wait-timed-out");
 

--- a/mcp-references.ts
+++ b/mcp-references.ts
@@ -1,0 +1,345 @@
+/**
+ * Native `mcp:`-reference resolution for pi-mcp-adapter.
+ *
+ * Translates `mcp:<server>`, `mcp:<server>/<tool>`, and `mcp:<tool>` references
+ * into the concrete tool names the adapter registers (via its own
+ * `formatToolName` naming) so consumers like tool-groups and slow-mode can
+ * validate them against the live registry instead of flagging them as unknown.
+ *
+ * This module is the package-native home of the resolution logic previously
+ * shipped as `agent/extensions/_shared/mcp-tools/` in the user's Pi harness.
+ * The contract is preserved: pure resolver with config + metadata cache
+ * injected, plus a ready-made `createMcpRefResolver` wrapper that loads them
+ * once from the standard discovery sources.
+ */
+import {
+  formatToolName,
+  isToolAllowed,
+  isServerDisabled,
+  resolveToolPrefix,
+  type McpConfig,
+  type McpSettings,
+  type ServerCacheEntry,
+  type ServerEntry,
+  type ToolPrefix,
+} from "./types.ts";
+import type { MetadataCache } from "./types.ts";
+import { resourceNameToToolName } from "./resource-tools.ts";
+import { loadMcpConfig } from "./config.ts";
+import { loadMetadataCache, parseDirectToolSelectors } from "./metadata-cache.ts";
+
+export interface McpToolReference {
+  /** Full original reference, e.g. "mcp:context7" or "mcp:context7/query_docs". */
+  raw: string;
+  /** Server name when the reference targets a server (or server/tool). */
+  server?: string;
+  /** Tool name when the reference targets a specific tool (server/tool). */
+  tool?: string;
+}
+
+export interface McpToolResolution {
+  /** Concrete registered tool names, order-preserving, deduplicated. */
+  names: string[];
+  /** Human-readable reasons for references that could not be resolved. */
+  diagnostics: string[];
+}
+
+export type McpRefResolver = (refs: string) => string[];
+
+/** Direct-tool override parsed from `MCP_DIRECT_TOOLS` (see `parseDirectToolSelectors`). */
+export interface McpDirectOverride {
+  servers: Set<string>;
+  tools: Map<string, Set<string>>;
+}
+
+/**
+ * Namespace-proxy tool name for a proxy-only server.
+ *
+ * Simple underscore form (`context-mode` → `mcp__context_mode`), deliberately
+ * identical to the harness resolver and `namespace-tools.ts` registration.
+ * Differs from upstream `formatToolName(..., "mcp")` which uses
+ * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
+ */
+export function namespaceProxyName(serverName: string): string {
+  return `mcp__${serverName.replace(/-/g, "_")}`;
+}
+
+export function parseMcpReference(raw: string): McpToolReference {
+  if (!raw.startsWith("mcp:")) return { raw };
+  const rest = raw.slice("mcp:".length).trim();
+  if (!rest) return { raw };
+
+  if (rest.includes("/")) {
+    const slash = rest.indexOf("/");
+    const server = rest.slice(0, slash).trim();
+    const tool = rest.slice(slash + 1).trim();
+    return {
+      ...(server ? { server } : {}),
+      ...(tool ? { tool } : {}),
+      raw,
+    };
+  }
+  return { raw, server: rest };
+}
+
+/** Effective tool-prefix mode for a server definition + global settings. */
+function effectivePrefix(settings: McpSettings | undefined, def: ServerEntry | undefined): ToolPrefix {
+  return resolveToolPrefix(def, settings?.toolPrefix);
+}
+
+/** Whether a server is forced direct by the `MCP_DIRECT_TOOLS` env override. */
+function isEnvDirect(serverName: string, envOverride: McpDirectOverride | null | undefined): boolean {
+  if (!envOverride) return false;
+  return envOverride.servers.has(serverName) || envOverride.tools.has(serverName);
+}
+
+/**
+ * Whether a server's tools are exposed under direct-tool names. Proxy-only
+ * servers (no directTools) expose their tools ONLY through the proxy `mcp`
+ * tool, so a bare reference cannot map to a concrete registered tool name.
+ */
+export function isProxyOnlyServer(
+  serverName: string,
+  def: ServerEntry | undefined,
+  settings: McpSettings | undefined,
+  envOverride?: McpDirectOverride | null,
+): boolean {
+  if (!def) return true;
+  if (def.disabled === true) return false;
+  if (isEnvDirect(serverName, envOverride)) return false;
+  const direct = def.directTools !== undefined ? def.directTools : settings?.directTools;
+  return !(direct === true || (Array.isArray(direct) && direct.length > 0));
+}
+
+function isServerCacheUsable(entry: ServerCacheEntry | undefined): entry is ServerCacheEntry {
+  return !!entry && Array.isArray(entry.tools);
+}
+
+function collectServerTools(
+  serverName: string,
+  def: ServerEntry,
+  entry: ServerCacheEntry,
+  prefix: ToolPrefix,
+  onlyTool?: string,
+): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  const matches = (baseName: string): boolean =>
+    onlyTool === undefined || baseName === onlyTool || formatToolName(baseName, serverName, prefix) === onlyTool;
+
+  const push = (baseName: string): void => {
+    if (!matches(baseName)) return;
+    if (!isToolAllowed(baseName, serverName, prefix, def.includeTools, def.excludeTools)) return;
+    const name = formatToolName(baseName, serverName, prefix);
+    if (seen.has(name)) return;
+    seen.add(name);
+    names.push(name);
+  };
+
+  for (const tool of entry.tools ?? []) {
+    if (tool?.name) push(tool.name);
+  }
+
+  if (def.exposeResources !== false) {
+    for (const resource of entry.resources ?? []) {
+      if (resource?.name) push(`read_${resourceNameToToolName(resource.name)}`);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Resolve `mcp:`-prefixed references to concrete registered tool names.
+ *
+ * Mutually validates against config + metadata cache. For a proxy-only server
+ * (no directTools), a bare server-level reference resolves to the server's
+ * namespace-proxy name rather than failing — the caller decides whether that
+ * proxy is actually registered.
+ */
+export function resolveMcpToolReferences(
+  refs: string[],
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride?: McpDirectOverride | null,
+): McpToolResolution {
+  const names: string[] = [];
+  const diagnostics: string[] = [];
+  const seen = new Set<string>();
+
+  const addName = (name: string): void => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  };
+
+  for (const raw of refs) {
+    if (!raw.startsWith("mcp:")) {
+      // Non-mcp references are passed through untouched by this helper.
+      addName(raw);
+      continue;
+    }
+
+    const parsed = parseMcpReference(raw);
+    if (!parsed.server) {
+      diagnostics.push(`MCP reference "${raw}" is empty after the "mcp:" prefix`);
+      continue;
+    }
+
+    if (!config) {
+      diagnostics.push(`MCP reference "${raw}" cannot be resolved: no MCP config`);
+      continue;
+    }
+
+    const def = config.mcpServers[parsed.server];
+    if (!def) {
+      // Bare tool reference (e.g. "mcp:ctx_execute"): seek the tool across servers.
+      resolveBareToolReference(raw, parsed.server, config, cache, envOverride, addName, diagnostics);
+      continue;
+    }
+    if (isServerDisabled(def)) {
+      diagnostics.push(`MCP reference "${raw}" refers to disabled server "${parsed.server}"`);
+      continue;
+    }
+
+    const prefix = effectivePrefix(config.settings, def);
+    const entry = cache?.servers?.[parsed.server];
+
+    if (!isServerCacheUsable(entry)) {
+      diagnostics.push(`MCP reference "${raw}" cannot be resolved: no metadata for server "${parsed.server}"`);
+      continue;
+    }
+
+    if (isProxyOnlyServer(parsed.server, def, config.settings, envOverride)) {
+      // Proxy-only server: resolve to the namespace-proxy name.
+      addName(namespaceProxyName(parsed.server));
+      continue;
+    }
+
+    if (parsed.tool !== undefined) {
+      const toolNames = collectServerTools(parsed.server, def, entry, prefix, parsed.tool);
+      if (toolNames.length === 0) {
+        diagnostics.push(`MCP reference "${raw}" refers to unknown tool "${parsed.tool}" on server "${parsed.server}"`);
+        continue;
+      }
+      for (const n of toolNames) addName(n);
+      continue;
+    }
+
+    // Server-level expansion to all tools.
+    const allNames = collectServerTools(parsed.server, def, entry, prefix);
+    if (allNames.length === 0) {
+      diagnostics.push(`MCP reference "${raw}" resolves to no tools on server "${parsed.server}"`);
+      continue;
+    }
+    for (const n of allNames) addName(n);
+  }
+
+  return { names, diagnostics };
+}
+
+/**
+ * Resolve a bare tool reference ("mcp:<tool>") that matched no server name by
+ * searching every configured server for a tool (or resource) that matches by
+ * original name or registered prefixed name. Returns the concrete registered
+ * name for direct servers, or the hosting server's namespace-proxy name for
+ * proxy-only servers.
+ */
+function resolveBareToolReference(
+  raw: string,
+  toolName: string,
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride: McpDirectOverride | null | undefined,
+  addName: (name: string) => void,
+  diagnostics: string[],
+): void {
+  if (!config || !cache) {
+    diagnostics.push(`MCP reference "${raw}" cannot be resolved: no MCP config/cache`);
+    return;
+  }
+
+  for (const [serverName, def] of Object.entries(config.mcpServers)) {
+    if (!def || isServerDisabled(def)) continue;
+    const entry = cache.servers?.[serverName];
+    if (!isServerCacheUsable(entry)) continue;
+
+    const prefix = effectivePrefix(config.settings, def);
+    const matchesTool = (baseName: string): boolean =>
+      baseName === toolName || formatToolName(baseName, serverName, prefix) === toolName;
+    const hasTool = (entry.tools ?? []).some((t) => t?.name && matchesTool(t.name));
+    const hasResource =
+      def.exposeResources !== false &&
+      (entry.resources ?? []).some((r) => r?.name && matchesTool(`read_${resourceNameToToolName(r.name)}`));
+
+    if (!hasTool && !hasResource) continue;
+
+    if (isProxyOnlyServer(serverName, def, config.settings, envOverride)) {
+      addName(namespaceProxyName(serverName));
+      return;
+    }
+
+    const found = collectServerTools(serverName, def, entry, prefix, toolName);
+    for (const n of found) addName(n);
+    return;
+  }
+
+  diagnostics.push(`MCP reference "${raw}" refers to no matching server or tool`);
+}
+
+export interface McpRefResolverDeps {
+  /** Config loader override for tests. Defaults to the package `loadMcpConfig`. */
+  loadConfig?: (cwd: string) => McpConfig | null;
+  /** Cache loader override for tests. Defaults to the package `loadMetadataCache`. */
+  loadCache?: () => MetadataCache | null;
+  /** Direct-tool selector override for tests. Defaults to `process.env.MCP_DIRECT_TOOLS`. */
+  envDirectTools?: string[] | undefined;
+}
+
+/**
+ * Ready-made `mcp:` reference resolver bound to the merged config + metadata
+ * cache. Loads once (memoized, including a null result for an absent config),
+ * so repeated calls are cheap and stable for the lifetime of the consumer.
+ * A load exception is retried on the next call rather than memoized.
+ *
+ * Non-`mcp:` references pass through unchanged (`[ref]`); unresolvable `mcp:`
+ * references return `[]`.
+ */
+export function createMcpRefResolver(
+  cwd: string = process.cwd(),
+  deps: McpRefResolverDeps = {},
+): McpRefResolver {
+  const loadConfig = deps.loadConfig ?? ((workingDir: string) => loadMcpConfig(undefined, workingDir));
+  const loadCache = deps.loadCache ?? loadMetadataCache;
+  const envRaw =
+    deps.envDirectTools !== undefined ? deps.envDirectTools : process.env.MCP_DIRECT_TOOLS;
+  const envValues: string[] | undefined = Array.isArray(envRaw)
+    ? envRaw
+    : envRaw
+      ? envRaw.split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+  let loaded = false;
+  let config: McpConfig | null = null;
+  let cache: MetadataCache | null = null;
+  let envOverride: McpDirectOverride | null = null;
+
+  return (ref: string): string[] => {
+    if (!ref.startsWith("mcp:")) return [ref];
+    if (!loaded) {
+      try {
+        config = loadConfig(cwd);
+        cache = loadCache();
+        envOverride = envValues && envValues.length > 0 ? parseDirectToolSelectors(envValues) : null;
+        loaded = true;
+      } catch {
+        // Retry on the next call; never memoize an exception.
+        return [];
+      }
+    }
+    if (!config) return [];
+    return resolveMcpToolReferences([ref], config, cache, envOverride).names;
+  };
+}

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -1,0 +1,243 @@
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { McpExtensionState } from "./state.ts";
+import type { McpConfig } from "./types.ts";
+import type { MetadataCache } from "./metadata-cache.ts";
+import { executeCall } from "./proxy-modes.ts";
+
+/**
+ * Namespace-proxy tool registration for proxy-only MCP servers.
+ *
+ * For each configured proxy-only server (no `directTools: true` and not a
+ * runtime server forced direct), register exactly one tool named
+ * `mcp__<server>` (matching the harness `_shared/mcp-tools` resolver's
+ * `namespaceProxyName`). Its execute accepts `{tool, args}` and forwards
+ * through the adapter's existing `executeCall`, so it inherits the same
+ * auto-auth, session recovery, output guard, and approval rules as the
+ * single `mcp` proxy tool — without polluting the prompt with one entry
+ * per tool.
+ *
+ * This unblocks `mcp:<server>` references from `tool-groups` and
+ * `slow-mode` against proxy-only servers without flipping `directTools: true`.
+ */
+
+export interface NamespaceProxySpec {
+  serverName: string;
+  toolName: string;
+  description: string;
+  prefix: string;
+}
+
+/**
+ * Mirror of the harness `_shared/mcp-tools` resolver's
+ * `namespaceProxyName`. Kept deliberately identical to the harness so
+ * tool-groups/slow-mode validation lines up without a config migration.
+ * Differs from upstream `formatToolName(..., "mcp")` which uses
+ * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
+ * When upstream adds its own namespace-proxy, we align conventions.
+ */
+export function namespaceProxyName(serverName: string): string {
+  return `mcp__${serverName.replace(/-/g, "_")}`;
+}
+
+function isServerDisabled(definition: { disabled?: boolean } | undefined): boolean {
+  return definition?.disabled === true;
+}
+
+function isDirectlyRegistered(
+  definition: { directTools?: boolean | string[] } | undefined,
+  settings: McpConfig["settings"],
+  serverName: string,
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+): boolean {
+  if (envOverride) {
+    if (envOverride.servers.has(serverName)) return true;
+    if (envOverride.tools.has(serverName)) return true;
+  }
+  if (definition?.directTools !== undefined) {
+    return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);
+  }
+  return settings?.directTools === true;
+}
+
+/**
+ * Resolve namespace-proxy tool specs for all proxy-only servers in `config`.
+ * A server qualifies when it is enabled, has cache metadata available, and is
+ * not directly registered. Server-name collisions with already-known direct
+ * tool prefixes (`mcp__<server>` reserved) are skipped.
+ */
+export function resolveNamespaceProxyTools(
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+  existingDirectNames: Set<string>,
+): NamespaceProxySpec[] {
+  if (!config || !cache) return [];
+  const specs: NamespaceProxySpec[] = [];
+  const seen = new Set<string>();
+
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (!definition || isServerDisabled(definition)) continue;
+
+    if (isDirectlyRegistered(definition, config.settings, serverName, envOverride)) {
+      continue;
+    }
+
+    const entry = cache.servers?.[serverName];
+    if (!entry || !Array.isArray(entry.tools) || entry.tools.length === 0) {
+      continue;
+    }
+
+    const toolName = namespaceProxyName(serverName);
+    if (existingDirectNames.has(toolName) || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+
+    specs.push({
+      serverName,
+      toolName,
+      description:
+        `Namespace-proxy for MCP server "${serverName}". ` +
+        `Forwards \`{tool, args}\` through the adapter's executeCall, so it inherits ` +
+        `the same auth / lifecycle / output-guard rules as the \`mcp\` proxy.`,
+      prefix: toolName,
+    });
+  }
+
+  return specs;
+}
+
+/**
+ * Lazily-required reference to the agent state — passed as a closure so the
+ * namespace proxy tool's execute can call `executeCall` once `state` exists.
+ * `getInitPromise` lets the executor await the first initialization round
+ * the same way `createDirectToolExecutor` does.
+ */
+export type GetState = () => McpExtensionState | null;
+export type GetInitPromise = () => Promise<McpExtensionState> | null;
+export type GetPiTools = () => Array<{ name: string }>;
+
+function namespaceExecute(
+  getState: GetState,
+  getInitPromise: GetInitPromise,
+  serverName: string,
+  getPiTools: GetPiTools,
+) {
+  return async (
+    _toolCallId: string,
+    params: { tool?: string; args?: Record<string, unknown> },
+    signal: AbortSignal | undefined,
+  ): Promise<AgentToolResult<Record<string, unknown>>> => {
+    if (typeof params.tool !== "string" || params.tool.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: `mcp__${serverName} requires a \`tool\` parameter naming the underlying MCP tool.` }],
+        details: { error: "missing_tool", server: serverName },
+      };
+    }
+    let state = getState();
+    if (!state) {
+      const initPromise = getInitPromise();
+      if (initPromise) {
+        try {
+          state = await initPromise;
+        } catch {
+          return {
+            content: [{ type: "text" as const, text: `MCP initialization failed for ${serverName}.` }],
+            details: { error: "init_failed", server: serverName },
+          };
+        }
+      }
+    }
+    if (!state) {
+      return {
+        content: [{ type: "text" as const, text: `MCP not initialized for ${serverName}.` }],
+        details: { error: "not_initialized", server: serverName },
+      };
+    }
+    return executeCall(
+      state,
+      params.tool,
+      params.args ?? {},
+      serverName,
+      getPiTools as never,
+      signal,
+      "proxy",
+    );
+  };
+}
+
+const parameters = Type.Object({
+  tool: Type.String({ description: "Underlying MCP tool name to call on this server." }),
+  args: Type.Optional(Type.Object({}, {
+    additionalProperties: true,
+    description: "Arguments for the underlying tool. The exact shape depends on the tool being called; use mcp({ describe: 'server/tool' }) to inspect.",
+  })),
+});
+
+export interface SyncNamespaceProxyToolsInput {
+  config: McpConfig | null;
+  cache: MetadataCache | null;
+  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null;
+  existingDirectNames: Set<string>;
+  pi: ExtensionAPI;
+  getState: GetState;
+  getInitPromise: GetInitPromise;
+  getPiTools: GetPiTools;
+}
+
+export interface SyncNamespaceProxyToolsResult {
+  specs: NamespaceProxySpec[];
+  added: string[];
+  updated: string[];
+  deactivated: string[];
+}
+
+/**
+ * Idempotent sync of namespace-proxy tool registrations:
+ * - Registers a new tool for each spec whose name is not yet registered.
+ * - Updates (re-registers with a fresh fingerprint) when the spec changes.
+ * - Unregisters tools for servers that are no longer proxy-only.
+ */
+export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): SyncNamespaceProxyToolsResult {
+  const specs = resolveNamespaceProxyTools(
+    input.config,
+    input.cache,
+    input.envOverride,
+    input.existingDirectNames,
+  );
+  const nextNames = new Set(specs.map((s) => s.toolName));
+  const result: SyncNamespaceProxyToolsResult = { specs, added: [], updated: [], deactivated: [] };
+
+  for (const spec of specs) {
+    input.pi.registerTool({
+      name: spec.toolName,
+      label: `MCP: ${spec.serverName}`,
+      description: spec.description,
+      parameters,
+      execute: namespaceExecute(
+        input.getState,
+        input.getInitPromise,
+        spec.serverName,
+        input.getPiTools,
+      ),
+    } as never);
+    result.added.push(spec.toolName);
+  }
+
+  // Deactivate stale entries.
+  const registered = (input.pi as unknown as {
+    unregisterTool?: (name: string) => boolean;
+  }).unregisterTool;
+  // We can't enumerate the registered map from outside the closure, so the
+  // caller owns lifecycle for stale entries by tracking previous names.
+  if (registered) {
+    for (const stale of input.existingDirectNames) {
+      if (stale.startsWith("mcp__") && !nextNames.has(stale)) {
+        if (registered(stale)) result.deactivated.push(stale);
+      }
+    }
+  }
+
+  return result;
+}

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -4,6 +4,9 @@ import type { McpExtensionState } from "./state.ts";
 import type { McpConfig } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
 import { executeCall } from "./proxy-modes.ts";
+import { namespaceProxyName } from "./mcp-references.ts";
+
+export { namespaceProxyName } from "./mcp-references.ts";
 
 /**
  * Namespace-proxy tool registration for proxy-only MCP servers.
@@ -26,18 +29,6 @@ export interface NamespaceProxySpec {
   toolName: string;
   description: string;
   prefix: string;
-}
-
-/**
- * Mirror of the harness `_shared/mcp-tools` resolver's
- * `namespaceProxyName`. Kept deliberately identical to the harness so
- * tool-groups/slow-mode validation lines up without a config migration.
- * Differs from upstream `formatToolName(..., "mcp")` which uses
- * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
- * When upstream adds its own namespace-proxy, we align conventions.
- */
-export function namespaceProxyName(serverName: string): string {
-  return `mcp__${serverName.replace(/-/g, "_")}`;
 }
 
 function isServerDisabled(definition: { disabled?: boolean } | undefined): boolean {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "proxy-modes.ts",
     "direct-tools.ts",
     "namespace-tools.ts",
+    "mcp-references.ts",
     "commands.ts",
     "prompts.ts",
     "onboarding-state.ts",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "ui-session.ts",
     "proxy-modes.ts",
     "direct-tools.ts",
+    "namespace-tools.ts",
     "commands.ts",
     "prompts.ts",
     "onboarding-state.ts",


### PR DESCRIPTION
## Problem

The `mcp:<server>` / `mcp:<server>/<tool>` / `mcp:<tool>` reference convention
is resolved by consumers that validate configured tool names against the live
tool registry. That resolution currently lives OUTSIDE this package, duplicated
in the user's Pi harness (`agent/extensions/_shared/mcp-tools/`). This PR moves
it into the adapter natively and exports it publicly so consumers import it
from the package instead of re-implementing it.

Companion to the existing PR #414 (namespace-proxy tools `mcp__<server>`).

## What's added

- `mcp-references.ts` — pure resolution API:
  - `parseMcpReference`, `isProxyOnlyServer`, `namespaceProxyName`
  - `resolveMcpToolReferences(refs, config, cache, envOverride?)` — resolves
    `mcp:` refs to the concrete tool names the adapter registers, honoring
    `includeTools` / `excludeTools` / `exposeResources` / `toolPrefix`, and
    reading `MCP_DIRECT_TOOLS` for envOverride parity with direct-tool
    registration.
  - `createMcpRefResolver(cwd?, deps?)` — ready-made resolver that loads the
    merged config + metadata cache once (memoized) and returns `(ref) => string[]`.
- `index.ts` — re-exports the resolution API plus `loadMcpConfig`,
  `loadMetadataCache`, `parseDirectToolSelectors` from the package entrypoint.
- `namespace-tools.ts` — single-sources `namespaceProxyName` (re-exported from
  `mcp-references.ts`) instead of redefining it.
- `__tests__/mcp-references.test.ts` — 28 tests (parser, proxy-only detection,
  server/tool/bare resolution, envOverride parity, wrapper memoization,
  public-export smoke).

## Naming contract

The namespace-proxy name uses the simple underscore form
(`mcp__context_mode`) for stable, readable tool names, matching the runtime
registration in `namespace-tools.ts`. This intentionally differs from
`formatToolName(..., "mcp")`, whose `sanitizeServerPrefix` preserves hyphens
(`mcp__context-mode`), for proxy-only servers.

## Behavior

No change for `directTools: true` servers (their direct tools resolve
identically). The resolver only affects reference *resolution*, not tool
registration. Tests: 1269 passed, 4 pre-existing flaky/dist failures
unrelated to this PR.

## Consumers

`tool-groups` and `slow-mode` (Pi harness extensions) will import
`createMcpRefResolver` from this package, replacing their local
`_shared/mcp-tools/` copy.