### PR TITLE
fix: sanitize namespace-proxy tool names for provider-safe characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Namespace proxy tool names now use provider-safe characters without making encoded-looking server names collide with non-ASCII server names. Thanks to [@nyankosama](https://github.com/nyankosama) for PR #463.
 - npm-installed token CLI commands now load their credential, config, and utility helpers from the published JavaScript build instead of package-local TypeScript files. Thanks to [@Qhilm](https://github.com/Qhilm) for #456.
 - Server-scoped MCP calls now resolve raw upstream tool names before normalized fallbacks without weakening ambiguity checks. Thanks to [@MikeLP](https://github.com/MikeLP) for #452.
 - Windows request-header command cleanup now treats an already-exited process (`taskkill` exit code 128) as successful cleanup. Thanks to [@peterxcx](https://github.com/peterxcx) for #457.

--- a/__tests__/mcp-references.test.ts
+++ b/__tests__/mcp-references.test.ts
@@ -138,6 +138,20 @@ describe("resolveMcpToolReferences", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("keeps Unicode namespace references distinct from literal encoded-form names", () => {
+    const unicode: ServerEntry = { command: "unicode" };
+    const encoded: ServerEntry = { command: "encoded" };
+    const config = configFor({ "数": unicode, _6570_: encoded });
+    const cache = cacheFor([
+      ["数", { definition: unicode, tools: [{ name: "search" }] }],
+      ["_6570_", { definition: encoded, tools: [{ name: "search" }] }],
+    ]);
+
+    const result = resolveMcpToolReferences(["mcp:数", "mcp:_6570_"], config, cache);
+
+    expect(result).toEqual({ names: ["mcp___mcpns_6570", "mcp___6570_"], diagnostics: [] });
+  });
+
   it("skips namespace proxies that collide with direct tool names", () => {
     const proxy: ServerEntry = { command: "proxy" };
     const direct: ServerEntry = { command: "direct", directTools: true, toolPrefix: "none" };

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -52,6 +52,14 @@ describe("namespaceProxyName", () => {
     expect(namespaceProxyName("context-mode")).toBe("mcp__context_mode");
     expect(namespaceProxyName("my-server-1")).toBe("mcp__my_server_1");
   });
+
+  it("uses provider-safe namespace names without encoded-form collisions", async () => {
+    const { namespaceProxyName } = await importSync();
+    expect(namespaceProxyName("数")).toBe("mcp___mcpns_6570");
+    expect(namespaceProxyName("_6570_")).toBe("mcp___6570_");
+    expect(namespaceProxyName("_mcpns_6570")).toBe("mcp___mcpns_5f_6d_63_70_6e_73_5f_36_35_37_30");
+    expect(namespaceProxyName("数")).toMatch(/^[A-Za-z0-9_]+$/);
+  });
 });
 
 describe("syncNamespaceProxyTools", () => {
@@ -426,6 +434,29 @@ describe("syncNamespaceProxyTools", () => {
 
     expect(registered.has("mcp__my_server")).toBe(false);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('servers "my-server", "my_server" normalize to the same name'));
+  });
+
+  it("registers Unicode and literal encoded-form server namespaces separately", async () => {
+    const { syncNamespaceProxyTools } = await importSync();
+    const { pi, registered } = makePi();
+
+    syncNamespaceProxyTools({
+      config: { mcpServers: { "数": { command: "unicode" }, _6570_: { command: "encoded" } } },
+      cache: CACHE_SHAPE([
+        ["数", { tools: [{ name: "search" }], definition: { command: "unicode" } }],
+        ["_6570_", { tools: [{ name: "search" }], definition: { command: "encoded" } }],
+      ]),
+      envOverride: null,
+      existingDirectNames: new Set(),
+      existingNamespaceNames: new Set(),
+      pi,
+      getState: () => null,
+      getInitPromise: () => null,
+      getPiTools: () => [],
+    });
+
+    expect(registered.has("mcp___mcpns_6570")).toBe(true);
+    expect(registered.has("mcp___6570_")).toBe(true);
   });
 
   it("keeps namespace collisions reserved when one server is in backoff", async () => {

--- a/mcp-references.ts
+++ b/mcp-references.ts
@@ -6,6 +6,7 @@ import {
   isServerDisabled,
   isToolAllowed,
   resolveToolPrefix,
+  sanitizeServerPrefix,
   type CachedTool,
   type McpConfig,
   type ServerCacheEntry,
@@ -34,7 +35,13 @@ type CachedServer = { serverName: string; definition: ServerEntry; entry: Server
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 
 export function namespaceProxyName(serverName: string): string {
-  return `mcp__${serverName.replace(/-/g, "_")}`;
+  // Keep the legacy `-` -> `_` normalization (matches the harness resolver
+  // contract) but hex-encode any remaining character outside the provider-safe
+  // set (`^[a-zA-Z0-9_-]+$`, which OpenAI's Responses/Codex API enforces on
+  // tool names), the same way direct-tool server prefixes are sanitized.
+  // Registration and `mcp:` reference resolution both route through this
+  // function, so server references keep resolving unchanged.
+  return `mcp__${sanitizeServerPrefix(serverName.replace(/-/g, "_"))}`;
 }
 
 export function parseMcpReference(raw: string): ParsedMcpReference {

--- a/mcp-references.ts
+++ b/mcp-references.ts
@@ -6,7 +6,6 @@ import {
   isServerDisabled,
   isToolAllowed,
   resolveToolPrefix,
-  sanitizeServerPrefix,
   type CachedTool,
   type McpConfig,
   type ServerCacheEntry,
@@ -33,15 +32,17 @@ type DirectNameEntry = { name: string; originalName: string };
 type CachedServer = { serverName: string; definition: ServerEntry; entry: ServerCacheEntry; prefix: ToolPrefix };
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
+const ENCODED_NAMESPACE_MARKER = "_mcpns_";
+
+function namespaceServerPart(serverName: string): string {
+  const normalized = serverName.replace(/-/g, "_");
+  if (normalized === "" || (/^[A-Za-z0-9_]+$/.test(normalized) && !normalized.startsWith(ENCODED_NAMESPACE_MARKER))) return normalized;
+  const codePoints = Array.from(normalized, char => char.codePointAt(0)!.toString(16)).join("_");
+  return `${ENCODED_NAMESPACE_MARKER}${codePoints}`;
+}
 
 export function namespaceProxyName(serverName: string): string {
-  // Keep the legacy `-` -> `_` normalization (matches the harness resolver
-  // contract) but hex-encode any remaining character outside the provider-safe
-  // set (`^[a-zA-Z0-9_-]+$`, which OpenAI's Responses/Codex API enforces on
-  // tool names), the same way direct-tool server prefixes are sanitized.
-  // Registration and `mcp:` reference resolution both route through this
-  // function, so server references keep resolving unchanged.
-  return `mcp__${sanitizeServerPrefix(serverName.replace(/-/g, "_"))}`;
+  return `mcp__${namespaceServerPart(serverName)}`;
 }
 
 export function parseMcpReference(raw: string): ParsedMcpReference {

--- a/types.ts
+++ b/types.ts
@@ -716,7 +716,7 @@ export interface McpPanelResult {
 /**
  * Get server prefix based on tool prefix mode.
  */
-export function sanitizeServerPrefix(serverName: string, preserveProviderValid = true): string {
+function sanitizeServerPrefix(serverName: string, preserveProviderValid = true): string {
   const validCharacters = preserveProviderValid ? /^[A-Za-z0-9_-]$/ : /^[A-Za-z0-9]$/;
   return Array.from(serverName, char =>
     validCharacters.test(char) ? char : `_${char.codePointAt(0)!.toString(16)}_`,

--- a/types.ts
+++ b/types.ts
@@ -716,7 +716,7 @@ export interface McpPanelResult {
 /**
  * Get server prefix based on tool prefix mode.
  */
-function sanitizeServerPrefix(serverName: string, preserveProviderValid = true): string {
+export function sanitizeServerPrefix(serverName: string, preserveProviderValid = true): string {
   const validCharacters = preserveProviderValid ? /^[A-Za-z0-9_-]$/ : /^[A-Za-z0-9]$/;
   return Array.from(serverName, char =>
     validCharacters.test(char) ? char : `_${char.codePointAt(0)!.toString(16)}_`,


### PR DESCRIPTION
## Problem

`namespaceProxyName()` builds the `mcp__<server>` namespace-proxy tool name by only replacing hyphens:

```ts
return `mcp__${serverName.replace(/-/g, "_")}`;
```

For servers whose name contains characters outside `^[a-zA-Z0-9_-]+$` (e.g. Chinese server labels, emoji, spaces), the registered tool name inherits those characters. **OpenAI's Responses/Codex API validates `tools[].name` against that exact pattern and rejects the request**:

```
Error: Codex error: [StringParam] [tools[26].name] [invalid_string]
Invalid 'tools[26].name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+'.
```

Anthropic/Gemini channels don't enforce the pattern, so only the Codex channel breaks. Sibling bug of #334/#342/#338/#190, which fixed the **direct-tool prefix** path via `sanitizeServerPrefix()` but missed the namespace-proxy path.

## Repro

1. Configure an MCP server with a non-ASCII name (e.g. `~/.config/mcp/mcp.json` with a Chinese server label).
2. Chat on the OpenAI Codex channel → 400 `invalid_string` on the tool name.

## Fix

Reuse the existing `sanitizeServerPrefix()` (now exported, already used for direct-tool server prefixes) after the legacy hyphen normalization:

```ts
return `mcp__${sanitizeServerPrefix(serverName.replace(/-/g, "_"))}`;
```

- Non-provider-safe characters are hex-encoded (`数` → `_5e73_`), so the tool name is always `^[a-zA-Z0-9_-]+$`-valid.
- Registration and `mcp:` reference resolution both route through `namespaceProxyName()`, so server references keep resolving unchanged.
- ASCII server names keep their exact previous names (`context-mode` → `mcp__context_mode`), preserving the existing harness resolver contract.

## Verification

- `npm run typecheck` passes.
- `npm test`: all namespace-proxy / reference-resolution tests pass; the only failures are pre-existing environment ones (missing `examples/interactive-visualizer/dist` build artifacts, Linux-keyring timeout, child-harness sandbox), confirmed identical on clean `main`.