### PR TITLE
fix: honor MCP metadata cache TTL hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Persistent metadata cache entries now honor server-advertised `ttlMs` hints without extending the default max age. Thanks to [@Seinra](https://github.com/Seinra) for #431.
 - Added a pure `mcp:` reference resolver API for consumers that validate adapter tool names from explicit config and cache inputs. Thanks to [@abdwhb-png](https://github.com/abdwhb-png) for PR #420.
 - Direct tools can opt into strict advertised-schema validation with one-layer JSON recovery for object and array properties. Thanks to [@4ndr3wxh1ll](https://github.com/4ndr3wxh1ll) for PR #430.
 - Direct tools can opt into guarded raw MCP result details, retaining bounded structured fields while summarizing oversized values.

--- a/__tests__/metadata-cache-ttl.test.ts
+++ b/__tests__/metadata-cache-ttl.test.ts
@@ -46,6 +46,7 @@ describe("metadata cache ttl hints", () => {
     const server = definition();
 
     expect(isServerCacheValid(entry(server, 0, 0), server)).toBe(false);
+    expect(isServerCacheValid(entry(server, -1, 0), server)).toBe(false);
     expect(isServerCacheValid(entry(server, 500, 1_000), server)).toBe(true);
     expect(isServerCacheValid(entry(server, 1_000, 1_000), server)).toBe(false);
   });

--- a/__tests__/metadata-cache-ttl.test.ts
+++ b/__tests__/metadata-cache-ttl.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McpServerManager } from "../server-manager.ts";
+import { computeServerHash, isServerCacheValid, loadMetadataCache } from "../metadata-cache.ts";
+import { updateMetadataCache } from "../init.ts";
+import type { ServerCacheEntry, ServerEntry } from "../types.ts";
+
+const BASE_TIME = 1_700_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function definition(): ServerEntry {
+  return { command: "node", args: ["server.js"] };
+}
+
+function entry(server: ServerEntry, ageMs: number, ttlMs?: number): ServerCacheEntry {
+  return {
+    configHash: computeServerHash(server),
+    tools: [{ name: "search" }],
+    resources: [],
+    ...(ttlMs === undefined ? {} : { ttlMs }),
+    cachedAt: Date.now() - ageMs,
+  };
+}
+
+describe("metadata cache ttl hints", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  let agentDir: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+    agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-cache-ttl-"));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("expires at the declared ttl, including ttlMs zero", () => {
+    const server = definition();
+
+    expect(isServerCacheValid(entry(server, 0, 0), server)).toBe(false);
+    expect(isServerCacheValid(entry(server, 500, 1_000), server)).toBe(true);
+    expect(isServerCacheValid(entry(server, 1_000, 1_000), server)).toBe(false);
+  });
+
+  it("never lets a declared ttl extend the default max age", () => {
+    const server = definition();
+
+    expect(isServerCacheValid(entry(server, 8 * DAY_MS, 14 * DAY_MS), server)).toBe(false);
+    expect(isServerCacheValid(entry(server, 6 * DAY_MS, 14 * DAY_MS), server)).toBe(true);
+  });
+
+  it("keeps list hints at the result and cache-entry levels, not on tools", async () => {
+    const manager = new McpServerManager();
+    const result = await (manager as any).fetchAllTools({
+      listTools: vi.fn().mockResolvedValue({
+        tools: [{ name: "search" }],
+        ttlMs: 5_000,
+        cacheScope: "private",
+      }),
+    });
+
+    expect(result).toEqual({
+      tools: [{ name: "search" }],
+      hints: { ttlMs: 5_000, cacheScope: "private" },
+    });
+    expect(result.tools[0]).not.toHaveProperty("ttlMs");
+    expect(result.tools[0]).not.toHaveProperty("cacheScope");
+
+    updateMetadataCache({
+      config: { mcpServers: { demo: definition() } },
+      manager: {
+        getConnection: () => ({
+          status: "connected",
+          tools: result.tools,
+          resources: [],
+          prompts: [],
+          toolListHints: result.hints,
+        }),
+      },
+    } as any, "demo");
+
+    const cached = loadMetadataCache()?.servers.demo;
+    expect(cached).toMatchObject({ ttlMs: 5_000, cacheScope: "private" });
+    expect(cached?.tools[0]).toEqual({ name: "search" });
+  });
+});

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -240,6 +240,19 @@ describe("McpServerManager sampling", () => {
     expect(metadataChanged).toHaveBeenCalledWith("demo", "resources-list-changed");
   });
 
