### PR TITLE
feat: bridge proxy tool-call progress to UI via request-local onprogress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Persistent metadata cache entries now honor server-advertised `ttlMs` hints without extending the default max age. Thanks to [@Seinra](https://github.com/Seinra) for #431.
+- Proxy tool calls now forward server progress notifications to the interactive UI notification path via the MCP SDK's request-local `onprogress` option. Thanks to [@Seinra](https://github.com/Seinra) for mapping the area in #431.
 - Added a pure `mcp:` reference resolver API for consumers that validate adapter tool names from explicit config and cache inputs. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420.
 - Direct tools can opt into strict advertised-schema validation with one-layer JSON recovery for object and array properties. Thanks to [@4ndr3wxh1ll](https://github.com/4ndr3wxh1ll) for PR #430.
 - Direct tools can opt into guarded raw MCP result details, retaining bounded structured fields while summarizing oversized values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Persistent metadata cache entries now honor server-advertised `ttlMs` hints without extending the default max age. Thanks to [@Seinra](https://github.com/Seinra) for #431.
-- Proxy tool calls now forward server progress notifications to the interactive UI notification path via the MCP SDK's request-local `onprogress` option. Thanks to [@Seinra](https://github.com/Seinra) for mapping the area in #431.
+- Proxy tool calls now forward server progress notifications to the interactive UI notification path via the MCP SDK's request-local `onprogress` option. Thanks to [@Seinra](https://github.com/Seinra) for PR #440 and for mapping the area in #431.
 - Added a pure `mcp:` reference resolver API for consumers that validate adapter tool names from explicit config and cache inputs. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420.
 - Direct tools can opt into strict advertised-schema validation with one-layer JSON recovery for object and array properties. Thanks to [@4ndr3wxh1ll](https://github.com/4ndr3wxh1ll) for PR #430.
 - Direct tools can opt into guarded raw MCP result details, retaining bounded structured fields while summarizing oversized values.

--- a/__tests__/proxy-modes-auto-auth.test.ts
+++ b/__tests__/proxy-modes-auto-auth.test.ts
@@ -445,7 +445,7 @@ describe("proxy auto auth", () => {
       name: "search",
       arguments: { q: "hello" },
       _meta: undefined,
-    }, { timeout: 1234 });
+    }, expect.objectContaining({ timeout: 1234, onprogress: expect.any(Function) }));
     expect(result.content[0].text).toContain("ok");
   });
 

--- a/__tests__/proxy-progress.test.ts
+++ b/__tests__/proxy-progress.test.ts
@@ -1,22 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { executeCall } from "../proxy-modes.ts";
 
