### PR TITLE
fix: support manual HTTPS OAuth callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-registered OAuth clients can use HTTPS callback URLs through manual callback completion instead of being rejected as non-local redirects.
+
 ## [2.30.0] - 2026-08-28
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pre-registered OAuth clients can use HTTPS callback URLs through manual callback completion instead of being rejected as non-local redirects.
+- Pre-registered OAuth clients can use HTTPS callback URLs through manual callback completion instead of being rejected as non-local redirects. Thanks to [@jluisrojas](https://github.com/jluisrojas) for PR #464.
 
 ## [2.30.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 | `oauth.clientId` | Pre-registered OAuth client ID. MCP 2026 prefers pre-registered clients or Client ID Metadata Documents; this adapter falls back to Dynamic Client Registration when the ID is omitted and the server supports it. |
 | `oauth.clientSecret` | OAuth client secret for confidential clients; a value beginning with `!` runs a command when OAuth authenticates, while `!!` escapes a literal leading `!` |
 | `oauth.scope` | Requested OAuth scopes |
-| `oauth.redirectUri` | Exact localhost redirect URI for browser OAuth, including port and path, for providers that pre-register callbacks |
+| `oauth.redirectUri` | Exact redirect URI for browser OAuth. Local `http://` loopback URIs need an explicit port. Pre-registered `https://` callbacks use manual completion by pasting the full callback URL. |
 | `oauth.clientName` | Client display name advertised during Dynamic Client Registration fallback |
 | `oauth.clientUri` | Client homepage URI advertised during Dynamic Client Registration fallback. Defaults to `piConfig.clientUri` from the host's manifest when set, and is omitted rather than guessed under a rebranded host |
 | `oauth.logoUri` | Client logo URL advertised during Dynamic Client Registration fallback (RFC 7591 `logo_uri`). Must be an absolute `http(s)` URL — consent screens fetch it server-side, so local paths render nothing. Omitted from the registration request when unset |
@@ -304,7 +304,7 @@ Use `"2026-07-28"` to pin that revision. Pinning has no legacy or SSE fallback a
 
 The stable SDK handles era-specific request envelopes, result decoding, list-changed subscriptions, cancellation, and multi-round-trip sampling/elicitation. The adapter keeps strict OAuth issuer validation in every mode. Adapter-level roots support, standard MCP logging presentation, and configuration/UI for protocol cache hints are not yet implemented.
 
-For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port.
+For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port. A configured `https://` callback runs in manual mode because the adapter cannot receive a callback on another host. After authorization, copy the full callback URL from the browser address bar and paste it into `/mcp-auth` or `mcp({ action: "auth-complete", ... })`.
 
 If an internal authorization server publishes mismatched OAuth metadata and cannot be fixed immediately, set `oauth.skipIssuerMetadataValidation: true` on that server only. This is security-weakening. It disables the RFC 8414 issuer echo check and should not be used for public or untrusted servers.
 

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -1152,6 +1152,32 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.open).not.toHaveBeenCalled();
   });
 
+  it("uses manual completion for a pre-registered HTTPS redirect URI", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      expect(provider.redirectUrl).toBe("https://claude.ai/api/mcp/auth_callback");
+      expect(provider.clientMetadata.redirect_uris).toEqual(["https://claude.ai/api/mcp/auth_callback"]);
+      await provider.redirectToAuthorization(new URL(
+        "https://auth.example.com/authorize?redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
+      ));
+      return "REDIRECT";
+    });
+    const { startAuth } = await import("../mcp-auth-flow.ts");
+
+    const result = await startAuth("remote-redirect", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+      oauth: {
+        clientId: "registered-client",
+        redirectUri: "https://claude.ai/api/mcp/auth_callback",
+      },
+    });
+
+    expect(result.authorizationUrl).toContain("https://auth.example.com/authorize");
+    expect(mocks.ensureCallbackServer).not.toHaveBeenCalled();
+    expect(mocks.waitForCallback).not.toHaveBeenCalled();
+    expect(mocks.open).not.toHaveBeenCalled();
+  });
+
   it("enforces strict callback port for pre-registered OAuth clients", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -1178,6 +1178,30 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.open).not.toHaveBeenCalled();
   });
 
