### PR TITLE
fix: guard non-callable UI themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- MCP status updates now fall back to plain text when a non-TUI host provides a non-callable theme. Thanks to [@jinnnyang](https://github.com/jinnnyang) for #449.
+
 ## [2.28.0] - 2026-08-26
 
 ### Highlights

--- a/__tests__/init-status.test.ts
+++ b/__tests__/init-status.test.ts
@@ -59,6 +59,15 @@ describe("updateStatusBar", () => {
     expect(setStatus).toHaveBeenCalledWith("mcp", "styled:🔌 MCP: 1 server enabled");
   });
 
+  it("keeps status text plain when the host provides a string theme", () => {
+    const setStatus = vi.fn();
+    const state = createState({ setStatus, theme: "light" });
+
+    updateStatusBar(state);
+
+    expect(setStatus).toHaveBeenCalledWith("mcp", "🔌 MCP: 1 server enabled");
+  });
+
   it("keeps the icon when explicitly enabled", () => {
     const setStatus = vi.fn();
     updateStatusBar(createState({ setStatus }, { showStatusIcon: true }));

--- a/init.ts
+++ b/init.ts
@@ -626,7 +626,8 @@ export function updateStatusBar(state: McpExtensionState): void {
     ui.setStatus("mcp", undefined);
     return;
   }
-  ui.setStatus("mcp", ui.theme ? ui.theme.fg("accent", formattedStatus) : formattedStatus);
+  const theme = ui.theme;
+  ui.setStatus("mcp", typeof theme?.fg === "function" ? theme.fg("accent", formattedStatus) : formattedStatus);
 }
 
 export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {


### PR DESCRIPTION
Closes #449.

This fixes a host compatibility bug in the MCP footer update path. Some non-TUI hosts provide `ui.theme` as a string. The adapter now only calls `theme.fg` when it is callable, and otherwise falls back to plain text.

Validation:
- `npm test -- --run __tests__/init-status.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review: No issues found.