-function connectedState(
-  client: Record<string, unknown>,
-  ui?: { notify: ReturnType<typeof vi.fn> },
-) {
+function connectedState(client: Record<string, unknown>, ui?: { notify: ReturnType<typeof vi.fn> }) {
   return {
     config: {
       settings: { toolPrefix: "server" },
       mcpServers: { demo: { command: "node", args: ["server.js"] } },
     },
     manager: {
-      getConnection: vi.fn(() => ({
-        status: "connected",
-        client,
-        tools: [],
-        resources: [],
-      })),
+      getConnection: vi.fn(() => ({ status: "connected", client, tools: [], resources: [] })),
       touch: vi.fn(),
       incrementInFlight: vi.fn(),
       decrementInFlight: vi.fn(),
@@ -45,16 +37,7 @@ describe("request-local progress bridging", () => {
   it("attaches an onprogress bridge to callTool when a UI is available", async () => {
     const notify = vi.fn();
     const callTool = vi.fn(
-      (
-        _params: unknown,
-        options?: {
-          onprogress?: (p: {
-            progress: number;
-            total?: number;
-            message?: string;
-          }) => void;
-        },
-      ) => {
+      (_params: unknown, options?: { onprogress?: (p: { progress: number; total?: number; message?: string }) => void }) => {
         options?.onprogress?.({ progress: 3, total: 10 });
         options?.onprogress?.({ progress: 9, total: 10, message: "indexing" });
         return Promise.resolve({ content: [{ type: "text", text: "done" }] });
@@ -66,61 +49,67 @@ describe("request-local progress bridging", () => {
 
     expect(callTool).toHaveBeenCalledWith(
       { name: "long", arguments: {}, _meta: undefined },
-      expect.objectContaining({
-        timeout: 5_000,
-        onprogress: expect.any(Function),
-      }),
+      expect.objectContaining({ timeout: 5_000, onprogress: expect.any(Function) }),
     );
     expect(notify).toHaveBeenCalledTimes(2);
-    expect(notify).toHaveBeenNthCalledWith(1, "MCP long: 3/10", "info");
-    expect(notify).toHaveBeenNthCalledWith(
-      2,
-      "MCP long: indexing (9/10)",
-      "info",
+    expect(notify).toHaveBeenNthCalledWith(1, expect.stringMatching(/^MCP demo\/long#\d+: 3\/10$/), "info");
+    expect(notify).toHaveBeenNthCalledWith(2, expect.stringMatching(/^MCP demo\/long#\d+: indexing \(9\/10\)$/), "info");
+  });
+
+  it("distinguishes overlapping calls to the same server tool", async () => {
+    const notify = vi.fn();
+    const progressCallbacks: Array<(p: { progress: number; total?: number; message?: string }) => void> = [];
+    const resolvers: Array<() => void> = [];
+    const callTool = vi.fn(
+      (_params: unknown, options?: { onprogress?: (p: { progress: number; total?: number; message?: string }) => void }) => {
+        progressCallbacks.push(options!.onprogress!);
+        return new Promise<{ content: Array<{ type: "text"; text: string }> }>((resolve) => {
+          resolvers.push(() => resolve({ content: [{ type: "text", text: "done" }] }));
+        });
+      },
     );
+    const state = connectedState({ callTool }, { notify });
+
+    const first = executeCall(state, "demo_long", {});
+    const second = executeCall(state, "demo_long", {});
+    for (let i = 0; i < 10 && progressCallbacks.length < 2; i++) await Promise.resolve();
+
+    expect(progressCallbacks).toHaveLength(2);
+    progressCallbacks[0]!({ progress: 1 });
+    progressCallbacks[1]!({ progress: 1 });
+    expect(notify.mock.calls[0]![0]).toMatch(/^MCP demo\/long#\d+: 1$/);
+    expect(notify.mock.calls[1]![0]).toMatch(/^MCP demo\/long#\d+: 1$/);
+    expect(notify.mock.calls[0]![0]).not.toBe(notify.mock.calls[1]![0]);
+
+    resolvers.forEach((resolve) => resolve());
+    await Promise.all([first, second]);
   });
 
   it("does not attach onprogress when no UI is available", async () => {
-    const callTool = vi.fn(async () => ({
-      content: [{ type: "text", text: "done" }],
-    }));
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "done" }] }));
     const state = connectedState({ callTool });
 
     await executeCall(state, "demo_long", {});
 
-    const options = callTool.mock.calls[0][1] as
-      | Record<string, unknown>
-      | undefined;
+    const options = callTool.mock.calls[0][1] as Record<string, unknown> | undefined;
     expect(options).toEqual({ timeout: 5_000 });
     expect(Object.hasOwn(options ?? {}, "onprogress")).toBe(false);
   });
 
   it("preserves the manager request options alongside the progress bridge", async () => {
     const notify = vi.fn();
-    let capturedOptions:
-      | { signal?: AbortSignal; onprogress?: unknown }
-      | undefined;
-    const callTool = vi.fn(
-      (_params: unknown, options?: typeof capturedOptions) => {
-        capturedOptions = options;
-        return Promise.resolve({ content: [{ type: "text", text: "done" }] });
-      },
-    );
+    let capturedOptions: { signal?: AbortSignal; onprogress?: unknown } | undefined;
+    const callTool = vi.fn((_params: unknown, options?: typeof capturedOptions) => {
+      capturedOptions = options;
+      return Promise.resolve({ content: [{ type: "text", text: "done" }] });
+    });
     const controller = new AbortController();
     const state = connectedState({ callTool }, { notify });
-    state.manager.getRequestOptions = vi.fn(
-      (_server: string, signal?: AbortSignal) =>
-        signal ? { signal } : undefined,
+    state.manager.getRequestOptions = vi.fn((_server: string, signal?: AbortSignal) =>
+      signal ? { signal } : undefined,
     );
 
-    await executeCall(
-      state,
-      "demo_long",
-      {},
-      undefined,
-      undefined,
-      controller.signal,
-    );
+    await executeCall(state, "demo_long", {}, undefined, undefined, controller.signal);
 
     expect(capturedOptions?.signal).toBe(controller.signal);
     expect(typeof capturedOptions?.onprogress).toBe("function");

--- a/__tests__/proxy-progress.test.ts
+++ b/__tests__/proxy-progress.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeCall } from "../proxy-modes.ts";
+
+function connectedState(client: Record<string, unknown>, ui?: { notify: ReturnType<typeof vi.fn> }) {
+  return {
+    config: {
+      settings: { toolPrefix: "server" },
+      mcpServers: { demo: { command: "node", args: ["server.js"] } },
+    },
+    manager: {
+      getConnection: vi.fn(() => ({ status: "connected", client, tools: [], resources: [] })),
+      touch: vi.fn(),
+      incrementInFlight: vi.fn(),
+      decrementInFlight: vi.fn(),
+      close: vi.fn(async () => undefined),
+      getRequestOptions: vi.fn(() => ({ timeout: 5_000 })),
+    },
+    toolMetadata: new Map([
+      [
+        "demo",
+        [
+          {
+            name: "demo_long",
+            originalName: "long",
+            description: "Long-running tool",
+          },
+        ],
+      ],
+    ]),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    ui,
+  } as any;
+}
+
+describe("request-local progress bridging", () => {
+  it("attaches an onprogress bridge to callTool when a UI is available", async () => {
+    const notify = vi.fn();
+    const callTool = vi.fn(
+      (_params: unknown, options?: { onprogress?: (p: { progress: number; total?: number; message?: string }) => void }) => {
+        options?.onprogress?.({ progress: 3, total: 10 });
+        options?.onprogress?.({ progress: 9, total: 10, message: "indexing" });
+        return Promise.resolve({ content: [{ type: "text", text: "done" }] });
+      },
+    );
+    const state = connectedState({ callTool }, { notify });
+
+    await executeCall(state, "demo_long", {});
+
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "long", arguments: {}, _meta: undefined },
+      expect.objectContaining({ timeout: 5_000, onprogress: expect.any(Function) }),
+    );
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenNthCalledWith(1, "MCP long: 3/10", "info");
+    expect(notify).toHaveBeenNthCalledWith(2, "indexing (9/10)", "info");
+  });
+
+  it("does not attach onprogress when no UI is available", async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "done" }] }));
+    const state = connectedState({ callTool });
+
+    await executeCall(state, "demo_long", {});
+
+    const options = callTool.mock.calls[0][1] as Record<string, unknown> | undefined;
+    expect(options).toEqual({ timeout: 5_000 });
+    expect(Object.hasOwn(options ?? {}, "onprogress")).toBe(false);
+  });
+
+  it("preserves the manager request options alongside the progress bridge", async () => {
+    const notify = vi.fn();
+    let capturedOptions: { signal?: AbortSignal; onprogress?: unknown } | undefined;
+    const callTool = vi.fn((_params: unknown, options?: typeof capturedOptions) => {
+      capturedOptions = options;
+      return Promise.resolve({ content: [{ type: "text", text: "done" }] });
+    });
+    const controller = new AbortController();
+    const state = connectedState({ callTool }, { notify });
+    state.manager.getRequestOptions = vi.fn((_server: string, signal?: AbortSignal) =>
+      signal ? { signal } : undefined,
+    );
+
+    await executeCall(state, "demo_long", {}, undefined, undefined, controller.signal);
+
+    expect(capturedOptions?.signal).toBe(controller.signal);
+    expect(typeof capturedOptions?.onprogress).toBe("function");
+  });
+});

--- a/__tests__/proxy-progress.test.ts
+++ b/__tests__/proxy-progress.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { executeCall } from "../proxy-modes.ts";
 
-function connectedState(client: Record<string, unknown>, ui?: { notify: ReturnType<typeof vi.fn> }) {
+function connectedState(
+  client: Record<string, unknown>,
+  ui?: { notify: ReturnType<typeof vi.fn> },
+) {
   return {
     config: {
       settings: { toolPrefix: "server" },
       mcpServers: { demo: { command: "node", args: ["server.js"] } },
     },
     manager: {
-      getConnection: vi.fn(() => ({ status: "connected", client, tools: [], resources: [] })),
+      getConnection: vi.fn(() => ({
+        status: "connected",
+        client,
+        tools: [],
+        resources: [],
+      })),
       touch: vi.fn(),
       incrementInFlight: vi.fn(),
       decrementInFlight: vi.fn(),
@@ -37,7 +45,16 @@ describe("request-local progress bridging", () => {
   it("attaches an onprogress bridge to callTool when a UI is available", async () => {
     const notify = vi.fn();
     const callTool = vi.fn(
-      (_params: unknown, options?: { onprogress?: (p: { progress: number; total?: number; message?: string }) => void }) => {
+      (
+        _params: unknown,
+        options?: {
+          onprogress?: (p: {
+            progress: number;
+            total?: number;
+            message?: string;
+          }) => void;
+        },
+      ) => {
         options?.onprogress?.({ progress: 3, total: 10 });
         options?.onprogress?.({ progress: 9, total: 10, message: "indexing" });
         return Promise.resolve({ content: [{ type: "text", text: "done" }] });
@@ -49,38 +66,61 @@ describe("request-local progress bridging", () => {
 
     expect(callTool).toHaveBeenCalledWith(
       { name: "long", arguments: {}, _meta: undefined },
-      expect.objectContaining({ timeout: 5_000, onprogress: expect.any(Function) }),
+      expect.objectContaining({
+        timeout: 5_000,
+        onprogress: expect.any(Function),
+      }),
     );
     expect(notify).toHaveBeenCalledTimes(2);
     expect(notify).toHaveBeenNthCalledWith(1, "MCP long: 3/10", "info");
-    expect(notify).toHaveBeenNthCalledWith(2, "indexing (9/10)", "info");
+    expect(notify).toHaveBeenNthCalledWith(
+      2,
+      "MCP long: indexing (9/10)",
+      "info",
+    );
   });
 
   it("does not attach onprogress when no UI is available", async () => {
-    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "done" }] }));
+    const callTool = vi.fn(async () => ({
+      content: [{ type: "text", text: "done" }],
+    }));
     const state = connectedState({ callTool });
 
     await executeCall(state, "demo_long", {});
 
-    const options = callTool.mock.calls[0][1] as Record<string, unknown> | undefined;
+    const options = callTool.mock.calls[0][1] as
+      | Record<string, unknown>
+      | undefined;
     expect(options).toEqual({ timeout: 5_000 });
     expect(Object.hasOwn(options ?? {}, "onprogress")).toBe(false);
   });
 
   it("preserves the manager request options alongside the progress bridge", async () => {
     const notify = vi.fn();
-    let capturedOptions: { signal?: AbortSignal; onprogress?: unknown } | undefined;
-    const callTool = vi.fn((_params: unknown, options?: typeof capturedOptions) => {
-      capturedOptions = options;
-      return Promise.resolve({ content: [{ type: "text", text: "done" }] });
-    });
+    let capturedOptions:
+      | { signal?: AbortSignal; onprogress?: unknown }
+      | undefined;
+    const callTool = vi.fn(
+      (_params: unknown, options?: typeof capturedOptions) => {
+        capturedOptions = options;
+        return Promise.resolve({ content: [{ type: "text", text: "done" }] });
+      },
+    );
     const controller = new AbortController();
     const state = connectedState({ callTool }, { notify });
-    state.manager.getRequestOptions = vi.fn((_server: string, signal?: AbortSignal) =>
-      signal ? { signal } : undefined,
+    state.manager.getRequestOptions = vi.fn(
+      (_server: string, signal?: AbortSignal) =>
+        signal ? { signal } : undefined,
     );
 
-    await executeCall(state, "demo_long", {}, undefined, undefined, controller.signal);
+    await executeCall(
+      state,
+      "demo_long",
+      {},
+      undefined,
+      undefined,
+      controller.signal,
+    );
 
     expect(capturedOptions?.signal).toBe(controller.signal);
     expect(typeof capturedOptions?.onprogress).toBe("function");

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,23 +1,84 @@
-import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
-import { UrlElicitationRequiredError, type Client, type Progress, type RequestOptions } from "@modelcontextprotocol/client";
+import type {
+  AgentToolResult,
+  ToolInfo,
+} from "@earendil-works/pi-coding-agent";
+import {
+  UrlElicitationRequiredError,
+  type Client,
+  type Progress,
+  type RequestOptions,
+} from "@modelcontextprotocol/client";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
-import { getServerPrefix, isServerDisabled, parseUiPromptHandoff } from "./types.ts";
-import { lazyConnect, markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
+import {
+  getServerPrefix,
+  isServerDisabled,
+  parseUiPromptHandoff,
+} from "./types.ts";
+import {
+  lazyConnect,
+  markKeepAliveAfterConnect,
+  notifyToolMetadataUpdated,
+  updateServerMetadata,
+  updateMetadataCache,
+  getFailureAgeSeconds,
+  updateStatusBar,
+  clearFailure,
+  recordFailure,
+} from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
-import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
+import {
+  buildToolMetadata,
+  getToolNames,
+  findToolByName,
+  formatSchema,
+} from "./tool-metadata.ts";
 import { renderTsShape } from "./ts-shape.ts";
 import { reconstructPromptMetadata } from "./metadata-cache.ts";
-import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
-import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
-import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
-import { formatAuthRequiredMessage, formatMcpStatus, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
-import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
-import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
-import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
-import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
+import {
+  resolveMcpResultContent,
+  transformMcpContent,
+  transformMcpResourceContents,
+} from "./tool-registrar.ts";
+import {
+  guardMcpOutput,
+  guardedMcpDetails,
+  resolveMcpOutputGuardOptions,
+} from "./mcp-output-guard.ts";
+import {
+  maybeStartUiSession,
+  summarizeUiSessionResult,
+  type UiSessionRuntime,
+} from "./ui-session.ts";
+import {
+  formatAuthRequiredMessage,
+  formatMcpStatus,
+  normalizeToolArguments,
+  resolveServerUrl,
+  truncateAtWord,
+} from "./utils.ts";
+import {
+  authenticate,
+  completeAuthFromInput,
+  startAuth,
+  supportsOAuth,
+} from "./mcp-auth-flow.ts";
+import {
+  SessionRecoveryAuthRequiredError,
+  withSessionRecovery,
+} from "./session-recovery.ts";
+import {
+  paginate,
+  rankSuggestions,
+  rankToolMatches,
+  resolveSearchKeywords,
+} from "./search-ranking.ts";
+import {
+  ensureToolCallApproved,
+  isToolCallApprovalRequired,
+} from "./tool-approval.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
@@ -30,8 +91,8 @@ const INSTRUCTIONS_PREVIEW_LENGTH = 300;
 const REGEX_SAFETY_CHECK_PARAMS = {
   attackTimeout: 50,
   incubationTimeout: 50,
-      timeout: 250,
-    } as const;
+  timeout: 250,
+} as const;
 
 type AutoAuthResult =
   | { status: "skipped" }
@@ -53,28 +114,48 @@ function withUiProgressBridge(
     ...options,
     onprogress: (progress: Progress) => {
       const ratio = `${progress.progress}${progress.total === undefined ? "" : `/${progress.total}`}`;
-      ui.notify(progress.message ? `${progress.message} (${ratio})` : `MCP ${toolName}: ${ratio}`, "info");
+      ui.notify(
+        progress.message
+          ? `MCP ${toolName}: ${progress.message} (${ratio})`
+          : `MCP ${toolName}: ${ratio}`,
+        "info",
+      );
     },
   };
 }
 
-function getToolMatches(metadata: ToolMetadata[] | undefined, toolName: string, exact: boolean): ToolMetadata[] {
+function getToolMatches(
+  metadata: ToolMetadata[] | undefined,
+  toolName: string,
+  exact: boolean,
+): ToolMetadata[] {
   if (!metadata) return [];
-  if (exact) return metadata.filter(tool => tool.name === toolName);
+  if (exact) return metadata.filter((tool) => tool.name === toolName);
   const normalizedName = toolName.replace(/-/g, "_");
-  return metadata.filter(tool => tool.name.replace(/-/g, "_") === normalizedName);
+  return metadata.filter(
+    (tool) => tool.name.replace(/-/g, "_") === normalizedName,
+  );
 }
 
-function getEnabledToolMatches(state: McpExtensionState, toolName: string, exact: boolean): { server: string; tool: ToolMetadata }[] {
+function getEnabledToolMatches(
+  state: McpExtensionState,
+  toolName: string,
+  exact: boolean,
+): { server: string; tool: ToolMetadata }[] {
   const matches: { server: string; tool: ToolMetadata }[] = [];
   for (const [server, metadata] of state.toolMetadata) {
     if (isServerDisabled(state.config.mcpServers[server])) continue;
-    for (const tool of getToolMatches(metadata, toolName, exact)) matches.push({ server, tool });
+    for (const tool of getToolMatches(metadata, toolName, exact))
+      matches.push({ server, tool });
   }
   return matches;
 }
 
-function serverBackoffResult(state: McpExtensionState, mode: string, serverName: string): ProxyToolResult {
+function serverBackoffResult(
+  state: McpExtensionState,
+  mode: string,
+  serverName: string,
+): ProxyToolResult {
   const failedAgo = getFailureAgeSeconds(state, serverName) ?? 0;
   const message = `Server "${serverName}" not available (last failed ${failedAgo}s ago)`;
   return {
@@ -83,17 +164,31 @@ function serverBackoffResult(state: McpExtensionState, mode: string, serverName:
   };
 }
 
-function getSingleToolMatch(metadata: ToolMetadata[] | undefined, toolName: string): ToolMetadata | "ambiguous" | undefined {
+function getSingleToolMatch(
+  metadata: ToolMetadata[] | undefined,
+  toolName: string,
+): ToolMetadata | "ambiguous" | undefined {
   const exactMatches = getToolMatches(metadata, toolName, true);
-  const matches = exactMatches.length > 0 ? exactMatches : getToolMatches(metadata, toolName, false);
+  const matches =
+    exactMatches.length > 0
+      ? exactMatches
+      : getToolMatches(metadata, toolName, false);
   return matches.length > 1 ? "ambiguous" : matches[0];
 }
 
-function ambiguousToolResult(mode: "call" | "describe", toolName: string): ProxyToolResult {
+function ambiguousToolResult(
+  mode: "call" | "describe",
+  toolName: string,
+): ProxyToolResult {
   const message = `Tool "${toolName}" matches multiple servers. Specify a server.`;
   return {
     content: [{ type: "text" as const, text: message }],
-    details: { mode, error: "ambiguous_tool", requestedTool: toolName, message },
+    details: {
+      mode,
+      error: "ambiguous_tool",
+      requestedTool: toolName,
+      message,
+    },
   };
 }
 
@@ -113,7 +208,11 @@ function getAuthRequiredMessage(
   return formatAuthRequiredMessage(state.config, serverName, defaultMessage);
 }
 
-function getAuthFailedMessage(state: McpExtensionState, serverName: string, message: string): string {
+function getAuthFailedMessage(
+  state: McpExtensionState,
+  serverName: string,
+  message: string,
+): string {
   const customGuidance = state.config.settings?.authRequiredMessage;
   if (customGuidance) {
     return `OAuth authentication failed for "${serverName}": ${message}. ${getAuthRequiredMessage(state, serverName)}`;
@@ -123,7 +222,9 @@ function getAuthFailedMessage(state: McpExtensionState, serverName: string, mess
 
 function getRedirectPort(authorizationUrl: string): number | undefined {
   try {
-    const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
+    const redirectUri = new URL(authorizationUrl).searchParams.get(
+      "redirect_uri",
+    );
     if (!redirectUri) return undefined;
     const port = Number.parseInt(new URL(redirectUri).port, 10);
     return Number.isInteger(port) ? port : undefined;
@@ -132,7 +233,10 @@ function getRedirectPort(authorizationUrl: string): number | undefined {
   }
 }
 
-function formatManualAuthInstructions(serverName: string, authorizationUrl: string): string {
+function formatManualAuthInstructions(
+  serverName: string,
+  authorizationUrl: string,
+): string {
   const port = getRedirectPort(authorizationUrl);
   const portNote = port
     ? `\nThe redirect URL will use local port ${port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
@@ -150,7 +254,9 @@ function formatManualAuthInstructions(serverName: string, authorizationUrl: stri
     "",
     'You can also pass just the `code` query parameter as `args: { code: "PASTE_CODE_HERE" }`. JSON-string args remain supported.',
     portNote.trimEnd(),
-  ].filter(Boolean).join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 async function attemptAutoAuth(
@@ -163,7 +269,11 @@ async function attemptAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (!definition || isServerDisabled(definition) || !supportsOAuth(definition)) {
+  if (
+    !definition ||
+    isServerDisabled(definition) ||
+    !supportsOAuth(definition)
+  ) {
     return { status: "skipped" };
   }
 
@@ -172,13 +282,18 @@ async function attemptAutoAuth(
     serverUrl = resolveServerUrl(definition);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { status: "failed", message: getAuthFailedMessage(state, serverName, message) };
+    return {
+      status: "failed",
+      message: getAuthFailedMessage(state, serverName, message),
+    };
   }
   if (!serverUrl) {
     return { status: "skipped" };
   }
 
-  const grantType = definition.oauth ? definition.oauth.grantType ?? "authorization_code" : "authorization_code";
+  const grantType = definition.oauth
+    ? (definition.oauth.grantType ?? "authorization_code")
+    : "authorization_code";
   if (!state.ui && grantType !== "client_credentials") {
     return {
       status: "failed",
@@ -197,14 +312,26 @@ async function attemptAutoAuth(
         serverUrl,
         definition,
         signal
-          ? { authStorageOptions: state.authStorageOptions, signal, runtime: state.oauthRuntime }
-          : { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime },
+          ? {
+              authStorageOptions: state.authStorageOptions,
+              signal,
+              runtime: state.oauthRuntime,
+            }
+          : {
+              authStorageOptions: state.authStorageOptions,
+              runtime: state.oauthRuntime,
+            },
       );
     } else {
       if (signal) {
-        await authenticate(serverName, serverUrl, definition, { signal, runtime: state.oauthRuntime });
+        await authenticate(serverName, serverUrl, definition, {
+          signal,
+          runtime: state.oauthRuntime,
+        });
       } else {
-        await authenticate(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
+        await authenticate(serverName, serverUrl, definition, {
+          runtime: state.oauthRuntime,
+        });
       }
     }
     return { status: "success" };
@@ -223,22 +350,32 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 
   if (sessions.length === 0) {
     return {
-      content: [{ type: "text" as const, text: "No UI session messages available." }],
+      content: [
+        { type: "text" as const, text: "No UI session messages available." },
+      ],
       details: { sessions: 0 },
     };
   }
 
   const output: string[] = [];
-  output.push(`UI Session Messages (${sessions.length} session${sessions.length > 1 ? "s" : ""}):\n`);
+  output.push(
+    `UI Session Messages (${sessions.length} session${sessions.length > 1 ? "s" : ""}):\n`,
+  );
 
   const allPrompts: string[] = [];
   const allIntents = sessions.flatMap((session) => session.messages.intents);
   const allContexts = sessions.flatMap((session) => session.messages.contexts);
-  const parsedHandoffs: Array<{ intent: string; params: Record<string, unknown>; raw: string }> = [];
+  const parsedHandoffs: Array<{
+    intent: string;
+    params: Record<string, unknown>;
+    raw: string;
+  }> = [];
 
   for (const session of sessions) {
     const timestamp = session.completedAt.toLocaleTimeString();
-    output.push(`\n## ${session.serverName} / ${session.toolName} (${timestamp}, ${session.reason})`);
+    output.push(
+      `\n## ${session.serverName} / ${session.toolName} (${timestamp}, ${session.reason})`,
+    );
 
     const plainPrompts: string[] = [];
     for (const prompt of session.messages.prompts) {
@@ -269,7 +406,9 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     if (intentsForSession.length > 0) {
       output.push("\n### Intents:");
       for (const intent of intentsForSession) {
-        const params = intent.params ? ` (${JSON.stringify(intent.params)})` : "";
+        const params = intent.params
+          ? ` (${JSON.stringify(intent.params)})`
+          : "";
         output.push(`- ${intent.intent}${params}`);
       }
     }
@@ -278,7 +417,9 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     if (contexts.length > 0) {
       output.push("\n### Context updates:");
       for (const context of contexts) {
-        output.push(`- ${context.summary}${context.truncated ? " (truncated)" : ""}`);
+        output.push(
+          `- ${context.summary}${context.truncated ? " (truncated)" : ""}`,
+        );
       }
     }
 
@@ -298,7 +439,10 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     details: {
       sessions: count,
       prompts: allPrompts,
-      intents: [...allIntents, ...parsedHandoffs.map(({ intent, params }) => ({ intent, params }))],
+      intents: [
+        ...allIntents,
+        ...parsedHandoffs.map(({ intent, params }) => ({ intent, params })),
+      ],
       contexts: allContexts,
       handoffs: parsedHandoffs,
       cleared: true,
@@ -307,7 +451,13 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 }
 
 export function executeStatus(state: McpExtensionState): ProxyToolResult {
-  const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null; disabled?: boolean }> = [];
+  const servers: Array<{
+    name: string;
+    status: string;
+    toolCount: number;
+    failedAgo: number | null;
+    disabled?: boolean;
+  }> = [];
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const definition = state.config.mcpServers[name];
@@ -326,15 +476,23 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
       status = "cached";
     }
 
-    const toolCount = status === "failed" ? 0 : metadata?.length ?? 0;
+    const toolCount = status === "failed" ? 0 : (metadata?.length ?? 0);
 
-    servers.push({ name, status, toolCount, failedAgo, ...(disabled ? { disabled: true } : {}) });
+    servers.push({
+      name,
+      status,
+      toolCount,
+      failedAgo,
+      ...(disabled ? { disabled: true } : {}),
+    });
   }
 
-  const disabledCount = servers.filter(s => s.disabled).length;
-  const enabledServers = servers.filter(s => !s.disabled);
+  const disabledCount = servers.filter((s) => s.disabled).length;
+  const enabledServers = servers.filter((s) => !s.disabled);
   const totalTools = enabledServers.reduce((sum, s) => sum + s.toolCount, 0);
-  const connectedCount = enabledServers.filter(s => s.status === "connected").length;
+  const connectedCount = enabledServers.filter(
+    (s) => s.status === "connected",
+  ).length;
 
   let text = `MCP: ${connectedCount}/${enabledServers.length} servers, ${totalTools} tools`;
   if (disabledCount > 0) text += ` (${disabledCount} disabled)`;
@@ -369,82 +527,180 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "status", servers, totalTools, connectedCount, disabledCount },
+    details: {
+      mode: "status",
+      servers,
+      totalTools,
+      connectedCount,
+      disabledCount,
+    },
   };
 }
 
-export async function executeAuthStart(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+export async function executeAuthStart(
+  state: McpExtensionState,
+  serverName: string,
+  signal?: AbortSignal,
+): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
       details: { mode: "auth-start", error: "not_found", server: serverName },
     };
   }
-  if (isServerDisabled(definition)) return disabledResult("auth-start", serverName);
+  if (isServerDisabled(definition))
+    return disabledResult("auth-start", serverName);
 
   try {
     const serverUrl = resolveServerUrl(definition);
     if (!serverUrl || !supportsOAuth(definition)) {
       return {
-        content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
-        details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
+        content: [
+          {
+            type: "text" as const,
+            text: `Server "${serverName}" is not configured for OAuth over HTTP.`,
+          },
+        ],
+        details: {
+          mode: "auth-start",
+          error: "oauth_not_supported",
+          server: serverName,
+        },
       };
     }
 
     const { authorizationUrl } = state.authStorageOptions
       ? ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
-        : await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
+        ? await startAuth(serverName, serverUrl, definition, {
+            authStorageOptions: state.authStorageOptions,
+            signal: ownedSignal,
+            runtime: state.oauthRuntime,
+          })
+        : await startAuth(serverName, serverUrl, definition, {
+            authStorageOptions: state.authStorageOptions,
+            runtime: state.oauthRuntime,
+          })
       : ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, { signal: ownedSignal, runtime: state.oauthRuntime })
-        : await startAuth(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
+        ? await startAuth(serverName, serverUrl, definition, {
+            signal: ownedSignal,
+            runtime: state.oauthRuntime,
+          })
+        : await startAuth(serverName, serverUrl, definition, {
+            runtime: state.oauthRuntime,
+          });
     if (!authorizationUrl) {
       return {
-        content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
-        details: { mode: "auth-start", server: serverName, authenticated: true },
+        content: [
+          {
+            type: "text" as const,
+            text: `OAuth authentication successful for "${serverName}".`,
+          },
+        ],
+        details: {
+          mode: "auth-start",
+          server: serverName,
+          authenticated: true,
+        },
       };
     }
 
     return {
-      content: [{ type: "text" as const, text: formatManualAuthInstructions(serverName, authorizationUrl) }],
+      content: [
+        {
+          type: "text" as const,
+          text: formatManualAuthInstructions(serverName, authorizationUrl),
+        },
+      ],
       details: { mode: "auth-start", server: serverName, authorizationUrl },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {
-      content: [{ type: "text" as const, text: `Failed to start OAuth for "${serverName}": ${message}` }],
-      details: { mode: "auth-start", error: "auth_start_failed", server: serverName, message },
+      content: [
+        {
+          type: "text" as const,
+          text: `Failed to start OAuth for "${serverName}": ${message}`,
+        },
+      ],
+      details: {
+        mode: "auth-start",
+        error: "auth_start_failed",
+        server: serverName,
+        message,
+      },
     };
   }
 }
 
-export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+export async function executeAuthComplete(
+  state: McpExtensionState,
+  serverName: string,
+  input: string,
+  signal?: AbortSignal,
+): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
-      details: { mode: "auth-complete", error: "not_found", server: serverName },
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
+      details: {
+        mode: "auth-complete",
+        error: "not_found",
+        server: serverName,
+      },
     };
   }
-  if (isServerDisabled(definition)) return disabledResult("auth-complete", serverName);
+  if (isServerDisabled(definition))
+    return disabledResult("auth-complete", serverName);
 
   try {
     const status = state.authStorageOptions
       ? ownedSignal
-        ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
-        : await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
+        ? await completeAuthFromInput(serverName, input, {
+            authStorageOptions: state.authStorageOptions,
+            signal: ownedSignal,
+            runtime: state.oauthRuntime,
+          })
+        : await completeAuthFromInput(serverName, input, {
+            authStorageOptions: state.authStorageOptions,
+            runtime: state.oauthRuntime,
+          })
       : ownedSignal
-        ? await completeAuthFromInput(serverName, input, { signal: ownedSignal, runtime: state.oauthRuntime })
-        : await completeAuthFromInput(serverName, input, { runtime: state.oauthRuntime });
+        ? await completeAuthFromInput(serverName, input, {
+            signal: ownedSignal,
+            runtime: state.oauthRuntime,
+          })
+        : await completeAuthFromInput(serverName, input, {
+            runtime: state.oauthRuntime,
+          });
     if (status !== "authenticated") {
       return {
-        content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],
-        details: { mode: "auth-complete", error: "not_authenticated", server: serverName, status },
+        content: [
+          {
+            type: "text" as const,
+            text: `OAuth authentication did not complete for "${serverName}".`,
+          },
+        ],
+        details: {
+          mode: "auth-complete",
+          error: "not_authenticated",
+          server: serverName,
+          status,
+        },
       };
     }
 
@@ -452,23 +708,51 @@ export async function executeAuthComplete(state: McpExtensionState, serverName: 
     clearFailure(state, serverName, "auth-complete");
     updateStatusBar(state);
     return {
-      content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.` }],
-      details: { mode: "auth-complete", server: serverName, authenticated: true },
+      content: [
+        {
+          type: "text" as const,
+          text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.`,
+        },
+      ],
+      details: {
+        mode: "auth-complete",
+        server: serverName,
+        authenticated: true,
+      },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {
-      content: [{ type: "text" as const, text: `Failed to complete OAuth for "${serverName}": ${message}` }],
-      details: { mode: "auth-complete", error: "auth_complete_failed", server: serverName, message },
+      content: [
+        {
+          type: "text" as const,
+          text: `Failed to complete OAuth for "${serverName}": ${message}`,
+        },
+      ],
+      details: {
+        mode: "auth-complete",
+        error: "auth_complete_failed",
+        server: serverName,
+        message,
+      },
     };
   }
 }
 
-export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
-  const exactMatches = getEnabledToolMatches(state, toolName, true)
-    .filter((match) => !isServerInActiveFailureBackoff(state, match.server));
+export function executeDescribe(
+  state: McpExtensionState,
+  toolName: string,
+): ProxyToolResult {
+  const exactMatches = getEnabledToolMatches(state, toolName, true).filter(
+    (match) => !isServerInActiveFailureBackoff(state, match.server),
+  );
   if (exactMatches.length > 1) return ambiguousToolResult("describe", toolName);
-  if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).filter((match) => !isServerInActiveFailureBackoff(state, match.server)).length > 1) {
+  if (
+    exactMatches.length === 0 &&
+    getEnabledToolMatches(state, toolName, false).filter(
+      (match) => !isServerInActiveFailureBackoff(state, match.server),
+    ).length > 1
+  ) {
     return ambiguousToolResult("describe", toolName);
   }
 
@@ -499,14 +783,30 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
     if (disabledMatch) return disabledResult("describe", disabledMatch);
     if (failedMatch) return serverBackoffResult(state, "describe", failedMatch);
     const suggestions = rankSuggestions(state, toolName, 5);
-    const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
+    const suggestionText =
+      suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
     return {
-      content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.${suggestionText}` }],
-      details: { mode: "describe", error: "tool_not_found", requestedTool: toolName, suggestions },
+      content: [
+        {
+          type: "text" as const,
+          text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.${suggestionText}`,
+        },
+      ],
+      details: {
+        mode: "describe",
+        error: "tool_not_found",
+        requestedTool: toolName,
+        suggestions,
+      },
     };
   }
 
-  const approvalMarker = isToolCallApprovalRequired(state.config, serverName, toolMeta, state.toolMetadata)
+  const approvalMarker = isToolCallApprovalRequired(
+    state.config,
+    serverName,
+    toolMeta,
+    state.toolMetadata,
+  )
     ? " (requires approval)"
     : "";
   let text = `${toolMeta.name}${approvalMarker}\n`;
@@ -518,7 +818,10 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
 
   if (toolMeta.inputSchema && !toolMeta.resourceUri) {
     const shape = renderTsShape(toolMeta.inputSchema);
-    text += shape === null ? `\nParameters:\n${formatSchema(toolMeta.inputSchema)}` : `\nShape:\n${shape}`;
+    text +=
+      shape === null
+        ? `\nParameters:\n${formatSchema(toolMeta.inputSchema)}`
+        : `\nShape:\n${shape}`;
   } else if (toolMeta.resourceUri) {
     text += `\nNo parameters required (resource tool).`;
   } else {
@@ -541,8 +844,10 @@ export function executeSearch(
   offset = 0,
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
-  if (server && isServerDisabled(state.config.mcpServers[server])) return disabledResult("search", server);
-  if (server && isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "search", server);
+  if (server && isServerDisabled(state.config.mcpServers[server]))
+    return disabledResult("search", server);
+  if (server && isServerInActiveFailureBackoff(state, server))
+    return serverBackoffResult(state, "search", server);
 
   let matches: Array<{ server: string; tool: ToolMetadata; score: number }>;
   if (regex) {
@@ -550,8 +855,18 @@ export function executeSearch(
     try {
       if (query.length > MAX_REGEX_SEARCH_QUERY_LENGTH) {
         return {
-          content: [{ type: "text" as const, text: `Regex query is too long; maximum length is ${MAX_REGEX_SEARCH_QUERY_LENGTH} characters.` }],
-          details: { mode: "search", error: "query_too_long", query, maxLength: MAX_REGEX_SEARCH_QUERY_LENGTH },
+          content: [
+            {
+              type: "text" as const,
+              text: `Regex query is too long; maximum length is ${MAX_REGEX_SEARCH_QUERY_LENGTH} characters.`,
+            },
+          ],
+          details: {
+            mode: "search",
+            error: "query_too_long",
+            query,
+            maxLength: MAX_REGEX_SEARCH_QUERY_LENGTH,
+          },
         };
       }
       pattern = new RegExp(query, "i");
@@ -562,14 +877,29 @@ export function executeSearch(
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
         return {
-          content: [{ type: "text" as const, text: "Regex query rejected because safety analysis failed." }],
+          content: [
+            {
+              type: "text" as const,
+              text: "Regex query rejected because safety analysis failed.",
+            },
+          ],
           details: { mode: "search", error: "unsafe_pattern", query, reason },
         };
       }
       if (safety.status !== "safe") {
         return {
-          content: [{ type: "text" as const, text: `Regex query rejected as unsafe (${safety.status}).` }],
-          details: { mode: "search", error: "unsafe_pattern", query, safetyStatus: safety.status },
+          content: [
+            {
+              type: "text" as const,
+              text: `Regex query rejected as unsafe (${safety.status}).`,
+            },
+          ],
+          details: {
+            mode: "search",
+            error: "unsafe_pattern",
+            query,
+            safetyStatus: safety.status,
+          },
         };
       }
     } catch {
@@ -587,20 +917,29 @@ export function executeSearch(
       if (isServerInActiveFailureBackoff(state, serverName)) continue;
       if (server && serverName !== server) continue;
       for (const tool of metadata) {
-        const matched = pattern.test(tool.name) || pattern.test(tool.description)
-          || resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix).some(keyword => pattern.test(keyword));
+        const matched =
+          pattern.test(tool.name) ||
+          pattern.test(tool.description) ||
+          resolveSearchKeywords(
+            definition,
+            tool.originalName,
+            serverName,
+            globalPrefix,
+          ).some((keyword) => pattern.test(keyword));
         if (matched) matches.push({ server: serverName, tool, score: 0 });
       }
     }
   } else if (query.trim().length === 0) {
     if (!server) {
       return {
-        content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+        content: [
+          { type: "text" as const, text: "Search query cannot be empty" },
+        ],
         details: { mode: "search", error: "empty_query" },
       };
     }
     matches = (state.toolMetadata.get(server) ?? [])
-      .map(tool => ({ server, tool, score: 0 }))
+      .map((tool) => ({ server, tool, score: 0 }))
       .sort((a, b) => a.tool.name.localeCompare(b.tool.name));
   } else {
     matches = rankToolMatches(state, query, server);
@@ -609,16 +948,25 @@ export function executeSearch(
   const page = paginate(matches, offset, limit);
   if (page.total === 0) {
     const connectingServers = server
-      ? state.config.mcpServers[server] && state.manager.isConnecting(server) ? [server] : []
+      ? state.config.mcpServers[server] && state.manager.isConnecting(server)
+        ? [server]
+        : []
       : Object.keys(state.config.mcpServers)
-        .filter(name => !isServerDisabled(state.config.mcpServers[name]) && state.manager.isConnecting(name))
-        .sort((a, b) => a.localeCompare(b));
-    const msg = server ? `No tools matching "${query}" in "${server}"` : `No tools matching "${query}"`;
-    const connectingMessage = connectingServers.length === 1
-      ? ` Server "${connectingServers[0]}" is still connecting; retry in a moment.`
-      : connectingServers.length > 1
-        ? ` Servers ${connectingServers.map(name => `"${name}"`).join(", ")} are still connecting; retry in a moment.`
-        : "";
+          .filter(
+            (name) =>
+              !isServerDisabled(state.config.mcpServers[name]) &&
+              state.manager.isConnecting(name),
+          )
+          .sort((a, b) => a.localeCompare(b));
+    const msg = server
+      ? `No tools matching "${query}" in "${server}"`
+      : `No tools matching "${query}"`;
+    const connectingMessage =
+      connectingServers.length === 1
+        ? ` Server "${connectingServers[0]}" is still connecting; retry in a moment.`
+        : connectingServers.length > 1
+          ? ` Servers ${connectingServers.map((name) => `"${name}"`).join(", ")} are still connecting; retry in a moment.`
+          : "";
     return {
       content: [{ type: "text" as const, text: `${msg}${connectingMessage}` }],
       details: {
@@ -635,7 +983,12 @@ export function executeSearch(
 
   let text = `Found ${page.total} tool${page.total === 1 ? "" : "s"} matching "${query}":\n\n`;
   for (const match of page.items) {
-    const approvalMarker = isToolCallApprovalRequired(state.config, match.server, match.tool, state.toolMetadata)
+    const approvalMarker = isToolCallApprovalRequired(
+      state.config,
+      match.server,
+      match.tool,
+      state.toolMetadata,
+    )
       ? " (requires approval)"
       : "";
     if (showSchemas) {
@@ -643,26 +996,36 @@ export function executeSearch(
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
         const shape = renderTsShape(match.tool.inputSchema);
-        text += shape === null
-          ? `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
-          : `\n  Shape:\n${shape.split("\n").map(line => `    ${line}`).join("\n")}\n`;
+        text +=
+          shape === null
+            ? `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
+            : `\n  Shape:\n${shape
+                .split("\n")
+                .map((line) => `    ${line}`)
+                .join("\n")}\n`;
       } else if (match.tool.resourceUri) {
         text += "  No parameters (resource tool).\n";
       }
       text += "\n";
     } else {
       text += `- ${match.tool.name}${approvalMarker}`;
-      if (match.tool.description) text += ` - ${truncateAtWord(match.tool.description, 50)}`;
+      if (match.tool.description)
+        text += ` - ${truncateAtWord(match.tool.description, 50)}`;
       text += "\n";
     }
   }
-  if (page.hasMore) text += `\n${page.items.length} of ${page.total} — offset: ${page.nextOffset} for more\n`;
+  if (page.hasMore)
+    text += `\n${page.items.length} of ${page.total} — offset: ${page.nextOffset} for more\n`;
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
     details: {
       mode: "search",
-      matches: page.items.map(match => ({ server: match.server, tool: match.tool.name, score: match.score })),
+      matches: page.items.map((match) => ({
+        server: match.server,
+        tool: match.tool.name,
+        score: match.score,
+      })),
       count: page.total,
       hasMore: page.hasMore,
       nextOffset: page.nextOffset,
@@ -671,23 +1034,43 @@ export function executeSearch(
   };
 }
 
-export function executeList(state: McpExtensionState, server: string): ProxyToolResult {
+export function executeList(
+  state: McpExtensionState,
+  server: string,
+): ProxyToolResult {
   const definition = state.config.mcpServers[server];
   if (!definition) {
     return {
-      content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
-      details: { mode: "list", server, tools: [], count: 0, error: "not_found" },
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${server}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
+      details: {
+        mode: "list",
+        server,
+        tools: [],
+        count: 0,
+        error: "not_found",
+      },
     };
   }
   if (isServerDisabled(definition)) return disabledResult("list", server);
 
   const metadata = state.toolMetadata.get(server);
-  const toolNames = metadata?.map(m => m.name) ?? [];
+  const toolNames = metadata?.map((m) => m.name) ?? [];
   const connection = state.manager.getConnection(server);
   if (isServerInActiveFailureBackoff(state, server)) {
     return {
       ...serverBackoffResult(state, "list", server),
-      details: { mode: "list", server, tools: [], count: 0, error: "server_backoff" },
+      details: {
+        mode: "list",
+        server,
+        tools: [],
+        count: 0,
+        error: "server_backoff",
+      },
     };
   }
   const instructions = state.serverInstructions.get(server);
@@ -703,23 +1086,59 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
   if (toolNames.length === 0) {
     if (connection?.status === "connected") {
       return {
-        content: [{ type: "text" as const, text: `Server "${server}" has no tools.${instructionsText}` }],
-        details: { mode: "list", server, tools: [], count: 0, hasInstructions: Boolean(instructions) },
+        content: [
+          {
+            type: "text" as const,
+            text: `Server "${server}" has no tools.${instructionsText}`,
+          },
+        ],
+        details: {
+          mode: "list",
+          server,
+          tools: [],
+          count: 0,
+          hasInstructions: Boolean(instructions),
+        },
       };
     }
     if (metadata !== undefined) {
       return {
-        content: [{ type: "text" as const, text: `Server "${server}" has no cached tools (not connected).${instructionsText}` }],
-        details: { mode: "list", server, tools: [], count: 0, cached: true, hasInstructions: Boolean(instructions) },
+        content: [
+          {
+            type: "text" as const,
+            text: `Server "${server}" has no cached tools (not connected).${instructionsText}`,
+          },
+        ],
+        details: {
+          mode: "list",
+          server,
+          tools: [],
+          count: 0,
+          cached: true,
+          hasInstructions: Boolean(instructions),
+        },
       };
     }
     return {
-      content: [{ type: "text" as const, text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.${instructionsText}` }],
-      details: { mode: "list", server, tools: [], count: 0, error: "not_connected", hasInstructions: Boolean(instructions) },
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.${instructionsText}`,
+        },
+      ],
+      details: {
+        mode: "list",
+        server,
+        tools: [],
+        count: 0,
+        error: "not_connected",
+        hasInstructions: Boolean(instructions),
+      },
     };
   }
 
-  const cachedNote = connection?.status === "connected" ? "" : " (not connected, cached)";
+  const cachedNote =
+    connection?.status === "connected" ? "" : " (not connected, cached)";
   let text = `${server} (${toolNames.length} tools${cachedNote}):\n\n`;
 
   const descMap = new Map<string, string>();
@@ -741,25 +1160,46 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "list", server, tools: toolNames, count: toolNames.length, hasInstructions: Boolean(instructions) },
+    details: {
+      mode: "list",
+      server,
+      tools: toolNames,
+      count: toolNames.length,
+      hasInstructions: Boolean(instructions),
+    },
   };
 }
 
-export function executeInstructions(state: McpExtensionState, server: string): ProxyToolResult {
+export function executeInstructions(
+  state: McpExtensionState,
+  server: string,
+): ProxyToolResult {
   const definition = state.config.mcpServers[server];
   if (!definition) {
     return {
-      content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${server}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
       details: { mode: "instructions", server, error: "not_found" },
     };
   }
-  if (isServerDisabled(definition)) return disabledResult("instructions", server);
-  if (isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "instructions", server);
+  if (isServerDisabled(definition))
+    return disabledResult("instructions", server);
+  if (isServerInActiveFailureBackoff(state, server))
+    return serverBackoffResult(state, "instructions", server);
 
   const instructions = state.serverInstructions.get(server);
   if (instructions) {
     return {
-      content: [{ type: "text" as const, text: `${server} instructions:\n\n${instructions}` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `${server} instructions:\n\n${instructions}`,
+        },
+      ],
       details: { mode: "instructions", server, length: instructions.length },
     };
   }
@@ -767,43 +1207,77 @@ export function executeInstructions(state: McpExtensionState, server: string): P
   const connection = state.manager.getConnection(server);
   if (connection?.status === "connected") {
     return {
-      content: [{ type: "text" as const, text: `Server "${server}" does not provide instructions.` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${server}" does not provide instructions.`,
+        },
+      ],
       details: { mode: "instructions", server, error: "no_instructions" },
     };
   }
 
   return {
-    content: [{ type: "text" as const, text: `No instructions cached for "${server}". Use mcp({ connect: "${server}" }) to connect and refresh.` }],
+    content: [
+      {
+        type: "text" as const,
+        text: `No instructions cached for "${server}". Use mcp({ connect: "${server}" }) to connect and refresh.`,
+      },
+    ],
     details: { mode: "instructions", server, error: "not_connected" },
   };
 }
 
-export async function executeConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
+export async function executeConnect(
+  state: McpExtensionState,
+  serverName: string,
+  signal?: AbortSignal,
+): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
       details: { mode: "connect", error: "not_found", server: serverName },
     };
   }
-  if (isServerDisabled(definition)) return disabledResult("connect", serverName);
+  if (isServerDisabled(definition))
+    return disabledResult("connect", serverName);
 
   try {
     if (state.ui) {
-      state.ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${serverName}...`));
+      state.ui.setStatus(
+        "mcp",
+        formatMcpStatus(state.config, `connecting to ${serverName}...`),
+      );
     }
     const currentConnection = state.manager.getConnection(serverName);
-    let connection = currentConnection?.status === "connected"
-      ? await state.manager.reconnect(serverName, definition, currentConnection, ownedSignal)
-      : await state.manager.connect(serverName, definition, ownedSignal);
+    let connection =
+      currentConnection?.status === "connected"
+        ? await state.manager.reconnect(
+            serverName,
+            definition,
+            currentConnection,
+            ownedSignal,
+          )
+        : await state.manager.connect(serverName, definition, ownedSignal);
     if (connection.status === "needs-auth") {
       const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
-          details: { mode: "connect", error: "auth_required", server: serverName, message: autoAuth.message },
+          details: {
+            mode: "connect",
+            error: "auth_required",
+            server: serverName,
+            message: autoAuth.message,
+          },
         };
       }
       if (autoAuth.status === "success") {
@@ -817,15 +1291,36 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
         const message = getAuthRequiredMessage(state, serverName);
         return {
           content: [{ type: "text" as const, text: message }],
-          details: { mode: "connect", error: "auth_required", server: serverName, message },
+          details: {
+            mode: "connect",
+            error: "auth_required",
+            server: serverName,
+            message,
+          },
         };
       }
     }
     const prefix = state.config.settings?.toolPrefix ?? "server";
-    const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix, state.config.mcpServers, state.toolMetadata);
+    const { metadata } = buildToolMetadata(
+      connection.tools,
+      connection.resources,
+      definition,
+      serverName,
+      prefix,
+      state.config.mcpServers,
+      state.toolMetadata,
+    );
     state.toolMetadata.set(serverName, metadata);
     if (!connection.promptDiscoveryFailed) {
-      state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix, definition));
+      state.promptMetadata?.set(
+        serverName,
+        reconstructPromptMetadata(
+          serverName,
+          connection.prompts ?? [],
+          prefix,
+          definition,
+        ),
+      );
       state.promptMetadataLive?.add(serverName);
     }
     if (connection.instructions) {
@@ -835,17 +1330,29 @@ export async function executeConnect(state: McpExtensionState, serverName: strin
     }
     updateMetadataCache(state, serverName);
     const restored = clearFailure(state, serverName, "proxy-connect");
-    if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-connect");
+    if (!restored)
+      notifyToolMetadataUpdated(state, serverName, "proxy-connect");
     markKeepAliveAfterConnect(state, serverName);
     updateStatusBar(state);
     return executeList(state, serverName);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
+    if (!isAbortError(error, ownedSignal))
+      recordFailure(state, serverName, message);
     updateStatusBar(state);
     return {
-      content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-      details: { mode: "connect", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", server: serverName, message },
+      content: [
+        {
+          type: "text" as const,
+          text: `Failed to connect to "${serverName}": ${message}`,
+        },
+      ],
+      details: {
+        mode: "connect",
+        error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed",
+        server: serverName,
+        message,
+      },
     };
   }
 }
@@ -865,12 +1372,21 @@ export async function executeCall(
   let toolMeta: ToolMetadata | undefined;
   let autoAuthAttempted = false;
   const prefixMode = state.config.settings?.toolPrefix ?? "server";
-  const disabledCallResult = (disabledServer: string, metadata?: ToolMetadata): ProxyToolResult => {
+  const disabledCallResult = (
+    disabledServer: string,
+    metadata?: ToolMetadata,
+  ): ProxyToolResult => {
     if (!metadata) {
       const message = `Server "${disabledServer}" is disabled. Run /mcp enable ${disabledServer} and /reload to enable it.`;
       return {
         content: [{ type: "text" as const, text: message }],
-        details: { mode: "call", error: "server_disabled", server: disabledServer, requestedTool: toolName, message },
+        details: {
+          mode: "call",
+          error: "server_disabled",
+          server: disabledServer,
+          requestedTool: toolName,
+          message,
+        },
       };
     }
     const message = `Server "${disabledServer}" is disabled. Run /mcp enable ${disabledServer} and /reload to enable it.`;
@@ -885,12 +1401,25 @@ export async function executeCall(
 
   if (serverName && !state.config.mcpServers[serverName]) {
     return {
-      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
-      details: { mode: "call", error: "server_not_found", server: serverName, requestedTool: toolName },
+      content: [
+        {
+          type: "text" as const,
+          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
+        },
+      ],
+      details: {
+        mode: "call",
+        error: "server_not_found",
+        server: serverName,
+        requestedTool: toolName,
+      },
     };
   }
   if (serverName) {
-    const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+    const match = getSingleToolMatch(
+      state.toolMetadata.get(serverName),
+      toolName,
+    );
     if (match === "ambiguous") return ambiguousToolResult("call", toolName);
     toolMeta = match;
     if (isServerDisabled(state.config.mcpServers[serverName])) {
@@ -899,13 +1428,18 @@ export async function executeCall(
   } else {
     const exactMatches = getEnabledToolMatches(state, toolName, true);
     if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
-    if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).length > 1) {
+    if (
+      exactMatches.length === 0 &&
+      getEnabledToolMatches(state, toolName, false).length > 1
+    ) {
       return ambiguousToolResult("call", toolName);
     }
 
-    let disabledMatch: { serverName: string; toolMeta: ToolMetadata } | undefined;
+    let disabledMatch:
+      | { serverName: string; toolMeta: ToolMetadata }
+      | undefined;
     for (const [server, metadata] of state.toolMetadata.entries()) {
-      const found = metadata.find(tool => tool.name === toolName);
+      const found = metadata.find((tool) => tool.name === toolName);
       if (!found) continue;
       if (isServerDisabled(state.config.mcpServers[server])) {
         disabledMatch ??= { serverName: server, toolMeta: found };
@@ -928,13 +1462,20 @@ export async function executeCall(
         break;
       }
     }
-    if (!toolMeta && disabledMatch) return disabledCallResult(disabledMatch.serverName, disabledMatch.toolMeta);
+    if (!toolMeta && disabledMatch)
+      return disabledCallResult(
+        disabledMatch.serverName,
+        disabledMatch.toolMeta,
+      );
   }
 
   if (serverName && !toolMeta) {
     const connected = await lazyConnect(state, serverName, ownedSignal);
     if (connected) {
-      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+      const match = getSingleToolMatch(
+        state.toolMetadata.get(serverName),
+        toolName,
+      );
       if (match === "ambiguous") return ambiguousToolResult("call", toolName);
       toolMeta = match;
     } else {
@@ -942,38 +1483,79 @@ export async function executeCall(
       if (needsAuthConnection?.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
+          const autoAuth = await attemptAutoAuth(
+            state,
+            serverName,
+            ownedSignal,
+          );
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
-              details: { mode: "call", error: "auth_required", server: serverName, requestedTool: toolName, message: autoAuth.message },
+              details: {
+                mode: "call",
+                error: "auth_required",
+                server: serverName,
+                requestedTool: toolName,
+                message: autoAuth.message,
+              },
             };
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
             clearFailure(state, serverName);
-            const connectedAfterAuth = await lazyConnect(state, serverName, ownedSignal);
+            const connectedAfterAuth = await lazyConnect(
+              state,
+              serverName,
+              ownedSignal,
+            );
             if (connectedAfterAuth) {
-              const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
-              if (match === "ambiguous") return ambiguousToolResult("call", toolName);
+              const match = getSingleToolMatch(
+                state.toolMetadata.get(serverName),
+                toolName,
+              );
+              if (match === "ambiguous")
+                return ambiguousToolResult("call", toolName);
               toolMeta = match;
               if (!toolMeta) {
                 const suggestions = rankSuggestions(state, toolName, 5);
-                const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
+                const suggestionText =
+                  suggestions.length > 0
+                    ? ` Did you mean: ${suggestions.join(", ")}`
+                    : "";
                 return {
-                  content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.${suggestionText}` }],
-                  details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
+                  content: [
+                    {
+                      type: "text" as const,
+                      text: `Tool "${toolName}" not found on "${serverName}" after reconnect.${suggestionText}`,
+                    },
+                  ],
+                  details: {
+                    mode: "call",
+                    error: "tool_not_found_after_reconnect",
+                    server: serverName,
+                    requestedTool: toolName,
+                    suggestions,
+                  },
                 };
               }
             }
           }
         }
 
-        if (!toolMeta && state.manager.getConnection(serverName)?.status === "needs-auth") {
+        if (
+          !toolMeta &&
+          state.manager.getConnection(serverName)?.status === "needs-auth"
+        ) {
           const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
-            details: { mode: "call", error: "auth_required", server: serverName, requestedTool: toolName, message },
+            details: {
+              mode: "call",
+              error: "auth_required",
+              server: serverName,
+              requestedTool: toolName,
+              message,
+            },
           };
         }
       }
@@ -982,8 +1564,18 @@ export async function executeCall(
         const failedAgo = getFailureAgeSeconds(state, serverName);
         if (failedAgo !== null) {
           return {
-            content: [{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` }],
-            details: { mode: "call", error: "server_backoff", server: serverName, requestedTool: toolName },
+            content: [
+              {
+                type: "text" as const,
+                text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)`,
+              },
+            ],
+            details: {
+              mode: "call",
+              error: "server_backoff",
+              server: serverName,
+              requestedTool: toolName,
+            },
           };
         }
       }
@@ -993,27 +1585,47 @@ export async function executeCall(
   let prefixMatchedServer: string | undefined;
 
   if (!serverName && !toolMeta && prefixMode !== "none") {
-    const lazyExactMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
-    const lazyFallbackMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
+    const lazyExactMatches: { serverName: string; toolMeta: ToolMetadata }[] =
+      [];
+    const lazyFallbackMatches: {
+      serverName: string;
+      toolMeta: ToolMetadata;
+    }[] = [];
     const candidates = Object.keys(state.config.mcpServers)
-      .filter(name => !isServerDisabled(state.config.mcpServers[name]))
-      .map(name => ({ name, prefix: getServerPrefix(name, prefixMode) }))
-      .filter(c => c.prefix && toolName.startsWith(c.prefix + "_"))
+      .filter((name) => !isServerDisabled(state.config.mcpServers[name]))
+      .map((name) => ({ name, prefix: getServerPrefix(name, prefixMode) }))
+      .filter((c) => c.prefix && toolName.startsWith(c.prefix + "_"))
       .sort((a, b) => b.prefix.length - a.prefix.length);
 
     for (const { name: configuredServer } of candidates) {
       const existingConnection = state.manager.getConnection(configuredServer);
       const failedAgo = getFailureAgeSeconds(state, configuredServer);
-      if (failedAgo !== null && existingConnection?.status !== "needs-auth") continue;
+      if (failedAgo !== null && existingConnection?.status !== "needs-auth")
+        continue;
 
       let connected = await lazyConnect(state, configuredServer, ownedSignal);
-      if (!connected && state.manager.getConnection(configuredServer)?.status === "needs-auth" && !autoAuthAttempted) {
+      if (
+        !connected &&
+        state.manager.getConnection(configuredServer)?.status ===
+          "needs-auth" &&
+        !autoAuthAttempted
+      ) {
         autoAuthAttempted = true;
-        const autoAuth = await attemptAutoAuth(state, configuredServer, ownedSignal);
+        const autoAuth = await attemptAutoAuth(
+          state,
+          configuredServer,
+          ownedSignal,
+        );
         if (autoAuth.status === "failed") {
           return {
             content: [{ type: "text" as const, text: autoAuth.message }],
-            details: { mode: "call", error: "auth_required", server: configuredServer, requestedTool: toolName, message: autoAuth.message },
+            details: {
+              mode: "call",
+              error: "auth_required",
+              server: configuredServer,
+              requestedTool: toolName,
+              message: autoAuth.message,
+            },
           };
         }
         if (autoAuth.status === "success") {
@@ -1029,14 +1641,23 @@ export async function executeCall(
       const exactMatches = getToolMatches(metadata, toolName, true);
       if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
       if (exactMatches.length === 1) {
-        lazyExactMatches.push({ serverName: configuredServer, toolMeta: exactMatches[0]! });
+        lazyExactMatches.push({
+          serverName: configuredServer,
+          toolMeta: exactMatches[0]!,
+        });
         continue;
       }
       const fallbackMatches = getToolMatches(metadata, toolName, false);
-      if (fallbackMatches.length > 1) return ambiguousToolResult("call", toolName);
-      if (fallbackMatches.length === 1) lazyFallbackMatches.push({ serverName: configuredServer, toolMeta: fallbackMatches[0]! });
+      if (fallbackMatches.length > 1)
+        return ambiguousToolResult("call", toolName);
+      if (fallbackMatches.length === 1)
+        lazyFallbackMatches.push({
+          serverName: configuredServer,
+          toolMeta: fallbackMatches[0]!,
+        });
     }
-    const lazyMatches = lazyExactMatches.length > 0 ? lazyExactMatches : lazyFallbackMatches;
+    const lazyMatches =
+      lazyExactMatches.length > 0 ? lazyExactMatches : lazyFallbackMatches;
     if (lazyMatches.length > 1) return ambiguousToolResult("call", toolName);
     if (lazyMatches.length === 1) {
       serverName = lazyMatches[0]!.serverName;
@@ -1046,12 +1667,23 @@ export async function executeCall(
 
   if (!serverName || !toolMeta) {
     const nativeTool = !serverOverride
-      ? getPiTools?.().find((tool) => tool.name === toolName && tool.name !== "mcp")
+      ? getPiTools?.().find(
+          (tool) => tool.name === toolName && tool.name !== "mcp",
+        )
       : undefined;
     if (nativeTool) {
       return {
-        content: [{ type: "text" as const, text: `"${toolName}" is a native Pi tool. Call ${toolName} directly instead of using mcp({ tool: "${toolName}" }).` }],
-        details: { mode: "call", error: "native_tool", requestedTool: toolName },
+        content: [
+          {
+            type: "text" as const,
+            text: `"${toolName}" is a native Pi tool. Call ${toolName} directly instead of using mcp({ tool: "${toolName}" }).`,
+          },
+        ],
+        details: {
+          mode: "call",
+          error: "native_tool",
+          requestedTool: toolName,
+        },
       };
     }
 
@@ -1064,10 +1696,17 @@ export async function executeCall(
       msg += ` Use mcp({ search: "..." }) to search.`;
     }
     const suggestions = rankSuggestions(state, toolName, 5);
-    if (suggestions.length > 0) msg += ` Did you mean: ${suggestions.join(", ")}`;
+    if (suggestions.length > 0)
+      msg += ` Did you mean: ${suggestions.join(", ")}`;
     return {
       content: [{ type: "text" as const, text: msg }],
-      details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer, suggestions },
+      details: {
+        mode: "call",
+        error: "tool_not_found",
+        requestedTool: toolName,
+        hintServer,
+        suggestions,
+      },
     };
   }
 
@@ -1083,7 +1722,12 @@ export async function executeCall(
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
-          details: { mode: "call", error: "auth_required", ...callIdentity, message: autoAuth.message },
+          details: {
+            mode: "call",
+            error: "auth_required",
+            ...callIdentity,
+            message: autoAuth.message,
+          },
         };
       }
       if (autoAuth.status === "success") {
@@ -1097,7 +1741,12 @@ export async function executeCall(
       const message = getAuthRequiredMessage(state, serverName);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: { mode: "call", error: "auth_required", ...callIdentity, message },
+        details: {
+          mode: "call",
+          error: "auth_required",
+          ...callIdentity,
+          message,
+        },
       };
     }
   }
@@ -1105,7 +1754,12 @@ export async function executeCall(
     const failedAgo = getFailureAgeSeconds(state, serverName);
     if (failedAgo !== null) {
       return {
-        content: [{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` }],
+        content: [
+          {
+            type: "text" as const,
+            text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)`,
+          },
+        ],
         details: { mode: "call", error: "server_backoff", ...callIdentity },
       };
     }
@@ -1113,29 +1767,58 @@ export async function executeCall(
     const definition = state.config.mcpServers[serverName];
     if (!definition) {
       return {
-        content: [{ type: "text" as const, text: `Server "${serverName}" not connected` }],
-        details: { mode: "call", error: "server_not_connected", ...callIdentity },
+        content: [
+          {
+            type: "text" as const,
+            text: `Server "${serverName}" not connected`,
+          },
+        ],
+        details: {
+          mode: "call",
+          error: "server_not_connected",
+          ...callIdentity,
+        },
       };
     }
 
     try {
       if (state.ui) {
-        state.ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${serverName}...`));
+        state.ui.setStatus(
+          "mcp",
+          formatMcpStatus(state.config, `connecting to ${serverName}...`),
+        );
       }
-      connection = await state.manager.connect(serverName, definition, ownedSignal);
+      connection = await state.manager.connect(
+        serverName,
+        definition,
+        ownedSignal,
+      );
       if (connection.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
+          const autoAuth = await attemptAutoAuth(
+            state,
+            serverName,
+            ownedSignal,
+          );
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
-              details: { mode: "call", error: "auth_required", ...callIdentity, message: autoAuth.message },
+              details: {
+                mode: "call",
+                error: "auth_required",
+                ...callIdentity,
+                message: autoAuth.message,
+              },
             };
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
-            connection = await state.manager.connect(serverName, definition, ownedSignal);
+            connection = await state.manager.connect(
+              serverName,
+              definition,
+              ownedSignal,
+            );
           }
         }
 
@@ -1143,38 +1826,75 @@ export async function executeCall(
           const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
-            details: { mode: "call", error: "auth_required", ...callIdentity, message },
+            details: {
+              mode: "call",
+              error: "auth_required",
+              ...callIdentity,
+              message,
+            },
           };
         }
       }
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
       const restored = clearFailure(state, serverName, "proxy-call-reconnect");
-      if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
+      if (!restored)
+        notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
       markKeepAliveAfterConnect(state, serverName);
       updateStatusBar(state);
-      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+      const match = getSingleToolMatch(
+        state.toolMetadata.get(serverName),
+        toolName,
+      );
       if (match === "ambiguous") return ambiguousToolResult("call", toolName);
       toolMeta = match;
       if (!toolMeta) {
         const available = getToolNames(state, serverName);
-        const hint = available.length > 0
-          ? `Available tools on "${serverName}": ${available.join(", ")}`
-          : `Server "${serverName}" has no tools.`;
+        const hint =
+          available.length > 0
+            ? `Available tools on "${serverName}": ${available.join(", ")}`
+            : `Server "${serverName}" has no tools.`;
         const suggestions = rankSuggestions(state, toolName, 5);
-        const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
+        const suggestionText =
+          suggestions.length > 0
+            ? ` Did you mean: ${suggestions.join(", ")}`
+            : "";
         return {
-          content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}${suggestionText}` }],
-          details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
+          content: [
+            {
+              type: "text" as const,
+              text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}${suggestionText}`,
+            },
+          ],
+          details: {
+            mode: "call",
+            error: "tool_not_found_after_reconnect",
+            server: serverName,
+            requestedTool: toolName,
+            suggestions,
+          },
         };
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
+      if (!isAbortError(error, ownedSignal))
+        recordFailure(state, serverName, message);
       updateStatusBar(state);
       return {
-        content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
-        details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", ...callIdentity, message },
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to connect to "${serverName}": ${message}`,
+          },
+        ],
+        details: {
+          mode: "call",
+          error: isAbortError(error, ownedSignal)
+            ? "aborted"
+            : "connect_failed",
+          ...callIdentity,
+          message,
+        },
       };
     }
   }
@@ -1183,7 +1903,9 @@ export async function executeCall(
     return disabledCallResult(serverName, toolMeta);
   }
 
-  const normalizedArgs = toolMeta.resourceUri ? args ?? {} : normalizeToolArguments(args);
+  const normalizedArgs = toolMeta.resourceUri
+    ? (args ?? {})
+    : normalizeToolArguments(args);
   const approval = await ensureToolCallApproved(
     state,
     serverName,
@@ -1210,12 +1932,15 @@ export async function executeCall(
 
   let uiSession: UiSessionRuntime | null = null;
   const requestOptions = withUiProgressBridge(
-    state.manager.getRequestOptions?.(serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined),
+    state.manager.getRequestOptions?.(serverName, ownedSignal) ??
+      (ownedSignal ? { signal: ownedSignal } : undefined),
     state.ui,
     toolMeta.originalName,
   );
 
-  const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
+  const outputGuardOptions = resolveMcpOutputGuardOptions(
+    state.config.settings,
+  );
   const recoverAuthConnection = async () => {
     const current = state.manager.getConnection(serverName);
     if (current?.status === "connected") return current;
@@ -1224,7 +1949,10 @@ export async function executeCall(
       autoAuthAttempted = true;
       const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
-        throw new SessionRecoveryAuthRequiredError(serverName, autoAuth.message);
+        throw new SessionRecoveryAuthRequiredError(
+          serverName,
+          autoAuth.message,
+        );
       }
       if (autoAuth.status === "success") {
         const definition = state.config.mcpServers[serverName];
@@ -1235,7 +1963,11 @@ export async function executeCall(
           await state.manager.close(serverName);
         }
         clearFailure(state, serverName);
-        connection = await state.manager.connect(serverName, definition, ownedSignal);
+        connection = await state.manager.connect(
+          serverName,
+          definition,
+          ownedSignal,
+        );
         return connection;
       }
     }
@@ -1255,13 +1987,29 @@ export async function executeCall(
           onNeedsAuth: recoverAuthConnection,
         },
         serverName,
-        (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
+        (conn) =>
+          conn.client.readResource(
+            { uri: toolMeta.resourceUri! },
+            requestOptions,
+          ),
       );
-      const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
-      const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
+      const content = transformMcpResourceContents(
+        result.contents ?? [],
+        state.owner?.signal,
+      );
+      const guarded = await guardMcpOutput(
+        content.length > 0
+          ? content
+          : [{ type: "text" as const, text: "(empty resource)" }],
+        outputGuardOptions,
+      );
       return {
         content: guarded.content,
-        details: { mode: "call", ...callIdentity, ...guardedMcpDetails(guarded) },
+        details: {
+          mode: "call",
+          ...callIdentity,
+          ...guardedMcpDetails(guarded),
+        },
       };
     }
 
@@ -1271,7 +2019,9 @@ export async function executeCall(
           toolName: toolMeta.originalName,
           toolArgs: normalizedArgs,
           uiResourceUri: toolMeta.uiResourceUri,
-          ...(toolMeta.uiStreamMode !== undefined ? { streamMode: toolMeta.uiStreamMode } : {}),
+          ...(toolMeta.uiStreamMode !== undefined
+            ? { streamMode: toolMeta.uiStreamMode }
+            : {}),
           ...(signal ? { signal } : {}),
           onNeedsAuth: recoverAuthConnection,
         })
@@ -1285,33 +2035,68 @@ export async function executeCall(
         onNeedsAuth: recoverAuthConnection,
       },
       serverName,
-      (conn) => abortable(conn.client.callTool({
-        name: toolMeta.originalName,
-        arguments: normalizedArgs,
-        _meta: uiSession?.requestMeta,
-      }, requestOptions), ownedSignal),
+      (conn) =>
+        abortable(
+          conn.client.callTool(
+            {
+              name: toolMeta.originalName,
+              arguments: normalizedArgs,
+              _meta: uiSession?.requestMeta,
+            },
+            requestOptions,
+          ),
+          ownedSignal,
+        ),
     );
 
     if (toolMeta.uiResourceUri) {
       // SAFETY: ui-session renderer consumes the raw wire result shape, which the SDK types do not expose publicly
-      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
+      uiSession?.sendToolResult(
+        result as unknown as import("@modelcontextprotocol/client").CallToolResult,
+      );
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];
         const content = transformMcpContent(mcpContent, state.owner?.signal);
-        const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
-        const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
-        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
+        const outputContent =
+          content.length > 0
+            ? content
+            : [{ type: "text" as const, text: "(empty result)" }];
+        const schemaText = toolMeta.inputSchema
+          ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+          : "";
+        const guarded = await guardMcpOutput(outputContent, {
+          ...outputGuardOptions,
+          prefix: "Error: ",
+          suffix: schemaText,
+          emptyTextFallback: "Tool execution failed",
+          rawMcpResult: result,
+        });
         return {
           content: guarded.content,
-          details: { mode: "call", error: "tool_error", ...callIdentity, ...guardedMcpDetails(guarded) },
+          details: {
+            mode: "call",
+            error: "tool_error",
+            ...callIdentity,
+            ...guardedMcpDetails(guarded),
+          },
         };
       }
 
-      const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
-      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
+      const content = resolveMcpResultContent(
+        result as Record<string, unknown>,
+        state.owner?.signal,
+      );
+      const outputContent =
+        content.length > 0
+          ? content
+          : [{ type: "text" as const, text: "(empty result)" }];
       const uiSummary = summarizeUiSessionResult(uiSession);
-      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiSummary.message}`, rawMcpResult: result });
+      const guarded = await guardMcpOutput(outputContent, {
+        ...outputGuardOptions,
+        suffix: `\n\n${uiSummary.message}`,
+        rawMcpResult: result,
+      });
       return {
         content: guarded.content,
         details: {
@@ -1328,51 +2113,109 @@ export async function executeCall(
     if (result.isError) {
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent, state.owner?.signal);
-      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
-      const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
-      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
+      const outputContent =
+        content.length > 0
+          ? content
+          : [{ type: "text" as const, text: "(empty result)" }];
+      const schemaText = toolMeta.inputSchema
+        ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+        : "";
+      const guarded = await guardMcpOutput(outputContent, {
+        ...outputGuardOptions,
+        prefix: "Error: ",
+        suffix: schemaText,
+        emptyTextFallback: "Tool execution failed",
+        rawMcpResult: result,
+      });
       return {
         content: guarded.content,
-        details: { mode: "call", error: "tool_error", ...callIdentity, ...guardedMcpDetails(guarded) },
+        details: {
+          mode: "call",
+          error: "tool_error",
+          ...callIdentity,
+          ...guardedMcpDetails(guarded),
+        },
       };
     }
 
-    const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
-    const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
-    const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
+    const content = resolveMcpResultContent(
+      result as Record<string, unknown>,
+      state.owner?.signal,
+    );
+    const outputContent =
+      content.length > 0
+        ? content
+        : [{ type: "text" as const, text: "(empty result)" }];
+    const guarded = await guardMcpOutput(outputContent, {
+      ...outputGuardOptions,
+      rawMcpResult: result,
+    });
     return {
       content: guarded.content,
       details: { mode: "call", ...guardedMcpDetails(guarded), ...callIdentity },
     };
   } catch (error) {
     if (error instanceof SessionRecoveryAuthRequiredError) {
-      const message = error.authMessage ?? getAuthRequiredMessage(state, serverName);
+      const message =
+        error.authMessage ?? getAuthRequiredMessage(state, serverName);
       uiSession?.sendToolCancelled(message);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: { mode: "call", error: "auth_required", ...callIdentity, message, autoAuthAttempted },
+        details: {
+          mode: "call",
+          error: "auth_required",
+          ...callIdentity,
+          message,
+          autoAuthAttempted,
+        },
       };
     }
     if (error instanceof UrlElicitationRequiredError) {
-      const action = await state.manager.handleUrlElicitationRequired(serverName, error);
-      const message = action === "accept"
-        ? "The original MCP tool did not run. Complete the opened browser interaction, then retry the tool."
-        : `The URL interaction was ${action === "decline" ? "declined" : "cancelled"}.`;
+      const action = await state.manager.handleUrlElicitationRequired(
+        serverName,
+        error,
+      );
+      const message =
+        action === "accept"
+          ? "The original MCP tool did not run. Complete the opened browser interaction, then retry the tool."
+          : `The URL interaction was ${action === "decline" ? "declined" : "cancelled"}.`;
       uiSession?.sendToolCancelled(message);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: { mode: "call", error: "url_elicitation_required", ...callIdentity, action },
+        details: {
+          mode: "call",
+          error: "url_elicitation_required",
+          ...callIdentity,
+          action,
+        },
       };
     }
     const message = error instanceof Error ? error.message : String(error);
     uiSession?.sendToolCancelled(message);
 
-    const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
-    const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
+    const schemaText = toolMeta.inputSchema
+      ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+      : "";
+    const guarded = await guardMcpOutput(
+      [{ type: "text" as const, text: message }],
+      {
+        ...outputGuardOptions,
+        prefix: "Failed to call tool: ",
+        suffix: schemaText,
+      },
+    );
 
     return {
       content: guarded.content,
-      details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed", ...callIdentity, message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedMcpDetails(guarded) },
+      details: {
+        mode: "call",
+        error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed",
+        ...callIdentity,
+        message: guarded.outputGuard
+          ? "output truncated; see outputGuard.fullOutputPath"
+          : message,
+        ...guardedMcpDetails(guarded),
+      },
     };
   } finally {
     if (uiSession?.reused) {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,84 +1,23 @@
-import type {
-  AgentToolResult,
-  ToolInfo,
-} from "@earendil-works/pi-coding-agent";
-import {
-  UrlElicitationRequiredError,
-  type Client,
-  type Progress,
-  type RequestOptions,
-} from "@modelcontextprotocol/client";
+import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
+import { UrlElicitationRequiredError, type Client, type Progress, type RequestOptions } from "@modelcontextprotocol/client";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
-import {
-  getServerPrefix,
-  isServerDisabled,
-  parseUiPromptHandoff,
-} from "./types.ts";
-import {
-  lazyConnect,
-  markKeepAliveAfterConnect,
-  notifyToolMetadataUpdated,
-  updateServerMetadata,
-  updateMetadataCache,
-  getFailureAgeSeconds,
-  updateStatusBar,
-  clearFailure,
-  recordFailure,
-} from "./init.ts";
+import { getServerPrefix, isServerDisabled, parseUiPromptHandoff } from "./types.ts";
+import { lazyConnect, markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
-import {
-  buildToolMetadata,
-  getToolNames,
-  findToolByName,
-  formatSchema,
-} from "./tool-metadata.ts";
+import { buildToolMetadata, getToolNames, findToolByName, formatSchema } from "./tool-metadata.ts";
 import { renderTsShape } from "./ts-shape.ts";
 import { reconstructPromptMetadata } from "./metadata-cache.ts";
-import {
-  resolveMcpResultContent,
-  transformMcpContent,
-  transformMcpResourceContents,
-} from "./tool-registrar.ts";
-import {
-  guardMcpOutput,
-  guardedMcpDetails,
-  resolveMcpOutputGuardOptions,
-} from "./mcp-output-guard.ts";
-import {
-  maybeStartUiSession,
-  summarizeUiSessionResult,
-  type UiSessionRuntime,
-} from "./ui-session.ts";
-import {
-  formatAuthRequiredMessage,
-  formatMcpStatus,
-  normalizeToolArguments,
-  resolveServerUrl,
-  truncateAtWord,
-} from "./utils.ts";
-import {
-  authenticate,
-  completeAuthFromInput,
-  startAuth,
-  supportsOAuth,
-} from "./mcp-auth-flow.ts";
-import {
-  SessionRecoveryAuthRequiredError,
-  withSessionRecovery,
-} from "./session-recovery.ts";
-import {
-  paginate,
-  rankSuggestions,
-  rankToolMatches,
-  resolveSearchKeywords,
-} from "./search-ranking.ts";
-import {
-  ensureToolCallApproved,
-  isToolCallApprovalRequired,
-} from "./tool-approval.ts";
+import { resolveMcpResultContent, transformMcpContent, transformMcpResourceContents } from "./tool-registrar.ts";
+import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
+import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
+import { formatAuthRequiredMessage, formatMcpStatus, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
+import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
+import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
+import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
+import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
@@ -99,6 +38,8 @@ type AutoAuthResult =
   | { status: "success" }
   | { status: "failed"; message: string };
 
+let nextProgressInvocationId = 1;
+
 /**
  * Bridges SDK request-local progress callbacks to the interactive UI notify
  * path (#437 item 3). The SDK owns `_meta.progressToken` injection when
@@ -107,55 +48,37 @@ type AutoAuthResult =
 function withUiProgressBridge(
   options: RequestOptions | undefined,
   ui: McpExtensionState["ui"],
+  serverName: string,
   toolName: string,
 ): RequestOptions | undefined {
   if (!ui) return options;
+  const label = `MCP ${serverName}/${toolName}#${nextProgressInvocationId++}`;
   return {
     ...options,
     onprogress: (progress: Progress) => {
       const ratio = `${progress.progress}${progress.total === undefined ? "" : `/${progress.total}`}`;
-      ui.notify(
-        progress.message
-          ? `MCP ${toolName}: ${progress.message} (${ratio})`
-          : `MCP ${toolName}: ${ratio}`,
-        "info",
-      );
+      ui.notify(progress.message ? `${label}: ${progress.message} (${ratio})` : `${label}: ${ratio}`, "info");
     },
   };
 }
 
-function getToolMatches(
-  metadata: ToolMetadata[] | undefined,
-  toolName: string,
-  exact: boolean,
-): ToolMetadata[] {
+function getToolMatches(metadata: ToolMetadata[] | undefined, toolName: string, exact: boolean): ToolMetadata[] {
   if (!metadata) return [];
-  if (exact) return metadata.filter((tool) => tool.name === toolName);
+  if (exact) return metadata.filter(tool => tool.name === toolName);
   const normalizedName = toolName.replace(/-/g, "_");
-  return metadata.filter(
-    (tool) => tool.name.replace(/-/g, "_") === normalizedName,
-  );
+  return metadata.filter(tool => tool.name.replace(/-/g, "_") === normalizedName);
 }
 
-function getEnabledToolMatches(
-  state: McpExtensionState,
-  toolName: string,
-  exact: boolean,
-): { server: string; tool: ToolMetadata }[] {
+function getEnabledToolMatches(state: McpExtensionState, toolName: string, exact: boolean): { server: string; tool: ToolMetadata }[] {
   const matches: { server: string; tool: ToolMetadata }[] = [];
   for (const [server, metadata] of state.toolMetadata) {
     if (isServerDisabled(state.config.mcpServers[server])) continue;
-    for (const tool of getToolMatches(metadata, toolName, exact))
-      matches.push({ server, tool });
+    for (const tool of getToolMatches(metadata, toolName, exact)) matches.push({ server, tool });
   }
   return matches;
 }
 
-function serverBackoffResult(
-  state: McpExtensionState,
-  mode: string,
-  serverName: string,
-): ProxyToolResult {
+function serverBackoffResult(state: McpExtensionState, mode: string, serverName: string): ProxyToolResult {
   const failedAgo = getFailureAgeSeconds(state, serverName) ?? 0;
   const message = `Server "${serverName}" not available (last failed ${failedAgo}s ago)`;
   return {
@@ -164,31 +87,17 @@ function serverBackoffResult(
   };
 }
 
-function getSingleToolMatch(
-  metadata: ToolMetadata[] | undefined,
-  toolName: string,
-): ToolMetadata | "ambiguous" | undefined {
+function getSingleToolMatch(metadata: ToolMetadata[] | undefined, toolName: string): ToolMetadata | "ambiguous" | undefined {
   const exactMatches = getToolMatches(metadata, toolName, true);
-  const matches =
-    exactMatches.length > 0
-      ? exactMatches
-      : getToolMatches(metadata, toolName, false);
+  const matches = exactMatches.length > 0 ? exactMatches : getToolMatches(metadata, toolName, false);
   return matches.length > 1 ? "ambiguous" : matches[0];
 }
 
-function ambiguousToolResult(
-  mode: "call" | "describe",
-  toolName: string,
-): ProxyToolResult {
+function ambiguousToolResult(mode: "call" | "describe", toolName: string): ProxyToolResult {
   const message = `Tool "${toolName}" matches multiple servers. Specify a server.`;
   return {
     content: [{ type: "text" as const, text: message }],
-    details: {
-      mode,
-      error: "ambiguous_tool",
-      requestedTool: toolName,
-      message,
-    },
+    details: { mode, error: "ambiguous_tool", requestedTool: toolName, message },
   };
 }
 
@@ -208,11 +117,7 @@ function getAuthRequiredMessage(
   return formatAuthRequiredMessage(state.config, serverName, defaultMessage);
 }
 
-function getAuthFailedMessage(
-  state: McpExtensionState,
-  serverName: string,
-  message: string,
-): string {
+function getAuthFailedMessage(state: McpExtensionState, serverName: string, message: string): string {
   const customGuidance = state.config.settings?.authRequiredMessage;
   if (customGuidance) {
     return `OAuth authentication failed for "${serverName}": ${message}. ${getAuthRequiredMessage(state, serverName)}`;
@@ -222,9 +127,7 @@ function getAuthFailedMessage(
 
 function getRedirectPort(authorizationUrl: string): number | undefined {
   try {
-    const redirectUri = new URL(authorizationUrl).searchParams.get(
-      "redirect_uri",
-    );
+    const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
     if (!redirectUri) return undefined;
     const port = Number.parseInt(new URL(redirectUri).port, 10);
     return Number.isInteger(port) ? port : undefined;
@@ -233,10 +136,7 @@ function getRedirectPort(authorizationUrl: string): number | undefined {
   }
 }
 
-function formatManualAuthInstructions(
-  serverName: string,
-  authorizationUrl: string,
-): string {
+function formatManualAuthInstructions(serverName: string, authorizationUrl: string): string {
   const port = getRedirectPort(authorizationUrl);
   const portNote = port
     ? `\nThe redirect URL will use local port ${port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
@@ -254,9 +154,7 @@ function formatManualAuthInstructions(
     "",
     'You can also pass just the `code` query parameter as `args: { code: "PASTE_CODE_HERE" }`. JSON-string args remain supported.',
     portNote.trimEnd(),
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ].filter(Boolean).join("\n");
 }
 
 async function attemptAutoAuth(
@@ -269,11 +167,7 @@ async function attemptAutoAuth(
   }
 
   const definition = state.config.mcpServers[serverName];
-  if (
-    !definition ||
-    isServerDisabled(definition) ||
-    !supportsOAuth(definition)
-  ) {
+  if (!definition || isServerDisabled(definition) || !supportsOAuth(definition)) {
     return { status: "skipped" };
   }
 
@@ -282,18 +176,13 @@ async function attemptAutoAuth(
     serverUrl = resolveServerUrl(definition);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return {
-      status: "failed",
-      message: getAuthFailedMessage(state, serverName, message),
-    };
+    return { status: "failed", message: getAuthFailedMessage(state, serverName, message) };
   }
   if (!serverUrl) {
     return { status: "skipped" };
   }
 
-  const grantType = definition.oauth
-    ? (definition.oauth.grantType ?? "authorization_code")
-    : "authorization_code";
+  const grantType = definition.oauth ? definition.oauth.grantType ?? "authorization_code" : "authorization_code";
   if (!state.ui && grantType !== "client_credentials") {
     return {
       status: "failed",
@@ -312,26 +201,14 @@ async function attemptAutoAuth(
         serverUrl,
         definition,
         signal
-          ? {
-              authStorageOptions: state.authStorageOptions,
-              signal,
-              runtime: state.oauthRuntime,
-            }
-          : {
-              authStorageOptions: state.authStorageOptions,
-              runtime: state.oauthRuntime,
-            },
+          ? { authStorageOptions: state.authStorageOptions, signal, runtime: state.oauthRuntime }
+          : { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime },
       );
     } else {
       if (signal) {
-        await authenticate(serverName, serverUrl, definition, {
-          signal,
-          runtime: state.oauthRuntime,
-        });
+        await authenticate(serverName, serverUrl, definition, { signal, runtime: state.oauthRuntime });
       } else {
-        await authenticate(serverName, serverUrl, definition, {
-          runtime: state.oauthRuntime,
-        });
+        await authenticate(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
       }
     }
     return { status: "success" };
@@ -350,32 +227,22 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 
   if (sessions.length === 0) {
     return {
-      content: [
-        { type: "text" as const, text: "No UI session messages available." },
-      ],
+      content: [{ type: "text" as const, text: "No UI session messages available." }],
       details: { sessions: 0 },
     };
   }
 
   const output: string[] = [];
-  output.push(
-    `UI Session Messages (${sessions.length} session${sessions.length > 1 ? "s" : ""}):\n`,
-  );
+  output.push(`UI Session Messages (${sessions.length} session${sessions.length > 1 ? "s" : ""}):\n`);
 
   const allPrompts: string[] = [];
   const allIntents = sessions.flatMap((session) => session.messages.intents);
   const allContexts = sessions.flatMap((session) => session.messages.contexts);
-  const parsedHandoffs: Array<{
-    intent: string;
-    params: Record<string, unknown>;
-    raw: string;
-  }> = [];
+  const parsedHandoffs: Array<{ intent: string; params: Record<string, unknown>; raw: string }> = [];
 
   for (const session of sessions) {
     const timestamp = session.completedAt.toLocaleTimeString();
-    output.push(
-      `\n## ${session.serverName} / ${session.toolName} (${timestamp}, ${session.reason})`,
-    );
+    output.push(`\n## ${session.serverName} / ${session.toolName} (${timestamp}, ${session.reason})`);
 
     const plainPrompts: string[] = [];
     for (const prompt of session.messages.prompts) {
@@ -406,9 +273,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     if (intentsForSession.length > 0) {
       output.push("\n### Intents:");
       for (const intent of intentsForSession) {
-        const params = intent.params
-          ? ` (${JSON.stringify(intent.params)})`
-          : "";
+        const params = intent.params ? ` (${JSON.stringify(intent.params)})` : "";
         output.push(`- ${intent.intent}${params}`);
       }
     }
@@ -417,9 +282,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     if (contexts.length > 0) {
       output.push("\n### Context updates:");
       for (const context of contexts) {
-        output.push(
-          `- ${context.summary}${context.truncated ? " (truncated)" : ""}`,
-        );
+        output.push(`- ${context.summary}${context.truncated ? " (truncated)" : ""}`);
       }
     }
 
@@ -439,10 +302,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
     details: {
       sessions: count,
       prompts: allPrompts,
-      intents: [
-        ...allIntents,
-        ...parsedHandoffs.map(({ intent, params }) => ({ intent, params })),
-      ],
+      intents: [...allIntents, ...parsedHandoffs.map(({ intent, params }) => ({ intent, params }))],
       contexts: allContexts,
       handoffs: parsedHandoffs,
       cleared: true,
@@ -451,13 +311,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 }
 
 export function executeStatus(state: McpExtensionState): ProxyToolResult {
-  const servers: Array<{
-    name: string;
-    status: string;
-    toolCount: number;
-    failedAgo: number | null;
-    disabled?: boolean;
-  }> = [];
+  const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null; disabled?: boolean }> = [];
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const definition = state.config.mcpServers[name];
@@ -476,23 +330,15 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
       status = "cached";
     }
 
-    const toolCount = status === "failed" ? 0 : (metadata?.length ?? 0);
+    const toolCount = status === "failed" ? 0 : metadata?.length ?? 0;
 
-    servers.push({
-      name,
-      status,
-      toolCount,
-      failedAgo,
-      ...(disabled ? { disabled: true } : {}),
-    });
+    servers.push({ name, status, toolCount, failedAgo, ...(disabled ? { disabled: true } : {}) });
   }
 
-  const disabledCount = servers.filter((s) => s.disabled).length;
-  const enabledServers = servers.filter((s) => !s.disabled);
+  const disabledCount = servers.filter(s => s.disabled).length;
+  const enabledServers = servers.filter(s => !s.disabled);
   const totalTools = enabledServers.reduce((sum, s) => sum + s.toolCount, 0);
-  const connectedCount = enabledServers.filter(
-    (s) => s.status === "connected",
-  ).length;
+  const connectedCount = enabledServers.filter(s => s.status === "connected").length;
 
   let text = `MCP: ${connectedCount}/${enabledServers.length} servers, ${totalTools} tools`;
   if (disabledCount > 0) text += ` (${disabledCount} disabled)`;
@@ -527,180 +373,82 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: {
-      mode: "status",
-      servers,
-      totalTools,
-      connectedCount,
-      disabledCount,
-    },
+    details: { mode: "status", servers, totalTools, connectedCount, disabledCount },
   };
 }
 
-export async function executeAuthStart(
-  state: McpExtensionState,
-  serverName: string,
-  signal?: AbortSignal,
-): Promise<ProxyToolResult> {
+export async function executeAuthStart(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "auth-start", error: "not_found", server: serverName },
     };
   }
-  if (isServerDisabled(definition))
-    return disabledResult("auth-start", serverName);
+  if (isServerDisabled(definition)) return disabledResult("auth-start", serverName);
 
   try {
     const serverUrl = resolveServerUrl(definition);
     if (!serverUrl || !supportsOAuth(definition)) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Server "${serverName}" is not configured for OAuth over HTTP.`,
-          },
-        ],
-        details: {
-          mode: "auth-start",
-          error: "oauth_not_supported",
-          server: serverName,
-        },
+        content: [{ type: "text" as const, text: `Server "${serverName}" is not configured for OAuth over HTTP.` }],
+        details: { mode: "auth-start", error: "oauth_not_supported", server: serverName },
       };
     }
 
     const { authorizationUrl } = state.authStorageOptions
       ? ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, {
-            authStorageOptions: state.authStorageOptions,
-            signal: ownedSignal,
-            runtime: state.oauthRuntime,
-          })
-        : await startAuth(serverName, serverUrl, definition, {
-            authStorageOptions: state.authStorageOptions,
-            runtime: state.oauthRuntime,
-          })
+        ? await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
+        : await startAuth(serverName, serverUrl, definition, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
       : ownedSignal
-        ? await startAuth(serverName, serverUrl, definition, {
-            signal: ownedSignal,
-            runtime: state.oauthRuntime,
-          })
-        : await startAuth(serverName, serverUrl, definition, {
-            runtime: state.oauthRuntime,
-          });
+        ? await startAuth(serverName, serverUrl, definition, { signal: ownedSignal, runtime: state.oauthRuntime })
+        : await startAuth(serverName, serverUrl, definition, { runtime: state.oauthRuntime });
     if (!authorizationUrl) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `OAuth authentication successful for "${serverName}".`,
-          },
-        ],
-        details: {
-          mode: "auth-start",
-          server: serverName,
-          authenticated: true,
-        },
+        content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
+        details: { mode: "auth-start", server: serverName, authenticated: true },
       };
     }
 
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: formatManualAuthInstructions(serverName, authorizationUrl),
-        },
-      ],
+      content: [{ type: "text" as const, text: formatManualAuthInstructions(serverName, authorizationUrl) }],
       details: { mode: "auth-start", server: serverName, authorizationUrl },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Failed to start OAuth for "${serverName}": ${message}`,
-        },
-      ],
-      details: {
-        mode: "auth-start",
-        error: "auth_start_failed",
-        server: serverName,
-        message,
-      },
+      content: [{ type: "text" as const, text: `Failed to start OAuth for "${serverName}": ${message}` }],
+      details: { mode: "auth-start", error: "auth_start_failed", server: serverName, message },
     };
   }
 }
 
-export async function executeAuthComplete(
-  state: McpExtensionState,
-  serverName: string,
-  input: string,
-  signal?: AbortSignal,
-): Promise<ProxyToolResult> {
+export async function executeAuthComplete(state: McpExtensionState, serverName: string, input: string, signal?: AbortSignal): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
-      details: {
-        mode: "auth-complete",
-        error: "not_found",
-        server: serverName,
-      },
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "auth-complete", error: "not_found", server: serverName },
     };
   }
-  if (isServerDisabled(definition))
-    return disabledResult("auth-complete", serverName);
+  if (isServerDisabled(definition)) return disabledResult("auth-complete", serverName);
 
   try {
     const status = state.authStorageOptions
       ? ownedSignal
-        ? await completeAuthFromInput(serverName, input, {
-            authStorageOptions: state.authStorageOptions,
-            signal: ownedSignal,
-            runtime: state.oauthRuntime,
-          })
-        : await completeAuthFromInput(serverName, input, {
-            authStorageOptions: state.authStorageOptions,
-            runtime: state.oauthRuntime,
-          })
+        ? await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, signal: ownedSignal, runtime: state.oauthRuntime })
+        : await completeAuthFromInput(serverName, input, { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime })
       : ownedSignal
-        ? await completeAuthFromInput(serverName, input, {
-            signal: ownedSignal,
-            runtime: state.oauthRuntime,
-          })
-        : await completeAuthFromInput(serverName, input, {
-            runtime: state.oauthRuntime,
-          });
+        ? await completeAuthFromInput(serverName, input, { signal: ownedSignal, runtime: state.oauthRuntime })
+        : await completeAuthFromInput(serverName, input, { runtime: state.oauthRuntime });
     if (status !== "authenticated") {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `OAuth authentication did not complete for "${serverName}".`,
-          },
-        ],
-        details: {
-          mode: "auth-complete",
-          error: "not_authenticated",
-          server: serverName,
-          status,
-        },
+        content: [{ type: "text" as const, text: `OAuth authentication did not complete for "${serverName}".` }],
+        details: { mode: "auth-complete", error: "not_authenticated", server: serverName, status },
       };
     }
 
@@ -708,51 +456,23 @@ export async function executeAuthComplete(
     clearFailure(state, serverName, "auth-complete");
     updateStatusBar(state);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.`,
-        },
-      ],
-      details: {
-        mode: "auth-complete",
-        server: serverName,
-        authenticated: true,
-      },
+      content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}". Run mcp({ connect: "${serverName}" }) to connect with the new token.` }],
+      details: { mode: "auth-complete", server: serverName, authenticated: true },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Failed to complete OAuth for "${serverName}": ${message}`,
-        },
-      ],
-      details: {
-        mode: "auth-complete",
-        error: "auth_complete_failed",
-        server: serverName,
-        message,
-      },
+      content: [{ type: "text" as const, text: `Failed to complete OAuth for "${serverName}": ${message}` }],
+      details: { mode: "auth-complete", error: "auth_complete_failed", server: serverName, message },
     };
   }
 }
 
-export function executeDescribe(
-  state: McpExtensionState,
-  toolName: string,
-): ProxyToolResult {
-  const exactMatches = getEnabledToolMatches(state, toolName, true).filter(
-    (match) => !isServerInActiveFailureBackoff(state, match.server),
-  );
+export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
+  const exactMatches = getEnabledToolMatches(state, toolName, true)
+    .filter((match) => !isServerInActiveFailureBackoff(state, match.server));
   if (exactMatches.length > 1) return ambiguousToolResult("describe", toolName);
-  if (
-    exactMatches.length === 0 &&
-    getEnabledToolMatches(state, toolName, false).filter(
-      (match) => !isServerInActiveFailureBackoff(state, match.server),
-    ).length > 1
-  ) {
+  if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).filter((match) => !isServerInActiveFailureBackoff(state, match.server)).length > 1) {
     return ambiguousToolResult("describe", toolName);
   }
 
@@ -783,30 +503,14 @@ export function executeDescribe(
     if (disabledMatch) return disabledResult("describe", disabledMatch);
     if (failedMatch) return serverBackoffResult(state, "describe", failedMatch);
     const suggestions = rankSuggestions(state, toolName, 5);
-    const suggestionText =
-      suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
+    const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.${suggestionText}`,
-        },
-      ],
-      details: {
-        mode: "describe",
-        error: "tool_not_found",
-        requestedTool: toolName,
-        suggestions,
-      },
+      content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.${suggestionText}` }],
+      details: { mode: "describe", error: "tool_not_found", requestedTool: toolName, suggestions },
     };
   }
 
-  const approvalMarker = isToolCallApprovalRequired(
-    state.config,
-    serverName,
-    toolMeta,
-    state.toolMetadata,
-  )
+  const approvalMarker = isToolCallApprovalRequired(state.config, serverName, toolMeta, state.toolMetadata)
     ? " (requires approval)"
     : "";
   let text = `${toolMeta.name}${approvalMarker}\n`;
@@ -818,10 +522,7 @@ export function executeDescribe(
 
   if (toolMeta.inputSchema && !toolMeta.resourceUri) {
     const shape = renderTsShape(toolMeta.inputSchema);
-    text +=
-      shape === null
-        ? `\nParameters:\n${formatSchema(toolMeta.inputSchema)}`
-        : `\nShape:\n${shape}`;
+    text += shape === null ? `\nParameters:\n${formatSchema(toolMeta.inputSchema)}` : `\nShape:\n${shape}`;
   } else if (toolMeta.resourceUri) {
     text += `\nNo parameters required (resource tool).`;
   } else {
@@ -844,10 +545,8 @@ export function executeSearch(
   offset = 0,
 ): ProxyToolResult {
   const showSchemas = includeSchemas !== false;
-  if (server && isServerDisabled(state.config.mcpServers[server]))
-    return disabledResult("search", server);
-  if (server && isServerInActiveFailureBackoff(state, server))
-    return serverBackoffResult(state, "search", server);
+  if (server && isServerDisabled(state.config.mcpServers[server])) return disabledResult("search", server);
+  if (server && isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "search", server);
 
   let matches: Array<{ server: string; tool: ToolMetadata; score: number }>;
   if (regex) {
@@ -855,18 +554,8 @@ export function executeSearch(
     try {
       if (query.length > MAX_REGEX_SEARCH_QUERY_LENGTH) {
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Regex query is too long; maximum length is ${MAX_REGEX_SEARCH_QUERY_LENGTH} characters.`,
-            },
-          ],
-          details: {
-            mode: "search",
-            error: "query_too_long",
-            query,
-            maxLength: MAX_REGEX_SEARCH_QUERY_LENGTH,
-          },
+          content: [{ type: "text" as const, text: `Regex query is too long; maximum length is ${MAX_REGEX_SEARCH_QUERY_LENGTH} characters.` }],
+          details: { mode: "search", error: "query_too_long", query, maxLength: MAX_REGEX_SEARCH_QUERY_LENGTH },
         };
       }
       pattern = new RegExp(query, "i");
@@ -877,29 +566,14 @@ export function executeSearch(
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: "Regex query rejected because safety analysis failed.",
-            },
-          ],
+          content: [{ type: "text" as const, text: "Regex query rejected because safety analysis failed." }],
           details: { mode: "search", error: "unsafe_pattern", query, reason },
         };
       }
       if (safety.status !== "safe") {
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Regex query rejected as unsafe (${safety.status}).`,
-            },
-          ],
-          details: {
-            mode: "search",
-            error: "unsafe_pattern",
-            query,
-            safetyStatus: safety.status,
-          },
+          content: [{ type: "text" as const, text: `Regex query rejected as unsafe (${safety.status}).` }],
+          details: { mode: "search", error: "unsafe_pattern", query, safetyStatus: safety.status },
         };
       }
     } catch {
@@ -917,29 +591,20 @@ export function executeSearch(
       if (isServerInActiveFailureBackoff(state, serverName)) continue;
       if (server && serverName !== server) continue;
       for (const tool of metadata) {
-        const matched =
-          pattern.test(tool.name) ||
-          pattern.test(tool.description) ||
-          resolveSearchKeywords(
-            definition,
-            tool.originalName,
-            serverName,
-            globalPrefix,
-          ).some((keyword) => pattern.test(keyword));
+        const matched = pattern.test(tool.name) || pattern.test(tool.description)
+          || resolveSearchKeywords(definition, tool.originalName, serverName, globalPrefix).some(keyword => pattern.test(keyword));
         if (matched) matches.push({ server: serverName, tool, score: 0 });
       }
     }
   } else if (query.trim().length === 0) {
     if (!server) {
       return {
-        content: [
-          { type: "text" as const, text: "Search query cannot be empty" },
-        ],
+        content: [{ type: "text" as const, text: "Search query cannot be empty" }],
         details: { mode: "search", error: "empty_query" },
       };
     }
     matches = (state.toolMetadata.get(server) ?? [])
-      .map((tool) => ({ server, tool, score: 0 }))
+      .map(tool => ({ server, tool, score: 0 }))
       .sort((a, b) => a.tool.name.localeCompare(b.tool.name));
   } else {
     matches = rankToolMatches(state, query, server);
@@ -948,25 +613,16 @@ export function executeSearch(
   const page = paginate(matches, offset, limit);
   if (page.total === 0) {
     const connectingServers = server
-      ? state.config.mcpServers[server] && state.manager.isConnecting(server)
-        ? [server]
-        : []
+      ? state.config.mcpServers[server] && state.manager.isConnecting(server) ? [server] : []
       : Object.keys(state.config.mcpServers)
-          .filter(
-            (name) =>
-              !isServerDisabled(state.config.mcpServers[name]) &&
-              state.manager.isConnecting(name),
-          )
-          .sort((a, b) => a.localeCompare(b));
-    const msg = server
-      ? `No tools matching "${query}" in "${server}"`
-      : `No tools matching "${query}"`;
-    const connectingMessage =
-      connectingServers.length === 1
-        ? ` Server "${connectingServers[0]}" is still connecting; retry in a moment.`
-        : connectingServers.length > 1
-          ? ` Servers ${connectingServers.map((name) => `"${name}"`).join(", ")} are still connecting; retry in a moment.`
-          : "";
+        .filter(name => !isServerDisabled(state.config.mcpServers[name]) && state.manager.isConnecting(name))
+        .sort((a, b) => a.localeCompare(b));
+    const msg = server ? `No tools matching "${query}" in "${server}"` : `No tools matching "${query}"`;
+    const connectingMessage = connectingServers.length === 1
+      ? ` Server "${connectingServers[0]}" is still connecting; retry in a moment.`
+      : connectingServers.length > 1
+        ? ` Servers ${connectingServers.map(name => `"${name}"`).join(", ")} are still connecting; retry in a moment.`
+        : "";
     return {
       content: [{ type: "text" as const, text: `${msg}${connectingMessage}` }],
       details: {
@@ -983,12 +639,7 @@ export function executeSearch(
 
   let text = `Found ${page.total} tool${page.total === 1 ? "" : "s"} matching "${query}":\n\n`;
   for (const match of page.items) {
-    const approvalMarker = isToolCallApprovalRequired(
-      state.config,
-      match.server,
-      match.tool,
-      state.toolMetadata,
-    )
+    const approvalMarker = isToolCallApprovalRequired(state.config, match.server, match.tool, state.toolMetadata)
       ? " (requires approval)"
       : "";
     if (showSchemas) {
@@ -996,36 +647,26 @@ export function executeSearch(
       text += `  ${match.tool.description || "(no description)"}\n`;
       if (match.tool.inputSchema && !match.tool.resourceUri) {
         const shape = renderTsShape(match.tool.inputSchema);
-        text +=
-          shape === null
-            ? `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
-            : `\n  Shape:\n${shape
-                .split("\n")
-                .map((line) => `    ${line}`)
-                .join("\n")}\n`;
+        text += shape === null
+          ? `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
+          : `\n  Shape:\n${shape.split("\n").map(line => `    ${line}`).join("\n")}\n`;
       } else if (match.tool.resourceUri) {
         text += "  No parameters (resource tool).\n";
       }
       text += "\n";
     } else {
       text += `- ${match.tool.name}${approvalMarker}`;
-      if (match.tool.description)
-        text += ` - ${truncateAtWord(match.tool.description, 50)}`;
+      if (match.tool.description) text += ` - ${truncateAtWord(match.tool.description, 50)}`;
       text += "\n";
     }
   }
-  if (page.hasMore)
-    text += `\n${page.items.length} of ${page.total} — offset: ${page.nextOffset} for more\n`;
+  if (page.hasMore) text += `\n${page.items.length} of ${page.total} — offset: ${page.nextOffset} for more\n`;
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
     details: {
       mode: "search",
-      matches: page.items.map((match) => ({
-        server: match.server,
-        tool: match.tool.name,
-        score: match.score,
-      })),
+      matches: page.items.map(match => ({ server: match.server, tool: match.tool.name, score: match.score })),
       count: page.total,
       hasMore: page.hasMore,
       nextOffset: page.nextOffset,
@@ -1034,43 +675,23 @@ export function executeSearch(
   };
 }
 
-export function executeList(
-  state: McpExtensionState,
-  server: string,
-): ProxyToolResult {
+export function executeList(state: McpExtensionState, server: string): ProxyToolResult {
   const definition = state.config.mcpServers[server];
   if (!definition) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${server}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
-      details: {
-        mode: "list",
-        server,
-        tools: [],
-        count: 0,
-        error: "not_found",
-      },
+      content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "list", server, tools: [], count: 0, error: "not_found" },
     };
   }
   if (isServerDisabled(definition)) return disabledResult("list", server);
 
   const metadata = state.toolMetadata.get(server);
-  const toolNames = metadata?.map((m) => m.name) ?? [];
+  const toolNames = metadata?.map(m => m.name) ?? [];
   const connection = state.manager.getConnection(server);
   if (isServerInActiveFailureBackoff(state, server)) {
     return {
       ...serverBackoffResult(state, "list", server),
-      details: {
-        mode: "list",
-        server,
-        tools: [],
-        count: 0,
-        error: "server_backoff",
-      },
+      details: { mode: "list", server, tools: [], count: 0, error: "server_backoff" },
     };
   }
   const instructions = state.serverInstructions.get(server);
@@ -1086,59 +707,23 @@ export function executeList(
   if (toolNames.length === 0) {
     if (connection?.status === "connected") {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Server "${server}" has no tools.${instructionsText}`,
-          },
-        ],
-        details: {
-          mode: "list",
-          server,
-          tools: [],
-          count: 0,
-          hasInstructions: Boolean(instructions),
-        },
+        content: [{ type: "text" as const, text: `Server "${server}" has no tools.${instructionsText}` }],
+        details: { mode: "list", server, tools: [], count: 0, hasInstructions: Boolean(instructions) },
       };
     }
     if (metadata !== undefined) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Server "${server}" has no cached tools (not connected).${instructionsText}`,
-          },
-        ],
-        details: {
-          mode: "list",
-          server,
-          tools: [],
-          count: 0,
-          cached: true,
-          hasInstructions: Boolean(instructions),
-        },
+        content: [{ type: "text" as const, text: `Server "${server}" has no cached tools (not connected).${instructionsText}` }],
+        details: { mode: "list", server, tools: [], count: 0, cached: true, hasInstructions: Boolean(instructions) },
       };
     }
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.${instructionsText}`,
-        },
-      ],
-      details: {
-        mode: "list",
-        server,
-        tools: [],
-        count: 0,
-        error: "not_connected",
-        hasInstructions: Boolean(instructions),
-      },
+      content: [{ type: "text" as const, text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.${instructionsText}` }],
+      details: { mode: "list", server, tools: [], count: 0, error: "not_connected", hasInstructions: Boolean(instructions) },
     };
   }
 
-  const cachedNote =
-    connection?.status === "connected" ? "" : " (not connected, cached)";
+  const cachedNote = connection?.status === "connected" ? "" : " (not connected, cached)";
   let text = `${server} (${toolNames.length} tools${cachedNote}):\n\n`;
 
   const descMap = new Map<string, string>();
@@ -1160,46 +745,25 @@ export function executeList(
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: {
-      mode: "list",
-      server,
-      tools: toolNames,
-      count: toolNames.length,
-      hasInstructions: Boolean(instructions),
-    },
+    details: { mode: "list", server, tools: toolNames, count: toolNames.length, hasInstructions: Boolean(instructions) },
   };
 }
 
-export function executeInstructions(
-  state: McpExtensionState,
-  server: string,
-): ProxyToolResult {
+export function executeInstructions(state: McpExtensionState, server: string): ProxyToolResult {
   const definition = state.config.mcpServers[server];
   if (!definition) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${server}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
+      content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "instructions", server, error: "not_found" },
     };
   }
-  if (isServerDisabled(definition))
-    return disabledResult("instructions", server);
-  if (isServerInActiveFailureBackoff(state, server))
-    return serverBackoffResult(state, "instructions", server);
+  if (isServerDisabled(definition)) return disabledResult("instructions", server);
+  if (isServerInActiveFailureBackoff(state, server)) return serverBackoffResult(state, "instructions", server);
 
   const instructions = state.serverInstructions.get(server);
   if (instructions) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `${server} instructions:\n\n${instructions}`,
-        },
-      ],
+      content: [{ type: "text" as const, text: `${server} instructions:\n\n${instructions}` }],
       details: { mode: "instructions", server, length: instructions.length },
     };
   }
@@ -1207,77 +771,43 @@ export function executeInstructions(
   const connection = state.manager.getConnection(server);
   if (connection?.status === "connected") {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${server}" does not provide instructions.`,
-        },
-      ],
+      content: [{ type: "text" as const, text: `Server "${server}" does not provide instructions.` }],
       details: { mode: "instructions", server, error: "no_instructions" },
     };
   }
 
   return {
-    content: [
-      {
-        type: "text" as const,
-        text: `No instructions cached for "${server}". Use mcp({ connect: "${server}" }) to connect and refresh.`,
-      },
-    ],
+    content: [{ type: "text" as const, text: `No instructions cached for "${server}". Use mcp({ connect: "${server}" }) to connect and refresh.` }],
     details: { mode: "instructions", server, error: "not_connected" },
   };
 }
 
