### PR TITLE
fix: keep failed servers out of discovery surfaces and report status honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - MCP gateway descriptions now stay stable across metadata-only refreshes and keep live counts behind `mcp({})`. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #432.
+- Failed MCP servers in active backoff no longer remain advertised through cached direct tools, gateway list/search/describe results, or status tool counts. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #434.
 - OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.
 - Failed first-time MCP initialization no longer leaves the session permanently stuck with only `MCP not initialized`; the gateway keeps the failure reason and retries initialization on the next `mcp(...)` call. Thanks to [@hara-seihun](https://github.com/hara-seihun) for #428.
 - HTTP 202 and unauthenticated HTTP 401 endpoint probes now report ambiguous endpoint shape instead of claiming the URL is not MCP. Thanks to [@jayshah5696](https://github.com/jayshah5696) for #415.

--- a/__tests__/direct-tools.test.ts
+++ b/__tests__/direct-tools.test.ts
@@ -344,6 +344,108 @@ describe("metadata cache hashing", () => {
 });
 
 describe("direct tool metadata bootstrap", () => {
+  it("omits cached direct tools from servers in active failure backoff", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true },
+      mcpServers: {
+        demo: { command: "demo", directTools: true },
+        failed: { command: "failed", directTools: true },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        demo: {
+          configHash: computeServerHash(config.mcpServers.demo),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Search" }],
+          resources: [],
+        },
+        failed: {
+          configHash: computeServerHash(config.mcpServers.failed),
+          cachedAt: Date.now(),
+          tools: [{ name: "stale", description: "Stale" }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "server", undefined, new Set(["failed"])).map(tool => tool.prefixedName)).toEqual([
+      "demo_search",
+    ]);
+  });
+
+  it("keeps duplicate direct names reserved by failed-backoff servers", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const config: McpConfig = {
+      settings: { toolPrefix: "none", directTools: true, warnOnLargeDirectTools: false },
+      mcpServers: {
+        failed: { command: "failed" },
+        healthy: { command: "healthy" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        failed: {
+          configHash: computeServerHash(config.mcpServers.failed),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Failed" }],
+          resources: [],
+        },
+        healthy: {
+          configHash: computeServerHash(config.mcpServers.healthy),
+          cachedAt: Date.now(),
+          tools: [{ name: "search", description: "Healthy" }],
+          resources: [],
+        },
+      },
+    };
+
+    expect(resolveDirectTools(config, cache, "none").map(tool => [tool.serverName, tool.prefixedName])).toEqual([
+      ["failed", "search"],
+    ]);
+    expect(resolveDirectTools(config, cache, "none", undefined, new Set(["failed"]))).toEqual([]);
+  });
+
+  it("keeps healthy selector results stable when another server is in backoff", () => {
+    const config: McpConfig = {
+      settings: { toolPrefix: "server", directTools: true, warnOnLargeDirectTools: false },
+      mcpServers: {
+        "my-server": { command: "healthy", excludeTools: ["my_2d_server_search_records"] },
+        my_2d_server: { command: "failed" },
+      },
+    };
+    const cache: MetadataCache = {
+      version: 1,
+      servers: {
+        "my-server": {
+          configHash: computeServerHash(config.mcpServers["my-server"]),
+          cachedAt: Date.now(),
+          tools: [{ name: "search-records", description: "Healthy" }],
+          resources: [],
+        },
+        my_2d_server: {
+          configHash: computeServerHash(config.mcpServers.my_2d_server),
+          cachedAt: Date.now(),
+          tools: [{ name: "search_records", description: "Failed" }],
+          resources: [],
+        },
+      },
+    };
+
+    const withoutBackoff = resolveDirectTools(config, cache, "server").map(tool => [tool.serverName, tool.prefixedName]);
+    const withBackoff = resolveDirectTools(config, cache, "server", undefined, new Set(["my_2d_server"])).map(tool => [tool.serverName, tool.prefixedName]);
+
+    expect(withoutBackoff).toEqual([
+      ["my-server", "my-server_search-records"],
+      ["my_2d_server", "my_2d_server_search_records"],
+    ]);
+    expect(withBackoff).toEqual([
+      ["my-server", "my-server_search-records"],
+    ]);
+  });
+
   it("includes env-selected servers without config-level direct tool settings", () => {
     const config: McpConfig = {
       mcpServers: {

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -104,7 +104,12 @@ vi.mock("../proxy-modes.ts", () => ({
 vi.mock("../utils.ts", () => ({
   formatTerminalError: (error: unknown) => error instanceof Error ? error.message : String(error),
   getConfigPathFromArgv: mocks.getConfigPathFromArgv,
+  interpolateEnvRecord: (value: Record<string, string> | undefined) => value,
+  interpolateEnvVars: (value: string | undefined) => value,
   normalizeDirectToolInputSchema: mocks.normalizeDirectToolInputSchema,
+  resolveBearerToken: (definition: { bearerToken?: string }) => definition.bearerToken,
+  resolveConfigPath: (value: string | undefined) => value,
+  resolveServerUrl: (definition: { url?: string }) => definition.url,
   sanitizeTerminalText: (text: string) => text,
   truncateAtWord: mocks.truncateAtWord,
 }));
@@ -121,7 +126,7 @@ function createDeferred<T>() {
 
 function createState() {
   return {
-    manager: { getAllConnections: () => new Map() },
+    manager: { getAllConnections: () => new Map(), getConnection: vi.fn(() => undefined) },
     lifecycle: {
       gracefulShutdown: vi.fn().mockResolvedValue(undefined),
       ensureConverged: vi.fn().mockResolvedValue(undefined),
@@ -669,6 +674,92 @@ describe("mcpAdapter session lifecycle", () => {
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
   });
 
+  it("does not refresh frozen direct tools on failure-backoff metadata updates", async () => {
+    const config = {
+      settings: { freezeDirectTools: true },
+      mcpServers: {
+        demo: { command: "npx", args: ["-y", "demo-server"], directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.resolveDirectTools.mockReturnValue([
+      {
+        serverName: "demo",
+        originalName: "search",
+        prefixedName: "demo_search",
+        description: "Search demo",
+      },
+    ]);
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const callsAfterInitialSync = mocks.resolveDirectTools.mock.calls.length;
+    state.onToolMetadataUpdated?.("demo", "failure-backoff-started");
+
+    expect(mocks.resolveDirectTools).toHaveBeenCalledTimes(callsAfterInitialSync);
+  });
+
+  it("keeps hidden direct tool names reserved against namespace proxies during backoff", async () => {
+    const { computeServerHash } = await import("../metadata-cache.ts");
+    const failedDefinition = { command: "failed", directTools: true };
+    const proxyDefinition = { command: "foo" };
+    const config = {
+      settings: { toolPrefix: "mcp" },
+      mcpServers: {
+        failed: failedDefinition,
+        foo: proxyDefinition,
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.loadMetadataCache.mockReturnValue({
+      version: 1,
+      servers: {
+        foo: {
+          configHash: computeServerHash(proxyDefinition),
+          cachedAt: Date.now(),
+          tools: [{ name: "run" }],
+          resources: [],
+        },
+      },
+    });
+    mocks.resolveDirectTools.mockImplementation((_config, _cache, _prefix, _env, unavailableServers, reservedNames) => {
+      reservedNames?.add("mcp__foo");
+      if (unavailableServers?.has("failed")) {
+        return [];
+      }
+      return [{
+        serverName: "failed",
+        originalName: "foo",
+        prefixedName: "mcp__foo",
+        description: "Failed direct",
+      }];
+    });
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    state.failureTracker.set("failed", Date.now());
+    state.onToolMetadataUpdated?.("failed", "failure-backoff-started");
+
+    expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({
+      name: "mcp__foo",
+      description: expect.stringContaining("Namespace-proxy"),
+    }));
+  });
+
   it("publishes connected status only after replacing stale cached direct tools", async () => {
     const config = {
       settings: { disableProxyTool: true },
@@ -1069,6 +1160,8 @@ describe("mcpAdapter session lifecycle", () => {
       null,
       "server",
       undefined,
+      expect.any(Set),
+      expect.any(Set),
     );
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "memory_search" }));
     expect(api.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "mcp" }));

--- a/__tests__/init-failure-state.test.ts
+++ b/__tests__/init-failure-state.test.ts
@@ -42,6 +42,50 @@ describe("MCP failure state", () => {
     expect(state.failureMessages.size).toBe(0);
   });
 
+  it("notifies discovery surfaces when failure backoff starts and expires", () => {
+    vi.useFakeTimers();
+    const onToolMetadataUpdated = vi.fn();
+    const state = {
+      failureTracker: new Map<string, number>(),
+      failureMessages: new Map<string, string>(),
+      config: { mcpServers: { demo: { command: "demo" } } },
+      manager: { getConnection: () => undefined },
+      toolMetadata: new Map(),
+      owner: { isActive: () => true },
+      statusEvents: { emit: vi.fn() },
+      onToolMetadataUpdated,
+    } as any;
+
+    recordFailure(state, "demo", "failed");
+    expect(onToolMetadataUpdated).toHaveBeenCalledWith("demo", "failure-backoff-started");
+
+    vi.advanceTimersByTime(60_001);
+
+    expect(onToolMetadataUpdated).toHaveBeenCalledWith("demo", "failure-backoff-expired");
+    vi.useRealTimers();
+  });
+
+  it("notifies recovery surfaces only after clearing active backoff", () => {
+    vi.useFakeTimers();
+    let state: any;
+    const onToolMetadataUpdated = vi.fn(() => {
+      expect(getFailureAgeSeconds(state, "demo")).toBeNull();
+    });
+    state = {
+      failureTracker: new Map<string, number>(),
+      failureMessages: new Map<string, string>(),
+      owner: { isActive: () => true },
+      statusEvents: { emit: vi.fn() },
+      onToolMetadataUpdated,
+    } as any;
+
+    recordFailure(state, "demo", "failed");
+    onToolMetadataUpdated.mockClear();
+    expect(clearFailure(state, "demo", "health-restored")).toBe(true);
+
+    expect(onToolMetadataUpdated).toHaveBeenCalledWith("demo", "health-restored");
+  });
+
   it("does not publish failure expiry after the runtime owner stops", async () => {
     vi.useFakeTimers();
     const owner = createMcpRuntimeOwner();

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -181,6 +181,31 @@ describe("runMcpScript", () => {
     });
   });
 
+  it("keeps active failed-backoff tools out of script describe results", async () => {
+    const backoffState = {
+      ...state,
+      manager: { getConnection: vi.fn(() => undefined) },
+      failureTracker: new Map([["fixture", Date.now()]]),
+    } as unknown as McpExtensionState;
+
+    const result = await runMcpScript(
+      backoffState,
+      'return { search: await tools.search({ query: "fixture" }), describe: await tools.describe({ path: "fixture_echo" }) };',
+    );
+
+    expect(JSON.parse(textBlocks(result).at(-1)!)).toEqual({
+      search: { items: [], total: 0, hasMore: false, nextOffset: null },
+      describe: {
+        path: "fixture_echo",
+        error: {
+          code: "tool_not_found",
+          message: "Tool not found: fixture_echo",
+          suggestions: [],
+        },
+      },
+    });
+  });
+
   it("records operation metadata and timing for search, describe, and calls", async () => {
     const result = await runMcpScript(
       state,

--- a/__tests__/mcp-status.test.ts
+++ b/__tests__/mcp-status.test.ts
@@ -5,6 +5,7 @@ import {
   publishMcpStatusShutdown,
   publishMcpStatusSnapshot,
 } from "../mcp-status.ts";
+import { executeStatus } from "../proxy-modes.ts";
 
 function createState() {
   const manager = {
@@ -25,6 +26,7 @@ function createState() {
     toolMetadata: new Map([
       ["connected", [{ name: "search" }]],
       ["cached", [{ name: "cached_search" }, { name: "read_doc" }]],
+      ["failed", [{ name: "failed_search" }, { name: "failed_read" }]],
       ["idle", [{ name: "old_search" }]],
     ]),
     resourceCounts: new Map([["connected", 2], ["cached", 1]]),
@@ -73,6 +75,44 @@ describe("MCP status snapshots", () => {
     expect(snapshot).not.toHaveProperty("client");
     expect(snapshot).not.toHaveProperty("transport");
     expect(snapshot).not.toHaveProperty("config");
+  });
+
+  it("keeps needs-auth status out of failure backoff even with a fresh failure entry", () => {
+    const state = createState();
+    state.failureTracker.set("auth", Date.now());
+    state.manager.getConnection.mockImplementation((name: string) => name === "auth"
+      ? { status: "needs-auth", tools: [], resources: [] }
+      : undefined);
+
+    const snapshot = createMcpStatusSnapshot(state);
+
+    expect(snapshot.servers.find(server => server.name === "auth")).toMatchObject({
+      name: "auth",
+      status: "needs-auth",
+      toolCount: 0,
+    });
+  });
+
+  it("keeps proxy status and shared snapshots in parity for cached failure states", () => {
+    const state = createState();
+    state.manager.getConnection.mockImplementation((name: string) => {
+      if (name === "connected") return { status: "connected", tools: [{ name: "search" }], resources: [] };
+      if (name === "auth") return { status: "needs-auth", tools: [], resources: [] };
+      return undefined;
+    });
+
+    const snapshot = createMcpStatusSnapshot(state);
+    const proxy = executeStatus(state).details as { servers: Array<{ name: string; status: string; toolCount: number }> };
+
+    for (const server of snapshot.servers) {
+      const proxyServer = proxy.servers.find(candidate => candidate.name === server.name);
+      expect(proxyServer).toBeDefined();
+      expect(proxyServer).toMatchObject({
+        name: server.name,
+        status: server.status === "not-connected" ? "not connected" : server.status,
+        toolCount: server.toolCount,
+      });
+    }
   });
 
   it("publishes an empty snapshot at shutdown", () => {

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -335,7 +335,7 @@ describe("syncNamespaceProxyTools", () => {
     expect(unregistered).toContain("mcp__context_mode");
   });
 
-  it("does not deactivate direct tools while cleaning stale namespace proxies", async () => {
+  it("deactivates stale namespace proxies when hidden direct tools reserve their names", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered, unregistered } = makePi();
     pi.registerTool({ name: "mcp__demo_search", execute: vi.fn() });
@@ -345,6 +345,28 @@ describe("syncNamespaceProxyTools", () => {
       cache: { version: 1, servers: {} },
       envOverride: null,
       existingDirectNames: new Set(["mcp__demo_search"]),
+      existingNamespaceNames: new Set(["mcp__demo_search"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__demo_search")).toBe(false);
+    expect(unregistered).toContain("mcp__demo_search");
+  });
+
+  it("keeps active direct tools when they replace stale namespace proxy names", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered, unregistered } = makePi();
+    pi.registerTool({ name: "mcp__demo_search", execute: vi.fn() });
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: {} },
+      cache: { version: 1, servers: {} },
+      envOverride: null,
+      existingDirectNames: new Set(["mcp__demo_search"]),
+      activeDirectNames: new Set(["mcp__demo_search"]),
       existingNamespaceNames: new Set(["mcp__demo_search"]),
       pi,
       getState: () => null,
@@ -404,6 +426,30 @@ describe("syncNamespaceProxyTools", () => {
 
     expect(registered.has("mcp__my_server")).toBe(false);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('servers "my-server", "my_server" normalize to the same name'));
+  });
+
+  it("keeps namespace collisions reserved when one server is in backoff", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "my-server": { command: "one" }, my_server: { command: "two" } } },
+      cache: CACHE_SHAPE([
+        ["my-server", { tools: [{ name: "one" }], definition: { command: "one" } }],
+        ["my_server", { tools: [{ name: "two" }], definition: { command: "two" } }],
+      ]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      unavailableServers: new Set(["my-server"]),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp__my_server")).toBe(false);
   });
 
   it("registers a new server and keeps existing ones in a single sync", async () => {

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { executeCall, executeDescribe, executeSearch } from "../proxy-modes.ts";
+import { executeCall, executeDescribe, executeList, executeSearch, executeStatus } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
 
 function createState(): McpExtensionState {
@@ -31,6 +31,7 @@ function createState(): McpExtensionState {
       getConnection: () => undefined,
       isConnecting: () => false,
     },
+    serverInstructions: new Map(),
     failureTracker: new Map(),
   } as unknown as McpExtensionState;
 }
@@ -167,6 +168,32 @@ describe("proxy discovery", () => {
 
     const describeResult = executeDescribe(state, "demo_find");
     expect(JSON.stringify(describeResult)).not.toContain("zzalias");
+  });
+
+  it("keeps cached failed-backoff tools out of proxy discovery surfaces", () => {
+    const state = createState();
+    state.failureTracker.set("demo", Date.now());
+
+    expect(executeSearch(state, "demo").details).toMatchObject({ count: 0, matches: [] });
+    expect(executeDescribe(state, "demo_search").details).toMatchObject({ mode: "describe", error: "server_backoff", server: "demo" });
+    expect(executeList(state, "demo").details).toMatchObject({ mode: "list", error: "server_backoff", tools: [], count: 0 });
+    expect(executeStatus(state).details).toMatchObject({
+      totalTools: 0,
+      servers: [expect.objectContaining({ name: "demo", status: "failed", toolCount: 0 })],
+    });
+  });
+
+  it("does not filter needs-auth servers with stale failure entries", () => {
+    const state = createState();
+    state.failureTracker.set("demo", Date.now());
+    state.manager.getConnection = () => ({ status: "needs-auth" }) as any;
+
+    expect(executeSearch(state, "demo").details).toMatchObject({ count: 2 });
+    expect(executeList(state, "demo").details).toMatchObject({ mode: "list", count: 2 });
+    expect(executeStatus(state).details).toMatchObject({
+      totalTools: 2,
+      servers: [expect.objectContaining({ name: "demo", status: "needs-auth", toolCount: 2 })],
+    });
   });
 
   it("suggests the matching tool for a prefix-mangled describe name", () => {

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -111,6 +111,7 @@ function createState() {
   return {
     manager: {
       getAllConnections: () => new Map(),
+      getConnection: vi.fn(() => undefined),
       close: vi.fn().mockResolvedValue(undefined),
     },
     lifecycle: {

--- a/__tests__/search-ranking.test.ts
+++ b/__tests__/search-ranking.test.ts
@@ -71,6 +71,8 @@ describe("search ranking", () => {
     const state = {
       toolMetadata: new Map([["demo", [tool("search_records", "Find records")]]]),
       config: { mcpServers: { demo: { command: "demo", searchKeywords: { search_records: ["fuzzy"] } } } },
+      manager: { getConnection: () => undefined },
+      failureTracker: new Map(),
     } as unknown as McpExtensionState;
 
     expect(rankToolMatches(state, "fuzzy")).toHaveLength(1);

--- a/commands.ts
+++ b/commands.ts
@@ -17,6 +17,7 @@ import {
   writeStarterProjectConfig,
 } from "./config.ts";
 import { markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateMetadataCache, updateStatusBar, getFailureAgeSeconds, getFailureMessage, clearFailure, recordFailure } from "./init.ts";
+import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import { loadMetadataCache, reconstructPromptMetadata } from "./metadata-cache.ts";
 import { buildToolMetadata } from "./tool-metadata.ts";
 import { supportsOAuth, authenticate, removeAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
@@ -131,6 +132,7 @@ export async function showTools(state: McpExtensionState, ctx: ExtensionContext)
 
   const allTools = [...state.toolMetadata.entries()]
     .filter(([serverName]) => !isServerDisabled(state.config.mcpServers[serverName]))
+    .filter(([serverName]) => !isServerInActiveFailureBackoff(state, serverName))
     .flatMap(([, metadata]) => metadata.map(m => m.name));
 
   if (allTools.length === 0) {
@@ -196,9 +198,9 @@ export async function reconnectServer(
       state.serverInstructions.delete(name);
     }
     updateMetadataCache(state, name);
-    notifyToolMetadataUpdated(state, name, "command-reconnect");
+    const restored = clearFailure(state, name, "command-reconnect");
+    if (!restored) notifyToolMetadataUpdated(state, name, "command-reconnect");
     markKeepAliveAfterConnect(state, name);
-    clearFailure(state, name);
 
     if (ui) {
       ui.notify(

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -169,6 +169,8 @@ export function resolveDirectTools(
   cache: MetadataCache | null,
   prefix: ToolPrefix,
   envOverride?: string[],
+  unavailableServers: ReadonlySet<string> = new Set(),
+  reservedNames?: Set<string>,
 ): DirectToolSpec[] {
   const specs: DirectToolSpec[] = [];
   if (!cache) return specs;
@@ -276,11 +278,17 @@ export function resolveDirectTools(
     }
   }
 
-  if (config.settings?.warnOnLargeDirectTools !== false && specs.length >= DIRECT_TOOLS_ADVISORY_THRESHOLD) {
-    console.warn(`MCP: ${specs.length} direct tools resolved. Each direct tool adds prompt context; README guidance recommends targeted sets of 5-20 tools and using the proxy or an explicit string[] when 75+ direct tools would be registered. Set settings.warnOnLargeDirectTools to false to hide this advisory.`);
+  for (const spec of specs) reservedNames?.add(spec.prefixedName);
+
+  const emittedSpecs = unavailableServers.size === 0
+    ? specs
+    : specs.filter((spec) => !unavailableServers.has(spec.serverName));
+
+  if (config.settings?.warnOnLargeDirectTools !== false && emittedSpecs.length >= DIRECT_TOOLS_ADVISORY_THRESHOLD) {
+    console.warn(`MCP: ${emittedSpecs.length} direct tools resolved. Each direct tool adds prompt context; README guidance recommends targeted sets of 5-20 tools and using the proxy or an explicit string[] when 75+ direct tools would be registered. Set settings.warnOnLargeDirectTools to false to hide this advisory.`);
   }
 
-  return specs;
+  return emittedSpecs;
 }
 
 /**

--- a/failure-backoff.ts
+++ b/failure-backoff.ts
@@ -1,0 +1,23 @@
+import type { McpExtensionState } from "./state.ts";
+
+export const FAILURE_BACKOFF_MS = 60 * 1000;
+
+export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {
+  const failedAt = state.failureTracker.get(serverName);
+  if (!failedAt) return null;
+  const ageMs = Date.now() - failedAt;
+  if (ageMs > FAILURE_BACKOFF_MS) return null;
+  return Math.round(ageMs / 1000);
+}
+
+export function getFailureMessage(state: McpExtensionState, serverName: string): string | null {
+  if (getFailureAgeSeconds(state, serverName) === null) return null;
+  return state.failureMessages?.get(serverName) ?? null;
+}
+
+export function isServerInActiveFailureBackoff(state: McpExtensionState, serverName: string): boolean {
+  const connection = state.manager.getConnection(serverName);
+  return connection?.status !== "connected"
+    && connection?.status !== "needs-auth"
+    && getFailureAgeSeconds(state, serverName) !== null;
+}

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, 
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, prepareDirectToolArguments, resolveDirectTools } from "./direct-tools.ts";
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
+import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
 import { logger } from "./logger.ts";
@@ -250,10 +251,16 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     });
   }
 
-  function resolveCurrentDirectTools(config: McpConfig, cache: MetadataCache | null): DirectToolSpec[] {
+  function activeFailureServers(): Set<string> {
+    const currentState = state;
+    if (!currentState) return new Set();
+    return new Set(Object.keys(currentState.config.mcpServers).filter((serverName) => isServerInActiveFailureBackoff(currentState, serverName)));
+  }
+
+  function resolveCurrentDirectTools(config: McpConfig, cache: MetadataCache | null, reservedNames?: Set<string>): DirectToolSpec[] {
     if (envRaw === "__none__") return [];
     const prefix = config.settings?.toolPrefix ?? "server";
-    return resolveDirectTools(config, cache, prefix, envDirectToolOverride);
+    return resolveDirectTools(config, cache, prefix, envDirectToolOverride, activeFailureServers(), reservedNames);
   }
 
   function getActiveToolsIfReady(): string[] | undefined {
@@ -287,11 +294,14 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   function syncDirectTools(config: McpConfig, cache: MetadataCache | null): {
     specs: DirectToolSpec[];
+    reservedDirectNames: Set<string>;
+    activeDirectNames: Set<string>;
     added: string[];
     updated: string[];
     deactivated: string[];
   } {
-    const specs = resolveCurrentDirectTools(config, cache);
+    const reservedDirectNames = new Set<string>();
+    const specs = resolveCurrentDirectTools(config, cache, reservedDirectNames);
     const nextNames = new Set(specs.map((spec) => spec.prefixedName));
     const added: string[] = [];
     const updated: string[] = [];
@@ -320,7 +330,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
 
     deactivateTools(deactivated);
-    return { specs, added, updated, deactivated };
+    return { specs, reservedDirectNames, activeDirectNames: nextNames, added, updated, deactivated };
   }
 
   function applyDirectToolConfigChanges(changes: Map<string, true | string[] | false>): void {
@@ -337,7 +347,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const cache = loadMetadataCache();
     const result = syncDirectTools(config, cache);
     syncProxyTool(config, cache, result.specs);
-    syncNamespaceTools(config, cache);
+    syncNamespaceTools(config, cache, result.reservedDirectNames, result.activeDirectNames);
     const changed = result.added.length + result.updated.length + result.deactivated.length;
     if (changed > 0 && ctx?.hasUI) {
       ctx.ui.notify(
@@ -347,13 +357,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
   }
 
-  function syncNamespaceTools(config: McpConfig, cache: MetadataCache | null): void {
+  function syncNamespaceTools(
+    config: McpConfig,
+    cache: MetadataCache | null,
+    reservedDirectNames: Set<string> = new Set(registeredDirectTools.keys()),
+    activeDirectNames: Set<string> = new Set(registeredDirectTools.keys()),
+  ): void {
     const result = syncNamespaceProxyTools({
       config,
       cache,
       envOverride: namespaceEnvOverride,
-      existingDirectNames: new Set(registeredDirectTools.keys()),
+      existingDirectNames: reservedDirectNames,
+      activeDirectNames,
       existingNamespaceNames: registeredNamespaceProxyTools,
+      unavailableServers: activeFailureServers(),
       pi,
       getState: () => state,
       getInitPromise: () => initPromise,
@@ -1115,13 +1132,13 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
   }
 
-  const initialDirectTools = syncDirectTools(earlyConfig, earlyCache).specs;
-  syncProxyTool(earlyConfig, earlyCache, initialDirectTools);
+  const initialDirectResult = syncDirectTools(earlyConfig, earlyCache);
+  syncProxyTool(earlyConfig, earlyCache, initialDirectResult.specs);
   // Register namespace-proxy tools eagerly so tool-groups/slow-mode can validate
   // `mcp:<server>` references on the first session_start turn. Without this
   // eager call, the tool-groups expansion runs before MCP initialization
   // completes and emits false `[unknown-tool] mcp__<server>` diagnostics.
-  syncNamespaceTools(earlyConfig, earlyCache);
+  syncNamespaceTools(earlyConfig, earlyCache, initialDirectResult.reservedDirectNames, initialDirectResult.activeDirectNames);
   startLoadTimeInitialization();
 }
 

--- a/init.ts
+++ b/init.ts
@@ -37,8 +37,9 @@ import {
   type McpRuntimeOwner,
 } from "./runtime-owner.ts";
 import { publishMcpStatusSnapshot } from "./mcp-status.ts";
+import { FAILURE_BACKOFF_MS, getFailureAgeSeconds } from "./failure-backoff.ts";
+export { getFailureAgeSeconds, getFailureMessage, isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
-const FAILURE_BACKOFF_MS = 60 * 1000;
 const MAX_FAILURE_MESSAGE_CHARS = 8 * 1024;
 const failureExpiryTimers = new WeakMap<McpExtensionState, Map<string, ReturnType<typeof setTimeout>>>();
 
@@ -51,13 +52,19 @@ function getFailureExpiryTimers(state: McpExtensionState): Map<string, ReturnTyp
   return timers;
 }
 
-export function clearFailure(state: McpExtensionState, serverName: string): void {
+export function clearFailure(state: McpExtensionState, serverName: string, restoredReason?: string): boolean {
+  const wasActive = getFailureAgeSeconds(state, serverName) !== null;
   state.failureTracker.delete(serverName);
   state.failureMessages?.delete(serverName);
   const timers = failureExpiryTimers.get(state);
   const timer = timers?.get(serverName);
   if (timer) clearTimeout(timer);
   timers?.delete(serverName);
+  if (restoredReason && wasActive) {
+    notifyToolMetadataUpdated(state, serverName, restoredReason);
+    publishMcpStatusSnapshot(state);
+  }
+  return wasActive;
 }
 
 export function recordFailure(state: McpExtensionState, serverName: string, message: string): void {
@@ -73,12 +80,15 @@ export function recordFailure(state: McpExtensionState, serverName: string, mess
     if (state.failureTracker.get(serverName) === failedAt) {
       state.failureTracker.delete(serverName);
       state.failureMessages?.delete(serverName);
+      notifyToolMetadataUpdated(state, serverName, "failure-backoff-expired");
       publishMcpStatusSnapshot(state);
     }
     getFailureExpiryTimers(state).delete(serverName);
   }, FAILURE_BACKOFF_MS);
   timer.unref?.();
   getFailureExpiryTimers(state).set(serverName, timer);
+  notifyToolMetadataUpdated(state, serverName, "failure-backoff-started");
+  publishMcpStatusSnapshot(state);
 }
 
 export function isTuiMode(ctx: Pick<ExtensionContext, "hasUI" | "mode">): boolean {
@@ -407,9 +417,9 @@ export async function initializeMcp(
             }
             updateServerMetadata(state, name);
             updateMetadataCache(state, name);
-            notifyToolMetadataUpdated(state, name, "direct-tools-bootstrap");
+            const restored = clearFailure(state, name, "direct-tools-bootstrap");
+            if (!restored) notifyToolMetadataUpdated(state, name, "direct-tools-bootstrap");
             markKeepAliveAfterConnect(state, name);
-            clearFailure(state, name);
             return { name, ok: true };
           } catch (error) {
             if (isAbortError(error, runtimeSignal)) {
@@ -435,8 +445,8 @@ export async function initializeMcp(
     if (!owner.isActive()) return;
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
-    notifyToolMetadataUpdated(state, serverName, "lifecycle-reconnect");
-    clearFailure(state, serverName);
+    const restored = clearFailure(state, serverName, "lifecycle-reconnect");
+    if (!restored) notifyToolMetadataUpdated(state, serverName, "lifecycle-reconnect");
     updateStatusBar(state);
   });
 
@@ -449,13 +459,13 @@ export async function initializeMcp(
 
   lifecycle.setHealthRestoredCallback((serverName) => {
     if (!owner.isActive()) return;
-    clearFailure(state, serverName);
+    clearFailure(state, serverName, "health-restored");
     updateStatusBar(state);
   });
 
   lifecycle.setAuthRequiredCallback((serverName) => {
     if (!owner.isActive()) return;
-    clearFailure(state, serverName);
+    clearFailure(state, serverName, "auth-required");
     updateStatusBar(state);
   });
 
@@ -617,19 +627,6 @@ export function updateStatusBar(state: McpExtensionState): void {
   ui.setStatus("mcp", ui.theme ? ui.theme.fg("accent", formattedStatus) : formattedStatus);
 }
 
-export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {
-  const failedAt = state.failureTracker.get(serverName);
-  if (!failedAt) return null;
-  const ageMs = Date.now() - failedAt;
-  if (ageMs > FAILURE_BACKOFF_MS) return null;
-  return Math.round(ageMs / 1000);
-}
-
-export function getFailureMessage(state: McpExtensionState, serverName: string): string | null {
-  if (getFailureAgeSeconds(state, serverName) === null) return null;
-  return state.failureMessages?.get(serverName) ?? null;
-}
-
 export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
@@ -658,10 +655,10 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     if (newConnection.status === "needs-auth") {
       return false;
     }
-    clearFailure(state, serverName);
     updateServerMetadata(state, serverName);
     updateMetadataCache(state, serverName);
-    notifyToolMetadataUpdated(state, serverName, "lazy-connect");
+    const restored = clearFailure(state, serverName, "lazy-connect");
+    if (!restored) notifyToolMetadataUpdated(state, serverName, "lazy-connect");
     markKeepAliveAfterConnect(state, serverName);
     updateStatusBar(state);
     return true;

--- a/mcp-code.ts
+++ b/mcp-code.ts
@@ -5,6 +5,7 @@ import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from 
 import { executeCall } from "./proxy-modes.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import { paginate, rankSuggestions, rankToolMatches } from "./search-ranking.ts";
+import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import type { McpExtensionState } from "./state.ts";
 import { findToolByName, formatSchema } from "./tool-metadata.ts";
 import { renderTsShape } from "./ts-shape.ts";
@@ -202,6 +203,7 @@ export async function runMcpScript(
     let error: unknown;
     try {
       for (const [server, metadata] of state.toolMetadata) {
+        if (isServerInActiveFailureBackoff(state, server)) continue;
         const tool = findToolByName(metadata, path);
         if (!tool) continue;
         const inputTypeScript = tool.inputSchema

--- a/mcp-status.ts
+++ b/mcp-status.ts
@@ -6,16 +6,7 @@ import {
   type McpStatusEventBus,
   type McpStatusSnapshot,
 } from "./types.ts";
-
-const FAILURE_BACKOFF_MS = 60 * 1000;
-
-function getActiveFailureAgeSeconds(state: McpExtensionState, serverName: string): number | undefined {
-  const failedAt = state.failureTracker.get(serverName);
-  if (!failedAt) return undefined;
-  const ageMs = Date.now() - failedAt;
-  if (ageMs > FAILURE_BACKOFF_MS) return undefined;
-  return Math.round(ageMs / 1000);
-}
+import { getFailureAgeSeconds, isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 /** Build a sanitized snapshot without connecting or querying any MCP server. */
 export function createMcpStatusSnapshot(state: McpExtensionState): McpStatusSnapshot {
@@ -29,12 +20,13 @@ export function createMcpStatusSnapshot(state: McpExtensionState): McpStatusSnap
     const definition = state.config.mcpServers[name];
     const disabled = definition?.disabled === true;
     const connection = disabled ? undefined : state.manager.getConnection(name);
-    const metadata = disabled ? undefined : state.toolMetadata.get(name);
+    const failedAgoSeconds = disabled ? null : getFailureAgeSeconds(state, name);
+    const activeFailure = !disabled && isServerInActiveFailureBackoff(state, name);
+    const metadata = disabled || activeFailure ? undefined : state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? (connection?.status === "connected" ? connection.tools.length : 0);
-    const resourceCount = disabled
+    const resourceCount = disabled || activeFailure
       ? undefined
       : state.resourceCounts?.get(name) ?? (connection?.status === "connected" ? connection.resources.length : undefined);
-    const failedAgoSeconds = disabled ? undefined : getActiveFailureAgeSeconds(state, name);
 
     let status: McpServerStatusSnapshot["status"] = "not-connected";
     if (disabled) {
@@ -45,7 +37,7 @@ export function createMcpStatusSnapshot(state: McpExtensionState): McpStatusSnap
       connectedCount++;
     } else if (connection?.status === "needs-auth") {
       status = "needs-auth";
-    } else if (failedAgoSeconds !== undefined) {
+    } else if (activeFailure) {
       status = "failed";
     } else if (metadata !== undefined) {
       status = "cached";
@@ -58,7 +50,7 @@ export function createMcpStatusSnapshot(state: McpExtensionState): McpStatusSnap
       status,
       toolCount,
       ...(resourceCount !== undefined ? { resourceCount } : {}),
-      ...(status === "failed" && failedAgoSeconds !== undefined ? { failedAgoSeconds } : {}),
+      ...(status === "failed" && failedAgoSeconds !== null ? { failedAgoSeconds } : {}),
       disabled,
     });
   }

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -76,13 +76,14 @@ function resolveNamespaceProxyTools(
   cache: MetadataCache | null,
   envOverride: DirectToolSelectorOverride | null,
   existingDirectNames: Set<string>,
+  unavailableServers: ReadonlySet<string>,
 ): NamespaceProxySpec[] {
   if (!config || !cache) return [];
   return filterCollidingNamespaceProxyTools(
     Object.keys(config.mcpServers)
       .map((serverName) => namespaceProxyCandidate(config, cache, envOverride, existingDirectNames, serverName))
       .filter((spec): spec is NamespaceProxySpec => spec !== null),
-  );
+  ).filter((spec) => !unavailableServers.has(spec.serverName));
 }
 
 /**
@@ -158,7 +159,9 @@ export interface SyncNamespaceProxyToolsInput {
   cache: MetadataCache | null;
   envOverride: DirectToolSelectorOverride | null;
   existingDirectNames: Set<string>;
+  activeDirectNames?: ReadonlySet<string>;
   existingNamespaceNames: Set<string>;
+  unavailableServers?: ReadonlySet<string>;
   pi: ExtensionAPI;
   getState: GetState;
   getInitPromise: GetInitPromise;
@@ -220,8 +223,9 @@ function getActiveToolsForStaleCleanup(pi: ExtensionAPI, staleNames: string[]): 
 }
 
 function deactivateStaleNamespaceTools(input: SyncNamespaceProxyToolsInput, nextNames: Set<string>): string[] {
+  const activeDirectNames = input.activeDirectNames ?? new Set<string>();
   const staleNames = [...input.existingNamespaceNames].filter(
-    (name) => !nextNames.has(name) && !input.existingDirectNames.has(name),
+    (name) => !nextNames.has(name) && !activeDirectNames.has(name),
   );
   const deactivated: string[] = [];
   const unregisterTool = (input.pi as unknown as {
@@ -253,6 +257,7 @@ export function syncNamespaceProxyTools(input: SyncNamespaceProxyToolsInput): Sy
     input.cache,
     input.envOverride,
     input.existingDirectNames,
+    input.unavailableServers ?? new Set(),
   );
   const nextNames = new Set(specs.map((s) => s.toolName));
   const result: SyncNamespaceProxyToolsResult = { specs, added: [], updated: [], deactivated: [] };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "search-ranking.ts",
     "tool-approval.ts",
     "init.ts",
+    "failure-backoff.ts",
     "ui-session.ts",
     "proxy-modes.ts",
     "direct-tools.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -18,6 +18,7 @@ import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from ".
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
+import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -51,6 +52,15 @@ function getEnabledToolMatches(state: McpExtensionState, toolName: string, exact
     for (const tool of getToolMatches(metadata, toolName, exact)) matches.push({ server, tool });
   }
   return matches;
+}
+
+function serverBackoffResult(state: McpExtensionState, mode: string, serverName: string): ProxyToolResult {
+  const failedAgo = getFailureAgeSeconds(state, serverName) ?? 0;
+  const message = `Server "${serverName}" not available (last failed ${failedAgo}s ago)`;
+  return {
+    content: [{ type: "text" as const, text: message }],
+    details: { mode, error: "server_backoff", server: serverName },
+  };
 }
 
 function getSingleToolMatch(metadata: ToolMetadata[] | undefined, toolName: string): ToolMetadata | "ambiguous" | undefined {
@@ -284,7 +294,6 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
     const disabled = isServerDisabled(definition);
     const connection = disabled ? undefined : state.manager.getConnection(name);
     const metadata = disabled ? undefined : state.toolMetadata.get(name);
-    const toolCount = metadata?.length ?? 0;
     const failedAgo = disabled ? null : getFailureAgeSeconds(state, name);
     let status = disabled ? "disabled" : "not connected";
     if (!disabled && connection?.status === "connected") {
@@ -296,6 +305,8 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
     } else if (!disabled && metadata !== undefined) {
       status = "cached";
     }
+
+    const toolCount = status === "failed" ? 0 : metadata?.length ?? 0;
 
     servers.push({ name, status, toolCount, failedAgo, ...(disabled ? { disabled: true } : {}) });
   }
@@ -418,7 +429,7 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
     }
 
     await state.manager.close(serverName);
-    clearFailure(state, serverName);
+    clearFailure(state, serverName, "auth-complete");
     updateStatusBar(state);
     return {
       content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.` }],
@@ -434,15 +445,17 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
 }
 
 export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
-  const exactMatches = getEnabledToolMatches(state, toolName, true);
+  const exactMatches = getEnabledToolMatches(state, toolName, true)
+    .filter((match) => !isServerInActiveFailureBackoff(state, match.server));
   if (exactMatches.length > 1) return ambiguousToolResult("describe", toolName);
-  if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).length > 1) {
+  if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).filter((match) => !isServerInActiveFailureBackoff(state, match.server)).length > 1) {
     return ambiguousToolResult("describe", toolName);
   }
 
   let serverName = exactMatches[0]?.server;
   let toolMeta = exactMatches[0]?.tool;
   let disabledMatch: string | undefined;
+  let failedMatch: string | undefined;
 
   if (!toolMeta) {
     for (const [server, metadata] of state.toolMetadata.entries()) {
@@ -450,6 +463,10 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
       if (!found) continue;
       if (isServerDisabled(state.config.mcpServers[server])) {
         disabledMatch ??= server;
+        continue;
+      }
+      if (isServerInActiveFailureBackoff(state, server)) {
+        failedMatch ??= server;
         continue;
       }
       serverName = server;
@@ -460,6 +477,7 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
 
   if (!serverName || !toolMeta) {
     if (disabledMatch) return disabledResult("describe", disabledMatch);
+    if (failedMatch) return serverBackoffResult(state, "describe", failedMatch);
     const suggestions = rankSuggestions(state, toolName, 5);
     const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
     return {
@@ -504,6 +522,7 @@ export function executeSearch(
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
   if (server && isServerDisabled(state.config.mcpServers[server])) return disabledResult("search", server);
+  if (server && isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "search", server);
 
   let matches: Array<{ server: string; tool: ToolMetadata; score: number }>;
   if (regex) {
@@ -545,6 +564,7 @@ export function executeSearch(
     for (const [serverName, metadata] of state.toolMetadata.entries()) {
       const definition = state.config.mcpServers[serverName];
       if (isServerDisabled(definition)) continue;
+      if (isServerInActiveFailureBackoff(state, serverName)) continue;
       if (server && serverName !== server) continue;
       for (const tool of metadata) {
         const matched = pattern.test(tool.name) || pattern.test(tool.description)
@@ -644,6 +664,12 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
   const metadata = state.toolMetadata.get(server);
   const toolNames = metadata?.map(m => m.name) ?? [];
   const connection = state.manager.getConnection(server);
+  if (isServerInActiveFailureBackoff(state, server)) {
+    return {
+      ...serverBackoffResult(state, "list", server),
+      details: { mode: "list", server, tools: [], count: 0, error: "server_backoff" },
+    };
+  }
   const instructions = state.serverInstructions.get(server);
   let instructionsText = "";
   if (instructions) {
@@ -708,6 +734,7 @@ export function executeInstructions(state: McpExtensionState, server: string): P
     };
   }
   if (isServerDisabled(definition)) return disabledResult("instructions", server);
+  if (isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "instructions", server);
 
   const instructions = state.serverInstructions.get(server);
   if (instructions) {
@@ -787,9 +814,9 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
       state.serverInstructions.delete(serverName);
     }
     updateMetadataCache(state, serverName);
-    notifyToolMetadataUpdated(state, serverName, "proxy-connect");
+    const restored = clearFailure(state, serverName, "proxy-connect");
+    if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-connect");
     markKeepAliveAfterConnect(state, serverName);
-    clearFailure(state, serverName);
     updateStatusBar(state);
     return executeList(state, serverName);
   } catch (error) {
@@ -1100,10 +1127,10 @@ export async function executeCall(
           };
         }
       }
-      clearFailure(state, serverName);
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
-      notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
+      const restored = clearFailure(state, serverName, "proxy-call-reconnect");
+      if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
       markKeepAliveAfterConnect(state, serverName);
       updateStatusBar(state);
       const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);

--- a/search-ranking.ts
+++ b/search-ranking.ts
@@ -1,6 +1,7 @@
 import type { McpExtensionState } from "./state.ts";
 import type { ServerEntry, ToolMetadata, ToolPrefix } from "./types.ts";
 import { getServerPrefix, getToolNameCandidates, isServerDisabled, matchesToolPattern, resolveToolPrefix } from "./types.ts";
+import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 /**
  * Shortest field token allowed to stem-match a longer query token.
@@ -242,6 +243,7 @@ export function rankToolMatches(
     if (server && serverName !== server) continue;
     const definition = state.config.mcpServers[serverName];
     if (isServerDisabled(definition)) continue;
+    if (isServerInActiveFailureBackoff(state, serverName)) continue;
     for (const prepared of getPreparedTools(state, serverName, metadata, definition, globalPrefix, includeKeywords)) {
       const score = scorePreparedToolMatch(prepared, normalizedQuery, queryTokens);
       if (score !== null) matches.push({ server: serverName, tool: prepared.tool, score });


### PR DESCRIPTION
## Problem

During the 60-second failure backoff window, `lazyConnect` already refuses to reconnect — but search, list, and status still advertised that server's cached tools as if they were callable. Two other lies in status: a connected server with zero tools looked healthy, and a disconnected server with no cached metadata showed **0 tools** instead of “we do not know.”

## Fix

- Recently-failed servers are left out of search, ranking, list, and tool totals, with a plain note (`Excluded while failing (retry after reconnect): …`)
- Connected empty servers get a warning glyph, not a checkmark
- Disconnected servers without metadata: “count unknown”, not zero
- A successful reconnect still clears the failure immediately; after 60s the window expires on its own

The 60s constant, previously copied in `init.ts` and `mcp-status.ts`, now lives once in `types.ts`.

Typecheck clean; full suite green (1,291 tests). Recut onto current `main` (`4755775`).

Note: this and the type-cycle cleanup both touch `mcp-status.ts` / `types.ts`. Independent on `main`; if one merges first, the other may need a rebase.