### PR TITLE
fix: clarify invalid stdio working directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedding hosts can validate cached metadata against an explicit private process environment.
 
 ### Fixed
+- Stdio MCP startup errors now identify a configured missing or non-directory `cwd` instead of blaming the executable. Thanks to [@SoyElf](https://github.com/SoyElf) for #442.
 - MCP gateway descriptions now stay stable across metadata-only refreshes and keep live counts behind `mcp({})`. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #432.
 - Failed MCP servers in active backoff no longer remain advertised through cached direct tools, gateway list/search/describe results, or status tool counts. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #434.
 - OAuth token invalidation now preserves credentials replaced by another Pi process instead of letting a stale refresh delete newly authorized shared credentials. Thanks to [@mjlbach](https://github.com/mjlbach) for PR #422.

--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
 
 const mocks = vi.hoisted(() => ({
   clients: [] as any[],
@@ -51,6 +52,11 @@ describe("MCP manager owner races", () => {
     mocks.connectGate = null;
     mocks.connectError = null;
     mocks.resolveGate = null;
+    mkdirSync("/tmp/session", { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync("/tmp/session", { recursive: true, force: true });
   });
 
   it("closes a connection that finishes after owner shutdown before insertion", async () => {

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { homedir } from "node:os";
+import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const mocks = vi.hoisted(() => ({
@@ -42,6 +42,7 @@ vi.mock("../npx-resolver.ts", () => ({
 
 describe("McpServerManager sampling", () => {
   const originalMcpTestCwd = process.env.MCP_TEST_CWD;
+  const originalHome = process.env.HOME;
 
   beforeEach(() => {
     mocks.clients.length = 0;
@@ -55,6 +56,15 @@ describe("McpServerManager sampling", () => {
     } else {
       process.env.MCP_TEST_CWD = originalMcpTestCwd;
     }
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    rmSync("/tmp/pi-mcp-cwd", { recursive: true, force: true });
+    rmSync("/tmp/pi-mcp-home", { recursive: true, force: true });
+    rmSync("/tmp/pi-session-cwd", { recursive: true, force: true });
+    rmSync("/tmp/server-cwd", { recursive: true, force: true });
   });
 
   it("advertises sampling and registers the handler before connecting", async () => {
@@ -429,6 +439,9 @@ describe("McpServerManager sampling", () => {
   it("expands environment variables and tilde in stdio cwd", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     process.env.MCP_TEST_CWD = "/tmp/pi-mcp-cwd";
+    process.env.HOME = "/tmp/pi-mcp-home";
+    mkdirSync("/tmp/pi-mcp-cwd/nested", { recursive: true });
+    mkdirSync("/tmp/pi-mcp-home/nested", { recursive: true });
 
     const envManager = new McpServerManager();
     await envManager.connect("env-cwd", {
@@ -445,11 +458,12 @@ describe("McpServerManager sampling", () => {
     });
 
     expect(mocks.transports[0].options).toMatchObject({ cwd: "/tmp/pi-mcp-cwd/nested" });
-    expect(mocks.transports[1].options).toMatchObject({ cwd: join(homedir(), "nested") });
+    expect(mocks.transports[1].options).toMatchObject({ cwd: "/tmp/pi-mcp-home/nested" });
   });
 
   it("uses the session cwd for stdio servers without an explicit cwd", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
+    mkdirSync("/tmp/pi-session-cwd", { recursive: true });
     const manager = new McpServerManager("/tmp/pi-session-cwd");
 
     await manager.connect("session-cwd", { command: "node", args: ["server.js"] });
@@ -459,6 +473,8 @@ describe("McpServerManager sampling", () => {
 
   it("prefers an explicit stdio cwd over the session cwd", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
+    mkdirSync("/tmp/pi-session-cwd", { recursive: true });
+    mkdirSync("/tmp/server-cwd", { recursive: true });
     const manager = new McpServerManager("/tmp/pi-session-cwd");
 
     await manager.connect("explicit-cwd", {

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { PassThrough } from "node:stream";
 
 const mocks = vi.hoisted(() => ({
@@ -85,6 +88,26 @@ describe("McpServerManager stderr capture", () => {
     expect(mocks.transports[0].options.args).toEqual(["--first=interpolated", "--second=interpolated"]);
   });
 
+  it("reports an invalid stdio cwd instead of blaming the command", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-mcp-cwd-"));
+    const missingCwd = join(root, "missing");
+    const fileCwd = join(root, "file");
+    writeFileSync(fileCwd, "");
+
+    try {
+      const { McpServerManager } = await import("../server-manager.ts");
+      const manager = new McpServerManager();
+
+      await expect(manager.connect("missing", { command: "missing-command", cwd: missingCwd }))
+        .rejects.toThrow(`MCP server "missing" configured cwd does not exist: "${missingCwd}"`);
+      await expect(manager.connect("file", { command: "missing-command", cwd: fileCwd }))
+        .rejects.toThrow(`MCP server "file" configured cwd is not a directory: "${fileCwd}"`);
+      expect(mocks.transports).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("passes interpolated npx arguments to the resolver", async () => {
     process.env.MCP_TEST_STDIO_ARG = "interpolated";
     const { McpServerManager } = await import("../server-manager.ts");
@@ -104,6 +127,23 @@ describe("McpServerManager stderr capture", () => {
       command: "npx",
       args: ["-y", "demo-pkg", "--token=interpolated"],
     });
+  });
+
+  it("validates cwd before resolving npx binaries", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-mcp-cwd-"));
+    const missingCwd = join(root, "missing");
+
+    try {
+      const { McpServerManager } = await import("../server-manager.ts");
+      const manager = new McpServerManager();
+
+      await expect(manager.connect("missing", { command: "npx", args: ["server-pkg"], cwd: missingCwd }))
+        .rejects.toThrow(`MCP server "missing" configured cwd does not exist: "${missingCwd}"`);
+      expect(resolveNpxBinary).not.toHaveBeenCalled();
+      expect(mocks.transports).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("appends captured stderr to the connection error", async () => {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, statSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import {
   Client,
@@ -514,6 +514,12 @@ export class McpServerManager {
       client = this.createClient(name, definition);
       let command = definition.command;
       let args = (definition.args ?? []).map((argument) => interpolateEnvVars(argument));
+      const cwd = resolveConfigPath(definition.cwd) ?? this.defaultCwd;
+      if (cwd !== undefined) {
+        const cwdStats = statSync(cwd, { throwIfNoEntry: false });
+        if (!cwdStats) throw new Error(`MCP server "${name}" configured cwd does not exist: "${cwd}"`);
+        if (!cwdStats.isDirectory()) throw new Error(`MCP server "${name}" configured cwd is not a directory: "${cwd}"`);
+      }
 
       if (command === "npx" || command === "npm") {
         const resolved = await resolveNpxBinary(command, args, signal);
@@ -526,7 +532,6 @@ export class McpServerManager {
       throwIfAborted(signal);
 
       if (definition.pluginDataDir) mkdirSync(definition.pluginDataDir, { recursive: true });
-      const cwd = resolveConfigPath(definition.cwd) ?? this.defaultCwd;
       const stdioTransport = new StdioClientTransport({
         command,
         args,


### PR DESCRIPTION
## Summary

Fixes #442 by validating a resolved stdio server `cwd` at the launch boundary before constructing the SDK transport.

A missing or non-directory `cwd` now reports the configured path directly instead of surfacing a misleading `spawn <command> ENOENT` error.

Closes #442.

## Validation

- `git diff --check origin/main...HEAD`
- `npm test -- --run __tests__/server-manager-stderr-capture.test.ts`
- `npm run typecheck`
- Fresh review: no issues found on `feabe0ef9167e0a30d187e0f5990207b3cca5469`

## Credit

Thanks to [@SoyElf](https://github.com/SoyElf) for #442.
