### PR TITLE
fix: advertise MCP Apps UI capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MCP Apps UI hosts now advertise the `io.modelcontextprotocol/ui` extension capability so compatible servers can expose their UI resources. Thanks to [@VikashLoomba](https://github.com/VikashLoomba) for #465.
+
 ### Fixed
 
 - Pre-registered OAuth clients can use HTTPS callback URLs through manual callback completion instead of being rejected as non-local redirects. Thanks to [@jluisrojas](https://github.com/jluisrojas) for PR #464.

--- a/__tests__/server-manager-sampling.test.ts
+++ b/__tests__/server-manager-sampling.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { RESOURCE_MIME_TYPE } from "../ui-app-bridge-helpers.ts";
 
 const mocks = vi.hoisted(() => ({
   clients: [] as any[],
@@ -216,10 +217,45 @@ describe("McpServerManager sampling", () => {
     await manager.connect("demo", { command: "node", args: ["server.js"] });
 
     const client = mocks.clients[0];
-    expect(client.options).not.toHaveProperty("capabilities");
+    expect(client.options.capabilities).not.toHaveProperty("sampling");
     expect(client.options.listChanged.tools.onChanged).toBeTypeOf("function");
     expect(client.options.listChanged.resources.onChanged).toBeTypeOf("function");
     expect(client.setRequestHandler).not.toHaveBeenCalled();
+  });
+
+  it("passes the MCP Apps capability through legacy and modern client paths", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+
+    await manager.connect("legacy", { command: "node", args: ["server.js"] });
+    await manager.connect("auto", {
+      command: "node",
+      args: ["server.js"],
+      protocolVersion: "auto",
+    });
+    await manager.connect("pinned", {
+      command: "node",
+      args: ["server.js"],
+      protocolVersion: "2026-07-28",
+    });
+
+    const expectedCapabilities = {
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: [RESOURCE_MIME_TYPE],
+        },
+      },
+    };
+    expect(mocks.clients.map(client => client.options.capabilities)).toEqual([
+      expectedCapabilities,
+      expectedCapabilities,
+      expectedCapabilities,
+    ]);
+    expect(mocks.clients.map(client => client.options.versionNegotiation)).toEqual([
+      undefined,
+      { mode: "auto" },
+      { mode: { pin: "2026-07-28" } },
+    ]);
   });
 
   it("refreshes cached lists and ignores notifications from replaced clients", async () => {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -34,6 +34,7 @@ import {
 import { resolveNpxBinary } from "./npx-resolver.ts";
 import { createJsonSchemaValidator } from "./json-schema-validator.ts";
 import { logger } from "./logger.ts";
+import { RESOURCE_MIME_TYPE } from "./ui-app-bridge-helpers.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { invalidateAuthEntryCache, type AuthStorageOptions } from "./mcp-auth.ts";
@@ -725,6 +726,11 @@ export class McpServerManager {
 
   private buildClientCapabilities() {
     return {
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: [RESOURCE_MIME_TYPE],
+        },
+      },
       ...(this.samplingConfig ? { sampling: {} } : {}),
       ...(this.elicitationConfig
         ? {


### PR DESCRIPTION
## Summary
- advertise the MCP Apps `io.modelcontextprotocol/ui` extension capability from MCP client setup
- reuse the existing MCP Apps HTML MIME constant so compatible servers can reveal UI resources
- cover legacy, auto-negotiated, and pinned `2026-07-28` client capability paths

Closes #465

## Validation
- `npm test -- --run __tests__/server-manager-sampling.test.ts`
- `npm run typecheck`
- `git diff --check`

Thanks to [@VikashLoomba](https://github.com/VikashLoomba) for reporting #465.