### PR TITLE
feat: add pure mcp reference resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a pure `mcp:` reference resolver API for consumers that validate adapter tool names from explicit config and cache inputs. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420.
+
 ### Fixed
 - OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.

--- a/__tests__/mcp-references.test.ts
+++ b/__tests__/mcp-references.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { computeServerHash } from "../metadata-cache.ts";
+import type { CachedTool, McpConfig, ServerEntry } from "../types.ts";
+import { namespaceProxyName, parseMcpReference, resolveMcpToolReferences } from "../mcp-references.ts";
+
+const cacheFor = (entries: Array<[string, { definition: ServerEntry; tools: CachedTool[]; cachedAt?: number; configHash?: string }]>) => ({
+  version: 1,
+  servers: Object.fromEntries(entries.map(([serverName, entry]) => [serverName, {
+    configHash: entry.configHash ?? computeServerHash(entry.definition),
+    cachedAt: entry.cachedAt ?? Date.now(),
+    tools: entry.tools,
+    resources: [],
+  }])),
+});
+
+const cacheWithResources = (entries: Array<[string, { definition: ServerEntry; tools: CachedTool[]; resources: Array<{ name: string; uri: string }>; cachedAt?: number; configHash?: string }]>) => ({
+  version: 1,
+  servers: Object.fromEntries(entries.map(([serverName, entry]) => [serverName, {
+    configHash: entry.configHash ?? computeServerHash(entry.definition),
+    cachedAt: entry.cachedAt ?? Date.now(),
+    tools: entry.tools,
+    resources: entry.resources,
+  }])),
+});
+
+const configFor = (mcpServers: Record<string, ServerEntry>, settings?: McpConfig["settings"]): McpConfig => ({
+  mcpServers,
+  ...(settings ? { settings } : {}),
+});
+
+describe("parseMcpReference", () => {
+  it("parses server and server/tool references", () => {
+    expect(parseMcpReference("mcp:context-mode")).toEqual({ raw: "mcp:context-mode", server: "context-mode" });
+    expect(parseMcpReference("mcp:context-mode/query_docs")).toEqual({ raw: "mcp:context-mode/query_docs", server: "context-mode", tool: "query_docs" });
+  });
+
+  it("does not parse non-mcp references", () => {
+    expect(parseMcpReference("read")).toEqual({ raw: "read" });
+  });
+});
+
+describe("namespaceProxyName", () => {
+  it("uses the runtime namespace proxy convention", () => {
+    expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+  });
+});
+
+describe("resolveMcpToolReferences", () => {
+  it("expands direct server references from explicit config and cache", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, tools: [{ name: "search" }, { name: "fetch" }] }]]),
+    );
+
+    expect(result).toEqual({ names: ["demo_search", "demo_fetch"], diagnostics: [] });
+  });
+
+  it("resolves direct server/tool and bare registered-tool references", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true };
+    const config = configFor({ demo: definition });
+    const cache = cacheFor([["demo", { definition, tools: [{ name: "search" }] }]]);
+
+    expect(resolveMcpToolReferences(["mcp:demo/search"], config, cache).names).toEqual(["demo_search"]);
+    expect(resolveMcpToolReferences(["mcp:demo_search"], config, cache).names).toEqual(["demo_search"]);
+  });
+
+  it("resolves proxy-only server/tool references to the namespace proxy after validating the tool", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/demo_search"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, tools: [{ name: "search" }] }]]),
+    );
+
+    expect(result).toEqual({ names: ["mcp__demo"], diagnostics: [] });
+  });
+
+  it("rejects unformatted proxy-only resource references", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/read_guide"],
+      configFor({ demo: definition }),
+      cacheWithResources([["demo", { definition, tools: [{ name: "search" }], resources: [{ name: "guide", uri: "file://guide" }] }]]),
+    );
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("unknown or hidden tool");
+  });
+
+  it("accepts formatted proxy resource references", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/demo_read_guide"],
+      configFor({ demo: definition }),
+      cacheWithResources([["demo", { definition, tools: [{ name: "search" }], resources: [{ name: "guide", uri: "file://guide" }] }]]),
+    );
+
+    expect(result).toEqual({ names: ["mcp__demo"], diagnostics: [] });
+  });
+
+  it("rejects unknown proxy-only server/tool references", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/missing"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, tools: [{ name: "search" }] }]]),
+    );
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("unknown or hidden tool");
+  });
+
+  it("skips ambiguous namespace proxies with colliding normalized server names", () => {
+    const first: ServerEntry = { command: "one" };
+    const second: ServerEntry = { command: "two" };
+    const config = configFor({ "my-server": first, my_server: second });
+    const cache = cacheFor([
+      ["my-server", { definition: first, tools: [{ name: "search" }] }],
+      ["my_server", { definition: second, tools: [{ name: "search" }] }],
+    ]);
+
+    const result = resolveMcpToolReferences(["mcp:my-server", "mcp:my_server"], config, cache);
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("skips namespace proxies that collide with direct tool names", () => {
+    const proxy: ServerEntry = { command: "proxy" };
+    const direct: ServerEntry = { command: "direct", directTools: true, toolPrefix: "none" };
+    const config = configFor({ proxy, direct });
+    const cache = cacheFor([
+      ["proxy", { definition: proxy, tools: [{ name: "search" }] }],
+      ["direct", { definition: direct, tools: [{ name: "mcp__proxy" }] }],
+    ]);
+
+    const result = resolveMcpToolReferences(["mcp:proxy"], config, cache);
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("no registered tool");
+  });
+
+  it("rejects server-qualified direct references that lose duplicate-name ownership", () => {
+    const first: ServerEntry = { command: "first", directTools: true, toolPrefix: "none" };
+    const second: ServerEntry = { command: "second", directTools: true, toolPrefix: "none" };
+    const config = configFor({ first, second });
+    const cache = cacheFor([
+      ["first", { definition: first, tools: [{ name: "get" }] }],
+      ["second", { definition: second, tools: [{ name: "get" }] }],
+    ]);
+
+    expect(resolveMcpToolReferences(["mcp:first/get"], config, cache).names).toEqual(["get"]);
+    const result = resolveMcpToolReferences(["mcp:second/get"], config, cache);
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("no registered tool");
+  });
+
+  it("requires valid cache entries", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, configHash: "stale", tools: [{ name: "search" }] }]]),
+    );
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("no valid cached metadata");
+  });
+
+  it("keeps a proxy namespace when MCP_DIRECT_TOOLS selects only one tool", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const config = configFor({ demo: definition });
+    const cache = cacheFor([["demo", { definition, tools: [{ name: "search" }, { name: "fetch" }] }]]);
+
+    expect(resolveMcpToolReferences(["mcp:demo/search"], config, cache, ["demo/search"]).names).toEqual(["demo_search"]);
+    expect(resolveMcpToolReferences(["mcp:demo/demo_fetch"], config, cache, ["demo/search"]).names).toEqual(["mcp__demo"]);
+  });
+
+  it("keeps a proxy namespace for unselected tools when env override narrows a directTools server", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true };
+    const config = configFor({ demo: definition });
+    const cache = cacheFor([["demo", { definition, tools: [{ name: "search" }, { name: "fetch" }] }]]);
+
+    expect(resolveMcpToolReferences(["mcp:demo/search"], config, cache, ["demo/search"]).names).toEqual(["demo_search"]);
+    expect(resolveMcpToolReferences(["mcp:demo/demo_fetch"], config, cache, ["demo/search"]).names).toEqual(["mcp__demo"]);
+  });
+
+  it("rejects direct references that collide with builtin tool names", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true, toolPrefix: "none" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/bash"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, tools: [{ name: "bash" }] }]]),
+    );
+
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("no registered tool");
+  });
+
+  it("rejects raw tool names that lost a same-name direct registration collision", () => {
+    const definition: ServerEntry = { command: "demo", directTools: true };
+    const config = configFor({ demo: definition });
+    const cache = cacheFor([["demo", { definition, tools: [{ name: "namespace.tool" }, { name: "namespace_tool" }] }]]);
+
+    expect(resolveMcpToolReferences(["mcp:demo/namespace.tool"], config, cache).names).toEqual(["demo_namespace_tool"]);
+    const result = resolveMcpToolReferences(["mcp:demo/namespace_tool"], config, cache);
+    expect(result.names).toEqual([]);
+    expect(result.diagnostics[0]).toContain("no registered tool");
+  });
+
+  it("passes non-mcp references through and deduplicates names", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["read", "mcp:demo", "mcp:demo/demo_search", "read"],
+      configFor({ demo: definition }),
+      cacheFor([["demo", { definition, tools: [{ name: "search" }] }]]),
+    );
+
+    expect(result.names).toEqual(["read", "mcp__demo"]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("is exported from the package entrypoint", async () => {
+    const mod = await import("../index.ts");
+
+    expect(mod.namespaceProxyName("context-mode")).toBe("mcp__context_mode");
+    expect(mod.parseMcpReference("mcp:demo/search")).toEqual({ raw: "mcp:demo/search", server: "demo", tool: "search" });
+    expect(typeof mod.resolveMcpToolReferences).toBe("function");
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,13 @@ import { syncNamespaceProxyTools } from "./namespace-tools.ts";
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
 export {
+  namespaceProxyName,
+  parseMcpReference,
+  resolveMcpToolReferences,
+  type McpReferenceResolution,
+  type ParsedMcpReference,
+} from "./mcp-references.ts";
+export {
   MCP_STATUS_EVENT,
   MCP_STATUS_SNAPSHOT_VERSION,
   MCP_TOOL_APPROVAL_REQUEST_EVENT,

--- a/mcp-references.ts
+++ b/mcp-references.ts
@@ -1,0 +1,372 @@
+import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
+import { resourceNameToToolName } from "./resource-tools.ts";
+import { isServerCacheValid, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
+import {
+  createToolSelectorCandidateIndex,
+  formatToolName,
+  getToolNameCandidates,
+  isServerDisabled,
+  isToolAllowed,
+  resolveToolPrefix,
+  type CachedTool,
+  type McpConfig,
+  type ServerCacheEntry,
+  type ServerEntry,
+  type ToolPrefix,
+  type ToolSelectorCandidateIndex,
+} from "./types.ts";
+
+export interface ParsedMcpReference {
+  raw: string;
+  server?: string;
+  tool?: string;
+}
+
+export interface McpReferenceResolution {
+  names: string[];
+  diagnostics: string[];
+}
+
+type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
+type DirectSelection = true | string[] | false;
+type DirectNameOwner = { serverName: string; originalName: string };
+type DirectNameEntry = { name: string; originalName: string };
+
+const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
+
+export function namespaceProxyName(serverName: string): string {
+  return `mcp__${serverName.replace(/-/g, "_")}`;
+}
+
+export function parseMcpReference(raw: string): ParsedMcpReference {
+  if (!raw.startsWith("mcp:")) return { raw };
+  const rest = raw.slice("mcp:".length).trim();
+  if (!rest) return { raw };
+
+  const slash = rest.indexOf("/");
+  if (slash === -1) return { raw, server: rest };
+
+  const server = rest.slice(0, slash).trim();
+  const tool = rest.slice(slash + 1).trim();
+  return {
+    raw,
+    ...(server ? { server } : {}),
+    ...(tool ? { tool } : {}),
+  };
+}
+
+function resolveDirectSelection(
+  config: McpConfig,
+  definition: Pick<ServerEntry, "directTools">,
+  serverName: string,
+  envOverride: DirectToolSelectorOverride | null,
+): DirectSelection {
+  if (envOverride) {
+    if (envOverride.servers.has(serverName)) return true;
+    const selectedTools = envOverride.tools.get(serverName);
+    return selectedTools ? [...selectedTools] : false;
+  }
+  if (definition.directTools !== undefined) return definition.directTools;
+  return config.settings?.directTools === true;
+}
+
+function hasNamespaceProxy(
+  config: McpConfig,
+  cache: MetadataCache,
+  envOverride: DirectToolSelectorOverride | null,
+  collidingNamespaceNames: ReadonlySet<string>,
+  existingDirectNames: ReadonlySet<string>,
+  serverName: string,
+): boolean {
+  const definition = config.mcpServers[serverName];
+  if (!definition || isServerDisabled(definition)) return false;
+  if (envOverride) {
+    if (envOverride.servers.has(serverName)) return false;
+  } else {
+    if (definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0)) return false;
+    if (definition.directTools === undefined && config.settings?.directTools === true) return false;
+  }
+  const toolName = namespaceProxyName(serverName);
+  if (collidingNamespaceNames.has(toolName) || existingDirectNames.has(toolName)) return false;
+  const entry = cache.servers[serverName];
+  return !!entry && isServerCacheValid(entry, definition) && entry.tools.length > 0;
+}
+
+function resolveValidCache(config: McpConfig, cache: MetadataCache | null, serverName: string): ServerCacheEntry | undefined {
+  const definition = config.mcpServers[serverName];
+  const entry = cache?.servers[serverName];
+  if (!definition || !entry || !isServerCacheValid(entry, definition)) return undefined;
+  return entry;
+}
+
+function namespaceCollisionNames(
+  config: McpConfig,
+  cache: MetadataCache | null,
+  envOverride: DirectToolSelectorOverride | null,
+  existingDirectNames: ReadonlySet<string>,
+): Set<string> {
+  const names = new Map<string, number>();
+  if (!cache) return new Set();
+  for (const serverName of Object.keys(config.mcpServers)) {
+    if (!hasNamespaceProxy(config, cache, envOverride, new Set(), existingDirectNames, serverName)) continue;
+    const toolName = namespaceProxyName(serverName);
+    names.set(toolName, (names.get(toolName) ?? 0) + 1);
+  }
+  return new Set([...names].filter(([, count]) => count > 1).map(([name]) => name));
+}
+
+function registeredDirectNames(
+  config: McpConfig,
+  cache: MetadataCache | null,
+  envOverride: DirectToolSelectorOverride | null,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+): Map<string, DirectNameOwner> {
+  const owners = new Map<string, DirectNameOwner>();
+  if (!cache) return owners;
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
+    const entry = resolveValidCache(config, cache, serverName);
+    if (!entry) continue;
+    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+    const selection = resolveDirectSelection(config, definition, serverName, envOverride);
+    for (const { name, originalName } of directNameEntries(entry, serverName, definition, prefix, selection, selectorIndex)) {
+      if (!owners.has(name)) owners.set(name, { serverName, originalName });
+    }
+  }
+  return owners;
+}
+
+function allCurrentCandidates(config: McpConfig, cache: MetadataCache | null): ToolSelectorCandidateIndex | undefined {
+  if (!cache) return undefined;
+  const candidates = new Set<string>();
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
+    const entry = resolveValidCache(config, cache, serverName);
+    if (!entry) continue;
+    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+    for (const tool of entry.tools) {
+      if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+      for (const candidate of getToolNameCandidates(tool.name, serverName, prefix, false)) candidates.add(candidate);
+    }
+    if (definition.exposeResources !== false) {
+      for (const resource of entry.resources ?? []) {
+        const baseName = `read_${resourceNameToToolName(resource.name)}`;
+        for (const candidate of getToolNameCandidates(baseName, serverName, prefix, false)) candidates.add(candidate);
+      }
+    }
+  }
+  return createToolSelectorCandidateIndex(candidates);
+}
+
+function directToolName(
+  toolName: string,
+  serverName: string,
+  definition: ServerEntry,
+  prefix: ToolPrefix,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+): string | undefined {
+  if (!isToolAllowed(toolName, serverName, prefix, definition.includeTools, definition.excludeTools, selectorIndex)) return undefined;
+  return formatToolName(toolName, serverName, prefix);
+}
+
+function directNameEntries(
+  entry: ServerCacheEntry,
+  serverName: string,
+  definition: ServerEntry,
+  prefix: ToolPrefix,
+  selection: DirectSelection,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+  onlyTool?: string,
+): DirectNameEntry[] {
+  if (!selection) return [];
+  const names: DirectNameEntry[] = [];
+  const addTool = (toolName: string): void => {
+    if (selection !== true && !selection.includes(toolName)) return;
+    const name = directToolName(toolName, serverName, definition, prefix, selectorIndex);
+    if (!name) return;
+    if (BUILTIN_NAMES.has(name)) return;
+    if (onlyTool !== undefined && toolName !== onlyTool && name !== onlyTool) return;
+    names.push({ name, originalName: toolName });
+  };
+
+  for (const tool of entry.tools) {
+    if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
+    addTool(tool.name);
+  }
+  if (definition.exposeResources !== false) {
+    for (const resource of entry.resources ?? []) addTool(`read_${resourceNameToToolName(resource.name)}`);
+  }
+  return names;
+}
+
+function ownedDirectToolNames(names: DirectNameEntry[], serverName: string, directNameOwners: ReadonlyMap<string, DirectNameOwner>): string[] {
+  return names
+    .filter(({ name, originalName }) => {
+      const owner = directNameOwners.get(name);
+      return owner?.serverName === serverName && owner.originalName === originalName;
+    })
+    .map(({ name }) => name);
+}
+
+function hasAllowedProxyTool(
+  entry: Pick<ServerCacheEntry, "tools" | "resources">,
+  serverName: string,
+  definition: ServerEntry,
+  prefix: ToolPrefix,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+  toolName: string | undefined,
+): boolean {
+  if (toolName === undefined) return true;
+  const matchesAllowedName = (baseName: string) => {
+    if (!isToolAllowed(baseName, serverName, prefix, definition.includeTools, definition.excludeTools, selectorIndex)) return false;
+    return toolName === formatToolName(baseName, serverName, prefix);
+  };
+  if (entry.tools.some((tool: CachedTool) =>
+    isUiToolVisibleToModel(tool.uiVisibility) &&
+    matchesAllowedName(tool.name)
+  )) return true;
+  if (definition.exposeResources === false) return false;
+  return (entry.resources ?? []).some((resource) => {
+    const baseName = `read_${resourceNameToToolName(resource.name)}`;
+    return matchesAllowedName(baseName);
+  });
+}
+
+function addName(names: string[], seen: Set<string>, name: string): void {
+  if (seen.has(name)) return;
+  seen.add(name);
+  names.push(name);
+}
+
+function resolveKnownServerReference(
+  parsed: ParsedMcpReference,
+  config: McpConfig,
+  cache: MetadataCache | null,
+  envOverride: DirectToolSelectorOverride | null,
+  collidingNamespaceNames: ReadonlySet<string>,
+  existingDirectNames: ReadonlySet<string>,
+  directNameOwners: ReadonlyMap<string, DirectNameOwner>,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+  names: string[],
+  seen: Set<string>,
+  diagnostics: string[],
+): void {
+  const serverName = parsed.server!;
+  const definition = config.mcpServers[serverName];
+  if (!definition || isServerDisabled(definition)) {
+    diagnostics.push(`MCP reference "${parsed.raw}" refers to disabled or unknown server "${serverName}"`);
+    return;
+  }
+  const entry = resolveValidCache(config, cache, serverName);
+  if (!entry) {
+    diagnostics.push(`MCP reference "${parsed.raw}" cannot be resolved: no valid cached metadata for server "${serverName}"`);
+    return;
+  }
+
+  const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+  const selection = resolveDirectSelection(config, definition, serverName, envOverride);
+  const directNames = ownedDirectToolNames(
+    directNameEntries(entry, serverName, definition, prefix, selection, selectorIndex, parsed.tool),
+    serverName,
+    directNameOwners,
+  );
+  if (directNames.length > 0) {
+    for (const name of directNames) addName(names, seen, name);
+    return;
+  }
+
+  if (hasNamespaceProxy(config, cache!, envOverride, collidingNamespaceNames, existingDirectNames, serverName)) {
+    if (hasAllowedProxyTool(entry, serverName, definition, prefix, selectorIndex, parsed.tool)) {
+      addName(names, seen, namespaceProxyName(serverName));
+      return;
+    }
+    diagnostics.push(`MCP reference "${parsed.raw}" refers to unknown or hidden tool "${parsed.tool}" on server "${serverName}"`);
+    return;
+  }
+
+  diagnostics.push(`MCP reference "${parsed.raw}" resolves to no registered tool`);
+}
+
+function resolveBareToolReference(
+  raw: string,
+  toolName: string,
+  config: McpConfig,
+  cache: MetadataCache | null,
+  envOverride: DirectToolSelectorOverride | null,
+  collidingNamespaceNames: ReadonlySet<string>,
+  existingDirectNames: ReadonlySet<string>,
+  directNameOwners: ReadonlyMap<string, DirectNameOwner>,
+  selectorIndex: ToolSelectorCandidateIndex | undefined,
+  names: string[],
+  seen: Set<string>,
+  diagnostics: string[],
+): void {
+  let matched = false;
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
+    const entry = resolveValidCache(config, cache, serverName);
+    if (!entry) continue;
+    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+    const selection = resolveDirectSelection(config, definition, serverName, envOverride);
+    const directNames = ownedDirectToolNames(
+      directNameEntries(entry, serverName, definition, prefix, selection, selectorIndex, toolName),
+      serverName,
+      directNameOwners,
+    );
+    for (const name of directNames) {
+      addName(names, seen, name);
+      matched = true;
+    }
+    if (hasNamespaceProxy(config, cache!, envOverride, collidingNamespaceNames, existingDirectNames, serverName) &&
+        hasAllowedProxyTool(entry, serverName, definition, prefix, selectorIndex, toolName)) {
+      addName(names, seen, namespaceProxyName(serverName));
+      matched = true;
+    }
+  }
+  if (!matched) diagnostics.push(`MCP reference "${raw}" does not match a configured server or cached tool`);
+}
+
+export function resolveMcpToolReferences(
+  refs: string[],
+  config: McpConfig | null,
+  cache: MetadataCache | null,
+  envOverride?: string[],
+): McpReferenceResolution {
+  const names: string[] = [];
+  const diagnostics: string[] = [];
+  const seen = new Set<string>();
+
+  if (!config) {
+    return {
+      names: refs.filter((ref) => !ref.startsWith("mcp:")),
+      diagnostics: refs.filter((ref) => ref.startsWith("mcp:")).map((ref) => `MCP reference "${ref}" cannot be resolved: no MCP config`),
+    };
+  }
+
+  const parsedOverride = envOverride ? parseDirectToolSelectors(envOverride) : null;
+  const selectorIndex = allCurrentCandidates(config, cache);
+  const directNameOwners = registeredDirectNames(config, cache, parsedOverride, selectorIndex);
+  const directNames = new Set(directNameOwners.keys());
+  const collidingNamespaceNames = namespaceCollisionNames(config, cache, parsedOverride, directNames);
+
+  for (const ref of refs) {
+    if (!ref.startsWith("mcp:")) {
+      addName(names, seen, ref);
+      continue;
+    }
+    const parsed = parseMcpReference(ref);
+    if (!parsed.server) {
+      diagnostics.push(`MCP reference "${ref}" is empty after the "mcp:" prefix`);
+      continue;
+    }
+    if (config.mcpServers[parsed.server]) {
+      resolveKnownServerReference(parsed, config, cache, parsedOverride, collidingNamespaceNames, directNames, directNameOwners, selectorIndex, names, seen, diagnostics);
+    } else if (parsed.tool === undefined) {
+      resolveBareToolReference(ref, parsed.server, config, cache, parsedOverride, collidingNamespaceNames, directNames, directNameOwners, selectorIndex, names, seen, diagnostics);
+    } else {
+      diagnostics.push(`MCP reference "${ref}" refers to unknown server "${parsed.server}"`);
+    }
+  }
+
+  return { names, diagnostics };
+}

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -5,6 +5,8 @@ import { isServerDisabled, type McpConfig } from "./types.ts";
 import { isServerCacheValid, type MetadataCache } from "./metadata-cache.ts";
 import { executeCall } from "./proxy-modes.ts";
 import { createMcpProxyToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions, type McpToolRenderOptions, type RenderTheme, type McpToolRenderContext } from "./tool-result-renderer.ts";
+export { namespaceProxyName } from "./mcp-references.ts";
+import { namespaceProxyName } from "./mcp-references.ts";
 
 /**
  * Namespace-proxy tool registration for proxy-only MCP servers.
@@ -29,18 +31,6 @@ export interface NamespaceProxySpec {
 }
 
 type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
-
-/**
- * Mirror of the harness `_shared/mcp-tools` resolver's
- * `namespaceProxyName`. Kept deliberately identical to the harness so
- * tool-groups/slow-mode validation lines up without a config migration.
- * Differs from `formatToolName(..., "mcp")` which uses
- * `sanitizeServerPrefix` and produces names like `mcp__context_2d_mode`.
- * Keep this convention aligned with the host resolver.
- */
-export function namespaceProxyName(serverName: string): string {
-  return `mcp__${serverName.replace(/-/g, "_")}`;
-}
 
 function isDirectlyRegistered(
   definition: { directTools?: boolean | string[] } | undefined,

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "proxy-modes.ts",
     "direct-tools.ts",
     "namespace-tools.ts",
+    "mcp-references.ts",
     "commands.ts",
     "prompts.ts",
     "onboarding-state.ts",


### PR DESCRIPTION
## Summary

This is the clean replacement for #420.

It keeps the useful part from @abdwhb-png's PR: a package-native `mcp:` reference resolver that other consumers can import instead of copying resolver logic.

The replacement narrows the API to the approved surface:

- pure inputs only: explicit `config`, `cache`, and optional env override
- no config/cache loader wrapper
- no memoized resolver lifecycle
- parity with current direct-tool and namespace-proxy registration rules

## Credit

Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420 and the original `mcp:` resolver work.

## Validation

- `npm run typecheck`
- `npm test -- --run __tests__/mcp-references.test.ts __tests__/namespace-tools.test.ts`
- `git diff --check`
- Fresh read-only review: `/tmp/pi-mcp-adapter-pr420-resolver-review.md` reported no issues.

## Notes

PR #420 also included namespace-proxy runtime changes. Those already landed separately through #414/#421, so this PR only adds the resolver API.
