### PR TITLE
docs: align MCP instructions wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ When `includeSchemas` is enabled, search and describe render common JSON Schema 
 
 For HTTP servers, Pi reports HTTP 503 as temporary unavailability and does not add another immediate retry loop. Keep-alive servers keep cached metadata available and retry after 30 seconds, backing off to 5 minutes. Other failed connects run a one-request shape probe that can turn opaque transport errors into setup hints such as `endpoint returned HTML (200) — this URL does not appear to speak MCP`. Healthy connections are not probed.
 
-Servers that provide usage guidance via the MCP `instructions` field surface it at three levels: a truncated head in the `mcp` proxy tool description itself (so the model sees it without any call), a longer preview at the end of `mcp({ server: "name" })` listings, and the full text via `mcp({ instructions: "name" })`. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
+Servers that provide usage guidance via the MCP `instructions` field surface it through discovery paths: `mcp({ server: "name" })` includes a preview, and `mcp({ instructions: "name" })` returns the full text. Instructions are captured at connect time and cached alongside tool metadata, so they stay available without a live connection.
 
 ## Commands
 


### PR DESCRIPTION
Updates the README to match the current stable `mcp` proxy description behavior from #432. Server instructions now stay in discovery/status/instructions paths instead of the proxy tool description.

Validation: `git diff --check origin/main...HEAD` passed.

No release or tag action.