-export async function executeConnect(
-  state: McpExtensionState,
-  serverName: string,
-  signal?: AbortSignal,
-): Promise<ProxyToolResult> {
+export async function executeConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<ProxyToolResult> {
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   throwIfAborted(ownedSignal);
   const definition = state.config.mcpServers[serverName];
   if (!definition) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
       details: { mode: "connect", error: "not_found", server: serverName },
     };
   }
-  if (isServerDisabled(definition))
-    return disabledResult("connect", serverName);
+  if (isServerDisabled(definition)) return disabledResult("connect", serverName);
 
   try {
     if (state.ui) {
-      state.ui.setStatus(
-        "mcp",
-        formatMcpStatus(state.config, `connecting to ${serverName}...`),
-      );
+      state.ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${serverName}...`));
     }
     const currentConnection = state.manager.getConnection(serverName);
-    let connection =
-      currentConnection?.status === "connected"
-        ? await state.manager.reconnect(
-            serverName,
-            definition,
-            currentConnection,
-            ownedSignal,
-          )
-        : await state.manager.connect(serverName, definition, ownedSignal);
+    let connection = currentConnection?.status === "connected"
+      ? await state.manager.reconnect(serverName, definition, currentConnection, ownedSignal)
+      : await state.manager.connect(serverName, definition, ownedSignal);
     if (connection.status === "needs-auth") {
       const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
-          details: {
-            mode: "connect",
-            error: "auth_required",
-            server: serverName,
-            message: autoAuth.message,
-          },
+          details: { mode: "connect", error: "auth_required", server: serverName, message: autoAuth.message },
         };
       }
       if (autoAuth.status === "success") {
@@ -1291,36 +821,15 @@ export async function executeConnect(
         const message = getAuthRequiredMessage(state, serverName);
         return {
           content: [{ type: "text" as const, text: message }],
-          details: {
-            mode: "connect",
-            error: "auth_required",
-            server: serverName,
-            message,
-          },
+          details: { mode: "connect", error: "auth_required", server: serverName, message },
         };
       }
     }
     const prefix = state.config.settings?.toolPrefix ?? "server";
-    const { metadata } = buildToolMetadata(
-      connection.tools,
-      connection.resources,
-      definition,
-      serverName,
-      prefix,
-      state.config.mcpServers,
-      state.toolMetadata,
-    );
+    const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix, state.config.mcpServers, state.toolMetadata);
     state.toolMetadata.set(serverName, metadata);
     if (!connection.promptDiscoveryFailed) {
-      state.promptMetadata?.set(
-        serverName,
-        reconstructPromptMetadata(
-          serverName,
-          connection.prompts ?? [],
-          prefix,
-          definition,
-        ),
-      );
+      state.promptMetadata?.set(serverName, reconstructPromptMetadata(serverName, connection.prompts ?? [], prefix, definition));
       state.promptMetadataLive?.add(serverName);
     }
     if (connection.instructions) {
@@ -1330,29 +839,17 @@ export async function executeConnect(
     }
     updateMetadataCache(state, serverName);
     const restored = clearFailure(state, serverName, "proxy-connect");
-    if (!restored)
-      notifyToolMetadataUpdated(state, serverName, "proxy-connect");
+    if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-connect");
     markKeepAliveAfterConnect(state, serverName);
     updateStatusBar(state);
     return executeList(state, serverName);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (!isAbortError(error, ownedSignal))
-      recordFailure(state, serverName, message);
+    if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
     updateStatusBar(state);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Failed to connect to "${serverName}": ${message}`,
-        },
-      ],
-      details: {
-        mode: "connect",
-        error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed",
-        server: serverName,
-        message,
-      },
+      content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
+      details: { mode: "connect", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", server: serverName, message },
     };
   }
 }
