### PR TITLE
fix: tolerate exited Windows header commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Server-scoped MCP calls now resolve raw upstream tool names before normalized fallbacks without weakening ambiguity checks. Thanks to [@MikeLP](https://github.com/MikeLP) for #452.
+- Windows request-header command cleanup now treats an already-exited process (`taskkill` exit code 128) as successful cleanup. Thanks to [@peterxcx](https://github.com/peterxcx) for #457.
 
 ## [2.29.0] - 2026-08-26
 

--- a/__tests__/request-headers-command.test.ts
+++ b/__tests__/request-headers-command.test.ts
@@ -1,5 +1,5 @@
 import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { createRequestHeadersCommandFetch } from "../request-headers-command.ts";
@@ -13,6 +13,28 @@ function commandScript(source: string): string {
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function runWithWindowsTaskkillExitCode(status: number): Promise<Response> {
+  const dir = mkdtempSync(join(tmpdir(), "pi-mcp-request-headers-taskkill-"));
+  const priorPlatform = process.platform;
+  const taskkill = join(dir, priorPlatform === "win32" ? "taskkill.cmd" : "taskkill");
+  writeFileSync(taskkill, priorPlatform === "win32" ? `@exit ${status}\r\n` : `#!/bin/sh\nexit ${status}\n`);
+  chmodSync(taskkill, 0o755);
+  const priorPath = process.env.PATH;
+  process.env.PATH = `${dir}${delimiter}${priorPath ?? ""}`;
+  Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+  try {
+    const script = commandScript('process.stdout.write(JSON.stringify({ "x-derived": "ok" }));\n');
+    const fetch = createRequestHeadersCommandFetch(
+      { command: process.execPath, args: [script] },
+      async () => new Response("ok"),
+    );
+    return await fetch("https://mcp.example.test/mcp");
+  } finally {
+    process.env.PATH = priorPath;
+    Object.defineProperty(process, "platform", { configurable: true, value: priorPlatform });
+  }
 }
 
 const readEnvelope = `
@@ -69,6 +91,16 @@ describe("per-request HTTP header commands", () => {
     await fetch("https://mcp.example.test/mcp", { method: "POST", body: "one" });
     await fetch("https://mcp.example.test/mcp", { method: "POST", body: "two" });
     expect(bodies).toEqual(["one", "two"]);
+  });
+
+  it("treats Windows taskkill exit code 128 as successful cleanup", async () => {
+    await expect(runWithWindowsTaskkillExitCode(128)).resolves.toBeInstanceOf(Response);
+  });
+
+  it("preserves real Windows taskkill cleanup failures", async () => {
+    await expect(runWithWindowsTaskkillExitCode(7)).rejects.toThrow(
+      "HTTP request headers command cleanup failed: taskkill exited with code 7",
+    );
   });
 
   it.skipIf(process.platform === "win32")("uses one cleanup process snapshot per stabilization pass", async () => {

--- a/request-headers-command.ts
+++ b/request-headers-command.ts
@@ -92,7 +92,7 @@ function killRequestHeadersCommand(child: ChildProcess, trackedPosixDescendantPi
       encoding: "utf8",
       windowsHide: true,
     });
-    if (result.status === 0 || isTaskkillNoSuchProcess(result)) return;
+    if (result.status === 0 || result.status === 128 || isTaskkillNoSuchProcess(result)) return;
     throw new Error(`HTTP request headers command cleanup failed: taskkill exited with code ${result.status ?? "unknown"}`);
   }
 


### PR DESCRIPTION
Fixes #457.

This treats Windows `taskkill` exit code `128` as successful request-header-command cleanup. That status means the process is already gone, which is the intended cleanup result. Other nonzero statuses still fail.

Validation passed locally:
- `npm test -- --run __tests__/request-headers-command.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh review: no issues found

Thanks to [@peterxcx](https://github.com/peterxcx) for #457.
