### PR TITLE
fix: preserve OAuth credentials across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials.
+- OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -652,6 +652,27 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual((await provider.tokens())?.access_token, "new-token")
     })
 
+    it("should invalidate the token observed by the latest auth read", async () => {
+      const provider = createProvider()
+      await provider.saveTokens({
+        access_token: "first-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await provider.tokens({ issuer: "https://issuer.example" }))?.access_token, "first-token")
+
+      await provider.saveTokens({
+        access_token: "second-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await provider.tokens({ issuer: "https://issuer.example" }))?.access_token, "second-token")
+
+      await provider.invalidateCredentials("tokens")
+
+      assert.strictEqual(await provider.tokens(), undefined)
+      const otherProvider = createProvider()
+      assert.strictEqual((await otherProvider.tokens())?.access_token, "second-token")
+    })
+
     it("should invalidate client info only for the current provider", async () => {
       const provider = createProvider()
       const futureTime = Math.floor(Date.now() / 1000) + 3600

--- a/mcp-oauth-provider.test.ts
+++ b/mcp-oauth-provider.test.ts
@@ -589,7 +589,7 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(await provider.clientInformation(), undefined)
     })
 
-    it("should only remove tokens when type is 'tokens'", async () => {
+    it("should invalidate tokens only for the current provider", async () => {
       const provider = createProvider()
       const futureTime = Math.floor(Date.now() / 1000) + 3600
 
@@ -610,9 +610,49 @@ describe("McpOAuthProvider", () => {
       assert.strictEqual(await provider.tokens(), undefined)
       const clientInfo = await provider.clientInformation()
       assert.strictEqual(clientInfo?.client_id, "client")
+
+      const otherProvider = createProvider()
+      assert.strictEqual((await otherProvider.tokens())?.access_token, "token")
     })
 
-    it("should only remove client info when type is 'client'", async () => {
+    it("should adopt tokens replaced by another process", async () => {
+      const staleProvider = createProvider()
+      await staleProvider.saveTokens({
+        access_token: "stale-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "stale-token")
+
+      // A separate process completes re-authentication after this provider has
+      // already observed and cached the old token.
+      saveAuthEntry(serverName, {
+        tokens: { accessToken: "replacement-token" },
+        serverUrl,
+      }, serverUrl)
+
+      await staleProvider.invalidateCredentials("tokens")
+
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "replacement-token")
+    })
+
+    it("should not invalidate a token saved after the failing token was observed", async () => {
+      const provider = createProvider()
+      await provider.saveTokens({
+        access_token: "old-token",
+        token_type: "Bearer",
+      })
+      assert.strictEqual((await provider.tokens({ issuer: "https://issuer.example" }))?.access_token, "old-token")
+
+      await provider.saveTokens({
+        access_token: "new-token",
+        token_type: "Bearer",
+      })
+      await provider.invalidateCredentials("tokens")
+
+      assert.strictEqual((await provider.tokens())?.access_token, "new-token")
+    })
+
+    it("should invalidate client info only for the current provider", async () => {
       const provider = createProvider()
       const futureTime = Math.floor(Date.now() / 1000) + 3600
 
@@ -633,6 +673,38 @@ describe("McpOAuthProvider", () => {
       const tokens = await provider.tokens()
       assert.strictEqual(tokens?.access_token, "token")
       assert.strictEqual(await provider.clientInformation(), undefined)
+
+      const otherProvider = createProvider()
+      assert.strictEqual((await otherProvider.clientInformation())?.client_id, "client")
+    })
+
+    it("should adopt client information replaced by another process", async () => {
+      const staleProvider = createProvider()
+      await staleProvider.saveTokens({
+        access_token: "replacement-token",
+        token_type: "Bearer",
+      })
+      await staleProvider.saveClientInformation({
+        client_id: "stale-client",
+        client_secret: "stale-secret",
+        redirect_uris: ["http://localhost/callback"],
+      })
+      assert.strictEqual((await staleProvider.clientInformation())?.client_id, "stale-client")
+
+      saveAuthEntry(serverName, {
+        tokens: { accessToken: "replacement-token" },
+        clientInfo: {
+          clientId: "replacement-client",
+          clientSecret: "replacement-secret",
+          redirectUris: ["http://localhost/callback"],
+        },
+        serverUrl,
+      }, serverUrl)
+
+      await staleProvider.invalidateCredentials("client")
+
+      assert.strictEqual((await staleProvider.clientInformation())?.client_id, "replacement-client")
+      assert.strictEqual((await staleProvider.tokens())?.access_token, "replacement-token")
     })
   })
 })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -8,6 +8,7 @@
 import {
   UnauthorizedError,
   type AddClientAuthentication,
+  type OAuthClientInformationContext,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
 } from "@modelcontextprotocol/client"
@@ -21,9 +22,8 @@ import {
   updateTokens,
   updateClientInfo,
   clearAllCredentials,
-  clearClientInfo,
   clearCodeVerifier,
-  clearTokens,
+  invalidateAuthEntryCache,
   type AuthEntry,
   type AuthStorageOptions,
   type StoredTokens,
@@ -161,6 +161,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   private flowDiscoveryState: OAuthDiscoveryState | undefined
   private flowIssuerMismatch = false
   private flowState: string | undefined
+  private invalidatedAccessToken: string | undefined
+  private invalidatedClientId: string | undefined
+  private lastObservedClientId: string | undefined
+  private lastSavedAccessToken: string | undefined
+  private pendingAuthAccessToken: string | undefined
 
   constructor(
     private serverName: string,
@@ -188,6 +193,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   deactivate(): void {
     this.active = false
+    this.invalidatedAccessToken = undefined
+    this.invalidatedClientId = undefined
+    this.lastObservedClientId = undefined
+    this.lastSavedAccessToken = undefined
+    this.pendingAuthAccessToken = undefined
   }
 
   private assertStoredIssuerBindings(entry: AuthEntry | undefined, issuer: string | undefined): void {
@@ -264,6 +274,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Returns undefined if no client info exists or if the server URL has changed.
    */
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    if (this.invalidatedClientId !== undefined) {
+      invalidateAuthEntryCache(this.serverName)
+    }
     const issuer = this.discoveredIssuer
     const stored = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
     this.assertStoredIssuerBindings(stored, issuer)
@@ -298,7 +311,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Keep client registration associated with this in-flight flow even if
     // another runtime writes the shared persistent entry for the same name.
     const clientInfo = this.flowClientInfo ?? stored?.clientInfo
+    if (clientInfo?.clientId === this.invalidatedClientId) return undefined
     if (clientInfo) {
+      this.invalidatedClientId = undefined
       // A stored SEP-2352 issuer stub for a config-pre-registered client
       // (identified by the explicit marker, or by the legacy stub shape of
       // {clientId, issuer} with no registration metadata) is only meaningful
@@ -329,6 +344,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       }
       // Return all registration metadata and the local issuer extension.
       // This keeps the SDK OAuth view and the stored issuer binding consistent.
+      this.lastObservedClientId = clientInfo.clientId
       return {
         client_id: clientInfo.clientId,
         client_secret: clientInfo.clientSecret,
@@ -380,6 +396,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
       ...(issuer !== undefined ? { issuer } : {}),
     }
     this.flowClientInfo = clientInfo
+    this.invalidatedClientId = undefined
+    this.lastObservedClientId = clientInfo.clientId
     updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
   }
 
@@ -387,15 +405,25 @@ export class McpOAuthProvider implements OAuthClientProvider {
    * Get stored OAuth tokens.
    * Returns undefined if no tokens exist or if the server URL has changed.
    */
-  async tokens(): Promise<OAuthTokens | undefined> {
+  async tokens(ctx?: OAuthClientInformationContext): Promise<OAuthTokens | undefined> {
+    // Once this provider rejects a token, bypass its process-local cache until
+    // another process replaces that token in shared secure storage.
+    if (this.invalidatedAccessToken !== undefined) {
+      invalidateAuthEntryCache(this.serverName)
+    }
+
     // Use getAuthForUrl to validate tokens are for the current server URL.
     const entry = await getAuthForUrl(this.serverName, this.serverUrl, this.storageOptions)
-    if (!entry?.tokens) return undefined
+    if (!entry?.tokens || entry.tokens.accessToken === this.invalidatedAccessToken) return undefined
+    this.invalidatedAccessToken = undefined
     const issuer = this.discoveredIssuer
     this.assertStoredIssuerBindings(entry, issuer)
     if (issuer && entry.tokens.issuer === undefined) {
       entry.tokens.issuer = issuer
       updateTokens(this.serverName, entry.tokens, this.serverUrl, this.storageOptions)
+    }
+    if (ctx !== undefined && this.pendingAuthAccessToken === undefined) {
+      this.pendingAuthAccessToken = entry.tokens.accessToken
     }
 
     return {
@@ -427,6 +455,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     this.throwIfInactive()
     updateTokens(this.serverName, storedTokens, this.serverUrl, this.storageOptions)
+    this.invalidatedAccessToken = undefined
+    this.lastSavedAccessToken = storedTokens.accessToken
     // Discovery must survive the browser redirect so the callback can verify
     // the authorization server that minted the code. Once token issuance
     // succeeds, clear it so a later 401 re-reads PRM and can observe an
@@ -533,14 +563,31 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.flowDiscoveryState = undefined
         this.flowIssuerMismatch = false
         this.flowState = undefined
+        this.invalidatedAccessToken = undefined
+        this.invalidatedClientId = undefined
+        this.lastObservedClientId = undefined
+        this.lastSavedAccessToken = undefined
+        this.pendingAuthAccessToken = undefined
         clearAllCredentials(this.serverName, this.storageOptions)
         break
       case "client":
+        // Dynamic client registrations share the same credential-store entry as
+        // tokens. Keep SDK invalidation local so a stale process cannot rewrite
+        // that entry over credentials another process just authorized.
+        this.invalidatedClientId = this.lastObservedClientId
+        this.lastObservedClientId = undefined
         this.flowClientInfo = undefined
-        clearClientInfo(this.serverName, this.storageOptions)
+        invalidateAuthEntryCache(this.serverName)
         break
       case "tokens":
-        clearTokens(this.serverName, this.storageOptions)
+        // Invalidation is provider-local. Persistently deleting a shared token
+        // here lets a process refreshing stale cached credentials erase a token
+        // that another process just authorized. A later tokens() call bypasses
+        // the local cache and adopts a replacement token when one exists.
+        this.invalidatedAccessToken = this.pendingAuthAccessToken ?? this.lastSavedAccessToken
+        this.lastSavedAccessToken = undefined
+        this.pendingAuthAccessToken = undefined
+        invalidateAuthEntryCache(this.serverName)
         break
       case "verifier":
         clearCodeVerifier(this.serverName, this.storageOptions)

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -422,7 +422,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       entry.tokens.issuer = issuer
       updateTokens(this.serverName, entry.tokens, this.serverUrl, this.storageOptions)
     }
-    if (ctx !== undefined && this.pendingAuthAccessToken === undefined) {
+    if (ctx !== undefined) {
       this.pendingAuthAccessToken = entry.tokens.accessToken
     }
 


### PR DESCRIPTION
## Summary

This is the maintainer replacement for #422.

It keeps the core #422 fix from @mjlbach: selective OAuth token and dynamic-client invalidation stay local to the provider that observed the rejected credential, so a stale Pi process does not delete newer credentials written by another process.

This branch adds one follow-up fix from fresh review: each SDK auth `tokens(ctx)` read now refreshes the observed access-token identity, so a later invalidation targets the latest rejected token instead of a stale token from an earlier refresh cycle.

## Credit

Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422 and the original cross-process credential preservation fix.

## Validation

- `npm run typecheck`
- `npm run test:oauth-provider`
- `npm run test:oauth`
- Fresh read-only review: `/tmp/pi-mcp-adapter-pr422-replacement-review.md` reported no issues.

## Notes

No release or tag action is part of this PR.
