### PR TITLE
feat: cut duplicated gateway description text

### DIFF
--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -58,7 +58,7 @@ describe("formatToolName", () => {
 });
 
 describe("buildProxyDescription", () => {
-  it("documents the ui-messages action", () => {
+  it("keeps the preamble and leaves usage guidance to the schema", () => {
     const config: McpConfig = {
       mcpServers: {
         demo: {
@@ -88,12 +88,13 @@ describe("buildProxyDescription", () => {
 
     const description = buildProxyDescription(config, cache, []);
 
-    expect(description).toContain('mcp({ action: "ui-messages" })');
-    expect(description).toContain("Retrieve accumulated messages from completed UI sessions");
     expect(description).toContain("server status, tool search/describe, auth, and single MCP tool calls");
     expect(description).toContain("When one request needs several MCP calls with logic between them, use mcpScript.");
-    expect(description).toContain("Search MCP tools by name/description");
     expect(description).toContain("Non-MCP Pi tools should be called directly, not through mcp.");
+    expect(description).not.toContain("Usage:");
+    expect(description).not.toContain("Mode: action");
+    expect(description).not.toContain("ui-messages");
+    expect(description).not.toContain("auth-start");
     expect(description).not.toContain("MCP + pi");
   });
 
@@ -196,7 +197,7 @@ describe("buildProxyDescription", () => {
     expect(description).not.toContain("stale instructions");
   });
 
-  it("includes a truncated instructions snippet for servers that provide one", () => {
+  it("does not embed server instructions in the description", () => {
     const config: McpConfig = {
       mcpServers: {
         demo: { command: "npx", args: ["-y", "demo-server"] },
@@ -218,35 +219,9 @@ describe("buildProxyDescription", () => {
 
     const description = buildProxyDescription(config, cache, []);
 
-    expect(description).toContain('Server instructions (truncated - full text via mcp({ instructions: "name" })):');
-    expect(description).toContain("demo: Skills catalog. Available skills: - skill-0:");
-    expect(description).toContain("...");
-    expect(description).not.toContain("skill-29");
-  });
-
-  it("omits the instructions section when no server provides instructions", () => {
-    const config: McpConfig = {
-      mcpServers: {
-        demo: { command: "npx", args: ["-y", "demo-server"] },
-      },
-    };
-
-    const cache: MetadataCache = {
-      version: 1,
-      servers: {
-        demo: {
-          configHash: "hash",
-          cachedAt: Date.now(),
-          tools: [{ name: "read_skill", description: "Read a skill" }],
-          resources: [],
-        },
-      },
-    };
-
-    const description = buildProxyDescription(config, cache, []);
-
     expect(description).not.toContain("Server instructions");
-    expect(description).toContain('mcp({ instructions: "name" })');
+    expect(description).not.toContain("Skills catalog");
+    expect(description).not.toContain("skill-0");
   });
 });
 

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -15,7 +15,7 @@ import { createToolSelectorCandidateIndex, formatToolName, getToolNameCandidates
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.ts";
-import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { formatAuthRequiredMessage, normalizeToolArguments, resolveServerUrl } from "./utils.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
@@ -24,7 +24,6 @@ type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
 type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
-const INSTRUCTIONS_SNIPPET_LENGTH = 150;
 export const DIRECT_TOOLS_ADVISORY_THRESHOLD = 75;
 
 type DirectAutoAuthResult =
@@ -308,33 +307,6 @@ export function buildProxyDescription(
   if (disabledServers.length > 0) {
     desc += `\nDisabled servers (enable with /mcp enable <server> and /reload): ${disabledServers.join(", ")}\n`;
   }
-
-  const instructionSummaries: string[] = [];
-  for (const serverName of Object.keys(config.mcpServers)) {
-    if (isServerDisabled(config.mcpServers[serverName])) continue;
-    const definition = config.mcpServers[serverName];
-    const entry = definition && cache?.servers?.[serverName];
-    const instructions = entry && definition && isServerCacheValid(entry, definition) ? entry.instructions : undefined;
-    if (!instructions) continue;
-    const snippet = truncateAtWord(instructions.replace(/\s+/g, " ").trim(), INSTRUCTIONS_SNIPPET_LENGTH);
-    instructionSummaries.push(`  ${serverName}: ${snippet}`);
-  }
-  if (instructionSummaries.length > 0) {
-    desc += `\nServer instructions (truncated - full text via mcp({ instructions: "name" })):\n${instructionSummaries.join("\n")}\n`;
-  }
-
-  desc += `\nUsage:\n`;
-  desc += `  mcp({ })                              → Show server status\n`;
-  desc += `  mcp({ server: "name" })               → List tools from server\n`;
-  desc += `  mcp({ search: "query" })              → Search MCP tools by name/description\n`;
-  desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`;
-  desc += `  mcp({ instructions: "name" })         → Show full server usage instructions\n`;
-  desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`;
-  desc += `  mcp({ tool: "name", args: { key: "value" } })         → Call a tool (object args; JSON string also accepted)\n`;
-  desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`;
-  desc += `  mcp({ action: "auth-start", server: "name" })      → Start manual OAuth and get a browser URL\n`;
-  desc += `  mcp({ action: "auth-complete", server: "name", args: { redirectUrl: "..." } }) → Complete manual OAuth\n`;
-  desc += `\nMode: action > tool (call) > connect > describe > instructions > search > server (list) > nothing (status)`;
 
   return desc;
 }

--- a/index.ts
+++ b/index.ts
@@ -862,7 +862,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     (pi.registerTool as (tool: unknown) => unknown)({
       name: "mcpScript",
       label: "MCP Script",
-      description: "Run trusted JavaScript that makes multiple MCP tool calls in one request — loop, filter, chain, or fan out between calls. For a single MCP call, search, describe, status check, or auth action, use the mcp tool instead. Discover with await tools.search({ query }) — resolves to { items: [{ path, name, server, description? }], total, hasMore, nextOffset }, not an { ok, data } envelope. Inspect with await tools.describe({ path }) — resolves to the tool descriptor with inputTypeScript, or { path, error: { code, message, suggestions } }. Then call tools.call(path, args) — resolves to { ok: true, data } or { ok: false, error: { code, message } } — or use direct flat calls when the name is already known; use emit(value) for user-visible output. Load the mcp-scripting skill for the full workflow guide.",
+      description: "Run trusted JavaScript that makes multiple MCP tool calls in one request — loop, filter, chain, or fan out between calls. Load the mcp-scripting skill for the full workflow guide.",
       promptSnippet: "Batch multiple MCP tool calls in one JavaScript request (loop, filter, chain)",
       parameters: Type.Object({
         code: Type.String({ description: "Trusted JavaScript MCP script. Use tools.<prefixedToolName>(args) and emit(value)." }),

--- a/skills/mcp-scripting/SKILL.md
+++ b/skills/mcp-scripting/SKILL.md
@@ -25,8 +25,8 @@ return result.data;
 
 ## Workflow
 
-1. Find candidate tools with `await tools.search({ query, server?, limit?, offset? })`.
-2. Inspect the exact returned path with `await tools.describe({ path })`.
+1. Find candidate tools with `await tools.search({ query, server?, limit?, offset? })` — resolves to `{ items: [{ path, name, server, description? }], total, hasMore, nextOffset }`; page with `offset` while `hasMore` is true.
+2. Inspect the exact returned path with `await tools.describe({ path })` — resolves to the tool descriptor (with `inputTypeScript`), or `{ path, error: { code, message, suggestions } }`.
 3. Call it with `tools.call(path, args)`.
 
 Calls resolve to `{ ok: true, data }` or `{ ok: false, error }`; handle failed calls instead of expecting them to stop the script. `emit(value)` adds user-visible output before the final `return` value. `console` output is captured too.


### PR DESCRIPTION
## Why this is a big deal

The `mcp` and `mcpScript` tool texts were repeating things the JSON schema and the scripting skill already say: a usage cheat-sheet, a mode-precedence line, auth/UI verbs that were not even true for the measured config, 150-character instruction teasers on every request, and the `mcp`/`mcpScript` routing rule stated three times.

That text sits in **every request**. Cutting it is not a micro-optimization.

Same five-task session, same four live servers plus one offline:

| | characters of `mcp` instruction text |
|---|---|
| current `main` | **3,852** |
| this cut (on a config-stable description) | **2,125 (−1,794 vs the column before it)** |
| this + the companion purity PR, vs `main` | **2,125 (−1,727, about −45%)** |

The companion PR ([#432](https://github.com/nicobailon/pi-mcp-adapter/pull/432)) is what stops the description rewriting as servers connect (4 rewrites → 0). Take both and you get a **much smaller prefix that actually stays still**.

`args` is unchanged: still advertised as object or JSON string.

## What was removed

- Usage cheat-sheet, mode-precedence line, and dead auth/UI verb lines (already in the schema)
- 150-character server-instruction teasers (already available via `mcp({ instructions })`)
- Triplicated `mcp`/`mcpScript` routing; search-result shape moved into the mcp-scripting skill

Typecheck clean; full suite green (1,291 tests). Recut onto current `main` (`4755775`).

Note: this and #432 both touch `direct-tools.ts`. Independent of each other on `main`; if one merges first, the other may need a rebase.