### PR TITLE
fix: clarify transient MCP startup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Namespace proxy tools now use valid cached metadata, clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
 - Kept transient HTTP 503 connection failures as availability errors without multiplying gateway retries or misdiagnosing the endpoint as non-MCP. Thanks to [@elkaix](https://github.com/elkaix) for PR #411.
 - Preserved cached keep-alive catalogs during transient 503 refresh outages while deferred recovery continues with bounded backoff.
+- Startup connections that fail with a transient HTTP 503 now surface one quiet "temporarily unavailable; retry later" warning instead of the full hard failure; documented lifecycle behavior is unchanged, and keep-alive health checks continue their existing self-healing path. Thanks to [@elkaix](https://github.com/elkaix) for PR #424.
 
 ## [2.27.0] - 2026-08-20
 

--- a/__tests__/init-transient-startup.test.ts
+++ b/__tests__/init-transient-startup.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+import { isTransientHttpConnectError, McpServerManager } from "../server-manager.ts";
+import { initializeMcp } from "../init.ts";
+
+const mocks = vi.hoisted(() => ({
+  cache: null as { version: 1; servers: Record<string, unknown> } | null,
+  states: [] as Array<{ owner: { stop: (reason: string) => Promise<void> } }>,
+  tempDirs: [] as string[],
+}));
+
+vi.mock("../metadata-cache.ts", () => ({
+  computeServerHash: vi.fn(() => "hash"),
+  createCachedToolSelectorCandidateIndex: vi.fn(() => undefined),
+  getMetadataCachePath: vi.fn(() => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-mcp-transient-cache-"));
+    mocks.tempDirs.push(dir);
+    return join(dir, "cache.json");
+  }),
+  getMissingConfiguredDirectToolServers: vi.fn(() => [] as string[]),
+  isServerCacheValid: vi.fn(() => false),
+  loadMetadataCache: vi.fn(() => mocks.cache),
+  reconstructPromptMetadata: vi.fn(() => []),
+  reconstructToolMetadata: vi.fn(() => []),
+  saveMetadataCache: vi.fn((cache) => {
+    mocks.cache = cache;
+  }),
+  serializePrompts: vi.fn(() => []),
+  serializeResources: vi.fn(() => []),
+  serializeTools: vi.fn(() => []),
+}));
+
+function http503(): SdkHttpError {
+  return new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, "HTTP 503", { status: 503 });
+}
+
+async function boot(notify: ReturnType<typeof vi.fn>, mcpServers?: Record<string, unknown>) {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-mcp-transient-init-"));
+  mocks.tempDirs.push(cwd);
+  const state = await initializeMcp({ getFlag: vi.fn() } as any, {
+    cwd,
+    hasUI: true,
+    mode: "tui",
+    ui: { notify, setStatus: vi.fn() },
+    signal: new AbortController().signal,
+  } as any, undefined, {
+    config: { mcpServers: mcpServers ?? {
+      firecrawl: { url: "http://127.0.0.1:8787/firecrawl/mcp", lifecycle: "keep-alive" },
+    } },
+  });
+  mocks.states.push(state);
+  return state;
+}
+
+describe("isTransientHttpConnectError", () => {
+  it("matches a direct HTTP 503 SDK error", () => {
+    expect(isTransientHttpConnectError(http503())).toBe(true);
+  });
+
+  it("matches an HTTP 503 wrapped as cause", () => {
+    const wrapped = new Error("Error POSTing to endpoint", { cause: http503() });
+    expect(isTransientHttpConnectError(wrapped)).toBe(true);
+  });
+
+  it("matches an HTTP 503 after manager error enrichment", () => {
+    const wrapped = new Error("Error POSTing to endpoint", { cause: http503() });
+    const enriched = new Error("Error POSTing to endpoint — endpoint is temporarily unavailable (HTTP 503)", { cause: wrapped });
+    expect(isTransientHttpConnectError(enriched)).toBe(true);
+  });
+
+  it("rejects other statuses and plain errors", () => {
+    expect(isTransientHttpConnectError(new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "HTTP 401", { status: 401 }))).toBe(false);
+    expect(isTransientHttpConnectError(new Error("boom"))).toBe(false);
+    expect(isTransientHttpConnectError("nope")).toBe(false);
+  });
+});
+
+describe("startup transient-503 handling", () => {
+  let notify: ReturnType<typeof vi.fn>;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    notify = vi.fn();
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.cache = null;
+  });
+
+  afterEach(async () => {
+    await Promise.all(mocks.states.splice(0).map(state => state.owner.stop("test cleanup")));
+    for (const dir of mocks.tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("reports a direct 503 softly and records failure state", async () => {
+    vi.spyOn(McpServerManager.prototype, "connect").mockRejectedValue(http503());
+
+    const state = await boot(notify);
+
+    expect(state.failureTracker.has("firecrawl")).toBe(true);
+    expect(notify).toHaveBeenCalledWith(
+      "MCP: firecrawl temporarily unavailable (HTTP 503); retry later",
+      "warning",
+    );
+    const hard = [...notify.mock.calls].filter(([message]) => String(message).includes("Failed to connect"));
+    expect(hard).toEqual([]);
+    expect(consoleError.mock.calls.some(args => String(args[0]).includes("Failed to connect"))).toBe(false);
+  });
+
+  it("reports a wrapped 503 cause softly", async () => {
+    vi.spyOn(McpServerManager.prototype, "connect").mockRejectedValue(
+      new Error("Error POSTing to endpoint", { cause: http503() }),
+    );
+
+    await boot(notify);
+
+    expect(notify).toHaveBeenCalledWith(
+      "MCP: firecrawl temporarily unavailable (HTTP 503); retry later",
+      "warning",
+    );
+    expect([...notify.mock.calls].filter(([message]) => String(message).includes("Failed to connect"))).toEqual([]);
+  });
+
+  it("keeps the hard failure path for non-transient errors", async () => {
+    vi.spyOn(McpServerManager.prototype, "connect").mockRejectedValue(new Error("connection refused"));
+
+    await boot(notify);
+
+    expect(notify).toHaveBeenCalledWith("MCP: Failed to connect to firecrawl: connection refused", "error");
+    expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("temporarily unavailable"), "warning");
+  });
+
+  it("self-heals only keep-alive after startup failure", async () => {
+    const connect = vi.spyOn(McpServerManager.prototype, "connect").mockRejectedValue(http503());
+    const callsFor = (name: string) => connect.mock.calls.filter(([server]) => server === name).length;
+
+    const state = await boot(notify, {
+      keepAlive: { url: "http://127.0.0.1:8787/keep-alive/mcp", lifecycle: "keep-alive" },
+      eager: { url: "http://127.0.0.1:8787/eager/mcp", lifecycle: "eager" },
+      lazyKeepAlive: { command: "lazy-resident", lifecycle: "lazy-keep-alive" },
+      lazyOne: { command: "lazy", lifecycle: "lazy" },
+    });
+    for (const name of ["keepAlive", "eager", "lazyKeepAlive", "lazyOne"]) {
+      expect(callsFor(name)).toBe(1); // first-run metadata bootstrap attempts every server once
+      expect(state.failureTracker.has(name)).toBe(true);
+    }
+
+    connect.mockResolvedValue({ status: "connected", tools: [], resources: [] } as any);
+    await state.lifecycle.ensureConverged();
+
+    expect(callsFor("keepAlive")).toBe(2);
+    expect(state.failureTracker.has("keepAlive")).toBe(false);
+    // Public lifecycle contract: eager never auto-reconnects; lazy modes remain
+    // tool-call driven until lazy-keep-alive has connected successfully once.
+    expect(callsFor("eager")).toBe(1);
+    expect(callsFor("lazyKeepAlive")).toBe(1);
+    expect(callsFor("lazyOne")).toBe(1);
+  });
+});