+  it("preserves tools list cache hints across list-changed refreshes", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const connection = await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const client = mocks.clients[0];
+    connection.toolListHints = { ttlMs: 0, cacheScope: "private" };
+
+    client.options.listChanged.tools.onChanged(null, [{ name: "fresh_tool" }]);
+
+    expect(connection.tools).toEqual([{ name: "fresh_tool" }]);
+    expect(connection.toolListHints).toEqual({ ttlMs: 0, cacheScope: "private" });
+  });
+
   it("forces an authoritative tool refresh and publishes catalog changes", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/init.ts
+++ b/init.ts
@@ -562,6 +562,8 @@ export function updateMetadataCache(
     resources,
     ...(prompts !== undefined ? { prompts } : {}),
     ...(connection.instructions !== undefined ? { instructions: connection.instructions } : {}),
+    ...(connection.toolListHints?.ttlMs !== undefined ? { ttlMs: connection.toolListHints.ttlMs } : {}),
+    ...(connection.toolListHints?.cacheScope !== undefined ? { cacheScope: connection.toolListHints.cacheScope } : {}),
     cachedAt: Date.now(),
   };
 

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -125,6 +125,12 @@ export function isServerCacheValid(
   }
   if (!entry || entry.configHash !== configHash) return false;
   if (!entry.cachedAt || typeof entry.cachedAt !== "number") return false;
+  const declaredTtlMs = entry.ttlMs;
+  if (typeof declaredTtlMs === "number" && Number.isSafeInteger(declaredTtlMs) && declaredTtlMs >= 0) {
+    const ageMs = Date.now() - entry.cachedAt;
+    const effectiveMaxAge = maxAgeMs > 0 ? Math.min(maxAgeMs, declaredTtlMs) : declaredTtlMs;
+    return ageMs < effectiveMaxAge;
+  }
   if (maxAgeMs > 0 && Date.now() - entry.cachedAt > maxAgeMs) return false;
   return true;
 }

