### PR TITLE
fix: support cross-extension MCP registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedding hosts can validate cached metadata against an explicit private process environment.
 
 ### Fixed
+- Runtime MCP registration now works across separately loaded Pi extensions through a versioned shared event contract. Thanks to [@fmoda3](https://github.com/fmoda3) for #443.
 - Stdio MCP startup errors now identify a configured missing or non-directory `cwd` instead of blaming the executable. Thanks to [@SoyElf](https://github.com/SoyElf) for #442.
 - Package installs with `--omit=dev` no longer run the public helper build during `prepare`; Git installs and package tarballs still include the built public exports. Thanks to [@KripaMishra](https://github.com/KripaMishra) for #441.
 - MCP gateway descriptions now stay stable across metadata-only refreshes and keep live counts behind `mcp({})`. Thanks to [@voidfreud](https://github.com/voidfreud) for PR #432.

--- a/README.md
+++ b/README.md
@@ -147,22 +147,43 @@ A Pi package can ship MCP servers for the installed adapter without requiring a 
 An extension can register MCP servers with the installed adapter at runtime, for example a plugin host that discovers plugins after load:
 
 ```ts
-import { registerMcpServer } from "pi-mcp-adapter";
+const MCP_RUNTIME_REGISTER_EVENT = "pi-mcp-adapter:runtime-register:v1";
+type RuntimeRegistrationRequest = {
+  version: 1;
+  name: string;
+  definition: { url: string };
+  result?:
+    | { ok: true; registration: { dispose(): Promise<void> } }
+    | { ok: false; error: Error };
+};
 
 export default function pluginHost(pi) {
-  const registration = registerMcpServer({
-    pi,
-    name: "acme__docs",
-    definition: {
-      url: "https://mcp.example.com/mcp",
-    },
+  let registration: { dispose(): Promise<void> } | undefined;
+
+  pi.on("session_start", () => {
+    if (registration) return;
+    const request: RuntimeRegistrationRequest = {
+      version: 1,
+      name: "acme__docs",
+      definition: { url: "https://mcp.example.com/mcp" },
+    };
+    pi.events.emit(MCP_RUNTIME_REGISTER_EVENT, request);
+    if (!request.result) throw new Error("pi-mcp-adapter is not installed");
+    if (!request.result.ok) throw request.result.error;
+    registration = request.result.registration;
   });
-  // Later, when the plugin is uninstalled:
-  await registration.dispose();
+
+  pi.on("session_shutdown", async () => {
+    const current = registration;
+    registration = undefined;
+    await current?.dispose();
+  });
 }
 ```
 
-Runtime registrations are session scoped and never written to config files. Duplicate server names fail closed against configured servers and other registrations. Registered servers use the normal lazy connection, OAuth, approval, and shutdown behavior, but they are proxy-tool-only and their tools become visible at the next tool sync. To change a definition, dispose the registration and register again. Registration throws when no adapter is installed for the given Pi instance.
+Cross-extension registration uses Pi's shared event bus and does not require a runtime import from `pi-mcp-adapter`. Emit during `session_start` or later so the adapter listener is installed. The adapter writes `request.result` synchronously; the first adapter listener to respond wins.
+
+Runtime registrations are session scoped and never written to config files. Duplicate server names fail closed against configured servers and other registrations. Registered servers use the normal lazy connection, OAuth, approval, and shutdown behavior, but they are proxy-tool-only and their tools become visible at the next tool sync. To change a definition, dispose the registration and register again.
 
 ### SDK configuration
 

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -160,6 +160,7 @@ function createPi(options: { unregisterTool?: false | ((name: string) => boolean
       on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
         handlers.set(event, handler);
       }),
+      events: { on: vi.fn(), emit: vi.fn() },
       getAllTools: vi.fn(() => []),
       getActiveTools: vi.fn(() => activeTools),
       setActiveTools: vi.fn((nextActiveTools: string[]) => {
@@ -187,6 +188,7 @@ function createStatusObservingPi() {
     activeTools = [...nextActiveTools];
   });
   api.events = {
+    on: vi.fn(),
     emit: vi.fn((channel: string, payload: { connectedCount?: number }) => {
       if (channel !== MCP_STATUS_EVENT || payload.connectedCount !== 1) return;
       connectedSurfaces.push(activeTools

--- a/__tests__/mcp-code.test.ts
+++ b/__tests__/mcp-code.test.ts
@@ -29,6 +29,7 @@ describe("runMcpScript", () => {
       registerFlag: vi.fn(),
       registerCommand: vi.fn(),
       on: vi.fn(),
+      events: { on: vi.fn(), emit: vi.fn() },
       getAllTools: vi.fn(() => []),
     } as any);
 
@@ -47,6 +48,7 @@ describe("runMcpScript", () => {
       registerFlag: vi.fn(),
       registerCommand: vi.fn(),
       on: vi.fn(),
+      events: { on: vi.fn(), emit: vi.fn() },
       getAllTools: vi.fn(() => []),
     } as any);
 

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -133,7 +133,22 @@ function createState() {
   } as any;
 }
 
-function createPi() {
+function createEventBus() {
+  const listeners = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    emit(channel: string, data: unknown) {
+      for (const listener of listeners.get(channel) ?? []) listener(data);
+    },
+    on(channel: string, listener: (data: unknown) => void) {
+      const channelListeners = listeners.get(channel) ?? new Set();
+      channelListeners.add(listener);
+      listeners.set(channel, channelListeners);
+      return () => channelListeners.delete(listener);
+    },
+  };
+}
+
+function createPi(events = createEventBus()) {
   const handlers = new Map<string, (...args: any[]) => unknown>();
   let activeTools = ["bash", "mcp"];
   return {
@@ -146,6 +161,7 @@ function createPi() {
       on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
         handlers.set(event, handler);
       }),
+      events,
       getAllTools: vi.fn(() => []),
       getActiveTools: vi.fn(() => activeTools),
       setActiveTools: vi.fn((nextActiveTools: string[]) => {
@@ -182,8 +198,96 @@ describe("runtime MCP server registration", () => {
 
   it("throws when no adapter is installed for the Pi instance", async () => {
     const { registerMcpServer } = await import("../index.ts");
-    expect(() => registerMcpServer({ pi: {} as any, name: "plugin", definition: { url: "https://example.test/mcp" } }))
+    const { api } = createPi();
+    expect(() => registerMcpServer({ pi: api, name: "plugin", definition: { url: "https://example.test/mcp" } }))
       .toThrow("pi-mcp-adapter is not installed for this Pi instance");
+  });
+
+  it("registers from a distinct extension wrapper over the shared event bus", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, MCP_RUNTIME_REGISTER_EVENT } = await import("../index.ts");
+    const events = createEventBus();
+    const { api: adapterApi, handlers } = createPi(events);
+    const { api: consumerApi } = createPi(events);
+    mcpAdapter(adapterApi);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    const request = {
+      version: 1 as const,
+      name: "plugin-event",
+      definition: { url: "https://event.test/mcp" },
+    } as any;
+    consumerApi.events.emit(MCP_RUNTIME_REGISTER_EVENT, request);
+
+    expect(request.result).toMatchObject({ ok: true });
+    expect(state.config.mcpServers["plugin-event"]).toMatchObject({
+      url: "https://event.test/mcp",
+      directTools: false,
+    });
+  });
+
+  it("returns event registration failures in the mutable result", async () => {
+    mocks.loadMcpConfig.mockReturnValue({ mcpServers: { configured: { url: "https://configured.test/mcp" } } });
+    const state = createState();
+    state.config.mcpServers = { configured: { url: "https://configured.test/mcp" } };
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, MCP_RUNTIME_REGISTER_EVENT } = await import("../index.ts");
+    const events = createEventBus();
+    const { api, handlers } = createPi(events);
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    const request = { version: 1, name: "configured", definition: { url: "https://other.test/mcp" } } as any;
+    expect(() => events.emit(MCP_RUNTIME_REGISTER_EVENT, request)).not.toThrow();
+    expect(request.result).toMatchObject({
+      ok: false,
+      error: expect.objectContaining({ message: 'MCP server "configured" is already registered' }),
+    });
+  });
+
+  it("leaves a prefilled event result untouched", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, MCP_RUNTIME_REGISTER_EVENT } = await import("../index.ts");
+    const events = createEventBus();
+    const { api, handlers } = createPi(events);
+    mcpAdapter(api);
+    const registration = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const request = {
+      version: 1,
+      name: "ignored",
+      definition: { url: "https://ignored.test/mcp" },
+      result: { ok: true, registration },
+    } as any;
+
+    events.emit(MCP_RUNTIME_REGISTER_EVENT, request);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    expect(request.result.registration).toBe(registration);
+    expect(state.config.mcpServers["ignored"]).toBeUndefined();
+  });
+
+  it("falls back to the shared event bus for a distinct extension wrapper", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const events = createEventBus();
+    const { api: adapterApi, handlers } = createPi(events);
+    const { api: consumerApi } = createPi(events);
+    mcpAdapter(adapterApi);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    registerMcpServer({ pi: consumerApi, name: "plugin-helper", definition: { url: "https://helper.test/mcp" } });
+
+    expect(state.config.mcpServers["plugin-helper"]).toMatchObject({
+      url: "https://helper.test/mcp",
+      directTools: false,
+    });
   });
 
   it("registers after init, exposes the server in state, and disposes cleanly", async () => {

--- a/index.ts
+++ b/index.ts
@@ -53,8 +53,21 @@ export interface McpServerRegistration {
   dispose(): Promise<void>;
 }
 
-// Routes runtime registrations to the adapter installed for a specific Pi
-// instance, so a process with several adapters cannot cross-register.
+export const MCP_RUNTIME_REGISTER_EVENT = "pi-mcp-adapter:runtime-register:v1" as const;
+export const MCP_RUNTIME_REGISTER_VERSION = 1 as const;
+
+export type McpRuntimeRegistrationResult =
+  | { ok: true; registration: McpServerRegistration }
+  | { ok: false; error: Error };
+
+export interface McpRuntimeRegistrationRequest {
+  version: typeof MCP_RUNTIME_REGISTER_VERSION;
+  name: string;
+  definition: ServerEntry;
+  result?: McpRuntimeRegistrationResult;
+}
+
+// Fast path for callers that share the adapter's module and ExtensionAPI.
 const runtimeRegistrars = new WeakMap<ExtensionAPI, (name: string, definition: ServerEntry) => McpServerRegistration>();
 
 async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof INIT_WAIT_TIMED_OUT> {
@@ -402,7 +415,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   registerPromptCommands(resolveCachedPrompts(earlyConfig));
 
-  runtimeRegistrars.set(pi, (name: string, definition: ServerEntry): McpServerRegistration => {
+  const registerRuntimeServer = (name: string, definition: ServerEntry): McpServerRegistration => {
     if (typeof name !== "string" || name.trim() === "") {
       throw new Error("MCP server name must be a non-empty string");
     }
@@ -439,6 +452,21 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         updateStatusBar(currentState);
       },
     };
+  };
+  runtimeRegistrars.set(pi, registerRuntimeServer);
+  pi.events.on(MCP_RUNTIME_REGISTER_EVENT, (rawRequest: unknown) => {
+    if (typeof rawRequest !== "object" || rawRequest === null || Array.isArray(rawRequest)) return;
+    const request = rawRequest as McpRuntimeRegistrationRequest;
+    if (request.result !== undefined) return;
+    if (request.version !== MCP_RUNTIME_REGISTER_VERSION) {
+      request.result = { ok: false, error: new Error(`Unsupported MCP runtime registration version: ${String(request.version)}`) };
+      return;
+    }
+    try {
+      request.result = { ok: true, registration: registerRuntimeServer(request.name, request.definition) };
+    } catch (error) {
+      request.result = { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+    }
   });
 
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
@@ -1162,10 +1190,18 @@ export function createMcpAdapter(options: McpAdapterOptions = {}) {
 export function registerMcpServer(options: { pi: ExtensionAPI; name: string; definition: ServerEntry }): McpServerRegistration {
   const { pi, name, definition } = options;
   const register = runtimeRegistrars.get(pi);
-  if (!register) {
+  if (register) return register(name, definition);
+  const request: McpRuntimeRegistrationRequest = {
+    version: MCP_RUNTIME_REGISTER_VERSION,
+    name,
+    definition,
+  };
+  pi.events.emit(MCP_RUNTIME_REGISTER_EVENT, request);
+  if (!request.result) {
     throw new Error("pi-mcp-adapter is not installed for this Pi instance");
   }
-  return register(name, definition);
+  if (!request.result.ok) throw request.result.error;
+  return request.result.registration;
 }
 
 export default createMcpAdapter();


### PR DESCRIPTION
Closes #443.\n\nThis adds the approved minimal runtime registration event contract for separately loaded Pi extensions. Cross-extension callers can emit `pi-mcp-adapter:runtime-register:v1` during `session_start` or later and read the synchronous mutable result. The existing `registerMcpServer(...)` helper stays for same-module callers and now falls back through the shared event bus.\n\nValidation:\n- `npm test -- --run __tests__/runtime-register.test.ts`\n- `npm run typecheck`\n- `git diff --check origin/main...HEAD`\n\nFresh review: `/tmp/pi-mcp-adapter-issue443-runtime-event-workflow.review.json` reported no issues.