### PR TITLE
fix: preserve OAuth credentials across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -589,7 +589,7 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(await provider.clientInformation(), undefined)
     })
 
-    it("should only remove tokens when type is 'tokens'", async () => {
+    it("should invalidate tokens only for the current provider", async () => {
       const provider = createProvider()
       const futureTime = Math.floor(Date.now() / 1000) + 3600
 
@@ -610,9 +610,49 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(await provider.tokens(), undefined)
       const clientInfo = await provider.clientInformation()
       assert.strictEqual(clientInfo?.client_id, "client")
+
+      const otherProvider = createProvider()
+      assert.strictEqual((await otherProvider.tokens())?.access_token, "token")
     })
 
-    it("should only remove client info when type is 'client'", async () => {
+    it("should adopt tokens replaced by another process", async () => {
+      const staleProvider = createProvider()
+      await staleProvider.saveTokens({
+        access_token: "stale-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "stale-token")
+
+      // A separate process completes re-authentication after this provider has
+      // already observed and cached the old token.
+      saveAuthEntry(serverName, {
+        tokens: { accessToken: "replacement-token" },
+        serverUrl,
+      }, serverUrl)
+
+      await staleProvider.invalidateCredentials("tokens")
+
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "replacement-token")
+    })
+
+    it("should not invalidate a token saved after the failing token was observed", async () => {
+      const provider = createProvider()
+      await provider.saveTokens({
+        access_token: "old-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await provider.tokens({ issuer: "https://issuer.example" }))?.access_token, "old-token")
+
+      await provider.saveTokens({
+        access_token: "new-token",
+        token_type: "Bearer",
+      })
+      await provider.invalidateCredentials("tokens")
+
+      assert.strictEqual((await provider.tokens())?.access_token, "new-token")
+    })
+
+    it("should invalidate client info only for the current provider", async () => {
       const provider = createProvider()
       const futureTime = Math.floor(Date.now() / 1000) + 3600
 
@@ -633,6 +673,38 @@ describe("McpOAuthProvider", () => {
       const tokens = await provider.tokens()
       assert.strictEqual(tokens?.access_token, "token")
       assert.strictEqual(await provider.clientInformation(), undefined)
+
+      const otherProvider = createProvider()
+      assert.strictEqual((await otherProvider.clientInformation())?.client_id, "client")
+    })
+
+    it("should adopt client information replaced by another process", async () => {
+      const staleProvider = createProvider()
+      await staleProvider.saveTokens({
+        access_token: "replacement-token",
+        token_type: "Bearer",
+      })
+      await staleProvider.saveClientInformation({
+        client_id: "stale-client",
+        client_secret: "stale-secret",
+        redirect_uris: ["http://localhost/callback"],
+      })
+      assert.strictEqual((await staleProvider.clientInformation())?.client_id, "stale-client")
+
+      saveAuthEntry(serverName, {
+        tokens: { accessToken: "replacement-token" },
+        clientInfo: {
+          clientId: "replacement-client",
+          clientSecret: "replacement-secret",
+          redirectUris: ["http://localhost/callback"],
+        },
+        serverUrl,
+      }, serverUrl)
+
+      await staleProvider.invalidateCredentials("client")
+
+      assert.strictEqual((await staleProvider.clientInformation())?.client_id, "replacement-client")
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "replacement-token")
     })
   })
 })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -8,6 +8,7 @@
 import {
   UnauthorizedError,
   type AddClientAuthentication,
+  type OAuthClientInformationContext,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
 } from "@modelcontextprotocol/client"
@@ -21,9 +22,8 @@ import {
   updateTokens,
   updateClientInfo,
   clearAllCredentials,
-  clearClientInfo,
   clearCodeVerifier,
-  clearTokens,
+  invalidateAuthEntryCache,
   type AuthEntry,
   type AuthStorageOptions,
   type StoredTokens,
@@ -161,6 +161,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   private flowDiscoveryState: OAuthDiscoveryState | undefined
   private flowIssuerMismatch = false
   private flowState: string | undefined
+  private invalidatedAccessToken: string | undefined
+  private invalidatedClientId: string | undefined
+  private lastObservedClientId: string | undefined
+  private lastSavedAccessToken: string | undefined
+  private pendingAuthAccessToken: string | undefined
 
   constructor(
     private serverName: string,
@@ -188,6 +193,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   deactivate(): void {
     this.active = false
+    this.invalidatedAccessToken = undefined
+    this.invalidatedClientId = undefined
+    this.lastObservedClientId = undefined
+    this.lastSavedAccessToken = undefined
+    this.pendingAuthAccessToken = undefined
   }
 
   private assertStoredIssuerBindings(entry: AuthEntry | undefined, issuer: string | undefined): void {
@@ -264,6 +274,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Returns undefined if no client info exists or if the server URL has changed.
    */
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    if (this.invalidatedClientId !== undefined) {
+      invalidateAuthEntryCache(this.serverName)
+    }
     const issuer = this.discoveredIssuer
     const stored = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     this.assertStoredIssuerBindings(stored, issuer)
@@ -298,7 +311,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Keep client registration associated with this in-flight flow even if
     // another runtime writes the shared persistent entry for the same name.
     const clientInfo = this.flowClientInfo ?? stored?.clientInfo
+    if (clientInfo?.clientId === this.invalidatedClientId) return undefined
     if (clientInfo) {
+      this.invalidatedClientId = undefined
       // A stored SEP-2352 issuer stub for a config-pre-registered client
       // (identified by the explicit marker, or by the legacy stub shape of
       // {clientId, issuer} with no registration metadata) is only meaningful
@@ -329,6 +344,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       }
       // Return all registration metadata and the local issuer extension.
       // This keeps the SDK OAuth view and the stored issuer binding consistent.
+      this.lastObservedClientId = clientInfo.clientId
       return {
         client_id: clientInfo.clientId,
         client_secret: clientInfo.clientSecret,
@@ -380,6 +396,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
       ...(issuer !== undefined ? { issuer } : {}),
     }
     this.flowClientInfo = clientInfo
+    this.invalidatedClientId = undefined
+    this.lastObservedClientId = clientInfo.clientId
     updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
   }
 
@@ -387,15 +405,25 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Get stored OAuth tokens.
    * Returns undefined if no tokens exist or if the server URL has changed.
    */
-  async tokens(): Promise<OAuthTokens | undefined> {
+  async tokens(ctx?: OAuthClientInformationContext): Promise<OAuthTokens | undefined> {
+    // Once this provider rejects a token, bypass its process-local cache until
+    // another process replaces that token in shared secure storage.
+    if (this.invalidatedAccessToken !== undefined) {
+      invalidateAuthEntryCache(this.serverName)
+    }
+
     // Use getAuthForUrl to validate tokens are for the current server URL.
     const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
-    if (!entry?.tokens) return undefined
+    if (!entry?.tokens || entry.tokens.accessToken === this.invalidatedAccessToken) return undefined
+    this.invalidatedAccessToken = undefined
     const issuer = this.discoveredIssuer
     this.assertStoredIssuerBindings(entry, issuer)
     if (issuer && entry.tokens.issuer === undefined) {
       entry.tokens.issuer = issuer
       updateTokens(this.serverName, entry.tokens, this.serverUrl, this.storageOptions)
+    }
+    if (ctx !== undefined && this.pendingAuthAccessToken === undefined) {
+      this.pendingAuthAccessToken = entry.tokens.accessToken
     }
 
     return {
@@ -427,6 +455,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     this.throwIfInactive()
     updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)
+    this.invalidatedAccessToken = undefined
+    this.lastSavedAccessToken = storedTokens.accessToken
     // Discovery must survive the browser redirect so the callback can verify
     // the authorization server that minted the code. Once token issuance
     // succeeds, clear it so a later 401 re-reads PRM and can observe an
@@ -533,14 +563,31 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.flowDiscoveryState = undefined
         this.flowIssuerMismatch = false
         this.flowState = undefined
+        this.invalidatedAccessToken = undefined
+        this.invalidatedClientId = undefined
+        this.lastObservedClientId = undefined
+        this.lastSavedAccessToken = undefined
+        this.pendingAuthAccessToken = undefined
         clearAllCredentials(this.serverName, this.storageOptions)
         break
       case "client":
+        // Dynamic client registrations share the same credential-store entry as
+        // tokens. Keep SDK invalidation local so a stale process cannot rewrite
+        // that entry over credentials another process just authorized.
+        this.invalidatedClientId = this.lastObservedClientId
+        this.lastObservedClientId = undefined
         this.flowClientInfo = undefined
-        clearClientInfo(this.serverName, this.storageOptions)
+        invalidateAuthEntryCache(this.serverName)
         break
       case "tokens":
-        clearTokens(this.serverName, this.storageOptions)
+        // Invalidation is provider-local. Persistently deleting a shared token
+        // here lets a process refreshing stale cached credentials erase a token
+        // that another process just authorized. A later tokens() call bypasses
+        // the local cache and adopts a replacement token when one exists.
+        this.invalidatedAccessToken = this.pendingAuthAccessToken ?? this.lastSavedAccessToken
+        this.lastSavedAccessToken = undefined
+        this.pendingAuthAccessToken = undefined
+        invalidateAuthEntryCache(this.serverName)
         break
       case "verifier":
         clearCodeVerifier(this.serverName, this.storageOptions)


### PR DESCRIPTION
## Summary

- keep SDK token and dynamic-client invalidation local to the provider that observed the rejected credentials
- evict the process-local auth cache after invalidation so stale processes can adopt credentials replaced in the shared OS credential store
- distinguish OAuth refresh reads (`tokens(ctx)`) from transport bearer reads, preserving a newer token saved while an older refresh was in flight
- clear retained credential identifiers when the provider is deactivated

## Problem

OAuth credentials are shared through the OS credential store, while each Pi process has its own auth cache. A long-lived process can therefore retain an old refresh token after another process completes reauthorization.

When the old refresh receives `invalid_grant`, the MCP SDK invokes `invalidateCredentials()`. The provider previously deleted tokens (and, for `invalid_client`, client information) using a cached read/modify/write of the shared credential entry. That stale process could erase the newly authorized token or overwrite the entire newer entry, causing OAuth to appear to expire immediately after the user fixed it.

This was observed with two Pi sessions using the Pylon MCP server: the shared Keychain entry was rewritten to retain only client registration at the exact time the stale session attempted its next call.

## Approach

SDK invalidation now rejects the observed token/client only inside that provider instance rather than mutating shared storage. While a value is locally invalidated, reads bypass the process cache:

- if secure storage still contains the rejected value, the current flow treats it as absent and can reauthorize;
- if another process has replaced it, the stale provider adopts the replacement without deleting it.

Explicit `all` invalidation/logout still removes shared credentials as before.

## Tests

- `npm run typecheck`
- `npm run test:oauth` — 140 passed
- `npm test` — OAuth changes pass; full suite reached 101/102 files, with the pre-existing timing-sensitive `request-headers-command` helper-marker test intermittently failing under full parallel load. The test file passes alone: `npx vitest run __tests__/request-headers-command.test.ts` (18/18).

Added focused regressions for:

- provider-local token invalidation
- adoption of a token replaced by another process
- delayed invalidation of an older token after a newer token is saved
- provider-local dynamic-client invalidation
- adoption of replacement client information without overwriting replacement tokens