--- a/metadata-cache.ts
+++ b/metadata-cache.ts
@@ -127,6 +127,7 @@ export function isServerCacheValid(
   if (!entry.cachedAt || typeof entry.cachedAt !== "number") return false;
   const declaredTtlMs = entry.ttlMs;
   if (typeof declaredTtlMs === "number" && Number.isSafeInteger(declaredTtlMs) && declaredTtlMs >= 0) {
+    if (declaredTtlMs === 0) return false;
     const ageMs = Date.now() - entry.cachedAt;
     const effectiveMaxAge = maxAgeMs > 0 ? Math.min(maxAgeMs, declaredTtlMs) : declaredTtlMs;
     return ageMs < effectiveMaxAge;

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -9,6 +9,7 @@ import {
   StreamableHTTPClientTransport,
   UnauthorizedError,
   type GetPromptResult,
+  type ListToolsResult,
   type ReadResourceResult,
   type CacheableRequestOptions,
   type RequestOptions,
@@ -128,6 +129,8 @@ export interface ServerConnection {
   transport: Transport;
   definition: ServerDefinition;
   tools: McpTool[];
+  /** Cache hints from the server's aggregated tools/list result. */
+  toolListHints?: Partial<Pick<ListToolsResult, "ttlMs" | "cacheScope">> | undefined;
   /** Monotonic guard against older refresh responses replacing newer notifications. */
   toolsRevision?: number;
   resources: McpResource[];
@@ -147,6 +150,9 @@ type UiStreamListener = (serverName: string, notification: ServerStreamResultPat
 type MetadataListChangedListener = (serverName: string, reason: string) => void;
 
 export type ToolRefreshResult = "updated" | "unchanged" | "superseded" | "refresh-timeout";
+
+type ToolListCacheHints = Partial<Pick<ListToolsResult, "ttlMs" | "cacheScope">>;
+type ToolListResult = { tools: McpTool[]; hints?: ToolListCacheHints };
 
 const KEEP_ALIVE_REFRESH_TIMEOUT_MS = 5_000;
 
@@ -384,9 +390,9 @@ export class McpServerManager {
 
     const toolsRevision = expectedConnection.toolsRevision ?? 0;
     const refreshSignal = combineAbortSignals(healthOptions.signal, AbortSignal.timeout(timeout));
-    let tools: McpTool[];
+    let toolResult: ToolListResult;
     try {
-      tools = await this.fetchAllTools(expectedConnection.client, {
+      toolResult = await this.fetchAllTools(expectedConnection.client, {
         ...healthOptions,
         ...(refreshSignal ? { signal: refreshSignal } : {}),
         cacheMode: "refresh",
@@ -410,20 +416,30 @@ export class McpServerManager {
       return "superseded";
     }
 
-    if (isDeepStrictEqual(expectedConnection.tools, tools)) {
+    if (
+      isDeepStrictEqual(expectedConnection.tools, toolResult.tools) &&
+      isDeepStrictEqual(expectedConnection.toolListHints, toolResult.hints)
+    ) {
       this.retryPendingMetadataPublication(name, expectedConnection);
       return "unchanged";
     }
 
     const previousTools = expectedConnection.tools;
-    expectedConnection.tools = tools;
+    const previousToolListHints = expectedConnection.toolListHints;
+    expectedConnection.tools = toolResult.tools;
+    expectedConnection.toolListHints = toolResult.hints;
     expectedConnection.toolsRevision = toolsRevision + 1;
     try {
       await this.metadataListChangedListener?.(name, "keep-alive-refresh");
       this.pendingMetadataPublications.delete(name);
     } catch (error) {
-      if (this.connections.get(name) === expectedConnection && expectedConnection.tools === tools) {
+      if (
+        this.connections.get(name) === expectedConnection &&
+        expectedConnection.tools === toolResult.tools &&
+        expectedConnection.toolListHints === toolResult.hints
+      ) {
         expectedConnection.tools = previousTools;
+        expectedConnection.toolListHints = previousToolListHints;
         expectedConnection.toolsRevision = toolsRevision;
       }
       throw error;
@@ -597,12 +613,13 @@ export class McpServerManager {
 
       // Discover tools, resources, and prompts. Resource and prompt listing is
       // optional: only servers advertising the capability are queried.
-      const [tools, resources, promptResult] = await Promise.all([
+      const [toolResult, resources, promptResult] = await Promise.all([
         this.fetchAllTools(client, requestOptions),
         this.fetchAllResources(client, requestOptions),
         this.fetchAllPrompts(client, requestOptions),
       ]);
-      connection.tools = tools;
+      connection.tools = toolResult.tools;
+      connection.toolListHints = toolResult.hints;
       connection.resources = resources;
       connection.prompts = promptResult.prompts;
       connection.promptDiscoveryFailed = promptResult.failed;
@@ -782,6 +799,7 @@ export class McpServerManager {
     const connection = this.connections.get(serverName);
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.tools = tools;
+    connection.toolListHints = undefined;
     connection.toolsRevision = (connection.toolsRevision ?? 0) + 1;
     this.metadataListChangedListener?.(serverName, "tools-list-changed");
     this.pendingMetadataPublications.delete(serverName);
@@ -999,17 +1017,34 @@ export class McpServerManager {
     }
   }
 
-  private async fetchAllTools(client: Client, requestOptions?: CacheableRequestOptions): Promise<McpTool[]> {
+  private async fetchAllTools(client: Client, requestOptions?: CacheableRequestOptions): Promise<ToolListResult> {
     const allTools: McpTool[] = [];
     let cursor: string | undefined;
+    let hints: ToolListCacheHints | undefined;
+    let firstPage = true;
 
     do {
       const result = await client.listTools(cursor ? { cursor } : undefined, requestOptions);
+      if (firstPage) {
+        const ttlMs = typeof result.ttlMs === "number" && Number.isSafeInteger(result.ttlMs) && result.ttlMs >= 0
+          ? result.ttlMs
+          : undefined;
+        const cacheScope = result.cacheScope === "public" || result.cacheScope === "private"
+          ? result.cacheScope
+          : undefined;
+        if (ttlMs !== undefined || cacheScope !== undefined) {
+          hints = {
+            ...(ttlMs !== undefined ? { ttlMs } : {}),
+            ...(cacheScope !== undefined ? { cacheScope } : {}),
+          };
+        }
+        firstPage = false;
+      }
       allTools.push(...(result.tools ?? []));
       cursor = result.nextCursor;
     } while (cursor);
 
-    return allTools;
+    return { tools: allTools, ...(hints !== undefined ? { hints } : {}) };
   }
 
   private async fetchAllPrompts(

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -799,7 +799,6 @@ export class McpServerManager {
     const connection = this.connections.get(serverName);
     if (!connection || connection.client !== client || connection.status !== "connected") return;
     connection.tools = tools;
-    connection.toolListHints = undefined;
     connection.toolsRevision = (connection.toolsRevision ?? 0) + 1;
     this.metadataListChangedListener?.(serverName, "tools-list-changed");
     this.pendingMetadataPublications.delete(serverName);

--- a/types.ts
+++ b/types.ts
@@ -686,6 +686,9 @@ export interface ServerCacheEntry {
   resources: CachedResource[];
   prompts?: CachedPrompt[];
   instructions?: string;
+  /** Server-level hints from the aggregated tools/list result. */
+  ttlMs?: ListToolsResult["ttlMs"];
+  cacheScope?: ListToolsResult["cacheScope"];
   cachedAt: number;
 }
 


### PR DESCRIPTION
## Summary

Implements the thin SDK-native metadata-cache TTL follow-up from #437.

The adapter now stores SDK-decoded aggregate `ttlMs` and `cacheScope` hints with the server cache entry, lets `ttlMs` shorten cache validity without extending the default max age, treats `ttlMs: 0` as always invalid, and preserves aggregate hints across `tools/list_changed` refresh publication.

Closes #437.

## Validation

- `git diff --check origin/main...HEAD`
- `npm test -- --run __tests__/metadata-cache-ttl.test.ts __tests__/metadata-cache-instructions.test.ts __tests__/direct-tools.test.ts __tests__/server-manager-sampling.test.ts`
- `npm run typecheck`
- Fresh review: no issues found on `ee9ff918071f1cdfa5b545b119bf1a9f681232a3`

## Credit

Thanks to [@Seinra](https://github.com/Seinra) for mapping the SDK-native follow-up area in #431.
