### PR TITLE
style: deslop MCP status theme fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- MCP status updates now fall back to plain text when a non-TUI host provides a non-callable theme. Thanks to [@jinnnyang](https://github.com/jinnnyang) for #449.
+- MCP status updates now use plain text when a non-TUI host provides a theme without styling methods. Thanks to [@jinnnyang](https://github.com/jinnnyang) for #449.
 
 ## [2.28.0] - 2026-08-26
 

--- a/init.ts
+++ b/init.ts
@@ -627,7 +627,10 @@ export function updateStatusBar(state: McpExtensionState): void {
     return;
   }
   const theme = ui.theme;
-  ui.setStatus("mcp", typeof theme?.fg === "function" ? theme.fg("accent", formattedStatus) : formattedStatus);
+  const styledStatus = typeof theme?.fg === "function"
+    ? theme.fg("accent", formattedStatus)
+    : formattedStatus;
+  ui.setStatus("mcp", styledStatus);
 }
 
 export async function lazyConnect(state: McpExtensionState, serverName: string, signal?: AbortSignal): Promise<boolean> {


### PR DESCRIPTION
This is a focused deslop pass over the current unreleased delta.

It keeps the #449 behavior unchanged, but makes the status-theme fallback easier to scan and tightens the unreleased changelog wording.

Validation:
- `npm test -- --run __tests__/init-status.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `npx fallow audit --changed-since v2.28.0 --format json --quiet`
- `slop-scan delta` against `v2.28.0`

Fresh review: No issues found.
