### PR TITLE
fix: make mcp proxy description a pure function of config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a pure `mcp:` reference resolver API for consumers that validate adapter tool names from explicit config and cache inputs. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420.
 
 ### Fixed
+- MCP gateway descriptions now stay stable across metadata-only refreshes and keep live counts behind `mcp({})`. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #432.
 - OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.
 - Failed first-time MCP initialization no longer leaves the session permanently stuck with only `MCP not initialized`; the gateway keeps the failure reason and retries initialization on the next `mcp(...)` call. Thanks to [@hara-seihun](https://github.com/hara-seihun) for #428.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.

--- a/__tests__/collision-scan-lazy.test.ts
+++ b/__tests__/collision-scan-lazy.test.ts
@@ -72,16 +72,10 @@ beforeEach(() => {
 });
 
 describe("cross-server collision scan is skipped without tool filters", () => {
-  it("buildProxyDescription does not generate candidates without filters", () => {
-    const { config, cache } = makeTwoServerConfig();
-    buildProxyDescription(config, cache, []);
+  it("buildProxyDescription never generates candidates — it is config-pure", () => {
+    const { config } = makeLargeFilteredConfig(40);
+    buildProxyDescription(config);
     expect(mockedGetToolNameCandidates).not.toHaveBeenCalled();
-  });
-
-  it("buildProxyDescription builds filtered candidates once", () => {
-    const { config, cache } = makeLargeFilteredConfig(40);
-    buildProxyDescription(config, cache, []);
-    expect(mockedGetToolNameCandidates).toHaveBeenCalledTimes(40);
   });
 
   it("resolveDirectTools does not generate candidates without filters", () => {

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -68,25 +68,7 @@ describe("buildProxyDescription", () => {
       },
     };
 
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        demo: {
-          configHash: "hash",
-          cachedAt: Date.now(),
-          tools: [
-            {
-              name: "launch_app",
-              description: "Launch the demo app",
-              inputSchema: { type: "object", properties: {} },
-            },
-          ],
-          resources: [],
-        },
-      },
-    };
-
-    const description = buildProxyDescription(config, cache, []);
+    const description = buildProxyDescription(config);
 
     expect(description).toContain('mcp({ action: "ui-messages" })');
     expect(description).toContain("Retrieve accumulated messages from completed UI sessions");
@@ -97,66 +79,13 @@ describe("buildProxyDescription", () => {
     expect(description).not.toContain("MCP + pi");
   });
 
-  it("excludes configured tools from proxy summaries", () => {
-    const config: McpConfig = {
-      settings: { toolPrefix: "server" },
-      mcpServers: {
-        figma: {
-          command: "npx",
-          args: ["-y", "figma"],
-          excludeTools: ["read_figjam", "figma_get_screenshot"],
-        },
-      },
-    };
-
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        figma: {
-          configHash: computeServerHash(config.mcpServers.figma),
-          cachedAt: Date.now(),
-          tools: [
-            { name: "get_screenshot", description: "Take screenshot" },
-            { name: "get_nodes", description: "Get nodes" },
-          ],
-          resources: [
-            { name: "figjam", uri: "ui://figjam", description: "FigJam" },
-          ],
-        },
-      },
-    };
-
-    const description = buildProxyDescription(config, cache, []);
-
-    expect(description).toContain("Servers: figma (1 tools)");
-    expect(description).not.toContain("figma (3 tools)");
-  });
-
-  it("keeps safe cached tools in proxy server summaries", () => {
-    const config: McpConfig = {
-      settings: { toolPrefix: "server" },
-      mcpServers: {
-        "my-server": { command: "hyphen", excludeTools: ["my_2d_server_do_thing"] },
-        my_2d_server: { command: "escaped", excludeTools: ["my_2d_server_do_thing"] },
-      },
-    };
-    const cache: MetadataCache = {
-      version: 1,
-      servers: Object.fromEntries(Object.entries(config.mcpServers).map(([serverName, definition]) => [serverName, {
-        configHash: computeServerHash(definition),
-        cachedAt: Date.now(),
-        tools: [{ name: "do_thing", description: serverName }],
-        resources: [],
-      }])),
-    };
-
-    expect(buildProxyDescription(config, cache, [])).toContain("Servers: my-server (1 tools)");
-  });
-
-  it("does not expose cached app-only tools to model-facing surfaces", () => {
+  it("is a pure function of config — runtime metadata never reaches the description (I5)", () => {
     const config: McpConfig = {
       settings: { toolPrefix: "server", directTools: true },
-      mcpServers: { demo: { command: "demo", directTools: true } },
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"], directTools: true },
+        ghost: { command: "npx", args: ["-y", "ghost-server"] },
+      },
     };
     const cache: MetadataCache = {
       version: 1,
@@ -164,89 +93,57 @@ describe("buildProxyDescription", () => {
         demo: {
           configHash: computeServerHash(config.mcpServers.demo),
           cachedAt: Date.now(),
-          tools: [{ name: "app_only", description: "App", uiVisibility: ["app"] }],
-          resources: [],
+          tools: [
+            { name: "launch_app", description: "Launch the demo app" },
+            { name: "close_app", description: "Close the demo app" },
+          ],
+          resources: [{ name: "guide", uri: "file://guide", description: "Guide" }],
+          instructions: "teaser words that must never leak: skill-29",
         },
-      },
-    };
-
-    expect(resolveDirectTools(config, cache, "server")).toEqual([]);
-    expect(buildProxyDescription(config, cache, [])).not.toContain("Servers: demo (1 tools)");
-  });
-
-  it("ignores invalid cache entries in proxy descriptions", () => {
-    const config: McpConfig = {
-      mcpServers: { demo: { command: "new", includeTools: ["demo_search"] } },
-    };
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        demo: {
-          configHash: "stale",
+        ghost: {
+          configHash: computeServerHash(config.mcpServers.ghost),
           cachedAt: Date.now(),
-          tools: [{ name: "search", description: "Stale" }],
-          resources: [],
-          instructions: "stale instructions",
-        },
-      },
-    };
-
-    const description = buildProxyDescription(config, cache, []);
-    expect(description).not.toContain("Servers: demo (1 tools)");
-    expect(description).not.toContain("stale instructions");
-  });
-
-  it("includes a truncated instructions snippet for servers that provide one", () => {
-    const config: McpConfig = {
-      mcpServers: {
-        demo: { command: "npx", args: ["-y", "demo-server"] },
-      },
-    };
-
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        demo: {
-          configHash: computeServerHash(config.mcpServers.demo),
-          cachedAt: Date.now(),
-          tools: [{ name: "read_skill", description: "Read a skill" }],
-          resources: [],
-          instructions: `Skills catalog.\n\nAvailable skills:\n${Array.from({ length: 30 }, (_, i) => `- skill-${i}: does thing ${i}`).join("\n")}`,
-        },
-      },
-    };
-
-    const description = buildProxyDescription(config, cache, []);
-
-    expect(description).toContain('Server instructions (truncated - full text via mcp({ instructions: "name" })):');
-    expect(description).toContain("demo: Skills catalog. Available skills: - skill-0:");
-    expect(description).toContain("...");
-    expect(description).not.toContain("skill-29");
-  });
-
-  it("omits the instructions section when no server provides instructions", () => {
-    const config: McpConfig = {
-      mcpServers: {
-        demo: { command: "npx", args: ["-y", "demo-server"] },
-      },
-    };
-
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        demo: {
-          configHash: "hash",
-          cachedAt: Date.now(),
-          tools: [{ name: "read_skill", description: "Read a skill" }],
+          tools: [],
           resources: [],
         },
       },
     };
 
-    const description = buildProxyDescription(config, cache, []);
+    // The cache is live (2 tools + 1 resource resolve from it) but the
+    // description cannot see it: no counts, no teasers, no connection state.
+    expect(resolveDirectTools(config, cache, "server").length).toBe(3);
 
+    const description = buildProxyDescription(config);
+
+    expect(description).toContain("Servers: demo, ghost");
+    expect(description).not.toMatch(/\(\d+ tools?\)/);
+    expect(description).not.toContain("Direct tools available");
+    expect(description).not.toContain("teaser words");
     expect(description).not.toContain("Server instructions");
-    expect(description).toContain('mcp({ instructions: "name" })');
+    expect(description).toBe(buildProxyDescription(config));
+  });
+
+  it("omits disabled servers from the Servers line and lists them as disabled", () => {
+    const config: McpConfig = {
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"] },
+        parked: { command: "npx", args: ["-y", "parked-server"], disabled: true },
+      },
+    };
+
+    const description = buildProxyDescription(config);
+
+    expect(description).toContain("Servers: demo\n");
+    expect(description).toContain("Disabled servers (enable with /mcp enable <server> and /reload): parked");
+  });
+
+  it("omits the Servers line entirely when no servers are configured", () => {
+    const config: McpConfig = { mcpServers: {} };
+
+    const description = buildProxyDescription(config);
+
+    expect(description).not.toContain("Servers:");
+    expect(description).toContain("Usage:");
   });
 });
 