@@ -1372,21 +869,12 @@ export async function executeCall(
   let toolMeta: ToolMetadata | undefined;
   let autoAuthAttempted = false;
   const prefixMode = state.config.settings?.toolPrefix ?? "server";
-  const disabledCallResult = (
-    disabledServer: string,
-    metadata?: ToolMetadata,
-  ): ProxyToolResult => {
+  const disabledCallResult = (disabledServer: string, metadata?: ToolMetadata): ProxyToolResult => {
     if (!metadata) {
       const message = `Server "${disabledServer}" is disabled. Run /mcp enable ${disabledServer} and /reload to enable it.`;
       return {
         content: [{ type: "text" as const, text: message }],
-        details: {
-          mode: "call",
-          error: "server_disabled",
-          server: disabledServer,
-          requestedTool: toolName,
-          message,
-        },
+        details: { mode: "call", error: "server_disabled", server: disabledServer, requestedTool: toolName, message },
       };
     }
     const message = `Server "${disabledServer}" is disabled. Run /mcp enable ${disabledServer} and /reload to enable it.`;
@@ -1401,25 +889,12 @@ export async function executeCall(
 
   if (serverName && !state.config.mcpServers[serverName]) {
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Server "${serverName}" not found. Use mcp({}) to see available servers.`,
-        },
-      ],
-      details: {
-        mode: "call",
-        error: "server_not_found",
-        server: serverName,
-        requestedTool: toolName,
-      },
+      content: [{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` }],
+      details: { mode: "call", error: "server_not_found", server: serverName, requestedTool: toolName },
     };
   }
   if (serverName) {
-    const match = getSingleToolMatch(
-      state.toolMetadata.get(serverName),
-      toolName,
-    );
+    const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
     if (match === "ambiguous") return ambiguousToolResult("call", toolName);
     toolMeta = match;
     if (isServerDisabled(state.config.mcpServers[serverName])) {
@@ -1428,18 +903,13 @@ export async function executeCall(
   } else {
     const exactMatches = getEnabledToolMatches(state, toolName, true);
     if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
-    if (
-      exactMatches.length === 0 &&
-      getEnabledToolMatches(state, toolName, false).length > 1
-    ) {
+    if (exactMatches.length === 0 && getEnabledToolMatches(state, toolName, false).length > 1) {
       return ambiguousToolResult("call", toolName);
     }
 
-    let disabledMatch:
-      | { serverName: string; toolMeta: ToolMetadata }
-      | undefined;
+    let disabledMatch: { serverName: string; toolMeta: ToolMetadata } | undefined;
     for (const [server, metadata] of state.toolMetadata.entries()) {
-      const found = metadata.find((tool) => tool.name === toolName);
+      const found = metadata.find(tool => tool.name === toolName);
       if (!found) continue;
       if (isServerDisabled(state.config.mcpServers[server])) {
         disabledMatch ??= { serverName: server, toolMeta: found };
@@ -1462,20 +932,13 @@ export async function executeCall(
         break;
       }
     }
-    if (!toolMeta && disabledMatch)
-      return disabledCallResult(
-        disabledMatch.serverName,
-        disabledMatch.toolMeta,
-      );
+    if (!toolMeta && disabledMatch) return disabledCallResult(disabledMatch.serverName, disabledMatch.toolMeta);
   }
 
   if (serverName && !toolMeta) {
     const connected = await lazyConnect(state, serverName, ownedSignal);
     if (connected) {
-      const match = getSingleToolMatch(
-        state.toolMetadata.get(serverName),
-        toolName,
-      );
+      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
       if (match === "ambiguous") return ambiguousToolResult("call", toolName);
       toolMeta = match;
     } else {
@@ -1483,79 +946,38 @@ export async function executeCall(
       if (needsAuthConnection?.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(
-            state,
-            serverName,
-            ownedSignal,
-          );
+          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
-              details: {
-                mode: "call",
-                error: "auth_required",
-                server: serverName,
-                requestedTool: toolName,
-                message: autoAuth.message,
-              },
+              details: { mode: "call", error: "auth_required", server: serverName, requestedTool: toolName, message: autoAuth.message },
             };
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
             clearFailure(state, serverName);
-            const connectedAfterAuth = await lazyConnect(
-              state,
-              serverName,
-              ownedSignal,
-            );
+            const connectedAfterAuth = await lazyConnect(state, serverName, ownedSignal);
             if (connectedAfterAuth) {
-              const match = getSingleToolMatch(
-                state.toolMetadata.get(serverName),
-                toolName,
-              );
-              if (match === "ambiguous")
-                return ambiguousToolResult("call", toolName);
+              const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
+              if (match === "ambiguous") return ambiguousToolResult("call", toolName);
               toolMeta = match;
               if (!toolMeta) {
                 const suggestions = rankSuggestions(state, toolName, 5);
-                const suggestionText =
-                  suggestions.length > 0
-                    ? ` Did you mean: ${suggestions.join(", ")}`
-                    : "";
+                const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
                 return {
-                  content: [
-                    {
-                      type: "text" as const,
-                      text: `Tool "${toolName}" not found on "${serverName}" after reconnect.${suggestionText}`,
-                    },
-                  ],
-                  details: {
-                    mode: "call",
-                    error: "tool_not_found_after_reconnect",
-                    server: serverName,
-                    requestedTool: toolName,
-                    suggestions,
-                  },
+                  content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.${suggestionText}` }],
+                  details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
                 };
               }
             }
           }
         }
 
-        if (
-          !toolMeta &&
-          state.manager.getConnection(serverName)?.status === "needs-auth"
-        ) {
+        if (!toolMeta && state.manager.getConnection(serverName)?.status === "needs-auth") {
           const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
-            details: {
-              mode: "call",
-              error: "auth_required",
-              server: serverName,
-              requestedTool: toolName,
-              message,
-            },
+            details: { mode: "call", error: "auth_required", server: serverName, requestedTool: toolName, message },
           };
         }
       }
@@ -1564,18 +986,8 @@ export async function executeCall(
         const failedAgo = getFailureAgeSeconds(state, serverName);
         if (failedAgo !== null) {
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)`,
-              },
-            ],
-            details: {
-              mode: "call",
-              error: "server_backoff",
-              server: serverName,
-              requestedTool: toolName,
-            },
+            content: [{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` }],
+            details: { mode: "call", error: "server_backoff", server: serverName, requestedTool: toolName },
           };
         }
       }
@@ -1585,47 +997,27 @@ export async function executeCall(
   let prefixMatchedServer: string | undefined;
 
   if (!serverName && !toolMeta && prefixMode !== "none") {
-    const lazyExactMatches: { serverName: string; toolMeta: ToolMetadata }[] =
-      [];
-    const lazyFallbackMatches: {
-      serverName: string;
-      toolMeta: ToolMetadata;
-    }[] = [];
+    const lazyExactMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
+    const lazyFallbackMatches: { serverName: string; toolMeta: ToolMetadata }[] = [];
     const candidates = Object.keys(state.config.mcpServers)
-      .filter((name) => !isServerDisabled(state.config.mcpServers[name]))
-      .map((name) => ({ name, prefix: getServerPrefix(name, prefixMode) }))
-      .filter((c) => c.prefix && toolName.startsWith(c.prefix + "_"))
+      .filter(name => !isServerDisabled(state.config.mcpServers[name]))
+      .map(name => ({ name, prefix: getServerPrefix(name, prefixMode) }))
+      .filter(c => c.prefix && toolName.startsWith(c.prefix + "_"))
       .sort((a, b) => b.prefix.length - a.prefix.length);
 
     for (const { name: configuredServer } of candidates) {
       const existingConnection = state.manager.getConnection(configuredServer);
       const failedAgo = getFailureAgeSeconds(state, configuredServer);
-      if (failedAgo !== null && existingConnection?.status !== "needs-auth")
-        continue;
+      if (failedAgo !== null && existingConnection?.status !== "needs-auth") continue;
 
       let connected = await lazyConnect(state, configuredServer, ownedSignal);
-      if (
-        !connected &&
-        state.manager.getConnection(configuredServer)?.status ===
-          "needs-auth" &&
-        !autoAuthAttempted
-      ) {
+      if (!connected && state.manager.getConnection(configuredServer)?.status === "needs-auth" && !autoAuthAttempted) {
         autoAuthAttempted = true;
-        const autoAuth = await attemptAutoAuth(
-          state,
-          configuredServer,
-          ownedSignal,
-        );
+        const autoAuth = await attemptAutoAuth(state, configuredServer, ownedSignal);
         if (autoAuth.status === "failed") {
           return {
             content: [{ type: "text" as const, text: autoAuth.message }],
-            details: {
-              mode: "call",
-              error: "auth_required",
-              server: configuredServer,
-              requestedTool: toolName,
-              message: autoAuth.message,
-            },
+            details: { mode: "call", error: "auth_required", server: configuredServer, requestedTool: toolName, message: autoAuth.message },
           };
         }
         if (autoAuth.status === "success") {
@@ -1641,23 +1033,14 @@ export async function executeCall(
       const exactMatches = getToolMatches(metadata, toolName, true);
       if (exactMatches.length > 1) return ambiguousToolResult("call", toolName);
       if (exactMatches.length === 1) {
-        lazyExactMatches.push({
-          serverName: configuredServer,
-          toolMeta: exactMatches[0]!,
-        });
+        lazyExactMatches.push({ serverName: configuredServer, toolMeta: exactMatches[0]! });
         continue;
       }
       const fallbackMatches = getToolMatches(metadata, toolName, false);
-      if (fallbackMatches.length > 1)
-        return ambiguousToolResult("call", toolName);
-      if (fallbackMatches.length === 1)
-        lazyFallbackMatches.push({
-          serverName: configuredServer,
-          toolMeta: fallbackMatches[0]!,
-        });
+      if (fallbackMatches.length > 1) return ambiguousToolResult("call", toolName);
+      if (fallbackMatches.length === 1) lazyFallbackMatches.push({ serverName: configuredServer, toolMeta: fallbackMatches[0]! });
     }
-    const lazyMatches =
-      lazyExactMatches.length > 0 ? lazyExactMatches : lazyFallbackMatches;
+    const lazyMatches = lazyExactMatches.length > 0 ? lazyExactMatches : lazyFallbackMatches;
     if (lazyMatches.length > 1) return ambiguousToolResult("call", toolName);
     if (lazyMatches.length === 1) {
       serverName = lazyMatches[0]!.serverName;
@@ -1667,23 +1050,12 @@ export async function executeCall(
 
   if (!serverName || !toolMeta) {
     const nativeTool = !serverOverride
-      ? getPiTools?.().find(
-          (tool) => tool.name === toolName && tool.name !== "mcp",
-        )
+      ? getPiTools?.().find((tool) => tool.name === toolName && tool.name !== "mcp")
       : undefined;
     if (nativeTool) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `"${toolName}" is a native Pi tool. Call ${toolName} directly instead of using mcp({ tool: "${toolName}" }).`,
-          },
-        ],
-        details: {
-          mode: "call",
-          error: "native_tool",
-          requestedTool: toolName,
-        },
+        content: [{ type: "text" as const, text: `"${toolName}" is a native Pi tool. Call ${toolName} directly instead of using mcp({ tool: "${toolName}" }).` }],
+        details: { mode: "call", error: "native_tool", requestedTool: toolName },
       };
     }
 
@@ -1696,17 +1068,10 @@ export async function executeCall(
       msg += ` Use mcp({ search: "..." }) to search.`;
     }
     const suggestions = rankSuggestions(state, toolName, 5);
-    if (suggestions.length > 0)
-      msg += ` Did you mean: ${suggestions.join(", ")}`;
+    if (suggestions.length > 0) msg += ` Did you mean: ${suggestions.join(", ")}`;
     return {
       content: [{ type: "text" as const, text: msg }],
-      details: {
-        mode: "call",
-        error: "tool_not_found",
-        requestedTool: toolName,
-        hintServer,
-        suggestions,
-      },
+      details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer, suggestions },
     };
   }
 
@@ -1722,12 +1087,7 @@ export async function executeCall(
       if (autoAuth.status === "failed") {
         return {
           content: [{ type: "text" as const, text: autoAuth.message }],
-          details: {
-            mode: "call",
-            error: "auth_required",
-            ...callIdentity,
-            message: autoAuth.message,
-          },
+          details: { mode: "call", error: "auth_required", ...callIdentity, message: autoAuth.message },
         };
       }
       if (autoAuth.status === "success") {
@@ -1741,12 +1101,7 @@ export async function executeCall(
       const message = getAuthRequiredMessage(state, serverName);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: {
-          mode: "call",
-          error: "auth_required",
-          ...callIdentity,
-          message,
-        },
+        details: { mode: "call", error: "auth_required", ...callIdentity, message },
       };
     }
   }
@@ -1754,12 +1109,7 @@ export async function executeCall(
     const failedAgo = getFailureAgeSeconds(state, serverName);
     if (failedAgo !== null) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)`,
-          },
-        ],
+        content: [{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` }],
         details: { mode: "call", error: "server_backoff", ...callIdentity },
       };
     }
@@ -1767,58 +1117,29 @@ export async function executeCall(
     const definition = state.config.mcpServers[serverName];
     if (!definition) {
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Server "${serverName}" not connected`,
-          },
-        ],
-        details: {
-          mode: "call",
-          error: "server_not_connected",
-          ...callIdentity,
-        },
+        content: [{ type: "text" as const, text: `Server "${serverName}" not connected` }],
+        details: { mode: "call", error: "server_not_connected", ...callIdentity },
       };
     }
 
     try {
       if (state.ui) {
-        state.ui.setStatus(
-          "mcp",
-          formatMcpStatus(state.config, `connecting to ${serverName}...`),
-        );
+        state.ui.setStatus("mcp", formatMcpStatus(state.config, `connecting to ${serverName}...`));
       }
-      connection = await state.manager.connect(
-        serverName,
-        definition,
-        ownedSignal,
-      );
+      connection = await state.manager.connect(serverName, definition, ownedSignal);
       if (connection.status === "needs-auth") {
         if (!autoAuthAttempted) {
           autoAuthAttempted = true;
-          const autoAuth = await attemptAutoAuth(
-            state,
-            serverName,
-            ownedSignal,
-          );
+          const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
           if (autoAuth.status === "failed") {
             return {
               content: [{ type: "text" as const, text: autoAuth.message }],
-              details: {
-                mode: "call",
-                error: "auth_required",
-                ...callIdentity,
-                message: autoAuth.message,
-              },
+              details: { mode: "call", error: "auth_required", ...callIdentity, message: autoAuth.message },
             };
           }
           if (autoAuth.status === "success") {
             await state.manager.close(serverName);
-            connection = await state.manager.connect(
-              serverName,
-              definition,
-              ownedSignal,
-            );
+            connection = await state.manager.connect(serverName, definition, ownedSignal);
           }
         }
 
@@ -1826,75 +1147,38 @@ export async function executeCall(
           const message = getAuthRequiredMessage(state, serverName);
           return {
             content: [{ type: "text" as const, text: message }],
-            details: {
-              mode: "call",
-              error: "auth_required",
-              ...callIdentity,
-              message,
-            },
+            details: { mode: "call", error: "auth_required", ...callIdentity, message },
           };
         }
       }
       updateServerMetadata(state, serverName);
       updateMetadataCache(state, serverName);
       const restored = clearFailure(state, serverName, "proxy-call-reconnect");
-      if (!restored)
-        notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
+      if (!restored) notifyToolMetadataUpdated(state, serverName, "proxy-call-reconnect");
       markKeepAliveAfterConnect(state, serverName);
       updateStatusBar(state);
-      const match = getSingleToolMatch(
-        state.toolMetadata.get(serverName),
-        toolName,
-      );
+      const match = getSingleToolMatch(state.toolMetadata.get(serverName), toolName);
       if (match === "ambiguous") return ambiguousToolResult("call", toolName);
       toolMeta = match;
       if (!toolMeta) {
         const available = getToolNames(state, serverName);
-        const hint =
-          available.length > 0
-            ? `Available tools on "${serverName}": ${available.join(", ")}`
-            : `Server "${serverName}" has no tools.`;
+        const hint = available.length > 0
+          ? `Available tools on "${serverName}": ${available.join(", ")}`
+          : `Server "${serverName}" has no tools.`;
         const suggestions = rankSuggestions(state, toolName, 5);
-        const suggestionText =
-          suggestions.length > 0
-            ? ` Did you mean: ${suggestions.join(", ")}`
-            : "";
+        const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}` : "";
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}${suggestionText}`,
-            },
-          ],
-          details: {
-            mode: "call",
-            error: "tool_not_found_after_reconnect",
-            server: serverName,
-            requestedTool: toolName,
-            suggestions,
-          },
+          content: [{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}${suggestionText}` }],
+          details: { mode: "call", error: "tool_not_found_after_reconnect", server: serverName, requestedTool: toolName, suggestions },
         };
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (!isAbortError(error, ownedSignal))
-        recordFailure(state, serverName, message);
+      if (!isAbortError(error, ownedSignal)) recordFailure(state, serverName, message);
       updateStatusBar(state);
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Failed to connect to "${serverName}": ${message}`,
-          },
-        ],
-        details: {
-          mode: "call",
-          error: isAbortError(error, ownedSignal)
-            ? "aborted"
-            : "connect_failed",
-          ...callIdentity,
-          message,
-        },
+        content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
+        details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "connect_failed", ...callIdentity, message },
       };
     }
   }
@@ -1903,9 +1187,7 @@ export async function executeCall(
     return disabledCallResult(serverName, toolMeta);
   }
 
-  const normalizedArgs = toolMeta.resourceUri
-    ? (args ?? {})
-    : normalizeToolArguments(args);
+  const normalizedArgs = toolMeta.resourceUri ? args ?? {} : normalizeToolArguments(args);
   const approval = await ensureToolCallApproved(
     state,
     serverName,
@@ -1932,15 +1214,13 @@ export async function executeCall(
 
   let uiSession: UiSessionRuntime | null = null;
   const requestOptions = withUiProgressBridge(
-    state.manager.getRequestOptions?.(serverName, ownedSignal) ??
-      (ownedSignal ? { signal: ownedSignal } : undefined),
+    state.manager.getRequestOptions?.(serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined),
     state.ui,
+    serverName,
     toolMeta.originalName,
   );
 
-  const outputGuardOptions = resolveMcpOutputGuardOptions(
-    state.config.settings,
-  );
+  const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
   const recoverAuthConnection = async () => {
     const current = state.manager.getConnection(serverName);
     if (current?.status === "connected") return current;
@@ -1949,10 +1229,7 @@ export async function executeCall(
       autoAuthAttempted = true;
       const autoAuth = await attemptAutoAuth(state, serverName, ownedSignal);
       if (autoAuth.status === "failed") {
-        throw new SessionRecoveryAuthRequiredError(
-          serverName,
-          autoAuth.message,
-        );
+        throw new SessionRecoveryAuthRequiredError(serverName, autoAuth.message);
       }
       if (autoAuth.status === "success") {
         const definition = state.config.mcpServers[serverName];
@@ -1963,11 +1240,7 @@ export async function executeCall(
           await state.manager.close(serverName);
         }
         clearFailure(state, serverName);
-        connection = await state.manager.connect(
-          serverName,
-          definition,
-          ownedSignal,
-        );
+        connection = await state.manager.connect(serverName, definition, ownedSignal);
         return connection;
       }
     }
@@ -1987,29 +1260,13 @@ export async function executeCall(
           onNeedsAuth: recoverAuthConnection,
         },
         serverName,
-        (conn) =>
-          conn.client.readResource(
-            { uri: toolMeta.resourceUri! },
-            requestOptions,
-          ),
+        (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
       );
-      const content = transformMcpResourceContents(
-        result.contents ?? [],
-        state.owner?.signal,
-      );
-      const guarded = await guardMcpOutput(
-        content.length > 0
-          ? content
-          : [{ type: "text" as const, text: "(empty resource)" }],
-        outputGuardOptions,
-      );
+      const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
+      const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
       return {
         content: guarded.content,
-        details: {
-          mode: "call",
-          ...callIdentity,
-          ...guardedMcpDetails(guarded),
-        },
+        details: { mode: "call", ...callIdentity, ...guardedMcpDetails(guarded) },
       };
     }
 
@@ -2019,9 +1276,7 @@ export async function executeCall(
           toolName: toolMeta.originalName,
           toolArgs: normalizedArgs,
           uiResourceUri: toolMeta.uiResourceUri,
-          ...(toolMeta.uiStreamMode !== undefined
-            ? { streamMode: toolMeta.uiStreamMode }
-            : {}),
+          ...(toolMeta.uiStreamMode !== undefined ? { streamMode: toolMeta.uiStreamMode } : {}),
           ...(signal ? { signal } : {}),
           onNeedsAuth: recoverAuthConnection,
         })
@@ -2035,68 +1290,32 @@ export async function executeCall(
         onNeedsAuth: recoverAuthConnection,
       },
       serverName,
-      (conn) =>
-        abortable(
-          conn.client.callTool(
-            {
-              name: toolMeta.originalName,
-              arguments: normalizedArgs,
-              _meta: uiSession?.requestMeta,
-            },
-            requestOptions,
-          ),
-          ownedSignal,
-        ),
+      (conn) => abortable(conn.client.callTool({
+        name: toolMeta.originalName,
+        arguments: normalizedArgs,
+        _meta: uiSession?.requestMeta,
+      }, requestOptions), ownedSignal),
     );
 
     if (toolMeta.uiResourceUri) {
-      // SAFETY: ui-session renderer consumes the raw wire result shape, which the SDK types do not expose publicly
-      uiSession?.sendToolResult(
-        result as unknown as import("@modelcontextprotocol/client").CallToolResult,
-      );
+      uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {
         const mcpContent = (result.content ?? []) as McpContent[];
         const content = transformMcpContent(mcpContent, state.owner?.signal);
-        const outputContent =
-          content.length > 0
-            ? content
-            : [{ type: "text" as const, text: "(empty result)" }];
-        const schemaText = toolMeta.inputSchema
-          ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
-          : "";
-        const guarded = await guardMcpOutput(outputContent, {
-          ...outputGuardOptions,
-          prefix: "Error: ",
-          suffix: schemaText,
-          emptyTextFallback: "Tool execution failed",
-          rawMcpResult: result,
-        });
+        const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
+        const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+        const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
         return {
           content: guarded.content,
-          details: {
-            mode: "call",
-            error: "tool_error",
-            ...callIdentity,
-            ...guardedMcpDetails(guarded),
-          },
+          details: { mode: "call", error: "tool_error", ...callIdentity, ...guardedMcpDetails(guarded) },
         };
       }
 
-      const content = resolveMcpResultContent(
-        result as Record<string, unknown>,
-        state.owner?.signal,
-      );
-      const outputContent =
-        content.length > 0
-          ? content
-          : [{ type: "text" as const, text: "(empty result)" }];
+      const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
       const uiSummary = summarizeUiSessionResult(uiSession);
-      const guarded = await guardMcpOutput(outputContent, {
-        ...outputGuardOptions,
-        suffix: `\n\n${uiSummary.message}`,
-        rawMcpResult: result,
-      });
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, suffix: `\n\n${uiSummary.message}`, rawMcpResult: result });
       return {
         content: guarded.content,
         details: {
@@ -2113,109 +1332,51 @@ export async function executeCall(
     if (result.isError) {
       const mcpContent = (result.content ?? []) as McpContent[];
       const content = transformMcpContent(mcpContent, state.owner?.signal);
-      const outputContent =
-        content.length > 0
-          ? content
-          : [{ type: "text" as const, text: "(empty result)" }];
-      const schemaText = toolMeta.inputSchema
-        ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
-        : "";
-      const guarded = await guardMcpOutput(outputContent, {
-        ...outputGuardOptions,
-        prefix: "Error: ",
-        suffix: schemaText,
-        emptyTextFallback: "Tool execution failed",
-        rawMcpResult: result,
-      });
+      const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
+      const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+      const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, prefix: "Error: ", suffix: schemaText, emptyTextFallback: "Tool execution failed", rawMcpResult: result });
       return {
         content: guarded.content,
-        details: {
-          mode: "call",
-          error: "tool_error",
-          ...callIdentity,
-          ...guardedMcpDetails(guarded),
-        },
+        details: { mode: "call", error: "tool_error", ...callIdentity, ...guardedMcpDetails(guarded) },
       };
     }
 
-    const content = resolveMcpResultContent(
-      result as Record<string, unknown>,
-      state.owner?.signal,
-    );
-    const outputContent =
-      content.length > 0
-        ? content
-        : [{ type: "text" as const, text: "(empty result)" }];
-    const guarded = await guardMcpOutput(outputContent, {
-      ...outputGuardOptions,
-      rawMcpResult: result,
-    });
+    const content = resolveMcpResultContent(result as Record<string, unknown>, state.owner?.signal);
+    const outputContent = content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }];
+    const guarded = await guardMcpOutput(outputContent, { ...outputGuardOptions, rawMcpResult: result });
     return {
       content: guarded.content,
       details: { mode: "call", ...guardedMcpDetails(guarded), ...callIdentity },
     };
   } catch (error) {
     if (error instanceof SessionRecoveryAuthRequiredError) {
-      const message =
-        error.authMessage ?? getAuthRequiredMessage(state, serverName);
+      const message = error.authMessage ?? getAuthRequiredMessage(state, serverName);
       uiSession?.sendToolCancelled(message);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: {
-          mode: "call",
-          error: "auth_required",
-          ...callIdentity,
-          message,
-          autoAuthAttempted,
-        },
+        details: { mode: "call", error: "auth_required", ...callIdentity, message, autoAuthAttempted },
       };
     }
     if (error instanceof UrlElicitationRequiredError) {
-      const action = await state.manager.handleUrlElicitationRequired(
-        serverName,
-        error,
-      );
-      const message =
-        action === "accept"
-          ? "The original MCP tool did not run. Complete the opened browser interaction, then retry the tool."
-          : `The URL interaction was ${action === "decline" ? "declined" : "cancelled"}.`;
+      const action = await state.manager.handleUrlElicitationRequired(serverName, error);
+      const message = action === "accept"
+        ? "The original MCP tool did not run. Complete the opened browser interaction, then retry the tool."
+        : `The URL interaction was ${action === "decline" ? "declined" : "cancelled"}.`;
       uiSession?.sendToolCancelled(message);
       return {
         content: [{ type: "text" as const, text: message }],
-        details: {
-          mode: "call",
-          error: "url_elicitation_required",
-          ...callIdentity,
-          action,
-        },
+        details: { mode: "call", error: "url_elicitation_required", ...callIdentity, action },
       };
     }
     const message = error instanceof Error ? error.message : String(error);
     uiSession?.sendToolCancelled(message);
 
