### PR TITLE
fix: retry failed MCP initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.
+- Failed first-time MCP initialization no longer leaves the session permanently stuck with only `MCP not initialized`; the gateway keeps the failure reason and retries initialization on the next `mcp(...)` call. Thanks to [@hara-seihun](https://github.com/hara-seihun) for #428.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.
 - Expanded `mcpScript` calls now show bounded submitted code. Thanks to [@DenisBalan](https://github.com/DenisBalan) for #413.
 - Gateway parameters nested inside `args` now fail with top-level guidance instead of dispatching inconsistently. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #417.

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -109,10 +109,12 @@ vi.mock("../utils.ts", () => ({
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function createState() {
@@ -1377,6 +1379,84 @@ describe("mcpAdapter session lifecycle", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("retries initialization from the proxy tool after an initialization failure", async () => {
+    const state = createState();
+    mocks.initializeMcp
+      .mockRejectedValueOnce(new Error("first boom"))
+      .mockResolvedValueOnce(state);
+    mocks.executeSearch.mockResolvedValue({ content: [{ type: "text", text: "results" }] });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { default: mcpAdapter } = await import("../index.ts");
+      const { api, handlers } = createPi();
+      mcpAdapter(api);
+
+      await handlers.get("session_start")?.({}, { hasUI: false });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+      const callCtx = { hasUI: false, cwd: "/tmp/retry", mode: "print" };
+      const result = await proxyTool.execute("call-1", { search: "demo" }, undefined, undefined, callCtx);
+
+      expect(mocks.initializeMcp).toHaveBeenCalledTimes(2);
+      expect(mocks.initializeMcp.mock.calls[1][1]).toBe(callCtx);
+      expect(result).toEqual({ content: [{ type: "text", text: "results" }] });
+      expect(mocks.executeSearch).toHaveBeenCalledWith(state, "demo", undefined, undefined, undefined, undefined, undefined);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("returns retry guidance when proxy retry initialization also fails", async () => {
+    mocks.initializeMcp
+      .mockRejectedValueOnce(new Error("first boom"))
+      .mockRejectedValueOnce(new Error("retry boom"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { default: mcpAdapter } = await import("../index.ts");
+      const { api, handlers } = createPi();
+      mcpAdapter(api);
+
+      await handlers.get("session_start")?.({}, { hasUI: false });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+      const result = await proxyTool.execute("call-1", { search: "demo" }, undefined, undefined, { hasUI: false });
+      const text = result.content[0].text;
+
+      expect(mocks.initializeMcp).toHaveBeenCalledTimes(2);
+      expect(text).not.toBe("MCP not initialized");
+      expect(text).toContain("retry boom");
+      expect(text).toContain("call mcp(...) again to retry initialization");
+      expect(result.details).toEqual({ error: "init_failed", message: "retry boom" });
+      expect(mocks.executeSearch).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not turn a shutdown-aborted initialization into retry guidance", async () => {
+    const initializing = createDeferred<any>();
+    mocks.initializeMcp.mockReturnValue(initializing.promise);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+
+    await handlers.get("session_start")?.({}, { hasUI: false });
+
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    const resultPromise = proxyTool.execute("call-1", { search: "demo" }, undefined, undefined, { hasUI: false });
+
+    await handlers.get("session_shutdown")?.();
+    initializing.reject(new Error("network down"));
+
+    await expect(resultPromise).rejects.toThrow("network down");
+    expect(mocks.executeSearch).not.toHaveBeenCalled();
   });
 
   it("shuts down OAuth on session_shutdown", async () => {

--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,7 @@ export {
 } from "./types.ts";
 
 const INIT_WAIT_TIMEOUT_MS = 30_000;
+const INIT_FAILURE_MESSAGE_MAX_CHARS = 1_000;
 const INIT_WAIT_TIMED_OUT: unique symbol = Symbol("init-wait-timed-out");
 
 export interface McpServerRegistration {
@@ -102,6 +103,41 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   let currentOwner: McpRuntimeOwner | null = null;
   let currentOAuthRuntime: McpOAuthRuntime | null = null;
   let lifecycleGeneration = 0;
+  let retainedInitFailure: string | null = null;
+
+  function retainInitFailure(error: unknown): string {
+    const message = truncateAtWord(formatTerminalError(error), INIT_FAILURE_MESSAGE_MAX_CHARS);
+    retainedInitFailure = message;
+    return message;
+  }
+
+  function clearRetainedInitFailure(): void {
+    retainedInitFailure = null;
+  }
+
+  function buildInitRetryInstruction(prefix: string, failure: string | null = retainedInitFailure): string {
+    const retry = "Fix the MCP server configuration or startup failure, then call mcp(...) again to retry initialization.";
+    return failure ? `${prefix}: ${failure}. ${retry}` : `${prefix}. ${retry}`;
+  }
+
+  function isOwnerAbortError(error: unknown, owner: McpRuntimeOwner): boolean {
+    if (!owner.signal.aborted) return isAbortError(error);
+    const reason = owner.signal.reason;
+    if (reason instanceof Error && reason.message === "MCP initialization failed" && error !== reason) {
+      return isAbortError(error);
+    }
+    return true;
+  }
+
+  function startGatewayRetryInitialization(ctx: ExtensionContext): void {
+    const generation = ++lifecycleGeneration;
+    const owner = createMcpRuntimeOwner();
+    const oauthRuntime = createOAuthRuntime(owner.signal);
+    currentOwner = owner;
+    currentOAuthRuntime = oauthRuntime;
+    state = null;
+    startInitialization(ctx, owner, oauthRuntime, generation, "stale_gateway_retry_initialization");
+  }
 
   async function shutdownState(currentState: McpExtensionState | null, reason: string): Promise<void> {
     if (!currentState) {
@@ -416,6 +452,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
 
       state = nextState;
+      clearRetainedInitFailure();
       for (const [name, definition] of runtimeServers) {
         if (Object.hasOwn(nextState.config.mcpServers, name)) {
           console.error(`MCP: runtime-registered server "${name}" now collides with a configured server; keeping the configured server`);
@@ -451,7 +488,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       if (initPromise !== promise && initPromise !== null) {
         return;
       }
-      console.error(`MCP initialization failed: ${formatTerminalError(err)}`);
+      const message = retainInitFailure(err);
+      console.error(`MCP initialization failed: ${message}`);
       initPromise = null;
       if (state) return;
 
@@ -501,6 +539,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     currentOAuthRuntime = oauthRuntime;
     state = null;
     initPromise = null;
+    clearRetainedInitFailure();
 
     // Abort synchronously before awaiting cleanup so old callbacks and startup
     // work cannot resume into a stale ExtensionContext.
@@ -562,6 +601,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     currentOAuthRuntime = null;
     state = null;
     initPromise = null;
+    clearRetainedInitFailure();
 
     // Abort before awaiting cleanup so delayed initialization cannot touch stale
     // Pi context after session shutdown.
@@ -844,7 +884,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
             executeOwner?.throwIfInactive();
             state = initialized;
           } catch (error) {
-            if (executeOwner && isAbortError(error, executeOwner.signal)) throw error;
+            if (executeOwner && isOwnerAbortError(error, executeOwner)) throw error;
             const message = error instanceof Error ? error.message : String(error);
             return {
               content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
@@ -854,8 +894,10 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         }
         if (!state) {
           return {
-            content: [{ type: "text" as const, text: "MCP not initialized" }],
-            details: { mode: "script", error: "not_initialized" },
+            content: [{ type: "text" as const, text: retainedInitFailure
+              ? buildInitRetryInstruction("MCP is not initialized after an earlier initialization failure")
+              : "MCP not initialized" }],
+            details: { mode: "script", error: "not_initialized", ...(retainedInitFailure ? { message: retainedInitFailure } : {}) },
           };
         }
         executeOwner?.throwIfInactive();
@@ -907,7 +949,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         server?: string;
         action?: string;
       }, signal: AbortSignal | undefined, _onUpdate: AgentToolUpdateCallback<Record<string, unknown>> | undefined, _ctx: ExtensionContext) {
-        const executeOwner = currentOwner;
+        let executeOwner = currentOwner;
         const parseArgs = (value: string | Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
           if (value === undefined || value === "") return undefined;
           let args: unknown;
@@ -943,6 +985,11 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           throw new Error("Gateway params were nested inside `args`; pass them top-level (for example, mcp({ search: \"...\" }) or mcp({ tool: \"...\", args: {} })).");
         }
 
+        if (!state && !initPromise && retainedInitFailure) {
+          startGatewayRetryInitialization(_ctx);
+          executeOwner = currentOwner;
+        }
+
         if (!state && initPromise) {
           try {
             const initialized = await awaitWithTimeout(initPromise, INIT_WAIT_TIMEOUT_MS);
@@ -955,18 +1002,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
             executeOwner?.throwIfInactive();
             state = initialized;
           } catch (error) {
-            if (executeOwner && isAbortError(error, executeOwner.signal)) throw error;
-            const message = error instanceof Error ? error.message : String(error);
+            if (executeOwner && isOwnerAbortError(error, executeOwner)) throw error;
+            const message = retainInitFailure(error);
             return {
-              content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
+              content: [{ type: "text" as const, text: buildInitRetryInstruction("MCP initialization failed", message) }],
               details: { error: "init_failed", message },
             };
           }
         }
         if (!state) {
           return {
-            content: [{ type: "text" as const, text: "MCP not initialized" }],
-            details: { error: "not_initialized" },
+            content: [{ type: "text" as const, text: retainedInitFailure
+              ? buildInitRetryInstruction("MCP is not initialized after an earlier initialization failure")
+              : "MCP not initialized" }],
+            details: { error: "not_initialized", ...(retainedInitFailure ? { message: retainedInitFailure } : {}) },
           };
         }
         executeOwner?.throwIfInactive();


### PR DESCRIPTION
## Summary

Fixes #428 by making the MCP gateway recover from a failed first initialization. When a session has a retained initialization failure, the next `mcp(...)` call starts a fresh initialization attempt instead of leaving MCP latched off. If that retry fails, the tool result includes the formatted failure cause and a direct retry instruction.

The change also keeps `mcpScript` from returning a bare `MCP not initialized` after a retained failure, and adds regressions for successful retry, failed retry guidance, and shutdown-aborted initialization.

Thanks to [@hara-seihun](https://github.com/hara-seihun) for #428.

## Validation

- `npm test -- --run __tests__/index-lifecycle.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `/tmp/pi-mcp-adapter-issue428-init-retry-fresh-review.md` (`No issues found`)