@@ -517,7 +414,6 @@ describe("excludeTools filtering", () => {
     expect(buildToolMetadata(entry.tools as any, [], config.mcpServers["my-server"], "my-server", "server", config.mcpServers).metadata).toEqual([]);
     expect(reconstructToolMetadata("my-server", entry, "server", config.mcpServers["my-server"], config.mcpServers, cache)).toEqual([]);
     expect(resolveDirectTools(config, cache, "server")).toEqual([]);
-    expect(buildProxyDescription(config, cache, [])).not.toContain("my-server (1 tools)");
   });
 
   it("ignores invalid cache entries for collision candidates", () => {
@@ -549,7 +445,6 @@ describe("excludeTools filtering", () => {
 
     expect(reconstructToolMetadata("my-server", currentEntry, "server", config.mcpServers["my-server"], config.mcpServers, cache)).toEqual([]);
     expect(resolveDirectTools(config, cache, "server")).toEqual([]);
-    expect(buildProxyDescription(config, cache, [])).not.toContain("my-server (1 tools)");
   });
 
   it("ignores cached app-only tools for reconstructed metadata collision candidates", () => {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -15,7 +15,7 @@ import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
@@ -24,7 +24,6 @@ type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
 type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
-const INSTRUCTIONS_SNIPPET_LENGTH = 150;
 export const DIRECT_TOOLS_ADVISORY_THRESHOLD = 75;
 
 type DirectAutoAuthResult =
@@ -231,75 +230,20 @@ export function resolveDirectTools(
   return specs;
 }
 
-export function buildProxyDescription(
-  config: McpConfig,
-  cache: MetadataCache | null,
-  directSpecs: DirectToolSpec[],
-): string {
-  const prefix = config.settings?.toolPrefix ?? "server";
+/**
+ * Pure function of config: the description must stay byte-stable across
+ * runtime metadata changes (tool counts, instructions, connection state) so
+ * re-registering the proxy tool never rewrites the cached prompt prefix.
+ * Live counts/status belong to `mcp({ })`, full instructions to
+ * `mcp({ instructions })`.
+ */
+export function buildProxyDescription(config: McpConfig): string {
   let desc = `MCP gateway — server status, tool search/describe, auth, and single MCP tool calls. When one request needs several MCP calls with logic between them, use mcpScript. Non-MCP Pi tools should be called directly, not through mcp.\n`;
 
-  const directByServer = new Map<string, number>();
-  for (const spec of directSpecs) {
-    directByServer.set(spec.serverName, (directByServer.get(spec.serverName) ?? 0) + 1);
-  }
-  if (directByServer.size > 0) {
-    const parts = [...directByServer.entries()].map(
-      ([server, count]) => `${server} (${count})`,
-    );
-    desc += `\nDirect tools available (call as normal tools): ${parts.join(", ")}\n`;
-  }
-
-  const serverSummaries: string[] = [];
-  for (const serverName of Object.keys(config.mcpServers)) {
-    const definition = config.mcpServers[serverName];
-    if (!definition || isServerDisabled(definition)) continue;
-    const cachedEntry = cache?.servers?.[serverName];
-    const entry = cachedEntry && isServerCacheValid(cachedEntry, definition) ? cachedEntry : undefined;
-    const effectivePrefix = resolveToolPrefix(definition, prefix);
-    const hasToolFilters =
-      (Array.isArray(definition.includeTools) && definition.includeTools.length > 0) ||
-      (Array.isArray(definition.excludeTools) && definition.excludeTools.length > 0);
-    const selectorCandidateIndex = hasToolFilters && cache ? (() => {
-      const candidates = new Set<string>();
-      for (const [otherServerName, otherDefinition] of Object.entries(config.mcpServers)) {
-        const otherEntry = cache.servers[otherServerName];
-        if (!otherEntry || !isServerCacheValid(otherEntry, otherDefinition) || isServerDisabled(otherDefinition)) continue;
-        const otherPrefix = resolveToolPrefix(otherDefinition, prefix);
-        for (const otherTool of otherEntry.tools ?? []) {
-          if (!isUiToolVisibleToModel(otherTool.uiVisibility)) continue;
-          for (const candidate of getToolNameCandidates(otherTool.name, otherServerName, otherPrefix, false)) candidates.add(candidate);
-        }
-        if (otherDefinition.exposeResources !== false) {
-          for (const resource of otherEntry.resources ?? []) {
-            const baseName = `read_${resourceNameToToolName(resource.name)}`;
-            for (const candidate of getToolNameCandidates(baseName, otherServerName, otherPrefix, false)) candidates.add(candidate);
-          }
-        }
-      }
-      return createToolSelectorCandidateIndex(candidates);
-    })() : undefined;
-    const toolCount = (entry?.tools ?? []).filter(
-      (tool) => isUiToolVisibleToModel(tool.uiVisibility)
-        && isToolAllowed(tool.name, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex),
-    ).length;
-    const resourceCount = definition?.exposeResources !== false
-      ? (entry?.resources ?? []).filter((resource) => {
-          const baseName = `read_${resourceNameToToolName(resource.name)}`;
-          return isToolAllowed(baseName, serverName, effectivePrefix, definition.includeTools, definition.excludeTools, selectorCandidateIndex);
-        }).length
-      : 0;
-    const totalItems = toolCount + resourceCount;
-    if (totalItems === 0) continue;
-    const directCount = directByServer.get(serverName) ?? 0;
-    const proxyCount = totalItems - directCount;
-    if (proxyCount > 0) {
-      serverSummaries.push(`${serverName} (${proxyCount} tools)`);
-    }
-  }
-
-  if (serverSummaries.length > 0) {
-    desc += `\nServers: ${serverSummaries.join(", ")}\n`;
+  const serverNames = Object.keys(config.mcpServers)
+    .filter((serverName) => !isServerDisabled(config.mcpServers[serverName]));
+  if (serverNames.length > 0) {
+    desc += `\nServers: ${serverNames.join(", ")}\n`;
   }
 
   const disabledServers = Object.entries(config.mcpServers)
@@ -309,22 +253,8 @@ export function buildProxyDescription(
     desc += `\nDisabled servers (enable with /mcp enable <server> and /reload): ${disabledServers.join(", ")}\n`;
   }
 
-  const instructionSummaries: string[] = [];
-  for (const serverName of Object.keys(config.mcpServers)) {
-    if (isServerDisabled(config.mcpServers[serverName])) continue;
-    const definition = config.mcpServers[serverName];
-    const entry = definition && cache?.servers?.[serverName];
-    const instructions = entry && definition && isServerCacheValid(entry, definition) ? entry.instructions : undefined;
-    if (!instructions) continue;
-    const snippet = truncateAtWord(instructions.replace(/\s+/g, " ").trim(), INSTRUCTIONS_SNIPPET_LENGTH);
-    instructionSummaries.push(`  ${serverName}: ${snippet}`);
-  }
-  if (instructionSummaries.length > 0) {
-    desc += `\nServer instructions (truncated - full text via mcp({ instructions: "name" })):\n${instructionSummaries.join("\n")}\n`;
-  }
-
   desc += `\nUsage:\n`;
-  desc += `  mcp({ })                              → Show server status\n`;
+  desc += `  mcp({ })                              → Show server status and tool counts\n`;
   desc += `  mcp({ server: "name" })               → List tools from server\n`;
   desc += `  mcp({ search: "query" })              → Search MCP tools by name/description\n`;
   desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`;

--- a/index.ts
+++ b/index.ts
@@ -1091,7 +1091,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       || missingConfiguredDirectToolServers.length > 0;
 
     if (shouldRegisterProxyTool) {
-      const description = buildProxyDescription(config, cache, directSpecs);
+      const description = buildProxyDescription(config);
       if (!proxyToolRegistered || proxyToolDescription !== description) {
         registerProxyTool(description);
         return;


### PR DESCRIPTION
## Why this matters

Every time an MCP server connects or refreshes, the `mcp` tool description used to change: live tool counts and 150-character instruction snippets got baked into the tool text. Pi then re-registered `mcp`, and the model had to re-read the whole prompt prefix.

On current `main`, that description **rewrites 4 times** as four servers fill in. After this change: **0 rewrites**. The prefix can stay cached.

Same five-task session, same four live servers plus one offline:

| | current `main` | this PR |
|---|---|---|
| How many times the `mcp` instruction text changes as servers connect | **4** | **0** |

Live counts still exist — they moved to `mcp({})`. Full server instructions stay behind `mcp({ instructions: "name" })`. The tool text now only lists configured server names and how to use the gateway.

The size cut (about **45% smaller** instruction text vs `main`) is the companion PR: [#433](https://github.com/nicobailon/pi-mcp-adapter/pull/433). Together: smaller **and** still.

## Fix

`buildProxyDescription` is a pure function of config. Metadata refresh no longer rewrites it, so `registerProxyTool` is not called again unless the config actually changed.

Typecheck clean; full suite green (1,291 tests). Recut onto current `main` (`4755775`).

Note: this and #433 both touch `direct-tools.ts`. Independent of each other on `main`; if one merges first, the other may need a rebase.