-    const schemaText = toolMeta.inputSchema
-      ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
-      : "";
-    const guarded = await guardMcpOutput(
-      [{ type: "text" as const, text: message }],
-      {
-        ...outputGuardOptions,
-        prefix: "Failed to call tool: ",
-        suffix: schemaText,
-      },
-    );
+    const schemaText = toolMeta.inputSchema ? `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}` : "";
+    const guarded = await guardMcpOutput([{ type: "text" as const, text: message }], { ...outputGuardOptions, prefix: "Failed to call tool: ", suffix: schemaText });
 
     return {
       content: guarded.content,
-      details: {
-        mode: "call",
-        error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed",
-        ...callIdentity,
-        message: guarded.outputGuard
-          ? "output truncated; see outputGuard.fullOutputPath"
-          : message,
-        ...guardedMcpDetails(guarded),
-      },
+      details: { mode: "call", error: isAbortError(error, ownedSignal) ? "aborted" : "call_failed", ...callIdentity, message: guarded.outputGuard ? "output truncated; see outputGuard.fullOutputPath" : message, ...guardedMcpDetails(guarded) },
     };
   } finally {
     if (uiSession?.reused) {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@earendil-works/pi-coding-agent";
-import { UrlElicitationRequiredError, type Client } from "@modelcontextprotocol/client";
+import { UrlElicitationRequiredError, type Client, type Progress, type RequestOptions } from "@modelcontextprotocol/client";
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
@@ -30,13 +30,33 @@ const INSTRUCTIONS_PREVIEW_LENGTH = 300;
 const REGEX_SAFETY_CHECK_PARAMS = {
   attackTimeout: 50,
   incubationTimeout: 50,
-  timeout: 250,
-} as const;
+      timeout: 250,
+    } as const;
 
 type AutoAuthResult =
   | { status: "skipped" }
   | { status: "success" }
   | { status: "failed"; message: string };
+
+/**
+ * Bridges SDK request-local progress callbacks to the interactive UI notify
+ * path (#437 item 3). The SDK owns `_meta.progressToken` injection when
+ * `onprogress` is set; this never writes the token manually.
+ */
+function withUiProgressBridge(
+  options: RequestOptions | undefined,
+  ui: McpExtensionState["ui"],
+  toolName: string,
+): RequestOptions | undefined {
+  if (!ui) return options;
+  return {
+    ...options,
+    onprogress: (progress: Progress) => {
+      const ratio = `${progress.progress}${progress.total === undefined ? "" : `/${progress.total}`}`;
+      ui.notify(progress.message ? `${progress.message} (${ratio})` : `MCP ${toolName}: ${ratio}`, "info");
+    },
+  };
+}
 
 function getToolMatches(metadata: ToolMetadata[] | undefined, toolName: string, exact: boolean): ToolMetadata[] {
   if (!metadata) return [];
@@ -1189,7 +1209,11 @@ export async function executeCall(
   }
 
   let uiSession: UiSessionRuntime | null = null;
-  const requestOptions = state.manager.getRequestOptions?.(serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined);
+  const requestOptions = withUiProgressBridge(
+    state.manager.getRequestOptions?.(serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined),
+    state.ui,
+    toolMeta.originalName,
+  );
 
   const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
   const recoverAuthConnection = async () => {
@@ -1269,6 +1293,7 @@ export async function executeCall(
     );
 
     if (toolMeta.uiResourceUri) {
+      // SAFETY: ui-session renderer consumes the raw wire result shape, which the SDK types do not expose publicly
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 
       if (result.isError) {


### PR DESCRIPTION
## Summary

Adds proxy tool-call progress notifications through the MCP SDK's **request-local** `onprogress` option, bridged to the adapter's existing interactive UI notification path (`ui.notify`).

Implements item 3 of #437.

## Design

- New module-level helper `withUiProgressBridge()` wraps the manager request options for proxy `callTool` only when a UI is available; each `onprogress` callback is formatted (`message (p/total)` / `MCP <tool>: p/total`) and forwarded to `ui.notify(..., "info")`.
- The pinned SDK owns `_meta.progressToken` injection when `onprogress` is set (and merges it with any existing `_meta`); this change never writes the token manually.
- No manager-global listener registry, no `progressToken` exposure in result details, no protocol-version threading.

Per #437 constraints: SDK-native mechanism, narrow diff, existing UI path reused.

## Focused tests run

- `__tests__/proxy-progress.test.ts` (new): bridge attached + message formatting when a UI exists; no `onprogress` attached without a UI; manager request options (signal/timeout) preserved alongside the bridge.
- `__tests__/abort-signal.test.ts`, `__tests__/proxy-modes-auto-auth.test.ts`, `__tests__/proxy-modes-ui-messages.test.ts`, `__tests__/proxy-modes-manual-auth.test.ts`, `__tests__/proxy-modes-discovery.test.ts`, `__tests__/proxy-modes-instructions.test.ts`: all pass (one assertion updated for the new expected `onprogress` presence).
- `npx tsc --noEmit` clean. Pre-existing failures elsewhere on `main` are unrelated and reproducible on a clean checkout.

## Changelog

Added an `[Unreleased]` entry crediting @Seinra's mapping work in #431.

## Credit

The audit and follow-up plan were prompted by @Seinra's #431 branch; this PR is materially informed by that work.
