### PR TITLE
fix(mcp): harden 2026 input-required flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
+
 ## [2.31.0] - 2026-08-28
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Use `"auto"` to probe for MCP 2026-07-28 and conservatively fall back to the cla
 
 Use `"2026-07-28"` to pin that revision. Pinning has no legacy or SSE fallback and fails if the server does not offer the requested version.
 
-The stable SDK handles era-specific request envelopes, result decoding, list-changed subscriptions, cancellation, and multi-round-trip sampling/elicitation. The adapter keeps strict OAuth issuer validation in every mode. Adapter-level roots support, standard MCP logging presentation, and configuration/UI for protocol cache hints are not yet implemented.
+The stable SDK handles era-specific request envelopes, result decoding, list-changed subscriptions, cancellation, and multi-round-trip sampling/elicitation. The SDK's embedded-input progress callback does not expose the originating tool or resource identity, so the adapter cannot maintain a durable per-tool waiting status row; interactive sessions keep the existing input dialog visible, and proxy calls show request progress when UI is available. The adapter keeps strict OAuth issuer validation in every mode. Adapter-level roots support, standard MCP logging presentation, and configuration/UI for protocol cache hints are not yet implemented.
 
 For pre-registered browser OAuth clients, set `oauth.redirectUri` to the exact callback registered with the provider, for example `"http://localhost:3118/callback"`. Dynamic clients normally omit it and use a lazy OS-assigned localhost callback port. A configured `https://` callback runs in manual mode because the adapter cannot receive a callback on another host. After authorization, copy the full callback URL from the browser address bar and paste it into `/mcp-auth` or `mcp({ action: "auth-complete", ... })`.
 