--- a/__tests__/lifecycle-lazy-keep-alive-init.test.ts
+++ b/__tests__/lifecycle-lazy-keep-alive-init.test.ts
@@ -41,9 +41,13 @@ vi.mock("../metadata-cache.ts", () => ({
   serializePrompts: vi.fn(() => []),
 }));
 
-vi.mock("../server-manager.ts", () => ({
-  McpServerManager: vi.fn(() => mocks.manager),
-}));
+vi.mock("../server-manager.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../server-manager.ts")>();
+  return {
+    ...actual,
+    McpServerManager: vi.fn(() => mocks.manager),
+  };
+});
 
 vi.mock("../tool-metadata.ts", () => ({
   buildToolMetadata: mocks.buildToolMetadata,

--- a/init.ts
+++ b/init.ts
@@ -20,7 +20,7 @@ import {
   serializeTools,
   type ServerCacheEntry,
 } from "./metadata-cache.ts";
-import { McpServerManager } from "./server-manager.ts";
+import { McpServerManager, isTransientHttpConnectError } from "./server-manager.ts";
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { UiResourceHandler } from "./ui-resource-handler.ts";
@@ -293,16 +293,17 @@ export async function initializeMcp(
     try {
       const connection = await manager.connect(name, definition, runtimeSignal);
       if (connection.status === "needs-auth") {
-        return { name, definition, connection: null, error: `OAuth authentication required. Run /mcp-auth ${name}.` };
+        return { name, definition, connection: null, error: `OAuth authentication required. Run /mcp-auth ${name}.`, transient: false };
       }
-      return { name, definition, connection, error: null };
+      return { name, definition, connection, error: null, transient: false };
     } catch (error) {
       if (isAbortError(error, runtimeSignal)) {
         if (owner.signal.aborted) throw error;
-        return { name, definition, connection: null, error: null };
+        return { name, definition, connection: null, error: null, transient: false };
       }
+      const transient = isTransientHttpConnectError(error);
       const message = error instanceof Error ? error.message : String(error);
-      return { name, definition, connection: null, error: message };
+      return { name, definition, connection: null, error: message, transient };
     }
   });
 
@@ -332,11 +333,18 @@ export async function initializeMcp(
     startupKnownMetadata.set(name, metadata);
   }
 
-  for (const { name, definition, connection, error } of results) {
+  for (const { name, definition, connection, error, transient } of results) {
     owner.throwIfInactive();
     if (error || !connection) {
       if (initialSignal?.aborted) continue;
       if (error) recordFailure(state, name, error);
+      if (transient) {
+        const notice = `MCP: ${name} temporarily unavailable (HTTP 503); retry later`;
+        logger.debug(`MCP: startup connect hit transient upstream outage for ${name}; will retry`);
+        if (ui) ui.notify(notice, "warning");
+        else console.error(notice);
+        continue;
+      }
       const displayError = sanitizeTerminalText(error ?? "Unknown connection failure");
       if (ui) {
         ui.notify(`MCP: Failed to connect to ${name}: ${displayError}`, "error");

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -1,6 +1,6 @@
-import { SdkError, SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+import { SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
 import { isServerDisabled, type ServerDefinition } from "./types.ts";
-import type { McpServerManager, ServerConnection } from "./server-manager.ts";
+import { isTransientHttpConnectError, type McpServerManager, type ServerConnection } from "./server-manager.ts";
 import { hasPendingAuth } from "./mcp-auth-flow.ts";
 import { logger } from "./logger.ts";
 import { formatTerminalError, parallelLimit, sanitizeTerminalText } from "./utils.ts";
@@ -348,11 +348,6 @@ export class McpLifecycleManager {
     return Date.now() >= retry.nextAttemptAt;
   }
 
-  private isTransientAvailabilityError(error: unknown): boolean {
-    return (error instanceof SdkHttpError && error.status === 503)
-      || (error instanceof Error && error.cause instanceof SdkHttpError && error.cause.status === 503);
-  }
-
   private connectionFailureTarget(action: "refresh" | "reconnect" | "publish", name: string): string {
     if (action === "reconnect") return `reconnect to ${name}`;
     if (action === "publish") return `publish metadata for ${name}`;
@@ -368,7 +363,7 @@ export class McpLifecycleManager {
   ): void {
     if (!this.recordRetry(name, definition, connection)) return;
     this.onReconnectFailure?.(name, error);
-    if (this.isTransientAvailabilityError(error)) return;
+    if (isTransientHttpConnectError(error)) return;
     const retry = this.retryStates.get(name);
     if (retry?.warningReported) return;
     if (retry) retry.warningReported = true;

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -150,8 +150,13 @@ export type ToolRefreshResult = "updated" | "unchanged" | "superseded" | "refres
 
 const KEEP_ALIVE_REFRESH_TIMEOUT_MS = 5_000;
 
-function isTransientHttpConnectError(error: unknown): error is SdkHttpError {
-  return error instanceof SdkHttpError && error.status === 503;
+export function isTransientHttpConnectError(error: unknown): boolean {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (current instanceof SdkHttpError && current.status === 503) return true;
+    current = current.cause;
+  }
+  return false;
 }
 
 export class McpServerManager {


### PR DESCRIPTION
## Summary

This is the maintainer replacement for #424.

It keeps @elkaix's focused startup-503 improvement and adds the review fix needed for the real manager path: a wrapped HTTP 503 stays classified as temporary even after connection-error enrichment adds another cause wrapper.

The replacement preserves the accepted lifecycle contract:

- startup HTTP 503 reports one quiet temporary warning
- non-transient startup errors still report the hard failure
- only `keep-alive` self-heals through convergence
- `eager`, `lazy`, and pre-first-connect `lazy-keep-alive` behavior stays unchanged

## Credit

Thanks to [@elkaix](https://github.com/elkaix) for PR #424 and the original transient startup UX fix.

## Validation

- `npm run typecheck`
- `npm test -- --run __tests__/init-transient-startup.test.ts __tests__/lifecycle-lazy-keep-alive-init.test.ts`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- Fresh read-only review: `/tmp/pi-mcp-adapter-pr424-replacement-review-37bab3d.main.md` reported no issues.

## Notes

The source PR #424 is from an external fork, so this replacement keeps the branch in the maintainer repository while preserving visible credit.
