### PR TITLE
docs: link DeepSeek Harness third-party bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pi install npm:pi-mcp-adapter
 
 Restart Pi after installation.
 
+> **DeepSeek Harness (third-party bridge):** Run the unmodified adapter in DSH via [pi2dsh](https://github.com/weijiafu14/pi2dsh); see the [verified dsh-TUI and Web MCP guide](https://github.com/weijiafu14/pi2dsh/tree/main/examples/tui-mcp).
+
 ## What happens on first run
 
 The adapter reads standard MCP files automatically. No extra setup needed if you already have them.


### PR DESCRIPTION
## Summary

- add the requested one-line DeepSeek Harness note under Install;
- frame pi2dsh explicitly as a third-party bridge;
- link the verified dsh-TUI and Web MCP guide rather than duplicating setup details here.

This follows the maintainer guidance in #438.

## Testing

Not run (documentation-only change).