--- a/__tests__/error-signal.test.ts
+++ b/__tests__/error-signal.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect } from "vitest";
 import { toolErrorOverride } from "../error-signal.ts";
 
 describe("toolErrorOverride", () => {
-  it("flags tool-execution failures (tool_error, call_failed)", () => {
+  it("flags tool-execution failures", () => {
     expect(toolErrorOverride({ error: "tool_error", server: "x" })).toEqual({ isError: true });
     expect(toolErrorOverride({ mode: "call", error: "call_failed", message: "boom" })).toEqual({ isError: true });
+    expect(toolErrorOverride({ mode: "call", error: "input_required_needs_ui", server: "demo" })).toEqual({ isError: true });
+    expect(toolErrorOverride({
+      mode: "script",
+      calls: [{ path: "demo_needs_ui", ok: false, error: "input_required_needs_ui" }],
+    })).toEqual({ isError: true });
   });
 
   it("leaves the adapter's other details.error codes as successes (auth, connection, validation, routing)", () => {

--- a/__tests__/fixtures/mrtr-server.mjs
+++ b/__tests__/fixtures/mrtr-server.mjs
@@ -1,0 +1,235 @@
+import { appendFileSync } from "node:fs";
+import readline from "node:readline";
+
+const lines = readline.createInterface({ input: process.stdin });
+const logFile = process.env.MRTR_LOG_FILE;
+let modern = false;
+const ONE_ROUND_STATE = "one-round-state:v1";
+const FIRST_ROUND_STATE = "two-round-state:first:v1";
+const SECOND_ROUND_STATE = "two-round-state:second:v1";
+
+function record(event) {
+  if (!logFile) return;
+  appendFileSync(logFile, `${JSON.stringify(event)}\n`);
+}
+
+function respond(id, result) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function reject(id, message) {
+  process.stdout.write(`${JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32602, message },
+  })}\n`);
+}
+
+function result(body) {
+  return modern ? { resultType: "complete", ...body } : body;
+}
+
+function elicitationRequest(key, message) {
+  return {
+    [key]: {
+      method: "elicitation/create",
+      params: {
+        mode: "form",
+        message,
+        requestedSchema: { type: "object", properties: {} },
+      },
+    },
+  };
+}
+
+function hasAcceptedResponse(params, key) {
+  const response = params?.inputResponses?.[key];
+  return response?.action === "accept";
+}
+
+function handleTool(request) {
+  const params = request.params ?? {};
+  const name = params.name;
+  record({ method: "tools/call", name, params });
+
+  if (name === "one_round") {
+    if (hasAcceptedResponse(params, "one-round-input")) {
+      respond(request.id, result({ content: [{ type: "text", text: "one-round complete" }] }));
+    } else if (params.inputResponses === undefined) {
+      respond(request.id, {
+        resultType: "input_required",
+        inputRequests: elicitationRequest("one-round-input", "Confirm one round"),
+        requestState: ONE_ROUND_STATE,
+      });
+    } else {
+      reject(request.id, "one_round did not receive an accepted input response");
+    }
+    return;
+  }
+
+  if (name === "two_rounds") {
+    if (params.inputResponses === undefined) {
+      respond(request.id, {
+        resultType: "input_required",
+        inputRequests: elicitationRequest("first-round-input", "Confirm the first round"),
+        requestState: FIRST_ROUND_STATE,
+      });
+    } else if (params.requestState === FIRST_ROUND_STATE && hasAcceptedResponse(params, "first-round-input")) {
+      respond(request.id, {
+        resultType: "input_required",
+        inputRequests: elicitationRequest("second-round-input", "Confirm the second round"),
+        requestState: SECOND_ROUND_STATE,
+      });
+    } else if (params.requestState === SECOND_ROUND_STATE && hasAcceptedResponse(params, "second-round-input")) {
+      respond(request.id, result({ content: [{ type: "text", text: "two-round complete" }] }));
+    } else {
+      reject(request.id, `two_rounds received an unexpected requestState: ${String(params.requestState)}`);
+    }
+    return;
+  }
+
+  if (name === "needs_ui" || name === "abort_pending") {
+    respond(request.id, {
+      resultType: "input_required",
+      inputRequests: elicitationRequest(
+        name === "abort_pending" ? "abort-pending-input" : "missing-ui-input",
+        name === "abort_pending" ? "Wait for input" : "Input is required",
+      ),
+      requestState: `${name}-state:v1`,
+    });
+    return;
+  }
+
+  if (name === "legacy_complete") {
+    respond(request.id, modern
+      ? result({ content: [{ type: "text", text: "modern complete" }] })
+      : { content: [{ type: "text", text: "legacy complete" }] });
+    return;
+  }
+
+  reject(request.id, `Unknown tool: ${String(name)}`);
+}
+
+function handleReadResource(request) {
+  const uri = request.params?.uri;
+  record({ method: "resources/read", uri, params: request.params });
+
+  if (uri === "test://mrtr/resource") {
+    const key = "resource-input";
+    const params = request.params ?? {};
+    if (params.inputResponses === undefined) {
+      respond(request.id, {
+        resultType: "input_required",
+        inputRequests: elicitationRequest(key, "Confirm resource read"),
+        requestState: "resource-state:v1",
+      });
+    } else if (params.requestState === "resource-state:v1" && hasAcceptedResponse(params, key)) {
+      respond(request.id, result({ ttlMs: 0, cacheScope: "private", contents: [{ uri, mimeType: "text/plain", text: "resource complete" }] }));
+    } else {
+      reject(request.id, "resource read received an unexpected input response");
+    }
+    return;
+  }
+
+  if (uri === "ui://mrtr/resource") {
+    const key = "ui-resource-input";
+    const params = request.params ?? {};
+    if (params.inputResponses === undefined) {
+      respond(request.id, {
+        resultType: "input_required",
+        inputRequests: elicitationRequest(key, "Confirm UI resource read"),
+        requestState: "ui-resource-state:v1",
+      });
+    } else if (params.requestState === "ui-resource-state:v1" && hasAcceptedResponse(params, key)) {
+      respond(request.id, result({ ttlMs: 0, cacheScope: "private", contents: [{ uri, mimeType: "text/html", text: "<main>resource UI complete</main>" }] }));
+    } else {
+      reject(request.id, "UI resource read received an unexpected input response");
+    }
+    return;
+  }
+
+  reject(request.id, `Unknown resource: ${String(uri)}`);
+}
+
+lines.on("line", line => {
+  const request = JSON.parse(line);
+  if (request.params?._meta?.["io.modelcontextprotocol/protocolVersion"] === "2026-07-28") {
+    modern = true;
+  }
+  if (request.method === "server/discover") {
+    modern = true;
+    respond(request.id, {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {}, resources: {} },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "mrtr",
+          version: "1.0.0",
+        },
+      },
+    });
+    return;
+  }
+  if (request.method === "initialize") {
+    modern = false;
+    respond(request.id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: "mrtr", version: "1.0.0" },
+    });
+    return;
+  }
+  if (request.method === "tools/list") {
+    respond(request.id, modern
+      ? {
+          resultType: "complete",
+          ttlMs: 0,
+          cacheScope: "private",
+          tools: [
+            { name: "one_round", description: "One input-required round", inputSchema: { type: "object", properties: {} } },
+            { name: "two_rounds", description: "Two input-required rounds", inputSchema: { type: "object", properties: {} } },
+            { name: "needs_ui", description: "Needs an input handler", inputSchema: { type: "object", properties: {} } },
+            { name: "abort_pending", description: "Waits for a pending input handler", inputSchema: { type: "object", properties: {} } },
+            { name: "legacy_complete", description: "Legacy result without a resultType", inputSchema: { type: "object", properties: {} } },
+          ],
+        }
+      : {
+          tools: [
+            { name: "one_round", description: "One input-required round", inputSchema: { type: "object", properties: {} } },
+            { name: "two_rounds", description: "Two input-required rounds", inputSchema: { type: "object", properties: {} } },
+            { name: "needs_ui", description: "Needs an input handler", inputSchema: { type: "object", properties: {} } },
+            { name: "abort_pending", description: "Waits for a pending input handler", inputSchema: { type: "object", properties: {} } },
+            { name: "legacy_complete", description: "Legacy result without a resultType", inputSchema: { type: "object", properties: {} } },
+          ],
+        });
+    return;
+  }
+  if (request.method === "resources/list") {
+    respond(request.id, modern
+      ? {
+          resultType: "complete",
+          ttlMs: 0,
+          cacheScope: "private",
+          resources: [
+            { uri: "test://mrtr/resource", name: "MRTR resource", mimeType: "text/plain" },
+            { uri: "ui://mrtr/resource", name: "MRTR UI resource", mimeType: "text/html" },
+          ],
+        }
+      : {
+          resources: [
+            { uri: "test://mrtr/resource", name: "MRTR resource", mimeType: "text/plain" },
+            { uri: "ui://mrtr/resource", name: "MRTR UI resource", mimeType: "text/html" },
+          ],
+        });
+    return;
+  }
+  if (request.method === "tools/call") {
+    handleTool(request);
+    return;
+  }
+  if (request.method === "resources/read") {
+    handleReadResource(request);
+    return;
+  }
+  if (request.id !== undefined) reject(request.id, `Method not found: ${request.method}`);
+});

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1970,6 +1970,10 @@ describe("mcpAdapter session lifecycle", () => {
     expect(toolResult?.({ details: { error: "tool_error", server: "demo" } })).toEqual({ isError: true });
     // the call itself threw and was caught (proxy path) -> tagged call_failed
     expect(toolResult?.({ details: { mode: "call", error: "call_failed", message: "boom" } })).toEqual({ isError: true });
+    expect(toolResult?.({ details: { mode: "call", error: "input_required_needs_ui", server: "demo" } })).toEqual({ isError: true });
+    expect(toolResult?.({
+      details: { mode: "script", calls: [{ path: "demo_needs_ui", ok: false, error: "input_required_needs_ui" }] },
+    })).toEqual({ isError: true });
     // a precondition code is not a tool-execution failure -> left untouched
     expect(toolResult?.({ details: { error: "auth_required", server: "demo" } })).toBeUndefined();
   });

--- a/__tests__/mrtr-sdk-integration.test.ts
+++ b/__tests__/mrtr-sdk-integration.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { getInputRequiredNeedsUiDetails } from "../errors.ts";
+import { executeCall } from "../proxy-modes.ts";
+import { runMcpScript } from "../mcp-code.ts";
+import { McpServerManager } from "../server-manager.ts";
+import type { McpExtensionState } from "../state.ts";
+import type { DirectToolSpec, ToolMetadata } from "../types.ts";
+import { UiResourceHandler } from "../ui-resource-handler.ts";
+
+const fixture = fileURLToPath(new URL("./fixtures/mrtr-server.mjs", import.meta.url));
+const managers: McpServerManager[] = [];
+const tempDirs: string[] = [];
+
+type TestUi = {
+  select: ReturnType<typeof vi.fn>;
+  input: ReturnType<typeof vi.fn>;
+  notify: ReturnType<typeof vi.fn>;
+};
+
+function createUi(answers: Array<string | undefined>): TestUi {
+  return {
+    select: vi.fn(async () => answers.shift()),
+    input: vi.fn(async () => undefined),
+    notify: vi.fn(),
+  };
+}
+
+function metadata(originalName: string, extra: Partial<ToolMetadata> = {}): ToolMetadata {
+  return {
+    name: `mrtr_${originalName}`,
+    originalName,
+    description: `MRTR ${originalName}`,
+    inputSchema: { type: "object", properties: {} },
+    ...extra,
+  };
+}
+
+async function createConnectedState(options: {
+  answers?: Array<string | undefined>;
+  log?: boolean;
+  protocolVersion?: "legacy" | "2026-07-28";
+  metadata?: ToolMetadata[];
+} = {}): Promise<{
+  manager: McpServerManager;
+  state: McpExtensionState;
+  ui?: TestUi;
+  logPath?: string;
+}> {
+  const ui = options.answers === undefined ? undefined : createUi(options.answers);
+  const definition: Record<string, unknown> = {
+    command: process.execPath,
+    args: [fixture],
+    protocolVersion: options.protocolVersion ?? "2026-07-28",
+  };
+  let logPath: string | undefined;
+  if (options.log) {
+    const tempDir = await mkdtemp(`${tmpdir()}/pi-mcp-mrtr-`);
+    tempDirs.push(tempDir);
+    logPath = `${tempDir}/events.jsonl`;
+    definition.env = { MRTR_LOG_FILE: logPath };
+  }
+
+  const manager = new McpServerManager();
+  manager.setDefaultRequestTimeoutMs(2_000);
+  if (ui) manager.setElicitationConfig({ ui, allowUrl: false });
+  await manager.connect("mrtr", definition as never);
+  managers.push(manager);
+
+  const defaultMetadata = [
+    metadata("one_round"),
+    metadata("two_rounds"),
+    metadata("needs_ui"),
+    metadata("abort_pending"),
+    metadata("legacy_complete"),
+  ];
+  const state = {
+    manager,
+    config: { settings: { toolPrefix: "server" }, mcpServers: { mrtr: definition } },
+    toolMetadata: new Map([["mrtr", options.metadata ?? defaultMetadata]]),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    ui,
+    uiResourceHandler: new UiResourceHandler(manager),
+    completedUiSessions: [],
+    uiServer: null,
+  } as unknown as McpExtensionState;
+
+  return { manager, state, ...(ui ? { ui } : {}), ...(logPath ? { logPath } : {}) };
+}
+
+function textOf(result: { content?: Array<{ type: string; text?: string }> }): string {
+  return result.content?.find((block) => block.type === "text")?.text ?? "";
+}
+
+async function readEvents(logPath: string | undefined): Promise<Array<Record<string, unknown>>> {
+  if (!logPath) return [];
+  const text = await readFile(logPath, "utf8").catch(() => "");
+  return text.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+afterEach(async () => {
+  await Promise.all(managers.splice(0).map((manager) => manager.closeAll()));
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("MCP 2026-07-28 SDK-native multi-round input flows", () => {
+  it("bounds typed missing-handler details without matching arbitrary error text", () => {
+    const details = getInputRequiredNeedsUiDetails({
+      code: "CAPABILITY_NOT_SUPPORTED",
+      data: { key: "k".repeat(500), method: "elicitation/create" },
+      message: "untrusted server text",
+    }, {
+      server: "server-".repeat(100),
+      tool: "tool-".repeat(100),
+    });
+
+    expect(details).toBeDefined();
+    expect(details?.error).toBe("input_required_needs_ui");
+    expect(details?.inputKey.length).toBeLessThanOrEqual(128);
+    expect(details?.inputMethod).toBe("elicitation/create");
+    expect(details?.message).not.toContain("untrusted server text");
+    expect(getInputRequiredNeedsUiDetails({ message: "CAPABILITY_NOT_SUPPORTED elicitation/create" }, {
+      server: "server",
+      tool: "tool",
+    })).toBeUndefined();
+  });
+
+  it("fulfills one input_required result through the proxy executeCall path and keeps final output compact", async () => {
+    const { state, ui } = await createConnectedState({ answers: ["Continue"] });
+
+    const result = await executeCall(state, "mrtr_one_round", {}, "mrtr");
+
+    expect(textOf(result)).toBe("one-round complete");
+    expect(textOf(result)).not.toMatch(/input_required|requestState|elicitation\/create|Fulfilling input required/);
+    expect(result.details).toMatchObject({ mode: "call", server: "mrtr", tool: "one_round" });
+    expect(ui?.select).toHaveBeenCalledOnce();
+  });
+
+  it("echoes requestState byte-for-byte on both retries", async () => {
+    const { state, ui, logPath } = await createConnectedState({ answers: ["Continue", "Continue"], log: true });
+
+    const result = await executeCall(state, "mrtr_two_rounds", {}, "mrtr");
+    const events = await readEvents(logPath);
+    const calls = events.filter((event) => event.method === "tools/call" && event.name === "two_rounds");
+
+    expect(textOf(result)).toBe("two-round complete");
+    expect(calls).toHaveLength(3);
+    expect((calls[0]?.params as Record<string, unknown> | undefined)?.requestState).toBeUndefined();
+    expect((calls[1]?.params as Record<string, unknown> | undefined)?.requestState).toBe("two-round-state:first:v1");
+    expect((calls[2]?.params as Record<string, unknown> | undefined)?.requestState).toBe("two-round-state:second:v1");
+    expect(ui?.select).toHaveBeenCalledTimes(2);
+  });
+
+  it("fulfills the same modern input flow through a direct MCP tool executor", async () => {
+    const { state, ui } = await createConnectedState({ answers: ["Continue"] });
+    const spec: DirectToolSpec = {
+      serverName: "mrtr",
+      prefixedName: "mrtr_one_round",
+      originalName: "one_round",
+      description: "MRTR one_round",
+      inputSchema: { type: "object", properties: {} },
+    };
+
+    const result = await createDirectToolExecutor(() => state, () => null, spec)(
+      "call-1",
+      {},
+      undefined,
+      undefined,
+      undefined as never,
+    );
+
+    expect(textOf(result)).toBe("one-round complete");
+    expect(result.details).toMatchObject({ server: "mrtr", tool: "one_round" });
+    expect(ui?.select).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["proxy resource", "proxy"],
+    ["direct resource", "direct"],
+  ] as const)("reads an input-required resource through the %s path", async (_label, adapter) => {
+    const resourceUri = "test://mrtr/resource";
+    const resource = metadata("resource", { resourceUri });
+    const { state, ui } = await createConnectedState({ answers: ["Continue"], metadata: [resource] });
+
+    const result = adapter === "proxy"
+      ? await executeCall(state, "mrtr_resource", {}, "mrtr")
+      : await createDirectToolExecutor(() => state, () => null, {
+          serverName: "mrtr",
+          prefixedName: "mrtr_resource",
+          originalName: "resource",
+          description: "MRTR resource",
+          resourceUri,
+        })("call-resource", {}, undefined, undefined, undefined as never);
+
+    expect(textOf(result)).toContain("resource complete");
+    expect(textOf(result)).not.toMatch(/input_required|requestState|elicitation\/create/);
+    expect(result.details).toMatchObject({ server: "mrtr", resourceUri });
+    expect(ui?.select).toHaveBeenCalledOnce();
+  });
+
+  it("reads an input-required UI resource through UiResourceHandler", async () => {
+    const { manager, state, ui } = await createConnectedState({ answers: ["Continue"] });
+
+    const result = await state.uiResourceHandler!.readUiResource("mrtr", "ui://mrtr/resource", {
+      config: state.config,
+    });
+
+    expect(result).toMatchObject({
+      uri: "ui://mrtr/resource",
+      html: "<main>resource UI complete</main>",
+      mimeType: "text/html",
+    });
+    expect(manager.getConnection("mrtr")?.inFlight).toBe(0);
+    expect(ui?.select).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a legacy result without resultType as a complete adapter result", async () => {
+    const { state } = await createConnectedState({ protocolVersion: "legacy" });
+
+    const result = await executeCall(state, "mrtr_legacy_complete", {}, "mrtr");
+
+    expect(textOf(result)).toBe("legacy complete");
+    expect(result.details).toMatchObject({ mode: "call", server: "mrtr", tool: "legacy_complete" });
+    expect(result.details).not.toHaveProperty("error");
+  });
+
+  it.each([
+    ["proxy", "tool"],
+    ["direct", "tool"],
+    ["proxy", "resource"],
+    ["direct", "resource"],
+    ["proxy", "ui"],
+    ["direct", "ui"],
+  ] as const)("shapes missing input handlers as input_required_needs_ui through the %s %s path", async (adapter, kind) => {
+    const resourceUri = kind === "resource" ? "test://mrtr/resource" : "ui://mrtr/resource";
+    const tool = kind === "tool"
+      ? metadata("needs_ui")
+      : kind === "resource"
+        ? metadata("resource", { resourceUri })
+        : metadata("app", { uiResourceUri: resourceUri });
+    const { state } = await createConnectedState({ metadata: [tool] });
+    const directSpec: DirectToolSpec = {
+      serverName: "mrtr",
+      prefixedName: tool.name,
+      originalName: tool.originalName,
+      description: tool.description,
+      ...(tool.resourceUri ? { resourceUri: tool.resourceUri } : {}),
+      ...(tool.uiResourceUri ? { uiResourceUri: tool.uiResourceUri } : {}),
+    };
+
+    const result = adapter === "proxy"
+      ? await executeCall(state, tool.name, {}, "mrtr")
+      : await createDirectToolExecutor(() => state, () => null, directSpec)(
+          "call-no-ui",
+          {},
+          undefined,
+          undefined,
+          undefined as never,
+        );
+
+    expect(result.details).toMatchObject({
+      error: "input_required_needs_ui",
+      server: "mrtr",
+      ...(kind === "resource" ? { resourceUri } : { tool: tool.originalName }),
+      ...(kind === "ui" ? { resourceUri } : {}),
+      inputMethod: "elicitation/create",
+      inputKey: expect.any(String),
+    });
+    expect(textOf(result)).toContain("Run this call in an interactive Pi session");
+    expect(textOf(result).length).toBeLessThan(600);
+  });
+
+  it("preserves input_required_needs_ui through a direct UI resource read", async () => {
+    const { state } = await createConnectedState();
+
+    await expect(state.uiResourceHandler!.readUiResource("mrtr", "ui://mrtr/resource", {
+      config: state.config,
+    })).rejects.toMatchObject({
+      code: "input_required_needs_ui",
+      details: expect.objectContaining({
+        error: "input_required_needs_ui",
+        server: "mrtr",
+        resourceUri: "ui://mrtr/resource",
+        inputMethod: "elicitation/create",
+      }),
+    });
+  });
+
+  it("keeps the shaped error in mcpScript's existing failure envelope", async () => {
+    const { state } = await createConnectedState();
+
+    const result = await runMcpScript(state, 'return await tools.call("mrtr_needs_ui", {});');
+    const payload = JSON.parse(textOf(result));
+
+    expect(payload).toMatchObject({
+      ok: false,
+      error: {
+        code: "input_required_needs_ui",
+        message: expect.stringContaining("Run this call in an interactive Pi session"),
+      },
+    });
+    expect(result.details).toMatchObject({
+      mode: "script",
+      calls: [{ path: "mrtr_needs_ui", ok: false, error: "input_required_needs_ui" }],
+    });
+  });
+
+  it("settles an aborted proxy call while embedded input is pending and never retries", async () => {
+    let releaseInput!: (value: string | undefined) => void;
+    const pendingInput = new Promise<string | undefined>((resolve) => {
+      releaseInput = resolve;
+    });
+    const ui = {
+      select: vi.fn(() => pendingInput),
+      input: vi.fn(async () => undefined),
+      notify: vi.fn(),
+    };
+    const logDir = await mkdtemp(`${tmpdir()}/pi-mcp-mrtr-abort-`);
+    tempDirs.push(logDir);
+    const logPath = `${logDir}/events.jsonl`;
+    const definition = {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28" as const,
+      env: { MRTR_LOG_FILE: logPath },
+    };
+    const manager = new McpServerManager();
+    manager.setDefaultRequestTimeoutMs(2_000);
+    manager.setElicitationConfig({ ui, allowUrl: false });
+    await manager.connect("mrtr", definition);
+    managers.push(manager);
+    const state = {
+      manager,
+      config: { settings: { toolPrefix: "server" }, mcpServers: { mrtr: definition } },
+      toolMetadata: new Map([["mrtr", [metadata("abort_pending")]]]),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+      ui,
+      uiResourceHandler: new UiResourceHandler(manager),
+      completedUiSessions: [],
+      uiServer: null,
+    } as unknown as McpExtensionState;
+    const controller = new AbortController();
+    const call = executeCall(state, "mrtr_abort_pending", {}, "mrtr", undefined, controller.signal);
+
+    for (let i = 0; i < 20 && ui.select.mock.calls.length === 0; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ui.select).toHaveBeenCalledOnce();
+    controller.abort(new Error("user cancelled"));
+    const result = await call;
+    expect(result.details).toMatchObject({ error: "aborted", server: "mrtr", tool: "abort_pending" });
+    expect(manager.getConnection("mrtr")?.inFlight).toBe(0);
+
+    releaseInput(undefined);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const events = await readEvents(logPath);
+    expect(events.filter((event) => event.method === "tools/call" && event.name === "abort_pending")).toHaveLength(1);
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -20,6 +20,7 @@ import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { ensureToolCallApproved } from "./tool-approval.ts";
 import { Check, Errors } from "typebox/value";
+import { getInputRequiredNeedsUiDetails } from "./errors.ts";
 
 type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
 type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
@@ -594,6 +595,16 @@ export function createDirectToolExecutor(
         return {
           content: [{ type: "text" as const, text: message }],
           details: { error: "url_elicitation_required", server: spec.serverName, action },
+        };
+      }
+      const inputRequired = getInputRequiredNeedsUiDetails(error, spec.resourceUri
+        ? { server: spec.serverName, resourceUri: spec.resourceUri }
+        : { server: spec.serverName, tool: spec.originalName });
+      if (inputRequired) {
+        uiSession?.sendToolCancelled(inputRequired.message);
+        return {
+          content: [{ type: "text" as const, text: inputRequired.message }],
+          details: { ...inputRequired },
         };
       }
       const message = error instanceof Error ? error.message : String(error);

--- a/error-signal.ts
+++ b/error-signal.ts
@@ -1,19 +1,30 @@
+import { INPUT_REQUIRED_NEEDS_UI } from "./errors.ts";
+
 /**
  * Decide the `isError` override for a finished tool result in the `tool_result` hook.
  *
  * A failed MCP tool call is *returned* (not thrown), tagged `details.error: "tool_error"` (the server
- * returned an error result) or `"call_failed"` (the call itself threw and was caught). pi never reads a
- * result-level `isError`, so without this such a call is recorded as a success. Returning
+ * returned an error result), `"call_failed"` (the call itself threw and was caught), or a typed
+ * input-required failure that could not run without UI. pi never reads a result-level `isError`,
+ * so without this such a call is recorded as a success. Returning
  * `{ isError: true }` (and nothing else) flips the flag; pi's field-by-field merge keeps the original
  * `content` and `details` intact.
  *
- * Limited to those two codes: the adapter's other `details.error` values (`auth_required`, connection
+ * Limited to execution-failure codes: the adapter's other `details.error` values (`auth_required`, connection
  * states, search/validation feedback, ...) are not failed tool calls, so they get no override.
  */
 export function toolErrorOverride(details: unknown): { isError: true } | undefined {
   if (details && typeof details === "object" && "error" in details) {
     const code = (details as { error?: unknown }).error;
-    if (code === "tool_error" || code === "call_failed") {
+    if (code === "tool_error" || code === "call_failed" || code === INPUT_REQUIRED_NEEDS_UI) {
+      return { isError: true };
+    }
+  }
+  if (details && typeof details === "object" && (details as { mode?: unknown }).mode === "script") {
+    const calls = (details as { calls?: unknown }).calls;
+    if (Array.isArray(calls) && calls.some((call) => (
+      !!call && typeof call === "object" && (call as { error?: unknown }).error === INPUT_REQUIRED_NEEDS_UI
+    ))) {
       return { isError: true };
     }
   }

--- a/errors.ts
+++ b/errors.ts
@@ -221,3 +221,144 @@ export function wrapError(error: unknown, context?: McpUiErrorContext): McpUiErr
 export function isErrorCode(error: unknown, code: string): boolean {
   return error instanceof McpUiError && error.code === code;
 }
+
+/**
+ * Stable adapter error code for an SDK-native input_required result that the
+ * current client cannot fulfil because its embedded-request handler is not
+ * registered. The SDK keeps the request key/method in `SdkError.data`; this
+ * adapter detail intentionally copies only bounded, actionable fields.
+ */
+export const INPUT_REQUIRED_NEEDS_UI = "input_required_needs_ui" as const;
+
+export interface InputRequiredNeedsUiDetails {
+  error: typeof INPUT_REQUIRED_NEEDS_UI;
+  server: string;
+  tool?: string;
+  resourceUri?: string;
+  inputKey: string;
+  inputMethod: string;
+  message: string;
+}
+
+export interface InputRequiredIdentity {
+  server: string;
+  tool?: string;
+  resourceUri?: string;
+}
+
+const INPUT_REQUIRED_METHODS = new Set([
+  "elicitation/create",
+  "sampling/createMessage",
+]);
+const MAX_INPUT_REQUIRED_SERVER_LENGTH = 96;
+const MAX_INPUT_REQUIRED_TARGET_LENGTH = 160;
+const MAX_INPUT_REQUIRED_DETAIL_LENGTH = 128;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function boundedText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}
+
+interface EmbeddedInputRequest {
+  inputKey: string;
+  inputMethod: string;
+  server?: string;
+  tool?: string;
+  resourceUri?: string;
+}
+
+function findEmbeddedInputRequest(error: unknown): EmbeddedInputRequest | undefined {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current !== undefined && current !== null; depth++) {
+    if (seen.has(current)) return undefined;
+    seen.add(current);
+    const record = asRecord(current);
+    if (!record) return undefined;
+
+    if (record.code === INPUT_REQUIRED_NEEDS_UI) {
+      const details = asRecord(record.details);
+      const inputKey = boundedText(details?.inputKey, MAX_INPUT_REQUIRED_DETAIL_LENGTH);
+      const inputMethod = boundedText(details?.inputMethod, MAX_INPUT_REQUIRED_DETAIL_LENGTH);
+      if (inputKey && inputMethod && INPUT_REQUIRED_METHODS.has(inputMethod)) {
+        const server = boundedText(details?.server, MAX_INPUT_REQUIRED_SERVER_LENGTH);
+        const tool = boundedText(details?.tool, MAX_INPUT_REQUIRED_TARGET_LENGTH);
+        const resourceUri = boundedText(details?.resourceUri, MAX_INPUT_REQUIRED_TARGET_LENGTH);
+        return {
+          inputKey,
+          inputMethod,
+          ...(server ? { server } : {}),
+          ...(tool ? { tool } : {}),
+          ...(resourceUri ? { resourceUri } : {}),
+        };
+      }
+    }
+
+    if (record.code === "CAPABILITY_NOT_SUPPORTED") {
+      const data = asRecord(record.data);
+      const inputKey = boundedText(data?.key, MAX_INPUT_REQUIRED_DETAIL_LENGTH);
+      const inputMethod = boundedText(data?.method, MAX_INPUT_REQUIRED_DETAIL_LENGTH);
+      if (inputKey && inputMethod && INPUT_REQUIRED_METHODS.has(inputMethod)) {
+        return { inputKey, inputMethod };
+      }
+    }
+
+    current = record.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Convert a missing embedded-input handler into an adapter-owned result
+ * detail. Matching requires the SDK's typed code/data shape (or this module's
+ * typed wrapper), rather than arbitrary error-message text.
+ */
+export function getInputRequiredNeedsUiDetails(
+  error: unknown,
+  identity: InputRequiredIdentity,
+): InputRequiredNeedsUiDetails | undefined {
+  const request = findEmbeddedInputRequest(error);
+  if (!request) return undefined;
+
+  const server = boundedText(request.server ?? identity.server, MAX_INPUT_REQUIRED_SERVER_LENGTH) ?? "unknown";
+  const tool = boundedText(request.tool ?? identity.tool, MAX_INPUT_REQUIRED_TARGET_LENGTH);
+  const resourceUri = boundedText(request.resourceUri ?? identity.resourceUri, MAX_INPUT_REQUIRED_TARGET_LENGTH);
+  const target = resourceUri
+    ? `read resource "${resourceUri}"`
+    : tool
+      ? `call tool "${tool}"`
+      : "complete the MCP request";
+  const guidance = request.inputMethod === "elicitation/create"
+    ? "Run this call in an interactive Pi session with elicitation enabled, then retry."
+    : "Run this call in an interactive Pi session with the required MCP capability enabled, then retry.";
+  const message = `MCP server "${server}" requested input to ${target}, but this session has no handler for "${request.inputMethod}" (input "${request.inputKey}"). ${guidance}`;
+
+  return {
+    error: INPUT_REQUIRED_NEEDS_UI,
+    server,
+    ...(tool ? { tool } : {}),
+    ...(resourceUri ? { resourceUri } : {}),
+    inputKey: request.inputKey,
+    inputMethod: request.inputMethod,
+    message,
+  };
+}
+
+/** Error form used by UiResourceHandler so an outer tool call can preserve the classification. */
+export class InputRequiredNeedsUiError extends McpUiError {
+  constructor(readonly details: InputRequiredNeedsUiDetails, cause?: Error) {
+    super(details.message, {
+      code: INPUT_REQUIRED_NEEDS_UI,
+      context: { ...details },
+      recoveryHint: "Run this call in an interactive Pi session with the required MCP input handler enabled, then retry.",
+      ...(cause ? { cause } : {}),
+    });
+    this.name = "InputRequiredNeedsUiError";
+  }
+}

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -19,6 +19,7 @@ import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session
 import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
+import { getInputRequiredNeedsUiDetails } from "./errors.ts";
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>;
 type ClientCallToolResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -1406,6 +1407,14 @@ export async function executeCall(
       return {
         content: [{ type: "text" as const, text: message }],
         details: { mode: "call", error: "url_elicitation_required", ...callIdentity, action },
+      };
+    }
+    const inputRequired = getInputRequiredNeedsUiDetails(error, callIdentity);
+    if (inputRequired) {
+      uiSession?.sendToolCancelled(inputRequired.message);
+      return {
+        content: [{ type: "text" as const, text: inputRequired.message }],
+        details: { mode: "call", ...inputRequired },
       };
     }
     const message = error instanceof Error ? error.message : String(error);

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -1,6 +1,11 @@
 import { RESOURCE_MIME_TYPE } from "./ui-app-bridge-helpers.ts";
 import { UrlElicitationRequiredError, type ReadResourceResult } from "@modelcontextprotocol/client";
-import { ResourceFetchError, ResourceParseError } from "./errors.ts";
+import {
+  getInputRequiredNeedsUiDetails,
+  InputRequiredNeedsUiError,
+  ResourceFetchError,
+  ResourceParseError,
+} from "./errors.ts";
 import { logger } from "./logger.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery, type SessionRecoveryDeps } from "./session-recovery.ts";
 import type { McpServerManager } from "./server-manager.ts";
@@ -63,6 +68,10 @@ export class UiResourceHandler {
       }
     } catch (error) {
       if (error instanceof UrlElicitationRequiredError || error instanceof SessionRecoveryAuthRequiredError) throw error;
+      const inputRequired = getInputRequiredNeedsUiDetails(error, { server: serverName, resourceUri: uri });
+      if (inputRequired) {
+        throw new InputRequiredNeedsUiError(inputRequired, error instanceof Error ? error : undefined);
+      }
       const message = error instanceof Error ? error.message : String(error);
       log.error("Failed to read resource", error instanceof Error ? error : undefined);
       throw new ResourceFetchError(uri, message, {

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -21,6 +21,7 @@ import { isGlimpseAvailable, openGlimpseWindow } from "./glimpse-ui.ts";
 import type { SessionRecoveryDeps } from "./session-recovery.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
 import { throwIfAborted } from "./abort.ts";
+import { InputRequiredNeedsUiError } from "./errors.ts";
 
 let activeGlimpseWindow: { close(): void } | null = null;
 
@@ -559,7 +560,7 @@ export async function maybeStartUiSession(
       },
     };
   } catch (error) {
-    if (error instanceof UrlElicitationRequiredError || isAbortError(error, runtimeSignal)) throw error;
+    if (error instanceof UrlElicitationRequiredError || error instanceof InputRequiredNeedsUiError || isAbortError(error, runtimeSignal)) throw error;
     const message = error instanceof Error ? error.message : String(error);
     log.error("Failed to start UI session", error instanceof Error ? error : undefined);
     state.ui?.notify(


### PR DESCRIPTION
Closes #467.

## Summary
- Add a pinned MCP 2026-07-28 MRTR stdio fixture and integration coverage for proxy, direct, resource-as-tool, UI-resource, script envelope, two-round requestState echo, legacy completion, and abort cleanup.
- Surface typed no-UI `input_required` SDK capability failures as bounded `input_required_needs_ui` details across proxy/direct/resource/UI paths.
- Document the SDK origin-hook limitation instead of inventing adapter-side MRTR state, and add an Unreleased changelog entry.

## Validation
- Fresh read-only review: PASS (`reports/issue-467-fresh-review.md`).
- `npx vitest run __tests__/elicitation-handler.test.ts __tests__/elicitation-sdk-integration.test.ts __tests__/init-elicitation.test.ts __tests__/mcp-code.test.ts __tests__/abort-signal.test.ts __tests__/resource-tool-materialization.test.ts __tests__/ui-resource-handler.test.ts __tests__/mcp-status.test.ts __tests__/proxy-progress.test.ts __tests__/mrtr-sdk-integration.test.ts` passed in the issue worktree.
- `npx vitest run __tests__/mrtr-sdk-integration.test.ts __tests__/proxy-progress.test.ts __tests__/ui-resource-handler.test.ts __tests__/errors.test.ts` passed in the issue worktree.
- `npm run typecheck` passed in the issue worktree.
- `git diff --check` passed in the issue worktree.

Known baseline from the issue worktree: broad `npm test` previously failed only because ignored/generated `examples/interactive-visualizer/dist/app.html` and `dist/server.js` were absent. That artifact setup is outside this diff.
