### PR TITLE
refactor: deslop unreleased MCP changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ conformance/results/
 *.log
 .DS_Store
 
-# bun lockfile (this fork uses npm/package-lock.json)
+# This package uses npm/package-lock.json.
 bun.lock
 bun.lockb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.
-- Namespace proxy tools now clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
+- Namespace proxy tools now use valid cached metadata, clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
 - Kept transient HTTP 503 connection failures as availability errors without multiplying gateway retries or misdiagnosing the endpoint as non-MCP. Thanks to [@elkaix](https://github.com/elkaix) for PR #411.
 - Preserved cached keep-alive catalogs during transient 503 refresh outages while deferred recovery continues with bounded backoff.
 

--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ Keys match a tool's original name, prefixed name, or a glob (`*` applies to ever
 
 When `includeSchemas` is enabled, search and describe render common JSON Schema parameters as compact TypeScript shapes like `{ query: string; limit?: number; }`, with the older schema formatter retained as a fallback for unsupported schemas.
 
-For HTTP servers, a connection-level HTTP 503 retains an availability diagnosis and skips the shape probe. Pi does not multiply immediate retries owned by an upstream gateway. Keep-alive servers retain cached metadata and retry health convergence after 30 seconds, backing off to 5 minutes. Other failed connects run a one-request shape probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
+For HTTP servers, Pi reports HTTP 503 as temporary unavailability and does not add another immediate retry loop. Keep-alive servers keep cached metadata available and retry after 30 seconds, backing off to 5 minutes. Other failed connects run a one-request shape probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
 
 Servers that provide usage guidance via the MCP `instructions` field surface it at three levels: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -62,28 +62,9 @@ vi.mock("../config.ts", () => ({
   writeProjectServerDisabledOverride: mocks.writeProjectServerDisabledOverride,
 }));
 
-vi.mock("../metadata-cache.ts", () => ({
+vi.mock("../metadata-cache.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../metadata-cache.ts")>()),
   loadMetadataCache: mocks.loadMetadataCache,
-  parseDirectToolSelectors: (selectors: string[]) => {
-    const servers = new Set<string>();
-    const tools = new Map<string, Set<string>>();
-    for (const raw of selectors) {
-      const sel = raw.replace(/\/+$/, "");
-      if (sel.includes("/")) {
-        const [server, tool] = sel.split("/", 2);
-        if (server && tool) {
-          const set = tools.get(server) ?? new Set<string>();
-          set.add(tool);
-          tools.set(server, set);
-        } else if (server) {
-          servers.add(server);
-        }
-      } else if (sel) {
-        servers.add(sel);
-      }
-    }
-    return { servers, tools };
-  },
 }));
 
 vi.mock("../direct-tools.ts", () => ({

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -1,24 +1,23 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeServerHash } from "../metadata-cache.ts";
+import type { ServerEntry } from "../types.ts";
 
-/**
- * Unit tests for the namespace-proxy tool registration logic.
- *
- * `syncNamespaceProxyTools` is the focused, side-effect-free function
- * (aside from the injected `pi.registerTool`) that the adapter calls from
- * `syncToolSurface`. We test it directly to keep the surface tight; the
- * existing `index-lifecycle.test.ts` covers the full adapter boot.
- */
-
-const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }> }]>) => ({
+const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }>; definition?: ServerEntry; configHash?: string; cachedAt?: number }]>) => ({
   version: 1,
-  servers: Object.fromEntries(entries.map(([server, v]) => [server, { tools: v.tools, configHash: "h", cachedAt: Date.now() }])),
+  servers: Object.fromEntries(entries.map(([server, v]) => [server, {
+    tools: v.tools,
+    configHash: v.configHash ?? computeServerHash(v.definition ?? { command: server }),
+    cachedAt: v.cachedAt ?? Date.now(),
+  }])),
 });
 
 function makePi() {
-  const registered = new Map<string, { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }>();
+  type RegisteredTool = { name: string; label?: string; execute: (...args: unknown[]) => unknown; parameters?: unknown };
+  const registered = new Map<string, RegisteredTool>();
   const unregistered: string[] = [];
   const api = {
-    registerTool: vi.fn((tool: { name: string; execute: (...args: any[]) => unknown; parameters?: unknown }) => {
+    registerTool: vi.fn((tool: RegisteredTool) => {
       registered.set(tool.name, tool);
     }),
     unregisterTool: vi.fn((name: string) => {
@@ -28,7 +27,7 @@ function makePi() {
       return had;
     }),
   };
-  return { pi: api as any, registered, unregistered };
+  return { pi: api as unknown as ExtensionAPI, registered, unregistered };
 }
 
 async function importSync() {
@@ -48,8 +47,6 @@ describe("namespaceProxyName", () => {
   });
 
   it("matches the harness _shared/mcp-tools resolver contract", async () => {
-    // The harness resolver produces `mcp__<server-with-dashes-as-underscores>`
-    // and validates against it. The fork must produce the same string.
     const { namespaceProxyName } = await importSync();
     expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
     expect(namespaceProxyName("my-server-1")).toBe("mcp__my_server_1");
@@ -91,7 +88,7 @@ describe("syncNamespaceProxyTools", () => {
 
     syncNamespaceProxyTools({
       config: { mcpServers: { context7: { url: "https://mcp.context7.com/mcp", directTools: true } } },
-      cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }] }]]),
+      cache: CACHE_SHAPE([["context7", { tools: [{ name: "query_docs" }], definition: { url: "https://mcp.context7.com/mcp", directTools: true } }]]),
       envOverride: null,
       existingDirectNames: new Set(["context7_query_docs"]),
       existingNamespaceNames: new Set(),
@@ -130,6 +127,25 @@ describe("syncNamespaceProxyTools", () => {
     syncNamespaceProxyTools({
       config: { mcpServers: { "context-mode": { command: "context-mode" } } },
       cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__context_mode")).toBe(false);
+  });
+
+  it("skips servers with stale cache metadata", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }], configHash: "stale" }]]),
       envOverride: null,
       existingDirectNames: new Set(),
       existingNamespaceNames: new Set(),
@@ -240,18 +256,18 @@ describe("syncNamespaceProxyTools", () => {
 
     const tool = registered.get("mcp__context_mode")!;
     expect(tool.parameters).toBeDefined();
-    const props = (tool.parameters as any).properties;
-    expect(props.tool).toBeDefined();
-    expect(props.args).toBeDefined();
+    expect(tool.parameters).toMatchObject({
+      properties: {
+        tool: expect.anything(),
+        args: expect.anything(),
+      },
+    });
   });
 
   it("skips registration when an existing direct tool already uses mcp__<server>", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered } = makePi();
 
-    // Edge case: a directTool is named "mcp__context_mode" (very unlikely but possible
-    // if the user defined directTools: ["mcp__context_mode"] on a server). We must
-    // not double-register the same name.
     syncNamespaceProxyTools({
       config: { mcpServers: { "context-mode": { command: "context-mode" } } },
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
@@ -271,7 +287,6 @@ describe("syncNamespaceProxyTools", () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered, unregistered } = makePi();
 
-    // First sync: register context-mode.
     syncNamespaceProxyTools({
       config: { mcpServers: { "context-mode": { command: "context-mode" } } },
       cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
@@ -285,9 +300,6 @@ describe("syncNamespaceProxyTools", () => {
     });
     expect(registered.has("mcp__context_mode")).toBe(true);
 
-    // Second sync: context-mode is gone, but the previous names list still
-    // includes the now-stale mcp__context_mode. Caller passes the union of
-    // previously-registered names so we can deactivate.
     syncNamespaceProxyTools({
       config: { mcpServers: {} },
       cache: { version: 1, servers: {} },
@@ -358,8 +370,8 @@ describe("syncNamespaceProxyTools", () => {
     syncNamespaceProxyTools({
       config: { mcpServers: { "my-server": { command: "one" }, my_server: { command: "two" } } },
       cache: CACHE_SHAPE([
-        ["my-server", { tools: [{ name: "one" }] }],
-        ["my_server", { tools: [{ name: "two" }] }],
+        ["my-server", { tools: [{ name: "one" }], definition: { command: "one" } }],
+        ["my_server", { tools: [{ name: "two" }], definition: { command: "two" } }],
       ]),
       envOverride: null,
       existingDirectNames: new Set(),
@@ -382,12 +394,12 @@ describe("syncNamespaceProxyTools", () => {
       config: {
         mcpServers: {
           "context-mode": { command: "context-mode" },
-          "context7": { url: "https://mcp.context7.com/mcp" }, // proxy-only (no directTools)
+          "context7": { url: "https://mcp.context7.com/mcp" },
         },
       },
       cache: CACHE_SHAPE([
         ["context-mode", { tools: [{ name: "ctx_execute" }] }],
-        ["context7", { tools: [{ name: "query_docs" }] }],
+        ["context7", { tools: [{ name: "query_docs" }], definition: { url: "https://mcp.context7.com/mcp" } }],
       ]),
       envOverride: null,
       existingDirectNames: new Set(),
@@ -400,5 +412,81 @@ describe("syncNamespaceProxyTools", () => {
 
     expect(registered.has("mcp__context_mode")).toBe(true);
     expect(registered.has("mcp__context7")).toBe(true);
+  });
+
+  it("reports existing namespace proxies as updated", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi } = makePi();
+
+    const result = syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(["mcp__context_mode"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(result.added).toEqual([]);
+    expect(result.updated).toEqual(["mcp__context_mode"]);
+    expect(pi.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes same-name namespace proxies after server replacement", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "my-server": { command: "one" } } },
+      cache: CACHE_SHAPE([["my-server", { tools: [{ name: "one" }], definition: { command: "one" } }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+    const result = syncNamespaceProxyTools({
+      config: { mcpServers: { my_server: { command: "two" } } },
+      cache: CACHE_SHAPE([["my_server", { tools: [{ name: "two" }], definition: { command: "two" } }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(["mcp__my_server"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(result.updated).toEqual(["mcp__my_server"]);
+    expect(pi.registerTool).toHaveBeenCalledTimes(2);
+    expect(registered.get("mcp__my_server")?.label).toBe("MCP: my_server");
+  });
+
+  it("preserves initialization error context", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "context-mode": { command: "context-mode" } } },
+      cache: CACHE_SHAPE([["context-mode", { tools: [{ name: "ctx_execute" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => Promise.reject(new Error("bad config")),
+      getPiTools: () => [],
+    });
+
+    const result = await registered.get("mcp__context_mode")!.execute("call-1", { tool: "ctx_execute" }, undefined);
+    expect(result).toMatchObject({
+      content: [{ text: "MCP initialization failed for context-mode: bad config" }],
+      details: { error: "init_failed", server: "context-mode", message: "bad config" },
+    });
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -75,6 +75,18 @@ function optionalNumber(options: { minimum?: number; description: string }): TSc
     : ({ type: "number", ...options } as unknown as TSchema);
 }
 
+function parseEnvDirectToolOverride(raw: string | undefined): string[] | undefined {
+  return raw?.split(",").map(s => s.trim()).filter(Boolean);
+}
+
+function resolveNamespaceEnvOverride(
+  raw: string | undefined,
+  selectors: string[] | undefined,
+): ReturnType<typeof parseDirectToolSelectors> | null {
+  if (raw === "__none__") return { servers: new Set<string>(), tools: new Map<string, Set<string>>() };
+  return selectors ? parseDirectToolSelectors(selectors) : null;
+}
+
 function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   const sessionConfig = options.config !== undefined ? cloneMcpConfig(options.config) : undefined;
   const programmaticConfig = sessionConfig !== undefined;
@@ -131,12 +143,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     : loadMcpConfig(earlyConfigPath);
   const earlyCache = loadMetadataCache();
   const envRaw = process.env.MCP_DIRECT_TOOLS;
-  const envDirectToolOverride = envRaw?.split(",").map(s => s.trim()).filter(Boolean);
-  const namespaceEnvOverride = envRaw === "__none__"
-    ? { servers: new Set<string>(), tools: new Map<string, Set<string>>() }
-    : envDirectToolOverride
-      ? parseDirectToolSelectors(envDirectToolOverride)
-      : null;
+  const envDirectToolOverride = parseEnvDirectToolOverride(envRaw);
+  const namespaceEnvOverride = resolveNamespaceEnvOverride(envRaw, envDirectToolOverride);
   const registeredDirectTools = new Map<string, string>();
   const registeredNamespaceProxyTools = new Set<string>();
   const fallbackDeactivatedTools = new Set<string>();
@@ -293,6 +301,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       getState: () => state,
       getInitPromise: () => initPromise,
       getPiTools: () => pi.getAllTools(),
+      renderOptions: toolRenderOptions,
+      renderShell: toolRenderShell,
+      renderResult: renderMcpToolResult,
     });
     for (const name of nsResult.added) registeredNamespaceProxyTools.add(name);
     for (const name of nsResult.deactivated) registeredNamespaceProxyTools.delete(name);
@@ -1047,7 +1058,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   // `mcp:<server>` references on the first session_start turn. Without this
   // eager call, the tool-groups expansion runs before MCP initialization
   // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
-  // Mirrors the upstream direct-tool install-time registration pattern.
   const initialNamespaceResult = syncNamespaceProxyTools({
     config: earlyConfig,
     cache: earlyCache,
@@ -1058,6 +1068,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     getState: () => state,
     getInitPromise: () => initPromise,
     getPiTools: () => pi.getAllTools(),
+    renderOptions: toolRenderOptions,
+    renderShell: toolRenderShell,
+    renderResult: renderMcpToolResult,
   });
   for (const name of initialNamespaceResult.added) registeredNamespaceProxyTools.add(name);
   startLoadTimeInitialization();

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -348,6 +348,17 @@ export class McpLifecycleManager {
     return Date.now() >= retry.nextAttemptAt;
   }
 
+  private isTransientAvailabilityError(error: unknown): boolean {
+    return (error instanceof SdkHttpError && error.status === 503)
+      || (error instanceof Error && error.cause instanceof SdkHttpError && error.cause.status === 503);
+  }
+
+  private connectionFailureTarget(action: "refresh" | "reconnect" | "publish", name: string): string {
+    if (action === "reconnect") return `reconnect to ${name}`;
+    if (action === "publish") return `publish metadata for ${name}`;
+    return `refresh ${name}`;
+  }
+
   private reportConnectionFailure(
     name: string,
     definition: ServerDefinition,
@@ -357,20 +368,12 @@ export class McpLifecycleManager {
   ): void {
     if (!this.recordRetry(name, definition, connection)) return;
     this.onReconnectFailure?.(name, error);
-    if (
-      (error instanceof SdkHttpError && error.status === 503)
-      || (error instanceof Error && error.cause instanceof SdkHttpError && error.cause.status === 503)
-    ) return;
+    if (this.isTransientAvailabilityError(error)) return;
     const retry = this.retryStates.get(name);
     if (retry?.warningReported) return;
     if (retry) retry.warningReported = true;
     const message = error instanceof Error ? error.message : String(error);
-    const target = action === "reconnect"
-      ? `reconnect to ${name}`
-      : action === "publish"
-        ? `publish metadata for ${name}`
-        : `refresh ${name}`;
-    console.error(`MCP: Failed to ${target}: ${sanitizeTerminalText(message)}`);
+    console.error(`MCP: Failed to ${this.connectionFailureTarget(action, name)}: ${sanitizeTerminalText(message)}`);
   }
 
   private deferRefreshTimeout(

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -1,9 +1,10 @@
-import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult, ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import type { McpExtensionState } from "./state.ts";
-import type { McpConfig } from "./types.ts";
-import type { MetadataCache } from "./metadata-cache.ts";
+import { isServerDisabled, type McpConfig } from "./types.ts";
+import { isServerCacheValid, type MetadataCache } from "./metadata-cache.ts";
 import { executeCall } from "./proxy-modes.ts";
+import { createMcpProxyToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions, type McpToolRenderOptions, type RenderTheme, type McpToolRenderContext } from "./tool-result-renderer.ts";
 
 /**
  * Namespace-proxy tool registration for proxy-only MCP servers.
@@ -25,30 +26,27 @@ export interface NamespaceProxySpec {
   serverName: string;
   toolName: string;
   description: string;
-  prefix: string;
 }
+
+type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
 
 /**
  * Mirror of the harness `_shared/mcp-tools` resolver's
  * `namespaceProxyName`. Kept deliberately identical to the harness so
  * tool-groups/slow-mode validation lines up without a config migration.
- * Differs from upstream `formatToolName(..., "mcp")` which uses
+ * Differs from `formatToolName(..., "mcp")` which uses
  * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
- * When upstream adds its own namespace-proxy, we align conventions.
+ * Keep this convention aligned with the host resolver.
  */
 export function namespaceProxyName(serverName: string): string {
   return `mcp__${serverName.replace(/-/g, "_")}`;
-}
-
-function isServerDisabled(definition: { disabled?: boolean } | undefined): boolean {
-  return definition?.disabled === true;
 }
 
 function isDirectlyRegistered(
   definition: { directTools?: boolean | string[] } | undefined,
   settings: McpConfig["settings"],
   serverName: string,
-  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+  envOverride: DirectToolSelectorOverride | null,
 ): boolean {
   if (envOverride) {
     return envOverride.servers.has(serverName);
@@ -59,49 +57,31 @@ function isDirectlyRegistered(
   return settings?.directTools === true;
 }
 
-/**
- * Resolve namespace-proxy tool specs for all proxy-only servers in `config`.
- * A server qualifies when it is enabled, has cache metadata available, and is
- * not directly registered. Collisions with direct tools and normalized server
- * names are skipped.
- */
-export function resolveNamespaceProxyTools(
-  config: McpConfig | null,
-  cache: MetadataCache | null,
-  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null,
+function namespaceProxyCandidate(
+  config: McpConfig,
+  cache: MetadataCache,
+  envOverride: DirectToolSelectorOverride | null,
   existingDirectNames: Set<string>,
-): NamespaceProxySpec[] {
-  if (!config || !cache) return [];
-  const candidates: NamespaceProxySpec[] = [];
+  serverName: string,
+): NamespaceProxySpec | null {
+  const definition = config.mcpServers[serverName];
+  if (!definition || isServerDisabled(definition)) return null;
+  if (isDirectlyRegistered(definition, config.settings, serverName, envOverride)) return null;
+  const entry = cache.servers?.[serverName];
+  if (!entry || !isServerCacheValid(entry, definition) || entry.tools.length === 0) return null;
+  const toolName = namespaceProxyName(serverName);
+  if (existingDirectNames.has(toolName)) return null;
+  return {
+    serverName,
+    toolName,
+    description:
+      `Namespace-proxy for MCP server "${serverName}". ` +
+      `Forwards \`{tool, args}\` through the adapter's executeCall, so it inherits ` +
+      `the same auth / lifecycle / output-guard rules as the \`mcp\` proxy.`,
+  };
+}
 
-  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
-    if (!definition || isServerDisabled(definition)) continue;
-
-    if (isDirectlyRegistered(definition, config.settings, serverName, envOverride)) {
-      continue;
-    }
-
-    const entry = cache.servers?.[serverName];
-    if (!entry || !Array.isArray(entry.tools) || entry.tools.length === 0) {
-      continue;
-    }
-
-    const toolName = namespaceProxyName(serverName);
-    if (existingDirectNames.has(toolName)) {
-      continue;
-    }
-
-    candidates.push({
-      serverName,
-      toolName,
-      description:
-        `Namespace-proxy for MCP server "${serverName}". ` +
-        `Forwards \`{tool, args}\` through the adapter's executeCall, so it inherits ` +
-        `the same auth / lifecycle / output-guard rules as the \`mcp\` proxy.`,
-      prefix: toolName,
-    });
-  }
-
+function filterCollidingNamespaceProxyTools(candidates: NamespaceProxySpec[]): NamespaceProxySpec[] {
   const names = new Map<string, NamespaceProxySpec[]>();
   for (const spec of candidates) {
     const colliding = names.get(spec.toolName) ?? [];
@@ -118,6 +98,20 @@ export function resolveNamespaceProxyTools(
   });
 }
 
+function resolveNamespaceProxyTools(
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride: DirectToolSelectorOverride | null,
+  existingDirectNames: Set<string>,
+): NamespaceProxySpec[] {
+  if (!config || !cache) return [];
+  return filterCollidingNamespaceProxyTools(
+    Object.keys(config.mcpServers)
+      .map((serverName) => namespaceProxyCandidate(config, cache, envOverride, existingDirectNames, serverName))
+      .filter((spec): spec is NamespaceProxySpec => spec !== null),
+  );
+}
+
 /**
  * Lazily-required reference to the agent state — passed as a closure so the
  * namespace proxy tool's execute can call `executeCall` once `state` exists.
@@ -126,7 +120,7 @@ export function resolveNamespaceProxyTools(
  */
 export type GetState = () => McpExtensionState | null;
 export type GetInitPromise = () => Promise<McpExtensionState> | null;
-export type GetPiTools = () => Array<{ name: string }>;
+export type GetPiTools = () => ToolInfo[];
 
 function namespaceExecute(
   getState: GetState,
@@ -151,10 +145,11 @@ function namespaceExecute(
       if (initPromise) {
         try {
           state = await initPromise;
-        } catch {
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
           return {
-            content: [{ type: "text" as const, text: `MCP initialization failed for ${serverName}.` }],
-            details: { error: "init_failed", server: serverName },
+            content: [{ type: "text" as const, text: `MCP initialization failed for ${serverName}: ${message}` }],
+            details: { error: "init_failed", server: serverName, message },
           };
         }
       }
@@ -170,7 +165,7 @@ function namespaceExecute(
       params.tool,
       params.args ?? {},
       serverName,
-      getPiTools as never,
+      getPiTools,
       signal,
       "proxy",
     );
@@ -188,13 +183,16 @@ const parameters = Type.Object({
 export interface SyncNamespaceProxyToolsInput {
   config: McpConfig | null;
   cache: MetadataCache | null;
-  envOverride: { servers: Set<string>; tools: Map<string, Set<string>> } | null;
+  envOverride: DirectToolSelectorOverride | null;
   existingDirectNames: Set<string>;
   existingNamespaceNames: Set<string>;
   pi: ExtensionAPI;
   getState: GetState;
   getInitPromise: GetInitPromise;
   getPiTools: GetPiTools;
+  renderOptions?: McpToolRenderOptions;
+  renderShell?: "self" | "default";
+  renderResult?: unknown;
 }
 
 export interface SyncNamespaceProxyToolsResult {
@@ -204,11 +202,77 @@ export interface SyncNamespaceProxyToolsResult {
   deactivated: string[];
 }
 
+function createNamespaceRenderCall(renderOptions: McpToolRenderOptions, serverName: string) {
+  const renderCall = createMcpProxyToolCallRenderer(renderOptions);
+  return (args: { tool?: string; args?: Record<string, unknown> }, theme?: RenderTheme, context?: McpToolRenderContext) => renderCall({
+    ...(args.tool !== undefined ? { tool: args.tool } : {}),
+    ...(args.args !== undefined ? { args: args.args } : {}),
+    server: serverName,
+  }, theme, context);
+}
+
+function registerNamespaceProxyTool(
+  input: SyncNamespaceProxyToolsInput,
+  spec: NamespaceProxySpec,
+  renderOptions: McpToolRenderOptions,
+  renderShell: "self" | "default",
+  renderResult: unknown,
+): void {
+  input.pi.registerTool({
+    name: spec.toolName,
+    label: `MCP: ${spec.serverName}`,
+    description: spec.description,
+    promptSnippet: `MCP namespace proxy for ${spec.serverName}`,
+    parameters,
+    renderShell,
+    renderCall: createNamespaceRenderCall(renderOptions, spec.serverName),
+    renderResult,
+    execute: namespaceExecute(
+      input.getState,
+      input.getInitPromise,
+      spec.serverName,
+      input.getPiTools,
+    ),
+  } as never);
+}
+
+function getActiveToolsForStaleCleanup(pi: ExtensionAPI, staleNames: string[]): string[] | undefined {
+  if (staleNames.length === 0) return undefined;
+  try {
+    return pi.getActiveTools?.();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Action methods cannot be called during extension loading")) return undefined;
+    throw error;
+  }
+}
+
+function deactivateStaleNamespaceTools(input: SyncNamespaceProxyToolsInput, nextNames: Set<string>): string[] {
+  const staleNames = [...input.existingNamespaceNames].filter(
+    (name) => !nextNames.has(name) && !input.existingDirectNames.has(name),
+  );
+  const deactivated: string[] = [];
+  const unregisterTool = (input.pi as unknown as {
+    unregisterTool?: (name: string) => boolean;
+  }).unregisterTool;
+  for (const stale of staleNames) {
+    if (unregisterTool?.(stale)) deactivated.push(stale);
+  }
+  const activeTools = getActiveToolsForStaleCleanup(input.pi, staleNames);
+  if (!activeTools) return deactivated;
+
+  const stale = new Set(staleNames);
+  const nextActiveTools = activeTools.filter((name) => !stale.has(name));
+  if (nextActiveTools.length === activeTools.length) return deactivated;
+
+  input.pi.setActiveTools(nextActiveTools);
+  for (const name of staleNames) {
+    if (!deactivated.includes(name)) deactivated.push(name);
+  }
+  return deactivated;
+}
+
 /**
- * Idempotent sync of namespace-proxy tool registrations:
- * - Registers a new tool for each spec whose name is not yet registered.
- * - Updates (re-registers with a fresh fingerprint) when the spec changes.
- * - Unregisters tools for servers that are no longer proxy-only.
+ * Idempotent sync of namespace-proxy tool registrations.
  */
 export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): SyncNamespaceProxyToolsResult {
   const specs = resolveNamespaceProxyTools(
@@ -219,52 +283,16 @@ export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): Sy
   );
   const nextNames = new Set(specs.map((s) => s.toolName));
   const result: SyncNamespaceProxyToolsResult = { specs, added: [], updated: [], deactivated: [] };
+  const renderOptions = input.renderOptions ?? resolveMcpToolRenderOptions();
+  const renderShell = input.renderShell ?? (renderOptions.resultRendering === "compact" ? "self" : "default");
+  const renderResult = input.renderResult ?? createMcpToolResultRenderer(renderOptions);
 
   for (const spec of specs) {
-    input.pi.registerTool({
-      name: spec.toolName,
-      label: `MCP: ${spec.serverName}`,
-      description: spec.description,
-      parameters,
-      execute: namespaceExecute(
-        input.getState,
-        input.getInitPromise,
-        spec.serverName,
-        input.getPiTools,
-      ),
-    } as never);
-    result.added.push(spec.toolName);
+    registerNamespaceProxyTool(input, spec, renderOptions, renderShell, renderResult);
+    (input.existingNamespaceNames.has(spec.toolName) ? result.updated : result.added).push(spec.toolName);
   }
 
-  // Deactivate stale entries.
-  const registered = (input.pi as unknown as {
-    unregisterTool?: (name: string) => boolean;
-  }).unregisterTool;
-  // The caller owns namespace lifecycle by tracking prior namespace names.
-  const staleNames = [...input.existingNamespaceNames].filter(
-    (name) => !nextNames.has(name) && !input.existingDirectNames.has(name),
-  );
-  for (const stale of staleNames) {
-    if (registered?.(stale)) result.deactivated.push(stale);
-  }
-  let activeTools: string[] | undefined;
-  if (staleNames.length > 0) {
-    try {
-      activeTools = input.pi.getActiveTools?.();
-    } catch (error) {
-      if (!(error instanceof Error && error.message.includes("Action methods cannot be called during extension loading"))) throw error;
-    }
-  }
-  if (activeTools) {
-    const stale = new Set(staleNames);
-    const nextActiveTools = activeTools.filter((name) => !stale.has(name));
-    if (nextActiveTools.length !== activeTools.length) {
-      input.pi.setActiveTools(nextActiveTools);
-      for (const name of staleNames) {
-        if (!result.deactivated.includes(name)) result.deactivated.push(name);
-      }
-    }
-  }
+  result.deactivated.push(...deactivateStaleNamespaceTools(input, nextNames));
 
   return result;
 }

--- a/tool-result-renderer.ts
+++ b/tool-result-renderer.ts
@@ -4,7 +4,7 @@ import { type Component, Text, truncateToWidth, visibleWidth } from "@earendil-w
 type McpToolResultDetails = Record<string, unknown> & { error?: unknown };
 type McpToolContentBlock = AgentToolResult<McpToolResultDetails>["content"][number];
 
-interface RenderTheme {
+export interface RenderTheme {
   fg: (name: string, text: string) => string;
   bold?: (text: string) => string;
 }
@@ -28,7 +28,7 @@ interface McpToolRenderState {
   compactInputPreview?: string;
 }
 
-interface McpToolRenderContext {
+export interface McpToolRenderContext {
   isError: boolean;
   isPartial?: boolean;
   expanded?: boolean;


### PR DESCRIPTION
## Summary

Runs a focused deslop pass over the current Unreleased changes. The cleanup keeps the shipped behavior intact while tightening the namespace proxy path and release-facing text.

Changes include:
- reuse valid metadata cache checks for namespace proxies
- avoid re-registering existing namespace proxy tools
- preserve initialization error context for namespace proxy calls
- wire namespace proxy tools into the same prompt and render surfaces as other MCP tools
- remove copied parser logic and test `any` casts
- tighten README, changelog, and ignore-file wording

## Deslop coverage

- extra-comments: fixed needless comments and fork/upstream wording
- defensive-checks: fixed namespace init error context
- any-cast: fixed new test casts and narrowed one namespace call type
- style-inconsistency: fixed namespace cache validity, sync reporting, renderer parity, and prose voice
- generated-docs: fixed README release-facing prose
- reinventing-wheel: reused existing parser and server/cache helpers
- ui-slop: clean, no UI copy in scope

Guardrail recommendation: recommended — this TS repo has no anti-slop guardrail configured, and this pass found type-evidence and structure slop. Install pointer: `npx skills add dmmulroy/anti-slop --skill install-anti-slop`.

## Validation

- `npm run typecheck`
- `npm test -- --run __tests__/namespace-tools.test.ts __tests__/index-lifecycle.test.ts __tests__/server-manager-streamable-http.test.ts __tests__/mcp-probe.test.ts __tests__/tool-result-renderer.test.ts __tests__/lifecycle-lazy-keep-alive.test.ts __tests__/direct-tools.test.ts`
- `npx --yes fallow audit --base v2.27.0 --format json --quiet`
- `git diff --check`
- Fresh read-only review: No issues found