+  it("rejects raw code-only completion for pre-registered HTTPS redirect URI", async () => {
+    mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      await provider.redirectToAuthorization(new URL(
+        "https://auth.example.com/authorize?redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
+      ));
+      return "REDIRECT";
+    });
+    const { completeAuthFromInput, hasPendingAuth, startAuth } = await import("../mcp-auth-flow.ts");
+
+    await startAuth("remote-redirect", "https://api.example.com/mcp", {
+      url: "https://api.example.com/mcp",
+      auth: "oauth",
+      oauth: {
+        clientId: "registered-client",
+        redirectUri: "https://claude.ai/api/mcp/auth_callback",
+      },
+    });
+
+    await expect(completeAuthFromInput("remote-redirect", "raw-code-only"))
+      .rejects.toThrow("Paste the full OAuth callback URL");
+    expect(hasPendingAuth("remote-redirect")).toBe(true);
+    expect(mocks.sdkAuth).toHaveBeenCalledTimes(1);
+  });
+
   it("closes hosted callback input when the pending flow times out", async () => {
     vi.useFakeTimers();
     try {

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -1178,6 +1178,52 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.open).not.toHaveBeenCalled();
   });
 
+  it("closes hosted callback input when the pending flow times out", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+        await provider.redirectToAuthorization(new URL(
+          "https://auth.example.com/authorize?redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
+        ));
+        return "REDIRECT";
+      });
+      mocks.open.mockResolvedValueOnce(undefined);
+      const { authenticate } = await import("../mcp-auth-flow.ts");
+      let promptSignal: AbortSignal | undefined;
+      let markPromptStarted: (() => void) | undefined;
+      const promptStarted = new Promise<void>((resolve) => {
+        markPromptStarted = resolve;
+      });
+
+      const operation = authenticate("remote-timeout", "https://api.example.com/mcp", {
+        url: "https://api.example.com/mcp",
+        auth: "oauth",
+        oauth: {
+          clientId: "registered-client",
+          redirectUri: "https://claude.ai/api/mcp/auth_callback",
+        },
+      }, {
+        onAuthorizationUrl: () => {},
+        onAuthorizationInput: async (_authorizationUrl, signal) => {
+          promptSignal = signal;
+          markPromptStarted?.();
+          return new Promise(() => {});
+        },
+      });
+
+      await promptStarted;
+      const rejection = expect(operation).rejects.toThrow(
+        "OAuth authorization timeout - authorization took too long",
+      );
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+      await rejection;
+      expect(promptSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("enforces strict callback port for pre-registered OAuth clients", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
       await provider.redirectToAuthorization(new URL("https://auth.example.com/authorize"));

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -84,6 +84,19 @@ describe("manual OAuth proxy actions", () => {
     expect(result.details).toMatchObject({ mode: "auth-start", server: "demo" });
   });
 
+  it("explains manual completion for pre-registered HTTPS callbacks", async () => {
+    mocks.startAuth.mockResolvedValueOnce({
+      authorizationUrl: "https://auth.example.com/authorize?redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
+    });
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+
+    const result = await executeAuthStart(createState(), "demo");
+
+    expect(result.content[0].text).toContain("pre-registered HTTPS callback");
+    expect(result.content[0].text).toContain("even if the destination page reports an error");
+    expect(result.content[0].text).not.toContain("redirected localhost URL");
+  });
+
   it("rejects auth-start for non-OAuth servers", async () => {
     const { executeAuthStart } = await import("../proxy-modes.ts");
 

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -94,6 +94,8 @@ describe("manual OAuth proxy actions", () => {
 
     expect(result.content[0].text).toContain("pre-registered HTTPS callback");
     expect(result.content[0].text).toContain("even if the destination page reports an error");
+    expect(result.content[0].text).toContain("Remote HTTPS callbacks must include the full callback URL");
+    expect(result.content[0].text).not.toContain('args: { code: "PASTE_CODE_HERE" }');
     expect(result.content[0].text).not.toContain("redirected localhost URL");
   });
 

--- a/commands.ts
+++ b/commands.ts
@@ -297,7 +297,7 @@ export async function authenticateServer(
         return ui.input(
           `Complete ${serverName} OAuth\n\n` +
             `${terminalHyperlink("Open authorization page", authorizationUrl)}\n${authorizationUrl}\n\n` +
-            "Approve access, then paste the full localhost callback URL below.",
+            "Approve access, then paste the full callback URL from the browser address bar below.",
           undefined,
           { signal: inputSignal },
         );

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -228,7 +228,7 @@ export interface OAuthConfig {
     scope?: string;
     /** Extra authorization URL parameters for provider-specific extensions. Flow-owned parameters cannot be overridden. */
     authorizationParams?: Record<string, string>;
-    /** Exact authorization-code redirect URI for pre-registered clients */
+    /** Exact authorization-code redirect URI for pre-registered clients. HTTPS redirects use manual callback URL completion. */
     redirectUri?: string;
     /** Client display name for dynamic registration */
     clientName?: string;

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -320,14 +320,14 @@ describe("mcp-auth-flow", () => {
       )
     })
 
-    it("should reject non-local OAuth redirectUri values", async () => {
+    it("should reject insecure non-local OAuth redirectUri values", async () => {
       await assert.rejects(
         async () => await startAuth("remote-redirect", "https://api.example.com/mcp", {
           url: "https://api.example.com/mcp",
           auth: "oauth",
-          oauth: { redirectUri: "https://example.com:3118/callback" },
+          oauth: { redirectUri: "http://example.com:3118/callback" },
         }),
-        /localhost or loopback/
+        /https:\/\/ URI or an http:\/\/ localhost or loopback URI/
       )
     })
 

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -331,6 +331,17 @@ describe("mcp-auth-flow", () => {
       )
     })
 
+    it("should reject non-local OAuth redirectUri values with invalid ports", async () => {
+      await assert.rejects(
+        async () => await startAuth("bad-remote-port", "https://api.example.com/mcp", {
+          url: "https://api.example.com/mcp",
+          auth: "oauth",
+          oauth: { redirectUri: "https://example.com:0/callback" },
+        }),
+        /positive numeric port/
+      )
+    })
+
     it("should reject OAuth redirectUri values without an explicit port", async () => {
       await assert.rejects(
         async () => await startAuth("no-port-redirect", "https://api.example.com/mcp", {

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -75,6 +75,7 @@ type PendingAuth = {
   authProvider: McpOAuthProvider
   serverUrl: string
   authorizationUrl: string
+  manualRedirect: boolean
   discovery: AuthDiscovery
   authStorageOptions: AuthStorageOptions
 }
@@ -307,18 +308,16 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
   }
 }
 
-function parseOAuthRedirectUri(redirectUri: string): { port: number; callbackHost: string; callbackPath: string } {
+type OAuthRedirectTarget =
+  | { mode: "local"; port: number; callbackHost: string; callbackPath: string }
+  | { mode: "manual" }
+
+function parseOAuthRedirectUri(redirectUri: string): OAuthRedirectTarget {
   let url: URL
   try {
     url = new URL(redirectUri)
   } catch (error) {
     throw new Error(`Invalid OAuth redirectUri: ${redirectUri}`, { cause: error })
-  }
-
-  const hostname = url.hostname.toLowerCase()
-  const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1"
-  if (url.protocol !== "http:" || !isLocalhost) {
-    throw new Error("OAuth redirectUri must be an http:// localhost or loopback URI")
   }
 
   if (url.username || url.password) {
@@ -329,17 +328,26 @@ function parseOAuthRedirectUri(redirectUri: string): { port: number; callbackHos
     throw new Error("OAuth redirectUri must not include a fragment")
   }
 
+  const hostname = url.hostname.toLowerCase()
+  const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1"
+  if (url.protocol === "https:" && !isLocalhost) {
+    return { mode: "manual" }
+  }
+  if (url.protocol !== "http:" || !isLocalhost) {
+    throw new Error("OAuth redirectUri must be an https:// URI or an http:// localhost or loopback URI")
+  }
+
   if (!url.port) {
-    throw new Error("OAuth redirectUri must include an explicit numeric port")
+    throw new Error("OAuth localhost redirectUri must include an explicit numeric port")
   }
 
   const port = Number.parseInt(url.port, 10)
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-    throw new Error("OAuth redirectUri must include an explicit numeric port")
+    throw new Error("OAuth localhost redirectUri must include an explicit numeric port")
   }
 
   const callbackHost = hostname === "[::1]" ? "::1" : hostname
-  return { port, callbackHost, callbackPath: url.pathname }
+  return { mode: "local", port, callbackHost, callbackPath: url.pathname }
 }
 
 /**
@@ -393,25 +401,30 @@ export async function startAuth(
     return { authorizationUrl: existingPendingAuth.authorizationUrl }
   }
 
-  const redirectCallback = config.redirectUri !== undefined ? parseOAuthRedirectUri(config.redirectUri) : undefined
+  const redirectTarget = config.redirectUri !== undefined ? parseOAuthRedirectUri(config.redirectUri) : undefined
+  const manualRedirect = redirectTarget?.mode === "manual"
   const oauthState = generateState()
 
-  try {
-    await ensureCallbackServer({
-      strictPort: Boolean(config.clientId) || config.redirectUri !== undefined,
-      oauthState,
-      reserveState: true,
-      ...(redirectCallback ? { port: redirectCallback.port, callbackHost: redirectCallback.callbackHost, callbackPath: redirectCallback.callbackPath } : {}),
-    })
-    throwIfAborted(signal)
-  } catch (error) {
-    releaseCallbackServer(oauthState)
+  if (!manualRedirect) {
     try {
-      await cleanupAndReleaseCallbackServerIfIdle(() => clearOAuthState(serverName, authStorageOptions))
-    } catch (cleanupError) {
-      throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
+      await ensureCallbackServer({
+        strictPort: Boolean(config.clientId) || config.redirectUri !== undefined,
+        oauthState,
+        reserveState: true,
+        ...(redirectTarget?.mode === "local"
+          ? { port: redirectTarget.port, callbackHost: redirectTarget.callbackHost, callbackPath: redirectTarget.callbackPath }
+          : {}),
+      })
+      throwIfAborted(signal)
+    } catch (error) {
+      releaseCallbackServer(oauthState)
+      try {
+        await cleanupAndReleaseCallbackServerIfIdle(() => clearOAuthState(serverName, authStorageOptions))
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], "OAuth startup cleanup failed")
+      }
+      throw error
     }
-    throw error
   }
 
   let capturedUrl: URL | undefined
@@ -455,7 +468,15 @@ export async function startAuth(
     if (!capturedUrl) {
       throw new UnauthorizedError("OAuth authorization URL was not provided")
     }
-    await setPendingAuth(runtime, serverName, { serverName, authProvider, serverUrl, authorizationUrl: capturedUrl.toString(), discovery, authStorageOptions }, oauthState, signal, generation)
+    await setPendingAuth(runtime, serverName, {
+      serverName,
+      authProvider,
+      serverUrl,
+      authorizationUrl: capturedUrl.toString(),
+      manualRedirect,
+      discovery,
+      authStorageOptions,
+    }, oauthState, signal, generation)
     return { authorizationUrl: capturedUrl.toString() }
   } catch (error) {
     authProvider.deactivate()
@@ -805,15 +826,28 @@ export async function authenticate(
     try {
       // Get the state that was already generated and stored in startAuth().
       // Keep this lookup and its abort check inside the cleanup boundary because
-      // startAuth has already reserved callback state at this point.
+      // startAuth already owns the pending flow at this point.
       oauthState = runtimeState.pendingAuthStates.get(getPendingAuthKey(serverName, authStorageOptions))
       throwIfAborted(signal)
       if (!oauthState) {
         throw new Error("OAuth state not found - this should not happen")
       }
 
-      // Register the callback BEFORE opening the browser.
-      const callbackPromise = waitForCallback(oauthState)
+      const pendingAuth = runtimeState.pendingAuths.get(getPendingAuthKey(serverName, authStorageOptions))
+      if (!pendingAuth) {
+        throw new Error(`No pending OAuth flow for server: ${serverName}`)
+      }
+      if (pendingAuth.manualRedirect && !options.onAuthorizationInput) {
+        throw new Error(
+          `OAuth for ${serverName} uses a remote redirect URI. Complete it with auth-start/auth-complete or /mcp-auth.`,
+        )
+      }
+
+      // Register the localhost callback before opening the browser. Remote
+      // pre-registered callbacks are completed by pasting their full URL.
+      const callbackPromise: Promise<AuthorizationCodeInput> = pendingAuth.manualRedirect
+        ? new Promise(() => {})
+        : waitForCallback(oauthState)
       void callbackPromise.catch(() => {})
 
       // Open browser. Always surface the URL first so remote/headless users can copy it

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -331,6 +331,12 @@ function parseOAuthRedirectUri(redirectUri: string): OAuthRedirectTarget {
 
   const hostname = url.hostname.toLowerCase()
   const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1"
+  if (url.port) {
+    const parsedPort = Number.parseInt(url.port, 10)
+    if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+      throw new Error("OAuth redirectUri port must be a positive numeric port")
+    }
+  }
   if (url.protocol === "https:" && !isLocalhost) {
     return { mode: "manual" }
   }
@@ -736,7 +742,11 @@ export async function completeAuthFromInput(
   throwIfAborted(signal)
   const key = getPendingAuthKey(serverName, fallbackAuthStorageOptions)
   const oauthState = runtimeState.pendingAuthStates.get(key)
+  const pendingAuth = runtimeState.pendingAuths.get(key)
   throwIfAborted(signal)
+  if (pendingAuth?.manualRedirect && !getSearchParamsFromInput(input.trim())) {
+    throw new Error("Paste the full OAuth callback URL, including its code and state parameters")
+  }
   const parsed = parseAuthorizationRedirectInput(input, oauthState)
   return completeAuth(serverName, parsed, options)
 }

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -76,6 +76,7 @@ type PendingAuth = {
   serverUrl: string
   authorizationUrl: string
   manualRedirect: boolean
+  manualCompletionController?: AbortController
   discovery: AuthDiscovery
   authStorageOptions: AuthStorageOptions
 }
@@ -474,6 +475,7 @@ export async function startAuth(
       serverUrl,
       authorizationUrl: capturedUrl.toString(),
       manualRedirect,
+      ...(manualRedirect ? { manualCompletionController: new AbortController() } : {}),
       discovery,
       authStorageOptions,
     }, oauthState, signal, generation)
@@ -505,7 +507,13 @@ async function setPendingAuth(
   state.pendingAuths.set(key, pendingAuth)
   state.pendingAuthStates.set(key, oauthState)
   const cleanupTimer = setTimeout(() => {
-    void clearPendingAuthAndReleaseIfIdle(runtime, serverName, oauthState, pendingAuth.authStorageOptions).catch(error => {
+    void clearPendingAuthAndReleaseIfIdle(
+      runtime,
+      serverName,
+      oauthState,
+      pendingAuth.authStorageOptions,
+      new Error("OAuth authorization timeout - authorization took too long"),
+    ).catch(error => {
       console.error(`MCP Auth: Timed-out flow cleanup failed: ${formatTerminalError(error)}`)
     })
   }, MANUAL_AUTH_TIMEOUT_MS)
@@ -513,7 +521,13 @@ async function setPendingAuth(
   state.pendingAuthCleanupTimers.set(key, cleanupTimer)
 }
 
-async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oauthState?: string, fallbackStorageOptions: AuthStorageOptions = {}): Promise<void> {
+async function clearPendingAuth(
+  runtime: McpOAuthRuntime,
+  serverName: string,
+  oauthState?: string,
+  fallbackStorageOptions: AuthStorageOptions = {},
+  reason: Error = new Error("Authorization cancelled"),
+): Promise<void> {
   const state = getRuntimeState(runtime)
   const key = getPendingAuthKey(serverName, fallbackStorageOptions)
   const pendingAuth = state.pendingAuths.get(key)
@@ -527,6 +541,7 @@ async function clearPendingAuth(runtime: McpOAuthRuntime, serverName: string, oa
     state.pendingAuthCleanupTimers.delete(key)
   }
 
+  pendingAuth?.manualCompletionController?.abort(reason)
   pendingAuth?.authProvider.deactivate()
   state.pendingAuths.delete(key)
   state.pendingAuthStates.delete(key)
@@ -545,9 +560,10 @@ async function clearPendingAuthAndReleaseIfIdle(
   serverName: string,
   oauthState: string | undefined,
   fallbackStorageOptions: AuthStorageOptions = {},
+  reason?: Error,
 ): Promise<void> {
   await cleanupAndReleaseCallbackServerIfIdle(
-    () => clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions),
+    () => clearPendingAuth(runtime, serverName, oauthState, fallbackStorageOptions, reason),
   )
 }
 
@@ -648,6 +664,19 @@ export function parseAuthorizationCodeInput(input: string, expectedState?: strin
 type AuthorizationResponse = {
   input: AuthorizationCodeInput
   source: "callback" | "manual"
+}
+
+function waitForManualCompletionCancellation(signal: AbortSignal): Promise<AuthorizationCodeInput> {
+  return new Promise((_, reject) => {
+    const rejectFromSignal = () => {
+      reject(signal.reason instanceof Error ? signal.reason : new Error("Authorization cancelled"))
+    }
+    if (signal.aborted) {
+      rejectFromSignal()
+      return
+    }
+    signal.addEventListener("abort", rejectFromSignal, { once: true })
+  })
 }
 
 /**
@@ -846,7 +875,7 @@ export async function authenticate(
       // Register the localhost callback before opening the browser. Remote
       // pre-registered callbacks are completed by pasting their full URL.
       const callbackPromise: Promise<AuthorizationCodeInput> = pendingAuth.manualRedirect
-        ? new Promise(() => {})
+        ? waitForManualCompletionCancellation(pendingAuth.manualCompletionController!.signal)
         : waitForCallback(oauthState)
       void callbackPromise.catch(() => {})
 

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -178,7 +178,9 @@ function formatManualAuthInstructions(serverName: string, authorizationUrl: stri
     "After approving, copy the full callback URL from your browser address bar and send it back with:",
     `mcp({ action: "auth-complete", server: "${serverName}", args: { redirectUrl: "PASTE_REDIRECT_URL_HERE" } })`,
     "",
-    'You can also pass just the `code` query parameter as `args: { code: "PASTE_CODE_HERE" }`. JSON-string args remain supported.',
+    redirect.remote
+      ? "Remote HTTPS callbacks must include the full callback URL so the OAuth state can be checked. JSON-string args remain supported."
+      : 'You can also pass just the `code` query parameter as `args: { code: "PASTE_CODE_HERE" }`. JSON-string args remain supported.',
     redirectNote,
   ].filter(Boolean).join("\n");
 }

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -143,22 +143,30 @@ function getAuthFailedMessage(state: McpExtensionState, serverName: string, mess
   return `OAuth authentication failed for "${serverName}": ${message}. Run mcp({ action: "auth-start", server: "${serverName}" }) to get a browser URL, or /mcp-auth ${serverName} in an interactive local session.`;
 }
 
-function getRedirectPort(authorizationUrl: string): number | undefined {
+function getRedirectDetails(authorizationUrl: string): { port?: number; remote: boolean } {
   try {
     const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
-    if (!redirectUri) return undefined;
-    const port = Number.parseInt(new URL(redirectUri).port, 10);
-    return Number.isInteger(port) ? port : undefined;
+    if (!redirectUri) return { remote: false };
+    const redirect = new URL(redirectUri);
+    const hostname = redirect.hostname.toLowerCase();
+    const local = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+    const port = Number.parseInt(redirect.port, 10);
+    return {
+      ...(Number.isInteger(port) ? { port } : {}),
+      remote: !local,
+    };
   } catch {
-    return undefined;
+    return { remote: false };
   }
 }
 
 function formatManualAuthInstructions(serverName: string, authorizationUrl: string): string {
-  const port = getRedirectPort(authorizationUrl);
-  const portNote = port
-    ? `\nThe redirect URL will use local port ${port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
-    : "";
+  const redirect = getRedirectDetails(authorizationUrl);
+  const redirectNote = redirect.remote
+    ? "The provider uses a pre-registered HTTPS callback. Copy its full URL from the browser address bar, even if the destination page reports an error."
+    : redirect.port
+      ? `The redirect URL will use local port ${redirect.port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
+      : "";
 
   return [
     `MCP OAuth required for "${serverName}".`,
@@ -167,11 +175,11 @@ function formatManualAuthInstructions(serverName: string, authorizationUrl: stri
     "",
     authorizationUrl,
     "",
-    "After approving, copy the full redirected localhost URL from your browser address bar and send it back with:",
+    "After approving, copy the full callback URL from your browser address bar and send it back with:",
     `mcp({ action: "auth-complete", server: "${serverName}", args: { redirectUrl: "PASTE_REDIRECT_URL_HERE" } })`,
     "",
     'You can also pass just the `code` query parameter as `args: { code: "PASTE_CODE_HERE" }`. JSON-string args remain supported.',
-    portNote.trimEnd(),
+    redirectNote,
   ].filter(Boolean).join("\n");
 }
 

--- a/types.ts
+++ b/types.ts
@@ -378,7 +378,7 @@ export interface OAuthConfig {
   scope?: string;
   /** Extra authorization URL parameters for provider-specific extensions. Flow-owned parameters cannot be overridden. */
   authorizationParams?: Record<string, string>;
-  /** Exact authorization-code redirect URI for pre-registered clients */
+  /** Exact authorization-code redirect URI for pre-registered clients. HTTPS redirects use manual callback URL completion. */
   redirectUri?: string;
   /** Client display name for dynamic registration */
   clientName?: string;


### PR DESCRIPTION
## Problem

The OAuth flow only accepts `http://` localhost or loopback redirect URIs. This blocks pre-registered clients for providers that require a hosted HTTPS callback and do not permit Dynamic Client Registration for local callbacks.

For example, such providers fail before browser authorization with an error like:

> Dynamic registration is not available for this client.

The adapter already supports completing OAuth by pasting the full callback URL, but configured HTTPS redirect URIs are rejected before that flow can start.

## Changes

- Accept configured non-local `https://` OAuth redirect URIs.
- Treat hosted HTTPS callbacks as manual-completion flows.
- Skip the localhost callback server when the redirect is hosted remotely.
- Require interactive callback input or the existing `auth-start` / `auth-complete` flow for remote redirects.
- Preserve OAuth state, PKCE, issuer, and token-exchange validation.
- Keep rejecting non-local plain HTTP callbacks, fragments, and embedded credentials.
- Update interactive and proxy instructions so they no longer assume every callback uses localhost.
- Document HTTPS callback behavior and update the generated public type declaration.
- Add regression coverage for remote callback startup and manual completion instructions.

## Validation

- `npm run typecheck`
- `npm test`
  - 108 test files passed
  - 1,346 tests passed, 1 skipped
  - public export tests passed
- `npm run test:oauth`
  - 143 tests passed
- `npm run test:conformance`
  - all MCP client conformance scenarios passed or matched the reviewed baseline
- `npm pack --dry-run`
- `git diff --check upstream/main...HEAD`
- conflict-marker scan passed

## Live verification

Verified against an OAuth provider using a pre-registered HTTPS callback:

- the authorization URL contains the configured client ID and HTTPS redirect URI
- OAuth state and PKCE are present
- no localhost callback server is started
- the returned HTTPS callback URL can be parsed and completed through the existing manual flow