### PR TITLE
feat: expose runtime server snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a fail-closed API for child extensions to snapshot one selected runtime MCP server without exporting configured servers or persisting the registration. (#453)
+
 ## [2.29.0] - 2026-08-26
 
 ### Highlights

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -290,6 +290,65 @@ describe("runtime MCP server registration", () => {
     });
   });
 
+  it("returns an isolated snapshot with the original direct-tool definition", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer, getRuntimeMcpServerSnapshot } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    const definition = {
+      url: "https://snapshot.test/mcp",
+      directTools: ["search"],
+      headers: { Authorization: "Bearer test" },
+    };
+    registerMcpServer({ pi: api, name: "snapshot", definition });
+
+    const first = getRuntimeMcpServerSnapshot({ pi: api, name: "snapshot" });
+    expect(first).toEqual({ name: "snapshot", definition, runtime: true, persisted: false });
+    expect(state.config.mcpServers["snapshot"]).toMatchObject({ directTools: false });
+    expect(first.definition).not.toBe(definition);
+    first.definition.headers!.Authorization = "Bearer changed";
+
+    expect(getRuntimeMcpServerSnapshot({ pi: api, name: "snapshot" }).definition).toEqual(definition);
+  });
+
+  it("snapshots through a distinct extension wrapper and fails after disposal", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer, getRuntimeMcpServerSnapshot, MCP_RUNTIME_SNAPSHOT_EVENT } = await import("../index.ts");
+    const events = createEventBus();
+    const { api: adapterApi, handlers } = createPi(events);
+    const { api: consumerApi } = createPi(events);
+    mcpAdapter(adapterApi);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    expect(() => getRuntimeMcpServerSnapshot({ pi: consumerApi, name: "missing" }))
+      .toThrow('MCP runtime server "missing" is not registered or has been disposed');
+
+    const registration = registerMcpServer({ pi: consumerApi, name: "event-snapshot", definition: { url: "https://event-snapshot.test/mcp" } });
+    expect(getRuntimeMcpServerSnapshot({ pi: consumerApi, name: "event-snapshot" })).toMatchObject({
+      name: "event-snapshot",
+      definition: { url: "https://event-snapshot.test/mcp" },
+      runtime: true,
+      persisted: false,
+    });
+
+    const unsupported = { version: 99, name: "event-snapshot" } as any;
+    events.emit(MCP_RUNTIME_SNAPSHOT_EVENT, unsupported);
+    expect(unsupported.result).toMatchObject({
+      ok: false,
+      error: expect.objectContaining({ message: "Unsupported MCP runtime snapshot version: 99" }),
+    });
+
+    await registration.dispose();
+    expect(() => getRuntimeMcpServerSnapshot({ pi: consumerApi, name: "event-snapshot" }))
+      .toThrow('MCP runtime server "event-snapshot" is not registered or has been disposed');
+  });
+
   it("registers after init, exposes the server in state, and disposes cleanly", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);
@@ -343,17 +402,26 @@ describe("runtime MCP server registration", () => {
   it("queues pre-init registrations and drains them when init completes", async () => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);
-    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { default: mcpAdapter, registerMcpServer, getRuntimeMcpServerSnapshot } = await import("../index.ts");
     const { api, handlers } = createPi();
     mcpAdapter(api);
 
     registerMcpServer({ pi: api, name: "early-plugin", definition: { url: "https://early.test/mcp" } });
+    expect(() => getRuntimeMcpServerSnapshot({ pi: api, name: "early-plugin" }))
+      .toThrow('MCP runtime server "early-plugin" is unavailable because the adapter has no active state');
+
     await handlers.get("session_start")?.({}, {});
     await settle();
 
     expect(state.config.mcpServers["early-plugin"]).toMatchObject({
       url: "https://early.test/mcp",
       directTools: false,
+    });
+    expect(getRuntimeMcpServerSnapshot({ pi: api, name: "early-plugin" })).toMatchObject({
+      name: "early-plugin",
+      definition: { url: "https://early.test/mcp" },
+      runtime: true,
+      persisted: false,
     });
   });
 
