### PR TITLE
refactor: deslop unreleased MCP behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.
 - Large direct-tool advisories now explain how to hide them with `settings.warnOnLargeDirectTools: false`. Thanks to [@afrodao2394](https://github.com/afrodao2394) for #412.
-- Namespace proxy tools now use valid cached metadata, clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
+- Namespace proxy tools now use valid cached metadata, include resource-only proxy servers, clean up only prior namespace registrations, follow `MCP_DIRECT_TOOLS` selection, and skip ambiguous normalized server names. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #414.
 - Kept transient HTTP 503 connection failures as availability errors without multiplying gateway retries or misdiagnosing the endpoint as non-MCP. Thanks to [@elkaix](https://github.com/elkaix) for PR #411.
 - Preserved cached keep-alive catalogs during transient 503 refresh outages while deferred recovery continues with bounded backoff.
 - Startup connections that fail with a transient HTTP 503 now surface one quiet "temporarily unavailable; retry later" warning instead of the full hard failure; documented lifecycle behavior is unchanged, and keep-alive health checks continue their existing self-healing path. Thanks to [@elkaix](https://github.com/elkaix) for PR #424.

--- a/__tests__/mcp-probe.test.ts
+++ b/__tests__/mcp-probe.test.ts
@@ -96,6 +96,23 @@ describe("MCP endpoint shape probe", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps an earlier unauthenticated probe classification when fallbacks are inconclusive", async () => {
+    mockFetch(
+      new Response("Unauthorized", { status: 401, headers: { "content-type": "application/json" } }),
+      new Response("Not Found", { status: 404, headers: { "content-type": "text/plain" } }),
+      new Response("Method Not Allowed", { status: 405, headers: { "content-type": "text/plain" } }),
+    );
+
+    const result = await probeMcpEndpoint("https://example.test/mcp");
+
+    expect(result).toMatchObject({
+      isMcp: false,
+      classification: "endpoint returned application/json (401) — authentication may be required; MCP endpoint shape could not be determined",
+    });
+    expect(result.classification).not.toContain("does not appear to speak MCP");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("recognizes a modern stateless server/discover response", async () => {
     mockFetch(new Response(JSON.stringify({
       jsonrpc: "2.0", id: 1, result: { protocolVersion: "2026-07-28" },

--- a/__tests__/mcp-references.test.ts
+++ b/__tests__/mcp-references.test.ts
@@ -100,6 +100,17 @@ describe("resolveMcpToolReferences", () => {
     expect(result).toEqual({ names: ["mcp__demo"], diagnostics: [] });
   });
 
+  it("resolves proxy-only resource references when the server has no tools", () => {
+    const definition: ServerEntry = { command: "demo" };
+    const result = resolveMcpToolReferences(
+      ["mcp:demo/demo_read_guide"],
+      configFor({ demo: definition }),
+      cacheWithResources([["demo", { definition, tools: [], resources: [{ name: "guide", uri: "file://guide" }] }]]),
+    );
+
+    expect(result).toEqual({ names: ["mcp__demo"], diagnostics: [] });
+  });
+
   it("rejects unknown proxy-only server/tool references", () => {
     const definition: ServerEntry = { command: "demo" };
     const result = resolveMcpToolReferences(

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -3,10 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { computeServerHash } from "../metadata-cache.ts";
 import type { ServerEntry } from "../types.ts";
 
-const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }>; definition?: ServerEntry; configHash?: string; cachedAt?: number }]>) => ({
+const CACHE_SHAPE = (entries: Array<[string, { tools: Array<{ name: string }>; resources?: Array<{ name: string; uri: string }>; definition?: ServerEntry; configHash?: string; cachedAt?: number }]>) => ({
   version: 1,
   servers: Object.fromEntries(entries.map(([server, v]) => [server, {
     tools: v.tools,
+    resources: v.resources ?? [],
     configHash: v.configHash ?? computeServerHash(v.definition ?? { command: server }),
     cachedAt: v.cachedAt ?? Date.now(),
   }])),
@@ -80,6 +81,25 @@ describe("syncNamespaceProxyTools", () => {
     expect(registered.has("mcp__context_mode")).toBe(true);
     const tool = registered.get("mcp__context_mode")!;
     expect(tool.execute).toBeTypeOf("function");
+  });
+
+  it("registers proxy-only servers that expose only resources", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { docs: { command: "docs" } } },
+      cache: CACHE_SHAPE([["docs", { tools: [], resources: [{ name: "guide", uri: "file://guide" }] }]]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__docs")).toBe(true);
   });
 
   it("does NOT register for directTools: true servers (avoids duplicating direct tools)", async () => {

--- a/index.ts
+++ b/index.ts
@@ -298,7 +298,18 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const cache = loadMetadataCache();
     const result = syncDirectTools(config, cache);
     syncProxyTool(config, cache, result.specs);
-    const nsResult = syncNamespaceProxyTools({
+    syncNamespaceTools(config, cache);
+    const changed = result.added.length + result.updated.length + result.deactivated.length;
+    if (changed > 0 && ctx?.hasUI) {
+      ctx.ui.notify(
+        `MCP: direct tools refreshed (+${result.added.length}, ~${result.updated.length}, -${result.deactivated.length})`,
+        "info",
+      );
+    }
+  }
+
+  function syncNamespaceTools(config: McpConfig, cache: MetadataCache | null): void {
+    const result = syncNamespaceProxyTools({
       config,
       cache,
       envOverride: namespaceEnvOverride,
@@ -312,15 +323,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       renderShell: toolRenderShell,
       renderResult: renderMcpToolResult,
     });
-    for (const name of nsResult.added) registeredNamespaceProxyTools.add(name);
-    for (const name of nsResult.deactivated) registeredNamespaceProxyTools.delete(name);
-    const changed = result.added.length + result.updated.length + result.deactivated.length;
-    if (changed > 0 && ctx?.hasUI) {
-      ctx.ui.notify(
-        `MCP: direct tools refreshed (+${result.added.length}, ~${result.updated.length}, -${result.deactivated.length})`,
-        "info",
-      );
-    }
+    for (const name of result.added) registeredNamespaceProxyTools.add(name);
+    for (const name of result.deactivated) registeredNamespaceProxyTools.delete(name);
   }
 
   const registeredPromptCommands = new Set<string>();
@@ -1065,21 +1069,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   // `mcp:<server>` references on the first session_start turn. Without this
   // eager call, the tool-groups expansion runs before MCP initialization
   // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
-  const initialNamespaceResult = syncNamespaceProxyTools({
-    config: earlyConfig,
-    cache: earlyCache,
-    envOverride: namespaceEnvOverride,
-    existingDirectNames: new Set(registeredDirectTools.keys()),
-    existingNamespaceNames: registeredNamespaceProxyTools,
-    pi,
-    getState: () => state,
-    getInitPromise: () => initPromise,
-    getPiTools: () => pi.getAllTools(),
-    renderOptions: toolRenderOptions,
-    renderShell: toolRenderShell,
-    renderResult: renderMcpToolResult,
-  });
-  for (const name of initialNamespaceResult.added) registeredNamespaceProxyTools.add(name);
+  syncNamespaceTools(earlyConfig, earlyCache);
   startLoadTimeInitialization();
 }
 

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -71,6 +71,18 @@ function issuersMatch(first: string, second: string): boolean {
     || (second.endsWith("/") && second.slice(0, -1) === first)
 }
 
+function toOAuthTokens(tokens: StoredTokens): IssuerBoundTokens {
+  const result: IssuerBoundTokens = {
+    access_token: tokens.accessToken,
+    token_type: "Bearer",
+  }
+  if (tokens.refreshToken !== undefined) result.refresh_token = tokens.refreshToken
+  if (tokens.expiresAt !== undefined) result.expires_in = Math.max(0, Math.floor(tokens.expiresAt - Date.now() / 1000))
+  if (tokens.scope !== undefined) result.scope = tokens.scope
+  if (tokens.issuer !== undefined) result.issuer = tokens.issuer
+  return result
+}
+
 // Callback server configuration
 const DEFAULT_OAUTH_CALLBACK_PORT = 19876
 const DEFAULT_OAUTH_CALLBACK_PATH = "/callback"
@@ -426,16 +438,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       this.pendingAuthAccessToken = entry.tokens.accessToken
     }
 
-    return {
-      access_token: entry.tokens.accessToken,
-      token_type: "Bearer",
-      refresh_token: entry.tokens.refreshToken,
-      expires_in: entry.tokens.expiresAt
-        ? Math.max(0, Math.floor(entry.tokens.expiresAt - Date.now() / 1000))
-        : undefined,
-      scope: entry.tokens.scope,
-      ...(entry.tokens.issuer !== undefined ? { issuer: entry.tokens.issuer } : {}),
-    } as IssuerBoundTokens
+    return toOAuthTokens(entry.tokens)
   }
 
   /**

--- a/mcp-probe.ts
+++ b/mcp-probe.ts
@@ -5,6 +5,7 @@ const JSON_ACCEPT = "application/json, text/event-stream";
 const SSE_ACCEPT = "text/event-stream";
 const MODERN_FALLBACK_STATUSES = new Set([400, 401, 404, 405, 406, 415]);
 const POST_ENDPOINT_MISMATCH_STATUSES = new Set([404, 405, 406, 415]);
+const AMBIGUOUS_STATUSES = new Set([202, 401, 503]);
 
 export interface McpProbeResult {
   isMcp: boolean;
@@ -176,19 +177,25 @@ function notMcp(response: Response): McpProbeResult {
   };
 }
 
+function ambiguousNotMcp(response: Response): McpProbeResult | undefined {
+  return AMBIGUOUS_STATUSES.has(response.status) ? notMcp(response) : undefined;
+}
+
 /** Makes one unauthenticated metadata-only request to identify an HTTP endpoint's protocol shape. */
 export async function probeMcpEndpoint(url: string | URL): Promise<McpProbeResult> {
   const { response: modernResponse, outcome: modernOutcome } = await probe(url, MODERN_STRATEGY);
   if (modernOutcome.kind === "mcp") return modernOutcome.result;
+  let ambiguousResult = ambiguousNotMcp(modernResponse);
 
   if (modernOutcome.kind !== "unsupported-modern" && !MODERN_FALLBACK_STATUSES.has(modernResponse.status)) {
-    return notMcp(modernResponse);
+    return ambiguousResult ?? notMcp(modernResponse);
   }
 
   const { response: postResponse, outcome: postOutcome } = await probe(url, LEGACY_POST_STRATEGY);
   if (postOutcome.kind === "mcp") return postOutcome.result;
-  if (!POST_ENDPOINT_MISMATCH_STATUSES.has(postResponse.status)) return notMcp(postResponse);
+  ambiguousResult ??= ambiguousNotMcp(postResponse);
+  if (!POST_ENDPOINT_MISMATCH_STATUSES.has(postResponse.status)) return ambiguousNotMcp(postResponse) ?? ambiguousResult ?? notMcp(postResponse);
 
   const { response: getResponse, outcome: getOutcome } = await probe(url, LEGACY_SSE_STRATEGY);
-  return getOutcome.kind === "mcp" ? getOutcome.result : notMcp(getResponse);
+  return getOutcome.kind === "mcp" ? getOutcome.result : ambiguousNotMcp(getResponse) ?? ambiguousResult ?? notMcp(getResponse);
 }

--- a/mcp-references.ts
+++ b/mcp-references.ts
@@ -1,10 +1,8 @@
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
-import { isServerCacheValid, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
+import { createCachedToolSelectorCandidateIndex, isServerCacheValid, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import {
-  createToolSelectorCandidateIndex,
   formatToolName,
-  getToolNameCandidates,
   isServerDisabled,
   isToolAllowed,
   resolveToolPrefix,
@@ -27,10 +25,11 @@ export interface McpReferenceResolution {
   diagnostics: string[];
 }
 
-type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
+export type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
 type DirectSelection = true | string[] | false;
 type DirectNameOwner = { serverName: string; originalName: string };
 type DirectNameEntry = { name: string; originalName: string };
+type CachedServer = { serverName: string; definition: ServerEntry; entry: ServerCacheEntry; prefix: ToolPrefix };
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 
@@ -70,9 +69,26 @@ function resolveDirectSelection(
   return config.settings?.directTools === true;
 }
 
+export function isMcpServerDirectlyRegistered(
+  definition: { directTools?: boolean | string[] } | undefined,
+  settings: McpConfig["settings"],
+  serverName: string,
+  envOverride: DirectToolSelectorOverride | null,
+): boolean {
+  if (envOverride) return envOverride.servers.has(serverName);
+  if (definition?.directTools !== undefined) {
+    return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);
+  }
+  return settings?.directTools === true;
+}
+
+export function hasCallableCachedTargets(entry: Pick<ServerCacheEntry, "tools" | "resources">, definition: Pick<ServerEntry, "exposeResources">): boolean {
+  return entry.tools.length > 0 || (definition.exposeResources !== false && (entry.resources?.length ?? 0) > 0);
+}
+
 function hasNamespaceProxy(
   config: McpConfig,
-  cache: MetadataCache,
+  cache: MetadataCache | null,
   envOverride: DirectToolSelectorOverride | null,
   collidingNamespaceNames: ReadonlySet<string>,
   existingDirectNames: ReadonlySet<string>,
@@ -80,23 +96,29 @@ function hasNamespaceProxy(
 ): boolean {
   const definition = config.mcpServers[serverName];
   if (!definition || isServerDisabled(definition)) return false;
-  if (envOverride) {
-    if (envOverride.servers.has(serverName)) return false;
-  } else {
-    if (definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0)) return false;
-    if (definition.directTools === undefined && config.settings?.directTools === true) return false;
-  }
+  if (isMcpServerDirectlyRegistered(definition, config.settings, serverName, envOverride)) return false;
   const toolName = namespaceProxyName(serverName);
   if (collidingNamespaceNames.has(toolName) || existingDirectNames.has(toolName)) return false;
-  const entry = cache.servers[serverName];
-  return !!entry && isServerCacheValid(entry, definition) && entry.tools.length > 0;
+  const entry = resolveValidCache(definition, cache, serverName);
+  return !!entry && hasCallableCachedTargets(entry, definition);
 }
 
-function resolveValidCache(config: McpConfig, cache: MetadataCache | null, serverName: string): ServerCacheEntry | undefined {
-  const definition = config.mcpServers[serverName];
+function resolveValidCache(definition: ServerEntry | undefined, cache: MetadataCache | null, serverName: string): ServerCacheEntry | undefined {
   const entry = cache?.servers[serverName];
   if (!definition || !entry || !isServerCacheValid(entry, definition)) return undefined;
   return entry;
+}
+
+function cachedServers(config: McpConfig, cache: MetadataCache | null): CachedServer[] {
+  const servers: CachedServer[] = [];
+  if (!cache) return servers;
+  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+    if (isServerDisabled(definition)) continue;
+    const entry = resolveValidCache(definition, cache, serverName);
+    if (!entry) continue;
+    servers.push({ serverName, definition, entry, prefix: resolveToolPrefix(definition, config.settings?.toolPrefix) });
+  }
+  return servers;
 }
 
 function namespaceCollisionNames(
@@ -122,12 +144,7 @@ function registeredDirectNames(
   selectorIndex: ToolSelectorCandidateIndex | undefined,
 ): Map<string, DirectNameOwner> {
   const owners = new Map<string, DirectNameOwner>();
-  if (!cache) return owners;
-  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
-    if (isServerDisabled(definition)) continue;
-    const entry = resolveValidCache(config, cache, serverName);
-    if (!entry) continue;
-    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+  for (const { serverName, definition, entry, prefix } of cachedServers(config, cache)) {
     const selection = resolveDirectSelection(config, definition, serverName, envOverride);
     for (const { name, originalName } of directNameEntries(entry, serverName, definition, prefix, selection, selectorIndex)) {
       if (!owners.has(name)) owners.set(name, { serverName, originalName });
@@ -138,24 +155,7 @@ function registeredDirectNames(
 
 function allCurrentCandidates(config: McpConfig, cache: MetadataCache | null): ToolSelectorCandidateIndex | undefined {
   if (!cache) return undefined;
-  const candidates = new Set<string>();
-  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
-    if (isServerDisabled(definition)) continue;
-    const entry = resolveValidCache(config, cache, serverName);
-    if (!entry) continue;
-    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
-    for (const tool of entry.tools) {
-      if (!isUiToolVisibleToModel(tool.uiVisibility)) continue;
-      for (const candidate of getToolNameCandidates(tool.name, serverName, prefix, false)) candidates.add(candidate);
-    }
-    if (definition.exposeResources !== false) {
-      for (const resource of entry.resources ?? []) {
-        const baseName = `read_${resourceNameToToolName(resource.name)}`;
-        for (const candidate of getToolNameCandidates(baseName, serverName, prefix, false)) candidates.add(candidate);
-      }
-    }
-  }
-  return createToolSelectorCandidateIndex(candidates);
+  return createCachedToolSelectorCandidateIndex(config.mcpServers, cache, config.settings?.toolPrefix ?? "server");
 }
 
 function directToolName(
@@ -257,7 +257,7 @@ function resolveKnownServerReference(
     diagnostics.push(`MCP reference "${parsed.raw}" refers to disabled or unknown server "${serverName}"`);
     return;
   }
-  const entry = resolveValidCache(config, cache, serverName);
+  const entry = resolveValidCache(definition, cache, serverName);
   if (!entry) {
     diagnostics.push(`MCP reference "${parsed.raw}" cannot be resolved: no valid cached metadata for server "${serverName}"`);
     return;
@@ -275,7 +275,7 @@ function resolveKnownServerReference(
     return;
   }
 
-  if (hasNamespaceProxy(config, cache!, envOverride, collidingNamespaceNames, existingDirectNames, serverName)) {
+  if (hasNamespaceProxy(config, cache, envOverride, collidingNamespaceNames, existingDirectNames, serverName)) {
     if (hasAllowedProxyTool(entry, serverName, definition, prefix, selectorIndex, parsed.tool)) {
       addName(names, seen, namespaceProxyName(serverName));
       return;
@@ -302,11 +302,7 @@ function resolveBareToolReference(
   diagnostics: string[],
 ): void {
   let matched = false;
-  for (const [serverName, definition] of Object.entries(config.mcpServers)) {
-    if (isServerDisabled(definition)) continue;
-    const entry = resolveValidCache(config, cache, serverName);
-    if (!entry) continue;
-    const prefix = resolveToolPrefix(definition, config.settings?.toolPrefix);
+  for (const { serverName, definition, entry, prefix } of cachedServers(config, cache)) {
     const selection = resolveDirectSelection(config, definition, serverName, envOverride);
     const directNames = ownedDirectToolNames(
       directNameEntries(entry, serverName, definition, prefix, selection, selectorIndex, toolName),
@@ -317,7 +313,7 @@ function resolveBareToolReference(
       addName(names, seen, name);
       matched = true;
     }
-    if (hasNamespaceProxy(config, cache!, envOverride, collidingNamespaceNames, existingDirectNames, serverName) &&
+    if (hasNamespaceProxy(config, cache, envOverride, collidingNamespaceNames, existingDirectNames, serverName) &&
         hasAllowedProxyTool(entry, serverName, definition, prefix, selectorIndex, toolName)) {
       addName(names, seen, namespaceProxyName(serverName));
       matched = true;

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -6,7 +6,7 @@ import { isServerCacheValid, type MetadataCache } from "./metadata-cache.ts";
 import { executeCall } from "./proxy-modes.ts";
 import { createMcpProxyToolCallRenderer, createMcpToolResultRenderer, resolveMcpToolRenderOptions, type McpToolRenderOptions, type RenderTheme, type McpToolRenderContext } from "./tool-result-renderer.ts";
 export { namespaceProxyName } from "./mcp-references.ts";
-import { namespaceProxyName } from "./mcp-references.ts";
+import { hasCallableCachedTargets, isMcpServerDirectlyRegistered, namespaceProxyName, type DirectToolSelectorOverride } from "./mcp-references.ts";
 
 /**
  * Namespace-proxy tool registration for proxy-only MCP servers.
@@ -30,23 +30,6 @@ export interface NamespaceProxySpec {
   description: string;
 }
 
-type DirectToolSelectorOverride = { servers: Set<string>; tools: Map<string, Set<string>> };
-
-function isDirectlyRegistered(
-  definition: { directTools?: boolean | string[] } | undefined,
-  settings: McpConfig["settings"],
-  serverName: string,
-  envOverride: DirectToolSelectorOverride | null,
-): boolean {
-  if (envOverride) {
-    return envOverride.servers.has(serverName);
-  }
-  if (definition?.directTools !== undefined) {
-    return definition.directTools === true || (Array.isArray(definition.directTools) && definition.directTools.length > 0);
-  }
-  return settings?.directTools === true;
-}
-
 function namespaceProxyCandidate(
   config: McpConfig,
   cache: MetadataCache,
@@ -56,9 +39,9 @@ function namespaceProxyCandidate(
 ): NamespaceProxySpec | null {
   const definition = config.mcpServers[serverName];
   if (!definition || isServerDisabled(definition)) return null;
-  if (isDirectlyRegistered(definition, config.settings, serverName, envOverride)) return null;
+  if (isMcpServerDirectlyRegistered(definition, config.settings, serverName, envOverride)) return null;
   const entry = cache.servers?.[serverName];
-  if (!entry || !isServerCacheValid(entry, definition) || entry.tools.length === 0) return null;
+  if (!entry || !isServerCacheValid(entry, definition) || !hasCallableCachedTargets(entry, definition)) return null;
   const toolName = namespaceProxyName(serverName);
   if (existingDirectNames.has(toolName)) return null;
   return {
@@ -208,7 +191,7 @@ function registerNamespaceProxyTool(
   renderShell: "self" | "default",
   renderResult: unknown,
 ): void {
-  input.pi.registerTool({
+  (input.pi.registerTool as (tool: unknown) => unknown)({
     name: spec.toolName,
     label: `MCP: ${spec.serverName}`,
     description: spec.description,
@@ -223,7 +206,7 @@ function registerNamespaceProxyTool(
       spec.serverName,
       input.getPiTools,
     ),
-  } as never);
+  });
 }
 
 function getActiveToolsForStaleCleanup(pi: ExtensionAPI, staleNames: string[]): string[] | undefined {


### PR DESCRIPTION
## Summary
- share namespace/reference eligibility helpers and include resource-only proxy servers
- preserve earlier ambiguous MCP probe results when fallback probes are inconclusive
- simplify OAuth token conversion and namespace sync setup

## Validation
- `npm run typecheck`
- `npm test -- --run` after building ignored `examples/interactive-visualizer/dist`
- `git diff --check`
- `npx fallow audit --changed-since v2.27.0 --format json --quiet`
- Fresh review: `/tmp/pi-mcp-adapter-unreleased-deslop-pass2-fresh-review.md` — No issues found
