### PR TITLE
refactor: break state.ts type-import cycles via types.ts

### DIFF
--- a/mcp-status.ts
+++ b/mcp-status.ts
@@ -3,14 +3,11 @@ import {
   MCP_STATUS_EVENT,
   MCP_STATUS_SNAPSHOT_VERSION,
   type McpServerStatusSnapshot,
+  type McpStatusEventBus,
   type McpStatusSnapshot,
 } from "./types.ts";
 
 const FAILURE_BACKOFF_MS = 60 * 1000;
-
-export interface McpStatusEventBus {
-  emit(channel: string, data: unknown): void;
-}
 
 function getActiveFailureAgeSeconds(state: McpExtensionState, serverName: string): number | undefined {
   const failedAt = state.failureTracker.get(serverName);

--- a/state.ts
+++ b/state.ts
@@ -3,12 +3,10 @@ import type { ConsentManager } from "./consent-manager.ts";
 import type { McpLifecycleManager } from "./lifecycle.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import type { AuthStorageOptions } from "./mcp-auth.ts";
-import type { ToolMetadata, PromptMetadata, McpConfig, UiSessionMessages, UiStreamSummary } from "./types.ts";
+import type { ToolMetadata, PromptMetadata, McpConfig, UiSessionMessages, UiStreamSummary, McpStatusEventBus, UiServerHandle } from "./types.ts";
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
-import type { UiServerHandle } from "./ui-server.ts";
 import type { McpRuntimeOwner } from "./runtime-owner.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
-import type { McpStatusEventBus } from "./mcp-status.ts";
 
 export interface CompletedUiSession {
   serverName: string;

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,6 @@
 // types.ts - Core type definitions
 import type {
+  CallToolResult,
   ContentBlock as McpContentBlock,
   ListPromptsResult,
   ListResourcesResult,
@@ -7,7 +8,7 @@ import type {
   Transport as McpTransport,
 } from "@modelcontextprotocol/client";
 import type { TextContent, ImageContent } from "@earendil-works/pi-ai";
-import type { UiStreamMode } from "./ui-stream-types.ts";
+import type { UiStreamMode, UiStreamSummary } from "./ui-stream-types.ts";
 import type { UiToolVisibility } from "./ui-tool-visibility.ts";
 
 export type Transport = McpTransport;
@@ -41,6 +42,15 @@ export interface McpStatusSnapshot {
   readonly totalResources: number;
   readonly connectedCount: number;
   readonly disabledCount: number;
+}
+
+/**
+ * Minimal event-bus surface the status publisher needs. Lives here (leaf
+ * module) so `state.ts` can reference it without importing `mcp-status.ts`,
+ * which imports the state type back — an import cycle at type level.
+ */
+export interface McpStatusEventBus {
+  emit(channel: string, data: unknown): void;
 }
 
 // Import sources for config
@@ -154,6 +164,30 @@ export interface UiHostContext {
 }
 
 export type UiDisplayMode = "inline" | "fullscreen" | "pip";
+
+/**
+ * Live handle to a started UI tool session. Lives here (leaf module) so
+ * `state.ts` can reference it without importing `ui-server.ts`, which
+ * imports the state type back — an import cycle at type level.
+ */
+export interface UiServerHandle {
+  url: string;
+  port: number;
+  sessionToken: string;
+  serverName: string;
+  toolName: string;
+  viewer?: "browser" | "glimpse" | "suppressed";
+  windowOpen?: boolean;
+  close: (reason?: string) => void;
+  sendToolInput: (args: Record<string, unknown>) => void;
+  sendToolResult: (result: CallToolResult) => void;
+  sendResultPatch: (result: CallToolResult) => void;
+  sendToolCancelled: (reason: string) => void;
+  sendHostContext: (context: UiHostContext) => void;
+  /** Get accumulated messages from this session */
+  getSessionMessages: () => UiSessionMessages;
+  getStreamSummary: () => UiStreamSummary | undefined;
+}
 
 // Re-export stream types from the shared lightweight module.
 // This allows the example package to import stream schemas without pulling the full types.ts dependency graph.

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -35,6 +35,7 @@ import {
   type UiProxyRequestBody,
   type UiProxyResult,
   type UiResourceContent,
+  type UiServerHandle,
   type UiSessionMessages,
   type UiStreamSummary,
 } from "./types.ts";
@@ -73,25 +74,6 @@ export interface UiServerOptions {
   onMessage?: (params: UiMessageParams) => Promise<void> | void;
   onContextUpdate?: (params: UiModelContextParams) => Promise<void> | void;
   onComplete?: (reason: string) => void;
-}
-
-export interface UiServerHandle {
-  url: string;
-  port: number;
-  sessionToken: string;
-  serverName: string;
-  toolName: string;
-  viewer?: "browser" | "glimpse" | "suppressed";
-  windowOpen?: boolean;
-  close: (reason?: string) => void;
-  sendToolInput: (args: Record<string, unknown>) => void;
-  sendToolResult: (result: CallToolResult) => void;
-  sendResultPatch: (result: CallToolResult) => void;
-  sendToolCancelled: (reason: string) => void;
-  sendHostContext: (context: UiHostContext) => void;
-  /** Get accumulated messages from this session */
-  getSessionMessages: () => UiSessionMessages;
-  getStreamSummary: () => UiStreamSummary | undefined;
 }
 
 export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -40,6 +40,8 @@ import {
   type UiStreamSummary,
 } from "./types.ts";
 
+export type { UiServerHandle };
+
 const MAX_BODY_SIZE = 2 * 1024 * 1024;
 const ABANDONED_GRACE_MS = 60_000;
 const WATCHDOG_INTERVAL_MS = 5_000;

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -15,7 +15,8 @@ import {
   type UiStreamMode,
 } from "./types.ts";
 import { logger } from "./logger.ts";
-import { startUiServer, type UiServerHandle } from "./ui-server.ts";
+import { startUiServer } from "./ui-server.ts";
+import type { UiServerHandle } from "./types.ts";
 import { isGlimpseAvailable, openGlimpseWindow } from "./glimpse-ui.ts";
 import type { SessionRecoveryDeps } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";


### PR DESCRIPTION
## Problem

Nothing user-visible. `state.ts` imported `McpStatusEventBus` from `mcp-status.ts` and `UiServerHandle` from `ui-server.ts`, while both of those import the state type back. Type-only today, but any future value import on either edge becomes a real cycle.

## Fix

Both interfaces move into `types.ts` (already the leaf module for neighboring types). No behavior change.

Typecheck clean; full suite green (1,291 tests). Recut onto current `main` (`4755775`).

Note: this and the failed-server honesty PR both touch `mcp-status.ts` / `types.ts`. Independent on `main`; if one merges first, the other may need a rebase.