@@ -362,7 +430,7 @@ describe("runtime MCP server registration", () => {
     const secondState = createState();
     secondState.config.mcpServers = { "plugin-a": { url: "https://now-configured.test/mcp" } };
     mocks.initializeMcp.mockResolvedValueOnce(firstState).mockResolvedValueOnce(secondState);
-    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { default: mcpAdapter, registerMcpServer, getRuntimeMcpServerSnapshot } = await import("../index.ts");
     const { api, handlers } = createPi();
     mcpAdapter(api);
     await handlers.get("session_start")?.({}, {});
@@ -377,5 +445,12 @@ describe("runtime MCP server registration", () => {
     // Collision after restart: the configured server wins, fail closed.
     expect(secondState.config.mcpServers["plugin-a"]).toMatchObject({ url: "https://now-configured.test/mcp" });
     expect(secondState.config.mcpServers["plugin-b"]).toMatchObject({ url: "https://plugin-b.test/mcp" });
+    expect(() => getRuntimeMcpServerSnapshot({ pi: api, name: "plugin-a" }))
+      .toThrow('MCP runtime server "plugin-a" is shadowed by a configured server');
+    expect(getRuntimeMcpServerSnapshot({ pi: api, name: "plugin-b" })).toMatchObject({
+      name: "plugin-b",
+      runtime: true,
+      persisted: false,
+    });
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -56,6 +56,9 @@ export interface McpServerRegistration {
 export const MCP_RUNTIME_REGISTER_EVENT = "pi-mcp-adapter:runtime-register:v1" as const;
 export const MCP_RUNTIME_REGISTER_VERSION = 1 as const;
 
+export const MCP_RUNTIME_SNAPSHOT_EVENT = "pi-mcp-adapter:runtime-snapshot:v1" as const;
+export const MCP_RUNTIME_SNAPSHOT_VERSION = 1 as const;
+
 export type McpRuntimeRegistrationResult =
   | { ok: true; registration: McpServerRegistration }
   | { ok: false; error: Error };
@@ -67,8 +70,26 @@ export interface McpRuntimeRegistrationRequest {
   result?: McpRuntimeRegistrationResult;
 }
 
+export interface McpRuntimeServerSnapshot {
+  readonly name: string;
+  readonly definition: ServerEntry;
+  readonly runtime: true;
+  readonly persisted: false;
+}
+
+export type McpRuntimeSnapshotResult =
+  | { ok: true; snapshot: McpRuntimeServerSnapshot }
+  | { ok: false; error: Error };
+
+export interface McpRuntimeSnapshotRequest {
+  version: typeof MCP_RUNTIME_SNAPSHOT_VERSION;
+  name: string;
+  result?: McpRuntimeSnapshotResult;
+}
+
 // Fast path for callers that share the adapter's module and ExtensionAPI.
 const runtimeRegistrars = new WeakMap<ExtensionAPI, (name: string, definition: ServerEntry) => McpServerRegistration>();
+const runtimeSnapshotters = new WeakMap<ExtensionAPI, (name: string) => McpRuntimeServerSnapshot>();
 
 async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof INIT_WAIT_TIMED_OUT> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -213,7 +234,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   let directToolsFrozen = false;
   // Session/runtime scoped server registrations from other extensions. They
   // survive session restarts within this install and die with the process.
-  const runtimeServers = new Map<string, ServerEntry>();
+  const runtimeServers = new Map<string, { definition: ServerEntry; entry: ServerEntry }>();
 
   // Mirrors init's per-server lifecycle registration so runtime servers get
   // idle cleanup and keep-alive health recovery like configured servers.
@@ -428,8 +449,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
     // Runtime-registered servers are proxy-tool-only: direct tools are frozen
     // at startup and must not be rebuilt for late registrations.
-    const entry: ServerEntry = { ...structuredClone(definition), directTools: false };
-    runtimeServers.set(name, entry);
+    const snapshotDefinition = structuredClone(definition);
+    const entry: ServerEntry = { ...structuredClone(snapshotDefinition), directTools: false };
+    runtimeServers.set(name, { definition: snapshotDefinition, entry });
     const registeredState = state;
     if (registeredState) {
       registeredState.config.mcpServers[name] = entry;
@@ -453,7 +475,34 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       },
     };
   };
+  const getRuntimeServerSnapshot = (name: string): McpRuntimeServerSnapshot => {
+    if (typeof name !== "string" || name.trim() === "") {
+      throw new Error("MCP runtime server name must be a non-empty string");
+    }
+    const runtimeServer = runtimeServers.get(name);
+    if (!runtimeServer) {
+      throw new Error(`MCP runtime server "${name}" is not registered or has been disposed`);
+    }
+    const activeState = state;
+    if (!activeState) {
+      throw new Error(`MCP runtime server "${name}" is unavailable because the adapter has no active state`);
+    }
+    const activeEntry = activeState.config.mcpServers[name];
+    if (Object.hasOwn(activeState.config.mcpServers, name) && activeEntry !== runtimeServer.entry) {
+      throw new Error(`MCP runtime server "${name}" is shadowed by a configured server`);
+    }
+    if (activeEntry !== runtimeServer.entry) {
+      throw new Error(`MCP runtime server "${name}" is unavailable in the active adapter state`);
+    }
+    return {
+      name,
+      definition: structuredClone(runtimeServer.definition),
+      runtime: true,
+      persisted: false,
+    };
+  };
   runtimeRegistrars.set(pi, registerRuntimeServer);
+  runtimeSnapshotters.set(pi, getRuntimeServerSnapshot);
   pi.events.on(MCP_RUNTIME_REGISTER_EVENT, (rawRequest: unknown) => {
     if (typeof rawRequest !== "object" || rawRequest === null || Array.isArray(rawRequest)) return;
     const request = rawRequest as McpRuntimeRegistrationRequest;
@@ -464,6 +513,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
     try {
       request.result = { ok: true, registration: registerRuntimeServer(request.name, request.definition) };
+    } catch (error) {
+      request.result = { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+    }
+  });
+  pi.events.on(MCP_RUNTIME_SNAPSHOT_EVENT, (rawRequest: unknown) => {
+    if (typeof rawRequest !== "object" || rawRequest === null || Array.isArray(rawRequest)) return;
+    const request = rawRequest as McpRuntimeSnapshotRequest;
+    if (request.result !== undefined) return;
+    if (request.version !== MCP_RUNTIME_SNAPSHOT_VERSION) {
+      request.result = { ok: false, error: new Error(`Unsupported MCP runtime snapshot version: ${String(request.version)}`) };
+      return;
+    }
+    try {
+      request.result = { ok: true, snapshot: getRuntimeServerSnapshot(request.name) };
     } catch (error) {
       request.result = { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     }
@@ -501,13 +564,13 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
       state = nextState;
       clearRetainedInitFailure();
-      for (const [name, definition] of runtimeServers) {
+      for (const [name, { entry }] of runtimeServers) {
         if (Object.hasOwn(nextState.config.mcpServers, name)) {
           console.error(`MCP: runtime-registered server "${name}" now collides with a configured server; keeping the configured server`);
           continue;
         }
-        nextState.config.mcpServers[name] = definition;
-        attachRuntimeServerLifecycle(nextState, name, definition);
+        nextState.config.mcpServers[name] = entry;
+        attachRuntimeServerLifecycle(nextState, name, entry);
       }
       nextState.onToolMetadataUpdated = (_serverName, _reason) => {
         if (state !== nextState || !owner.isActive()) return;
@@ -1202,6 +1265,27 @@ export function registerMcpServer(options: { pi: ExtensionAPI; name: string; def
   }
   if (!request.result.ok) throw request.result.error;
   return request.result.registration;
+}
+
+/**
+ * Return a detached, non-persisted snapshot of one runtime-registered MCP
+ * server. Configured servers and runtime registrations shadowed by config are
+ * never exported through this API.
+ */
+export function getRuntimeMcpServerSnapshot(options: { pi: ExtensionAPI; name: string }): McpRuntimeServerSnapshot {
+  const { pi, name } = options;
+  const getSnapshot = runtimeSnapshotters.get(pi);
+  if (getSnapshot) return getSnapshot(name);
+  const request: McpRuntimeSnapshotRequest = {
+    version: MCP_RUNTIME_SNAPSHOT_VERSION,
+    name,
+  };
+  pi.events.emit(MCP_RUNTIME_SNAPSHOT_EVENT, request);
+  if (!request.result) {
+    throw new Error("pi-mcp-adapter is not installed for this Pi instance");
+  }
+  if (!request.result.ok) throw request.result.error;
+  return request.result.snapshot;
 }
 
 export default createMcpAdapter();


### PR DESCRIPTION
## Summary

This adds a narrow fail-closed snapshot API for one selected runtime-registered MCP server. It lets another extension request a detached runtime snapshot without exporting configured servers, persisting runtime registrations, or using the generic `mcp` gateway as a fallback.

Closes #453.

## Validation

- `npm exec -- vitest run __tests__/runtime-register.test.ts`
- `npm run typecheck`
- `npm run build:public`
- `git diff --check`
- `git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- ':!package-lock.json'`
