### PR TITLE
fix(mcp): harden modern listen lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
+- Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)
 
 ## [2.31.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ When any enabled server uses `eager` or `keep-alive`, initialization also starts
 | `strictDirectToolArguments` | Validate direct-tool inputs against their advertised schemas and recover one JSON string layer for object and array properties (default: false). |
 | `directToolResultDetails` | Direct-tool result details: `"lean"` (default) or `"bounded"` to retain the guarded raw MCP result. |
 | `warnOnLargeDirectTools` | Show the advisory when 75 or more direct tools resolve (default: `true`). Set to `false` to suppress only this advisory. |
-| `freezeDirectTools` | Keep direct-tool registration stable after the initial sync so automatic reconnects and list-change notifications do not rebuild the system prompt. Use `mcp({ connect: "server" })` or `/mcp reconnect <server>` to refresh deliberately. Default: false. |
+| `freezeDirectTools` | Keep direct-tool registration stable after the initial sync so metadata updates and explicit reconnects do not rebuild the system prompt. Proxy/search/cache metadata still refreshes. Default: false. |
 | `scriptMode` | Register the MCP-only `mcpScript` plain-JavaScript tool (default: true). Set to `false` to hide it. |
 | `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
 | `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
@@ -624,7 +624,7 @@ Models sometimes encode an object or array argument as a JSON string. Set `setti
 
 Set `settings.directToolResultDetails` to `"bounded"` when an extension needs structured MCP result fields in Pi's direct-tool result details. The same output guard limits apply. Small leading structured fields stay available, while large fields receive bounded summaries and the complete guarded result follows the output guard's spill-file policy. The default `"lean"` mode keeps the existing server and tool metadata only.
 
-If prompt-cache stability matters more than automatic direct-tool hot-loading, set `settings.freezeDirectTools` to `true`. The initial direct-tool sync still runs, but later automatic reconnects, lazy-connects, and list-change notifications keep the registered tool surface unchanged. Deliberate refreshes through `mcp({ connect: "server" })` or `/mcp reconnect <server>` still update direct tools.
+If prompt-cache stability matters more than direct-tool hot-loading, set `settings.freezeDirectTools` to `true`. The initial direct-tool sync still runs, but later metadata updates and explicit reconnects keep the registered tool surface unchanged while proxy/search/cache metadata refreshes normally.
 
 When you change direct-tool toggles in `/mcp`, the extension updates direct tool registration in the current session. Broader setup writes from `/mcp setup` still use Pi's normal reload flow because they can add or restructure MCP config files.
 

--- a/__tests__/direct-tool-host-contract.test.ts
+++ b/__tests__/direct-tool-host-contract.test.ts
@@ -66,6 +66,7 @@ describe("direct tool host contracts", () => {
         mcpServers: { demo: { command: "demo" } },
       },
       manager: {
+        ensureListen: vi.fn().mockResolvedValue(undefined),
         getConnection: vi.fn(() => connection),
         getRequestOptions: vi.fn(() => undefined),
         touch: vi.fn(),
@@ -90,6 +91,7 @@ describe("direct tool host contracts", () => {
       tool: "commit",
       mcpResult: rawResult,
     });
+    expect(state.manager.ensureListen).toHaveBeenCalledWith("demo", connection);
   });
 
   it("invalidates a connected transport after a direct tool call fails", async () => {
@@ -144,6 +146,7 @@ describe("direct tool host contracts", () => {
         mcpServers: { demo: { command: "demo" } },
       },
       manager: {
+        prepareResourceUse: vi.fn().mockResolvedValue(undefined),
         getConnection: vi.fn(() => connection),
         getRequestOptions: vi.fn(() => undefined),
         touch: vi.fn(),
@@ -170,5 +173,6 @@ describe("direct tool host contracts", () => {
       mcpResult: rawResult,
     });
     expect(connection.client.readResource).toHaveBeenCalledWith({ uri: "docs://handbook" }, undefined);
+    expect(state.manager.prepareResourceUse).toHaveBeenCalledWith("demo", "docs://handbook", connection);
   });
 });

--- a/__tests__/fixtures/modern-listen-server.mjs
+++ b/__tests__/fixtures/modern-listen-server.mjs
@@ -1,0 +1,159 @@
+import readline from "node:readline";
+
+const SUBSCRIPTION_ID_KEY = "io.modelcontextprotocol/subscriptionId";
+const lines = readline.createInterface({ input: process.stdin });
+let revision = 0;
+let listenCount = 0;
+let activeListenId;
+let lastFilter = {};
+let ignoreNextListen = false;
+let narrowNextListen = false;
+let failNextPrompts = false;
+let failNextResources = false;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", ...message })}\n`);
+}
+
+function respond(id, result) {
+  send({ id, result });
+}
+
+function notify(method, params = {}) {
+  send({ method, params });
+}
+
+function subscriptionMeta() {
+  return activeListenId ? { [SUBSCRIPTION_ID_KEY]: activeListenId } : {};
+}
+
+function complete(result) {
+  return { resultType: "complete", ttlMs: 0, cacheScope: "private", ...result };
+}
+
+function emitCatalogChanges() {
+  const _meta = subscriptionMeta();
+  notify("notifications/tools/list_changed", { _meta });
+  notify("notifications/prompts/list_changed", { _meta });
+  notify("notifications/resources/list_changed", { _meta });
+}
+
+lines.on("line", line => {
+  const message = JSON.parse(line);
+  if (message.method === "server/discover") {
+    respond(message.id, {
+      supportedVersions: ["2026-07-28"],
+      capabilities: {
+        tools: { listChanged: true },
+        prompts: { listChanged: true },
+        resources: { listChanged: true },
+      },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": { name: "modern-listen", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "subscriptions/listen") {
+    listenCount += 1;
+    activeListenId = message.id;
+    lastFilter = message.params?.notifications ?? {};
+    if (ignoreNextListen) {
+      ignoreNextListen = false;
+      return;
+    }
+    const honoredFilter = narrowNextListen ? { toolsListChanged: true } : lastFilter;
+    narrowNextListen = false;
+    notify("notifications/subscriptions/acknowledged", {
+      notifications: honoredFilter,
+      _meta: { [SUBSCRIPTION_ID_KEY]: activeListenId },
+    });
+    return;
+  }
+  if (message.method === "notifications/cancelled") {
+    if (message.params?.requestId === activeListenId) activeListenId = undefined;
+    return;
+  }
+  if (message.method === "tools/list") {
+    respond(message.id, complete({
+      tools: [
+        {
+          name: "fixture_control",
+          description: "Controls the modern listen fixture",
+          inputSchema: { type: "object", properties: { action: { type: "string" } } },
+        },
+        {
+          name: revision ? "updated_tool" : "initial_tool",
+          description: revision ? "Updated tool" : "Initial tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    }));
+    return;
+  }
+  if (message.method === "prompts/list") {
+    if (failNextPrompts) {
+      failNextPrompts = false;
+      send({ id: message.id, error: { code: -32000, message: "prompts unavailable" } });
+      return;
+    }
+    respond(message.id, complete({
+      prompts: [{ name: revision ? "updated_prompt" : "initial_prompt" }],
+    }));
+    return;
+  }
+  if (message.method === "resources/list") {
+    if (failNextResources) {
+      failNextResources = false;
+      send({ id: message.id, error: { code: -32000, message: "resources unavailable" } });
+      return;
+    }
+    respond(message.id, complete({
+      resources: [{
+        uri: revision ? "ui://fixture/updated" : "ui://fixture/initial",
+        name: revision ? "Updated resource" : "Initial resource",
+        mimeType: "text/html",
+      }],
+    }));
+    return;
+  }
+  if (message.method === "resources/read") {
+    respond(message.id, { resultType: "complete", ttlMs: 60_000, cacheScope: "private",
+      contents: [{ uri: message.params.uri, mimeType: "text/html", text: `<p>revision ${revision}</p>` }],
+    });
+    return;
+  }
+  if (message.method === "tools/call") {
+    const action = message.params?.arguments?.action;
+    const report = JSON.stringify({ listenCount, filter: lastFilter });
+    respond(message.id, complete({ content: [{ type: "text", text: report }] }));
+    if (action === "mutate") {
+      revision += 1;
+      setTimeout(emitCatalogChanges, 5);
+    } else if (action === "mutate-silent") {
+      revision += 1;
+    } else if (action === "fail-next-optional-lists") {
+      failNextPrompts = true;
+      failNextResources = true;
+    } else if ((action === "drop" || action === "drop-ignore-next") && activeListenId) {
+      if (action === "drop-ignore-next") ignoreNextListen = true;
+      const requestId = activeListenId;
+      setTimeout(() => notify("notifications/cancelled", { requestId }), 5);
+    } else if (action === "graceful" && activeListenId) {
+      const requestId = activeListenId;
+      activeListenId = undefined;
+      setTimeout(() => respond(requestId, {}), 5);
+    } else if (action === "resource-updated") {
+      setTimeout(() => notify("notifications/resources/updated", {
+        uri: "ui://fixture/initial",
+        _meta: subscriptionMeta(),
+      }), 5);
+    } else if (action === "narrow-next-listen") {
+      narrowNextListen = true;
+    }
+    return;
+  }
+  if (message.id !== undefined) {
+    send({ id: message.id, error: { code: -32601, message: "Method not found" } });
+  }
+});

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -709,6 +709,43 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.resolveDirectTools).toHaveBeenCalledTimes(callsAfterInitialSync);
   });
 
+  it("does not mutate frozen direct tools on explicit proxy connect or slash reconnect", async () => {
+    const config = {
+      settings: { freezeDirectTools: true },
+      mcpServers: {
+        demo: { command: "demo", directTools: true },
+      },
+    };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.resolveDirectTools.mockReturnValue([{
+      serverName: "demo",
+      originalName: "search",
+      prefixedName: "demo_search",
+      description: "Search demo",
+    }]);
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeConnect.mockResolvedValue({ content: [{ type: "text", text: "connected" }] });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    await Promise.resolve();
+    await Promise.resolve();
+    const callsAfterInitialSync = mocks.resolveDirectTools.mock.calls.length;
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+
+    await proxyTool.execute("call-1", { connect: "demo" });
+    const commandDef = api.registerCommand.mock.calls.find((call: any[]) => call[0] === "mcp")?.[1];
+    await commandDef.handler("reconnect demo", { hasUI: false });
+
+    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "demo", undefined);
+    expect(mocks.reconnectServers).toHaveBeenCalledWith(state, expect.any(Object), "demo");
+    expect(mocks.resolveDirectTools).toHaveBeenCalledTimes(callsAfterInitialSync);
+  });
+
   it("keeps hidden direct tool names reserved against namespace proxies during backoff", async () => {
     const { computeServerHash } = await import("../metadata-cache.ts");
     const failedDefinition = { command: "failed", directTools: true };

--- a/__tests__/mcp-status.test.ts
+++ b/__tests__/mcp-status.test.ts
@@ -42,6 +42,7 @@ describe("MCP status snapshots", () => {
       if (name === "connected") {
         return {
           status: "connected",
+          listenState: "active",
           tools: [{ name: "search" }],
           resources: [{ name: "doc", uri: "file://doc" }, { name: "other", uri: "file://other" }],
           client: { secret: true },
@@ -61,12 +62,12 @@ describe("MCP status snapshots", () => {
       disabledCount: 1,
     });
     expect(snapshot.servers).toEqual(expect.arrayContaining([
-      { name: "connected", status: "connected", toolCount: 1, resourceCount: 2, disabled: false },
-      { name: "cached", status: "cached", toolCount: 2, resourceCount: 1, disabled: false },
+      { name: "connected", status: "connected", listenState: "active", toolCount: 1, resourceCount: 2, disabled: false },
+      { name: "cached", status: "cached", listenState: "disconnected", toolCount: 2, resourceCount: 1, disabled: false },
       expect.objectContaining({ name: "failed", status: "failed", toolCount: 0, disabled: false }),
-      { name: "auth", status: "needs-auth", toolCount: 0, disabled: false },
-      { name: "idle", status: "cached", toolCount: 1, disabled: false },
-      { name: "disabled", status: "disabled", toolCount: 0, disabled: true },
+      { name: "auth", status: "needs-auth", listenState: "disconnected", toolCount: 0, disabled: false },
+      { name: "idle", status: "cached", listenState: "disconnected", toolCount: 1, disabled: false },
+      { name: "disabled", status: "disabled", listenState: "disconnected", toolCount: 0, disabled: true },
     ]));
     const failed = snapshot.servers.find(server => server.name === "failed");
     expect(failed?.failedAgoSeconds).toBeGreaterThanOrEqual(4);
@@ -91,6 +92,35 @@ describe("MCP status snapshots", () => {
       status: "needs-auth",
       toolCount: 0,
     });
+  });
+
+  it("reports a dropped listen separately from a connected transport", () => {
+    const state = createState();
+    state.manager.getConnection.mockImplementation((name: string) => name === "connected"
+      ? { status: "connected", listenState: "dropped", tools: [{ name: "search" }], resources: [] }
+      : undefined);
+
+    expect(createMcpStatusSnapshot(state).servers.find(server => server.name === "connected")).toMatchObject({
+      status: "connected",
+      listenState: "dropped",
+    });
+    expect(executeStatus(state).content[0]?.text).toContain(
+      "catalog may be stale; will reconcile on next keep-alive or tool use",
+    );
+  });
+
+  it("reports an active listen with unconfirmed catalog freshness", () => {
+    const state = createState();
+    state.manager.getConnection.mockImplementation((name: string) => name === "connected"
+      ? { status: "connected", listenState: "active", listenCatalogStale: true, tools: [{ name: "search" }], resources: [] }
+      : undefined);
+
+    expect(createMcpStatusSnapshot(state).servers.find(server => server.name === "connected")).toMatchObject({
+      status: "connected",
+      listenState: "active",
+      catalogStale: true,
+    });
+    expect(executeStatus(state).content[0]?.text).toContain("listen active, catalog may be stale");
   });
 
   it("keeps proxy status and shared snapshots in parity for cached failure states", () => {

--- a/__tests__/server-manager-modern-listen.test.ts
+++ b/__tests__/server-manager-modern-listen.test.ts
@@ -1,0 +1,368 @@
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateMetadataCache, updateServerMetadata } from "../init.ts";
+import { executeCall } from "../proxy-modes.ts";
+import { McpServerManager } from "../server-manager.ts";
+
+const fixture = fileURLToPath(new URL("./fixtures/modern-listen-server.mjs", import.meta.url));
+const managers: McpServerManager[] = [];
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for modern listen fixture");
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
+
+async function control(connection: Awaited<ReturnType<McpServerManager["connect"]>>, action: string) {
+  return connection.client.callTool({ name: "fixture_control", arguments: { action } });
+}
+
+function report(result: Awaited<ReturnType<typeof control>>): { listenCount: number; filter: Record<string, unknown> } {
+  const text = result.content?.find(block => block.type === "text")?.text;
+  if (!text) throw new Error("Fixture report was missing text");
+  return JSON.parse(text) as { listenCount: number; filter: Record<string, unknown> };
+}
+
+afterEach(async () => {
+  await Promise.all(managers.map(manager => manager.closeAll()));
+  managers.length = 0;
+  vi.restoreAllMocks();
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+});
+
+describe("McpServerManager modern subscriptions/listen", () => {
+  it("publishes tools, prompts, and resources list changes to metadata and disk cache", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-mcp-listen-"));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const definition = {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28" as const,
+    };
+    const state = {
+      manager,
+      config: { mcpServers: { modern: definition } },
+      toolMetadata: new Map(),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+    } as any;
+    const reasons: string[] = [];
+    manager.setMetadataListChangedListener((serverName, reason) => {
+      reasons.push(reason);
+      updateServerMetadata(state, serverName);
+      updateMetadataCache(state, serverName, { preserveEmptyResources: false });
+    });
+
+    try {
+      const connection = await manager.connect("modern", definition);
+      expect(connection.listenState).toBe("active");
+      expect(connection.listenFilter).toEqual({
+        toolsListChanged: true,
+        promptsListChanged: true,
+        resourcesListChanged: true,
+      });
+
+      await control(connection, "mutate");
+      await waitFor(() => reasons.length === 3);
+
+      expect(connection.tools.map(tool => tool.name)).toContain("updated_tool");
+      expect(connection.prompts.map(prompt => prompt.name)).toEqual(["updated_prompt"]);
+      expect(connection.resources.map(resource => resource.uri)).toEqual(["ui://fixture/updated"]);
+      expect(state.toolMetadata.get("modern").map((tool: { originalName: string }) => tool.originalName))
+        .toContain("updated_tool");
+      expect(reasons).toEqual(expect.arrayContaining([
+        "tools-list-changed",
+        "prompts-list-changed",
+        "resources-list-changed",
+      ]));
+
+      const cache = JSON.parse(readFileSync(join(agentDir, "mcp-cache.json"), "utf8"));
+      expect(cache.servers.modern.tools.map((tool: { name: string }) => tool.name)).toContain("updated_tool");
+      expect(cache.servers.modern.prompts).toEqual([{ name: "updated_prompt" }]);
+      expect(cache.servers.modern.resources).toEqual(expect.arrayContaining([
+        expect.objectContaining({ uri: "ui://fixture/updated" }),
+      ]));
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true });
+    }
+  }, 5_000);
+
+  it("marks only a remote listen close as dropped and repairs once at the next activity boundary", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const connection = await manager.connect("modern", {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28",
+    });
+
+    expect(report(await control(connection, "report")).listenCount).toBe(1);
+    await control(connection, "drop");
+    await waitFor(() => connection.listenState === "dropped");
+    expect(connection.status).toBe("connected");
+
+    await Promise.all([
+      manager.ensureListen("modern", connection),
+      manager.ensureListen("modern", connection),
+      manager.ensureListen("modern", connection),
+    ]);
+    expect(connection.listenState).toBe("active");
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+  }, 5_000);
+
+  it("reconciles catalog changes missed while the listen was dropped", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const state = {
+      manager,
+      config: { mcpServers: { modern: { command: process.execPath, args: [fixture], protocolVersion: "2026-07-28" } } },
+      toolMetadata: new Map(),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+    } as any;
+    const reasons: string[] = [];
+    manager.setMetadataListChangedListener((serverName, reason) => {
+      reasons.push(reason);
+      updateServerMetadata(state, serverName);
+    });
+    const connection = await manager.connect("modern", state.config.mcpServers.modern);
+    updateServerMetadata(state, "modern");
+    expect(state.toolMetadata.get("modern").map((tool: { originalName: string }) => tool.originalName)).not.toContain("updated_tool");
+
+    await control(connection, "drop");
+    await waitFor(() => connection.listenState === "dropped");
+    await control(connection, "mutate-silent");
+    await manager.ensureListen("modern", connection);
+
+    expect(connection.listenState).toBe("active");
+    expect(connection.tools.map(tool => tool.name)).toContain("updated_tool");
+    expect(connection.prompts.map(prompt => prompt.name)).toEqual(["updated_prompt"]);
+    expect(connection.resources.map(resource => resource.uri)).toEqual(["ui://fixture/updated"]);
+    expect(state.toolMetadata.get("modern").map((tool: { originalName: string }) => tool.originalName)).toContain("updated_tool");
+    expect(reasons).toContain("listen-recovered");
+  }, 5_000);
+
+  it("keeps the recovered listen active when optional catalog confirmation fails", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const definition = { command: process.execPath, args: [fixture], protocolVersion: "2026-07-28" as const };
+    const state = {
+      manager,
+      config: { mcpServers: { modern: definition } },
+      toolMetadata: new Map(),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+    } as any;
+    manager.setMetadataListChangedListener((serverName) => updateServerMetadata(state, serverName));
+    const connection = await manager.connect("modern", definition);
+    updateServerMetadata(state, "modern");
+
+    await control(connection, "drop");
+    await waitFor(() => connection.listenState === "dropped");
+    await control(connection, "mutate-silent");
+    await control(connection, "fail-next-optional-lists");
+    await manager.ensureListen("modern", connection);
+
+    expect(connection.listenState).toBe("active");
+    expect(connection.listenCatalogStale).toBe(true);
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+    expect(connection.tools.map(tool => tool.name)).toContain("updated_tool");
+    expect(connection.prompts.map(prompt => prompt.name)).toEqual(["initial_prompt"]);
+    expect(connection.resources.map(resource => resource.uri)).toEqual(["ui://fixture/initial"]);
+
+    connection.listenRetryAfter = Date.now() - 1;
+    await manager.ensureListen("modern", connection);
+    expect(connection.listenState).toBe("active");
+    expect(connection.listenCatalogStale).toBeUndefined();
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+    expect(connection.prompts.map(prompt => prompt.name)).toEqual(["updated_prompt"]);
+    expect(connection.resources.map(resource => resource.uri)).toEqual(["ui://fixture/updated"]);
+  }, 5_000);
+
+  it("repairs before returning tool_not_found for a stale server-scoped catalog", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const definition = { command: process.execPath, args: [fixture], protocolVersion: "2026-07-28" as const };
+    const state = {
+      manager,
+      config: { settings: { toolPrefix: "server" }, mcpServers: { modern: definition } },
+      toolMetadata: new Map(),
+      resourceCounts: new Map(),
+      promptMetadata: new Map(),
+      promptMetadataLive: new Set(),
+      serverInstructions: new Map(),
+      failureTracker: new Map(),
+    } as any;
+    const connection = await manager.connect("modern", definition);
+    updateServerMetadata(state, "modern");
+
+    await control(connection, "drop");
+    await waitFor(() => connection.listenState === "dropped");
+    await control(connection, "mutate-silent");
+    const result = await executeCall(state, "updated_tool", {}, "modern");
+
+    expect(result.details).toMatchObject({ mode: "call", server: "modern", tool: "updated_tool" });
+    expect(result.details).not.toMatchObject({ error: "tool_not_found" });
+  }, 5_000);
+
+  it("refreshes a resource read after a dropped listen could have missed an update", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const connection = await manager.connect("modern", {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28",
+    });
+
+    const first = await manager.readResource("modern", "ui://fixture/initial");
+    expect(first.contents?.[0]?.text).toBe("<p>revision 0</p>");
+    await control(connection, "drop");
+    await waitFor(() => connection.listenState === "dropped");
+    await control(connection, "mutate-silent");
+
+    const second = await manager.readResource("modern", "ui://fixture/initial");
+    expect(second.contents?.[0]?.text).toBe("<p>revision 1</p>");
+  }, 5_000);
+
+  it("bounds a failed repair and suppresses another attempt during cooldown", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(100);
+    const connection = await manager.connect("modern", {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28",
+    });
+
+    await control(connection, "drop-ignore-next");
+    await waitFor(() => connection.listenState === "dropped");
+    await expect(Promise.race([
+      manager.ensureListen("modern", connection),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("repair did not finish")), 1_000)),
+    ])).resolves.toBeUndefined();
+    expect(connection.listenState).toBe("dropped");
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+
+    await manager.ensureListen("modern", connection);
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+  }, 5_000);
+
+  it("does not loop when the server honors only part of a requested filter", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const connection = await manager.connect("modern", {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28",
+    });
+
+    await control(connection, "narrow-next-listen");
+    await manager.prepareResourceUse("modern", "ui://fixture/recent", connection);
+    expect(connection.listenSubscription?.honoredFilter).toEqual({ toolsListChanged: true });
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+
+    await manager.ensureListen("modern", connection);
+    expect(report(await control(connection, "report")).listenCount).toBe(2);
+  }, 5_000);
+
+  it.each(["local", "graceful"] as const)("does not retry a %s listen close", async cause => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const connection = await manager.connect(`modern-${cause}`, {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28",
+    });
+
+    if (cause === "local") await connection.listenSubscription?.close();
+    else await control(connection, "graceful");
+    await waitFor(() => connection.listenState === "not-listening");
+
+    await manager.ensureListen(`modern-${cause}`, connection);
+    expect(connection.listenState).toBe("not-listening");
+    expect(report(await control(connection, "report")).listenCount).toBe(1);
+  }, 5_000);
+
+  it("subscribes only to recent/open resource URIs and signals matching open sessions", async () => {
+    const manager = new McpServerManager();
+    managers.push(manager);
+    manager.setDefaultRequestTimeoutMs(1_000);
+    const definition = {
+      command: process.execPath,
+      args: [fixture],
+      protocolVersion: "2026-07-28" as const,
+    };
+    let connection = await manager.connect("modern", definition);
+    const matching = vi.fn();
+    const other = vi.fn();
+
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    manager.registerResourceUpdatedListener("matching", "modern", "ui://fixture/initial", matching);
+    manager.registerResourceUpdatedListener("other", "modern", "ui://fixture/other", other);
+    await waitFor(() => connection.listenState === "active" &&
+      connection.listenFilter?.resourceSubscriptions?.length === 2);
+
+    const current = report(await control(connection, "report"));
+    expect(current.filter.resourceSubscriptions).toEqual([
+      "ui://fixture/initial",
+      "ui://fixture/other",
+    ]);
+    await control(connection, "resource-updated");
+    await waitFor(() => matching.mock.calls.length === 1);
+    expect(matching).toHaveBeenCalledWith("modern", "ui://fixture/initial");
+    expect(other).not.toHaveBeenCalled();
+
+    const previous = connection;
+    connection = await manager.reconnect("modern", definition, previous);
+    await waitFor(() => connection.listenState === "active" &&
+      connection.listenFilter?.resourceSubscriptions?.length === 2);
+    expect(report(await control(connection, "report")).filter.resourceSubscriptions).toEqual([
+      "ui://fixture/initial",
+      "ui://fixture/other",
+    ]);
+
+    connection.recentResourceUris = new Map(Array.from({ length: 40 }, (_, index) => [
+      `ui://fixture/recent-${index}`,
+      now + index,
+    ]));
+    await manager.ensureListen("modern", connection);
+    const bounded = report(await control(connection, "report")).filter.resourceSubscriptions as string[];
+    expect(bounded).toHaveLength(32);
+    expect(bounded).toContain("ui://fixture/initial");
+    expect(bounded).toContain("ui://fixture/other");
+
+    manager.removeResourceUpdatedListener("matching");
+    manager.removeResourceUpdatedListener("other");
+    vi.mocked(Date.now).mockReturnValue(now + 11 * 60_000);
+    await manager.ensureListen("modern", connection);
+    expect(report(await control(connection, "report")).filter.resourceSubscriptions).toBeUndefined();
+    await control(connection, "resource-updated");
+    await new Promise(resolve => setTimeout(resolve, 25));
+    expect(matching).toHaveBeenCalledTimes(1);
+    expect(other).not.toHaveBeenCalled();
+  }, 5_000);
+});

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -471,6 +471,23 @@ describe("UiServer", () => {
       expect(events.some((e) => e.name === "tool-result")).toBe(true);
     });
 
+    it("signals resource updates without reloading the open UI", async () => {
+      handle = await startUiServer(createServerOptions());
+      const url = `http://localhost:${handle.port}/events?session=${handle.sessionToken}`;
+      const events: Array<{ name: string; data: unknown }> = [];
+      const sse = await connectSSE(url, (name, data) => events.push({ name, data }));
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      handle.sendResourceUpdated("ui://fixture/app");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      sse.close();
+
+      expect(events.find(event => event.name === "resource-updated")?.data).toEqual({
+        uri: "ui://fixture/app",
+      });
+      expect(events.some(event => event.name === "session-complete")).toBe(false);
+    });
+
     it("receives result-patch events when sent", async () => {
       handle = await startUiServer(createServerOptions());
       const url = `http://localhost:${handle.port}/events?session=${handle.sessionToken}`;

--- a/__tests__/ui-streaming.test.ts
+++ b/__tests__/ui-streaming.test.ts
@@ -201,9 +201,12 @@ describe("UI Streaming", () => {
           client: { setNotificationHandler: (...args: unknown[]) => void },
         ) => void;
       }).attachAdapterNotificationHandlers(serverName, client);
-      expect(setNotificationHandler).toHaveBeenCalledOnce();
-      expect(setNotificationHandler.mock.calls[0][0]).toBe(SERVER_STREAM_RESULT_PATCH_METHOD);
-      const handler = setNotificationHandler.mock.calls[0][2] as (params: {
+      expect(setNotificationHandler).toHaveBeenCalledTimes(2);
+      const streamRegistration = setNotificationHandler.mock.calls.find(
+        call => call[0] === SERVER_STREAM_RESULT_PATCH_METHOD,
+      );
+      expect(streamRegistration).toBeDefined();
+      const handler = streamRegistration?.[2] as (params: {
         streamToken: string;
         result: { content?: unknown[]; structuredContent?: Record<string, unknown> };
       }) => void;

--- a/commands.ts
+++ b/commands.ts
@@ -59,12 +59,22 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
     const metadata = state.toolMetadata.get(name);
     const toolCount = metadata?.length ?? 0;
     const failedAgo = getFailureAgeSeconds(state, name);
-    let status = "not connected";
+    let status = "not listening (disconnected)";
     let statusIcon = "○";
     let failed = false;
 
     if (connection?.status === "connected") {
-      status = "connected";
+      status = connection.listenState === "active"
+        ? connection.listenCatalogStale
+          ? "connected; listen active; catalog may be stale"
+          : "connected; listen active"
+        : connection.listenState === "dropped"
+          ? "connected; catalog may be stale — will reconcile on next keep-alive or tool use"
+          : connection.listenState === "re-establishing"
+            ? "connected; re-establishing listen"
+            : connection.listenState === "legacy"
+              ? "connected; legacy notification path"
+              : "connected; not listening for catalog updates";
       statusIcon = "✓";
     } else if (connection?.status === "needs-auth") {
       status = "needs auth";
@@ -75,11 +85,15 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
       statusIcon = "✗";
       failed = true;
     } else if (metadata !== undefined) {
-      status = "cached";
+      status = "cached; not listening (disconnected)";
     }
 
-    const toolSuffix = failed ? "" : ` (${toolCount} tools${status === "cached" ? ", cached" : ""})`;
+    const toolSuffix = failed ? "" : ` (${toolCount} tools${status.startsWith("cached") ? ", cached" : ""})`;
     lines.push(`${statusIcon} ${name}: ${status}${toolSuffix}`);
+  }
+
+  if (state.config.settings?.freezeDirectTools === true) {
+    lines.push("", "Direct tools frozen; active registrations may differ from current metadata.");
   }
 
   if (Object.keys(state.config.mcpServers).length === 0) {

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -487,7 +487,13 @@ export function createDirectToolExecutor(
             onNeedsAuth: recoverAuthConnection,
           },
           spec.serverName,
-          (conn) => conn.client.readResource({ uri: spec.resourceUri! }, requestOptions),
+          async (conn) => {
+            const refreshRead = await state.manager.prepareResourceUse?.(spec.serverName, spec.resourceUri!, conn);
+            return conn.client.readResource(
+              { uri: spec.resourceUri! },
+              refreshRead ? { ...requestOptions, cacheMode: "refresh" } : requestOptions,
+            );
+          },
         );
         const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
         const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], {
@@ -521,11 +527,14 @@ export function createDirectToolExecutor(
           onNeedsAuth: recoverAuthConnection,
         },
         spec.serverName,
-        (conn) => abortable(conn.client.callTool({
-          name: spec.originalName,
-          arguments: normalizedParams,
-          _meta: uiSession?.requestMeta,
-        }, requestOptions), ownedSignal),
+        async (conn) => {
+          await state.manager.ensureListen?.(spec.serverName, conn);
+          return abortable(conn.client.callTool({
+            name: spec.originalName,
+            arguments: normalizedParams,
+            _meta: uiSession?.requestMeta,
+          }, requestOptions), ownedSignal);
+        },
       );
       uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/client").CallToolResult);
 

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -340,6 +340,9 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
         showError("Failed to forward cancellation: " + String(error));
       }
     });
+    eventSource.addEventListener("resource-updated", () => {
+      setStatus("Resource updated on the server. Reopen this UI to load the latest version.");
+    });
     eventSource.addEventListener("result-patch", async (event) => {
       try {
         await bridge.notification({

--- a/index.ts
+++ b/index.ts
@@ -590,7 +590,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       initPromise = null;
       if (earlyConfig.settings?.freezeDirectTools === true) {
         directToolsFrozen = true;
-        logger.info("MCP: direct tools frozen after initial sync — reconnects won't rebuild the system prompt; use mcp({ connect: \"server\" }) to rediscover");
+        logger.info("MCP: direct tools frozen after initial sync — metadata can refresh without rebuilding the active tool surface");
       }
     }).catch(async err => {
       if (!owner.isActive() || generation !== lifecycleGeneration) {
@@ -817,7 +817,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         case "reconnect":
           commandOwner?.throwIfInactive();
           await reconnectServers(state, commandCtx, targetServer);
-          if (directToolsFrozen) syncToolSurface(commandCtx);
           break;
         case "tools":
           await showTools(state, commandCtx);
@@ -1168,7 +1167,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         }
         if (params.connect) {
           const result = await executeConnect(state, params.connect, signal);
-          syncToolSurface(_ctx as ExtensionContext);
+          if (!directToolsFrozen) syncToolSurface(_ctx as ExtensionContext);
           return result;
         }
         if (params.describe) {

--- a/init.ts
+++ b/init.ts
@@ -215,6 +215,10 @@ export async function initializeMcp(
     notifyToolMetadataUpdated(state, serverName, reason);
     updateStatusBar(state);
   });
+  manager.setListenStateChangedListener?.(() => {
+    if (!owner.isActive()) return;
+    updateStatusBar(state);
+  });
   owner.addCleanup(() => lifecycle.gracefulShutdown());
   owner.addCleanup(() => {
     if (state.uiServer) {
@@ -641,6 +645,7 @@ export async function lazyConnect(state: McpExtensionState, serverName: string, 
     return false;
   }
   if (connection?.status === "connected") {
+    await state.manager.ensureListen?.(serverName, connection);
     updateServerMetadata(state, serverName);
     markKeepAliveAfterConnect(state, serverName);
     return true;

--- a/mcp-status.ts
+++ b/mcp-status.ts
@@ -48,7 +48,9 @@ export function createMcpStatusSnapshot(state: McpExtensionState): McpStatusSnap
     servers.push({
       name,
       status,
+      listenState: connection?.status === "connected" ? connection.listenState : "disconnected",
       toolCount,
+      ...(connection?.status === "connected" && connection.listenCatalogStale ? { catalogStale: true } : {}),
       ...(resourceCount !== undefined ? { resourceCount } : {}),
       ...(status === "failed" && failedAgoSeconds !== null ? { failedAgoSeconds } : {}),
       disabled,

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -340,7 +340,7 @@ export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
 }
 
 export function executeStatus(state: McpExtensionState): ProxyToolResult {
-  const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null; disabled?: boolean }> = [];
+  const servers: Array<{ name: string; status: string; listenState: string; catalogStale?: boolean; toolCount: number; failedAgo: number | null; disabled?: boolean }> = [];
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const definition = state.config.mcpServers[name];
@@ -361,7 +361,16 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
     const toolCount = status === "failed" ? 0 : metadata?.length ?? 0;
 
-    servers.push({ name, status, toolCount, failedAgo, ...(disabled ? { disabled: true } : {}) });
+    const listenState = connection?.status === "connected" ? connection.listenState : "disconnected";
+    servers.push({
+      name,
+      status,
+      listenState,
+      ...(connection?.status === "connected" && connection.listenCatalogStale ? { catalogStale: true } : {}),
+      toolCount,
+      failedAgo,
+      ...(disabled ? { disabled: true } : {}),
+    });
   }
 
   const disabledCount = servers.filter(s => s.disabled).length;
@@ -378,7 +387,18 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
       continue;
     }
     if (server.status === "connected") {
-      text += `✓ ${server.name} (${server.toolCount} tools)\n`;
+      const listen = server.listenState === "active"
+        ? server.catalogStale
+          ? ", listen active, catalog may be stale"
+          : ", listen active"
+        : server.listenState === "dropped"
+          ? ", catalog may be stale; will reconcile on next keep-alive or tool use"
+          : server.listenState === "re-establishing"
+            ? ", re-establishing listen"
+            : server.listenState === "legacy"
+              ? ", legacy notification path"
+              : ", not listening for catalog updates";
+      text += `✓ ${server.name} (${server.toolCount} tools${listen})\n`;
       continue;
     }
     if (server.status === "needs-auth") {
@@ -386,14 +406,19 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
       continue;
     }
     if (server.status === "cached") {
-      text += `○ ${server.name} (${server.toolCount} tools, cached)\n`;
+      text += `○ ${server.name} (${server.toolCount} tools, cached; not listening)\n`;
       continue;
     }
     if (server.status === "failed") {
       text += `✗ ${server.name} (failed ${server.failedAgo ?? 0}s ago)\n`;
       continue;
     }
-    text += `○ ${server.name} (not connected)\n`;
+    text += `○ ${server.name} (not listening; disconnected)\n`;
+  }
+
+  const directToolsFrozen = state.config.settings?.freezeDirectTools === true;
+  if (directToolsFrozen) {
+    text += "\nDirect tools frozen; active registrations may differ from current metadata.\n";
   }
 
   if (servers.length > 0) {
@@ -402,7 +427,7 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 
   return {
     content: [{ type: "text" as const, text: text.trim() }],
-    details: { mode: "status", servers, totalTools, connectedCount, disabledCount },
+    details: { mode: "status", servers, totalTools, connectedCount, disabledCount, directToolsFrozen },
   };
 }
 
@@ -1301,7 +1326,13 @@ export async function executeCall(
           onNeedsAuth: recoverAuthConnection,
         },
         serverName,
-        (conn) => conn.client.readResource({ uri: toolMeta.resourceUri! }, requestOptions),
+        async (conn) => {
+          const refreshRead = await state.manager.prepareResourceUse?.(serverName, toolMeta.resourceUri!, conn);
+          return conn.client.readResource(
+            { uri: toolMeta.resourceUri! },
+            refreshRead ? { ...requestOptions, cacheMode: "refresh" } : requestOptions,
+          );
+        },
       );
       const content = transformMcpResourceContents(result.contents ?? [], state.owner?.signal);
       const guarded = await guardMcpOutput(content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }], outputGuardOptions);
@@ -1331,11 +1362,14 @@ export async function executeCall(
         onNeedsAuth: recoverAuthConnection,
       },
       serverName,
-      (conn) => abortable(conn.client.callTool({
-        name: toolMeta.originalName,
-        arguments: normalizedArgs,
-        _meta: uiSession?.requestMeta,
-      }, requestOptions), ownedSignal),
+      async (conn) => {
+        await state.manager.ensureListen?.(serverName, conn);
+        return abortable(conn.client.callTool({
+          name: toolMeta.originalName,
+          arguments: normalizedArgs,
+          _meta: uiSession?.requestMeta,
+        }, requestOptions), ownedSignal);
+      },
     );
 
     if (toolMeta.uiResourceUri) {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -11,6 +11,8 @@ import {
   type GetPromptResult,
   type ListToolsResult,
   type ReadResourceResult,
+  type McpSubscription,
+  type SubscriptionFilter,
   type CacheableRequestOptions,
   type RequestOptions,
   type UrlElicitationRequiredError,
@@ -28,6 +30,7 @@ import {
   type ServerStreamResultPatchNotification,
   type Transport,
   type McpTraceSettings,
+  type McpListenState,
   SERVER_STREAM_RESULT_PATCH_METHOD,
   serverStreamResultPatchNotificationSchema,
 } from "./types.ts";
@@ -142,6 +145,18 @@ export interface ServerConnection {
   lastUsedAt: number;
   inFlight: number;
   status: "connected" | "closed" | "needs-auth";
+  /** Catalog subscription health, tracked independently from transport health. */
+  listenState: McpListenState;
+  listenSubscription?: McpSubscription;
+  /** Last requested filter; the server's honored filter may be a subset. */
+  listenFilter?: SubscriptionFilter;
+  /** True when recovery has an active listen but could not confirm every catalog list. */
+  listenCatalogStale?: boolean;
+  listenPromise?: Promise<void>;
+  listenRetryAfter?: number;
+  listenStopped?: boolean;
+  recentResourceUris?: Map<string, number>;
+  resourceReadRefreshUris?: Set<string>;
   /** True once this needs-auth episode discarded the cached credential. */
   credentialsInvalidated?: boolean;
 }
@@ -149,6 +164,8 @@ export interface ServerConnection {
 
 type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void;
 type MetadataListChangedListener = (serverName: string, reason: string) => void;
+type ListenStateChangedListener = (serverName: string, state: McpListenState) => void;
+type ResourceUpdatedListener = (serverName: string, uri: string) => void;
 
 export type ToolRefreshResult = "updated" | "unchanged" | "superseded" | "refresh-timeout";
 
@@ -156,6 +173,9 @@ type ToolListCacheHints = Partial<Pick<ListToolsResult, "ttlMs" | "cacheScope">>
 type ToolListResult = { tools: McpTool[]; hints?: ToolListCacheHints };
 
 const KEEP_ALIVE_REFRESH_TIMEOUT_MS = 5_000;
+const LISTEN_RETRY_DELAY_MS = 5_000;
+const RECENT_RESOURCE_TTL_MS = 10 * 60_000;
+const MAX_RESOURCE_SUBSCRIPTIONS = 32;
 
 export function isTransientHttpConnectError(error: unknown): boolean {
   let current: unknown = error;
@@ -173,6 +193,12 @@ export class McpServerManager {
   private uiStreamListeners = new Map<string, UiStreamListener>();
   private samplingConfig: ServerSamplingConfig | undefined;
   private metadataListChangedListener: MetadataListChangedListener | undefined;
+  private listenStateChangedListener: ListenStateChangedListener | undefined;
+  private resourceUpdatedListeners = new Map<string, {
+    serverName: string;
+    uri: string;
+    listener: ResourceUpdatedListener;
+  }>();
   private pendingMetadataPublications = new Map<
     string,
     { connection: ServerConnection; reason: string }
@@ -199,6 +225,10 @@ export class McpServerManager {
 
   setMetadataListChangedListener(listener: MetadataListChangedListener | undefined): void {
     this.metadataListChangedListener = listener;
+  }
+
+  setListenStateChangedListener(listener: ListenStateChangedListener | undefined): void {
+    this.listenStateChangedListener = listener;
   }
 
   publishMetadataChanged(
@@ -313,6 +343,10 @@ export class McpServerManager {
         throw new Error(`MCP connection for ${name} was closed while connecting`);
       }
       this.connections.set(name, connection);
+      this.watchListenSubscription(name, connection, connection.listenSubscription);
+      if ([...this.resourceUpdatedListeners.values()].some(registration => registration.serverName === name)) {
+        void this.ensureListen(name, connection);
+      }
       return connection;
     } finally {
       if (this.connectPromises.get(name) === promise) this.connectPromises.delete(name);
@@ -372,6 +406,8 @@ export class McpServerManager {
     if (current !== expectedConnection || current.status !== "connected") {
       return "superseded";
     }
+
+    await this.ensureListen(name, expectedConnection);
 
     const requestOptions = this.buildRequestOptions(expectedConnection.definition, signal);
     const timeout = Math.min(requestOptions?.timeout ?? KEEP_ALIVE_REFRESH_TIMEOUT_MS, KEEP_ALIVE_REFRESH_TIMEOUT_MS);
@@ -455,6 +491,250 @@ export class McpServerManager {
     if (this.pendingMetadataPublications.get(name) === pendingPublication) {
       this.pendingMetadataPublications.delete(name);
     }
+  }
+
+  private setListenState(name: string, connection: ServerConnection, state: McpListenState): void {
+    if (connection.listenState === state) return;
+    connection.listenState = state;
+    if (this.connections.get(name) === connection) {
+      try {
+        this.listenStateChangedListener?.(name, state);
+      } catch {
+        // Status consumers must not interrupt listen lifecycle recovery.
+      }
+    }
+  }
+
+  private catalogListenFilter(connection: ServerConnection): SubscriptionFilter {
+    const capabilities = connection.client.getServerCapabilities?.();
+    return {
+      ...(capabilities?.tools?.listChanged ? { toolsListChanged: true } : {}),
+      ...(capabilities?.prompts?.listChanged ? { promptsListChanged: true } : {}),
+      ...(capabilities?.resources?.listChanged ? { resourcesListChanged: true } : {}),
+    };
+  }
+
+  private currentListenFilter(name: string, connection: ServerConnection): SubscriptionFilter {
+    const now = Date.now();
+    const recent = connection.recentResourceUris;
+    if (recent) {
+      for (const [uri, touchedAt] of recent) {
+        if (now - touchedAt > RECENT_RESOURCE_TTL_MS) recent.delete(uri);
+      }
+    }
+    const openResourceUris = [...new Set(
+      [...this.resourceUpdatedListeners.values()]
+        .filter(registration => registration.serverName === name)
+        .map(registration => registration.uri),
+    )].slice(-MAX_RESOURCE_SUBSCRIPTIONS);
+    const openSet = new Set(openResourceUris);
+    const recentSlots = MAX_RESOURCE_SUBSCRIPTIONS - openResourceUris.length;
+    const recentResourceUris = recentSlots > 0
+      ? [...(recent?.keys() ?? [])].filter(uri => !openSet.has(uri)).slice(-recentSlots)
+      : [];
+    const resourceSubscriptions = [...openResourceUris, ...recentResourceUris];
+    return {
+      ...this.catalogListenFilter(connection),
+      ...(resourceSubscriptions.length > 0 ? { resourceSubscriptions } : {}),
+    };
+  }
+
+  private watchListenSubscription(
+    name: string,
+    connection: ServerConnection,
+    subscription: McpSubscription | undefined,
+  ): void {
+    if (!subscription) return;
+    void subscription.closed.then(cause => {
+      if (
+        this.stopped ||
+        this.connections.get(name) !== connection ||
+        connection.status !== "connected" ||
+        connection.listenSubscription !== subscription
+      ) return;
+      if (cause === "remote") {
+        const staleUris = connection.listenFilter?.resourceSubscriptions ?? [];
+        if (staleUris.length > 0) connection.resourceReadRefreshUris = new Set(staleUris);
+        connection.listenCatalogStale = true;
+        connection.listenRetryAfter = Date.now();
+        this.setListenState(name, connection, "dropped");
+      } else if (cause === "graceful" || connection.listenState !== "re-establishing") {
+        connection.listenStopped = true;
+        this.setListenState(name, connection, "not-listening");
+      }
+    });
+  }
+
+  /** Quietly repairs a modern catalog listen at an existing activity boundary. */
+  async ensureListen(name: string, expectedConnection: ServerConnection): Promise<void> {
+    if (
+      this.stopped ||
+      this.connections.get(name) !== expectedConnection ||
+      expectedConnection.status !== "connected" ||
+      expectedConnection.listenStopped ||
+      expectedConnection.client.getProtocolEra?.() !== "modern"
+    ) return;
+
+    const filter = this.currentListenFilter(name, expectedConnection);
+    if (Object.keys(filter).length === 0) {
+      this.setListenState(name, expectedConnection, "not-listening");
+      return;
+    }
+    if (expectedConnection.listenPromise) {
+      await expectedConnection.listenPromise;
+      return this.ensureListen(name, expectedConnection);
+    }
+    if ((expectedConnection.listenRetryAfter ?? 0) > Date.now()) return;
+
+    const sameFilter = isDeepStrictEqual(expectedConnection.listenFilter, filter);
+    if (expectedConnection.listenState === "active" && sameFilter) {
+      if (!expectedConnection.listenCatalogStale) return;
+      const attempt = (async () => {
+        this.setListenState(name, expectedConnection, "re-establishing");
+        const confirmed = await this.reconcileCatalogAfterListen(name, expectedConnection, this.buildRequestOptions(expectedConnection.definition));
+        if (!confirmed) expectedConnection.listenRetryAfter = Date.now() + LISTEN_RETRY_DELAY_MS;
+        this.setListenState(name, expectedConnection, "active");
+      })().finally(() => {
+        if (expectedConnection.listenPromise === attempt) delete expectedConnection.listenPromise;
+      });
+      expectedConnection.listenPromise = attempt;
+      return attempt;
+    }
+
+    const attempt = (async () => {
+      const recoverDroppedListen = expectedConnection.listenState === "dropped";
+      this.setListenState(name, expectedConnection, "re-establishing");
+      const previous = expectedConnection.listenSubscription;
+      if (previous) await previous.close().catch(() => {});
+      if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") return;
+      try {
+        const requestOptions = this.buildRequestOptions(expectedConnection.definition);
+        const subscription = await expectedConnection.client.listen(
+          filter,
+          {
+            ...requestOptions,
+            timeout: Math.min(requestOptions?.timeout ?? KEEP_ALIVE_REFRESH_TIMEOUT_MS, KEEP_ALIVE_REFRESH_TIMEOUT_MS),
+          },
+        );
+        if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") {
+          await subscription.close().catch(() => {});
+          return;
+        }
+        expectedConnection.listenSubscription = subscription;
+        expectedConnection.listenFilter = filter;
+        delete expectedConnection.listenStopped;
+        delete expectedConnection.listenRetryAfter;
+        this.watchListenSubscription(name, expectedConnection, subscription);
+        const confirmed = recoverDroppedListen
+          ? await this.reconcileCatalogAfterListen(name, expectedConnection, requestOptions)
+          : true;
+        if (!confirmed) expectedConnection.listenRetryAfter = Date.now() + LISTEN_RETRY_DELAY_MS;
+        this.setListenState(name, expectedConnection, "active");
+      } catch (error) {
+        if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") return;
+        if (expectedConnection.listenSubscription) await expectedConnection.listenSubscription.close().catch(() => {});
+        expectedConnection.listenRetryAfter = Date.now() + LISTEN_RETRY_DELAY_MS;
+        this.setListenState(name, expectedConnection, "dropped");
+        logger.debug(`MCP: catalog listen repair failed for ${name}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    })().finally(() => {
+      if (expectedConnection.listenPromise === attempt) delete expectedConnection.listenPromise;
+    });
+    expectedConnection.listenPromise = attempt;
+    return attempt;
+  }
+
+  private async reconcileCatalogAfterListen(
+    name: string,
+    expectedConnection: ServerConnection,
+    requestOptions?: CacheableRequestOptions,
+  ): Promise<boolean> {
+    const timeout = Math.min(requestOptions?.timeout ?? KEEP_ALIVE_REFRESH_TIMEOUT_MS, KEEP_ALIVE_REFRESH_TIMEOUT_MS);
+    const refreshSignal = combineAbortSignals(requestOptions?.signal, AbortSignal.timeout(timeout));
+    const refreshOptions: CacheableRequestOptions = {
+      ...requestOptions,
+      timeout,
+      cacheMode: "refresh",
+      ...(refreshSignal ? { signal: refreshSignal } : {}),
+    };
+    const [toolResult, resources, promptResult] = await Promise.allSettled([
+      this.fetchAllTools(expectedConnection.client, refreshOptions),
+      this.fetchAllResources(expectedConnection.client, refreshOptions, true),
+      this.fetchAllPrompts(expectedConnection.client, refreshOptions),
+    ]);
+    if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") return false;
+
+    const nextTools = toolResult.status === "fulfilled" ? toolResult.value : undefined;
+    const nextResources = resources.status === "fulfilled" ? resources.value : undefined;
+    const nextPrompts = promptResult.status === "fulfilled" && !promptResult.value.failed ? promptResult.value : undefined;
+    const confirmed = nextTools !== undefined && nextResources !== undefined && nextPrompts !== undefined;
+    const changed = (nextTools !== undefined && (
+      !isDeepStrictEqual(expectedConnection.tools, nextTools.tools) ||
+      !isDeepStrictEqual(expectedConnection.toolListHints, nextTools.hints)
+    )) ||
+      (nextResources !== undefined && !isDeepStrictEqual(expectedConnection.resources, nextResources)) ||
+      (nextPrompts !== undefined && (
+        !isDeepStrictEqual(expectedConnection.prompts, nextPrompts.prompts) ||
+        expectedConnection.promptDiscoveryFailed !== false
+      ));
+    if (!changed) {
+      this.retryPendingMetadataPublication(name, expectedConnection);
+      if (confirmed) delete expectedConnection.listenCatalogStale;
+      else expectedConnection.listenCatalogStale = true;
+      return confirmed;
+    }
+
+    if (nextTools !== undefined) {
+      expectedConnection.tools = nextTools.tools;
+      expectedConnection.toolListHints = nextTools.hints;
+      expectedConnection.toolsRevision = (expectedConnection.toolsRevision ?? 0) + 1;
+    }
+    if (nextResources !== undefined) expectedConnection.resources = nextResources;
+    if (nextPrompts !== undefined) {
+      expectedConnection.prompts = nextPrompts.prompts;
+      expectedConnection.promptDiscoveryFailed = false;
+    }
+    if (confirmed) delete expectedConnection.listenCatalogStale;
+    else expectedConnection.listenCatalogStale = true;
+    this.metadataListChangedListener?.(name, "listen-recovered");
+    this.pendingMetadataPublications.delete(name);
+    return confirmed;
+  }
+
+  async prepareResourceUse(name: string, uri: string, expectedConnection: ServerConnection): Promise<boolean> {
+    if (this.connections.get(name) !== expectedConnection || expectedConnection.status !== "connected") return false;
+    const refreshRead = expectedConnection.listenState === "dropped" ||
+      expectedConnection.listenState === "re-establishing" ||
+      expectedConnection.resourceReadRefreshUris?.has(uri) === true;
+    const recent = expectedConnection.recentResourceUris ?? new Map<string, number>();
+    recent.delete(uri);
+    recent.set(uri, Date.now());
+    while (recent.size > MAX_RESOURCE_SUBSCRIPTIONS) {
+      const oldest = recent.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      recent.delete(oldest);
+    }
+    expectedConnection.recentResourceUris = recent;
+    await this.ensureListen(name, expectedConnection);
+    expectedConnection.resourceReadRefreshUris?.delete(uri);
+    return refreshRead;
+  }
+
+  registerResourceUpdatedListener(
+    token: string,
+    serverName: string,
+    uri: string,
+    listener: ResourceUpdatedListener,
+  ): void {
+    this.removeResourceUpdatedListener(token);
+    this.resourceUpdatedListeners.set(token, { serverName, uri, listener });
+    const connection = this.connections.get(serverName);
+    if (!connection || connection.status !== "connected") return;
+    void this.prepareResourceUse(serverName, uri, connection);
+  }
+
+  removeResourceUpdatedListener(token: string): void {
+    this.resourceUpdatedListeners.delete(token);
   }
 
   private async doReconnect(
@@ -571,6 +851,7 @@ export class McpServerManager {
           lastUsedAt: Date.now(),
           inFlight: 0,
           status: "needs-auth",
+          listenState: "disconnected",
           credentialsInvalidated: invalidated,
         };
       }
@@ -594,6 +875,8 @@ export class McpServerManager {
       this.attachAdapterNotificationHandlers(name, client);
 
       const instructions = client.getInstructions?.();
+      const protocolEra = client.getProtocolEra?.();
+      const autoOpenedSubscription = client.autoOpenedSubscription;
       const connection: ServerConnection = {
         client,
         transport,
@@ -606,7 +889,16 @@ export class McpServerManager {
         lastUsedAt: Date.now(),
         inFlight: 0,
         status: "connected",
+        listenState: protocolEra === "modern"
+          ? autoOpenedSubscription
+            ? "active"
+            : "not-listening"
+          : "legacy",
+        ...(autoOpenedSubscription ? {
+          listenSubscription: autoOpenedSubscription,
+        } : {}),
       };
+      if (autoOpenedSubscription) connection.listenFilter = this.catalogListenFilter(connection);
 
       // Reflect the SDK's own close signal in connection status, guarded by
       // identity so a stale connection's late close can never clobber a fresh
@@ -664,6 +956,7 @@ export class McpServerManager {
           lastUsedAt: Date.now(),
           inFlight: 0,
           status: "needs-auth",
+          listenState: "disconnected",
           credentialsInvalidated: invalidated,
         };
       }
@@ -1082,7 +1375,7 @@ export class McpServerManager {
     }
   }
 
-  private async fetchAllResources(client: Client, requestOptions?: RequestOptions): Promise<McpResource[]> {
+  private async fetchAllResources(client: Client, requestOptions?: RequestOptions, strict = false): Promise<McpResource[]> {
     const capabilities = client.getServerCapabilities?.();
     if (!capabilities?.resources) return [];
 
@@ -1102,12 +1395,27 @@ export class McpServerManager {
         throwIfAborted(requestOptions.signal);
       }
       if (isUnauthorizedHttpError(error)) throw error;
+      if (strict) throw error;
       // The server advertises resources but the listing failed
       return [];
     }
   }
 
   private attachAdapterNotificationHandlers(serverName: string, client: Client): void {
+    client.setNotificationHandler("notifications/resources/updated", notification => {
+      const uri = notification.params.uri;
+      const connection = this.connections.get(serverName);
+      if (!connection || connection.client !== client || connection.status !== "connected") return;
+      for (const registration of this.resourceUpdatedListeners.values()) {
+        if (registration.serverName === serverName && registration.uri === uri) {
+          try {
+            registration.listener(serverName, uri);
+          } catch {
+            // One UI listener must not block resource invalidation for others.
+          }
+        }
+      }
+    });
     client.setNotificationHandler(
       SERVER_STREAM_RESULT_PATCH_METHOD,
       { params: serverStreamResultPatchNotificationSchema.shape.params },
@@ -1140,6 +1448,7 @@ export class McpServerManager {
     try {
       this.touch(name);
       this.incrementInFlight(name);
+      await this.ensureListen(name, connection);
       return await connection.client.getPrompt(
         { name: promptName, ...(args ? { arguments: args } : {}) },
         this.getRequestOptions(name, signal),
@@ -1162,7 +1471,12 @@ export class McpServerManager {
     try {
       this.touch(name);
       this.incrementInFlight(name);
-      return await connection.client.readResource({ uri }, this.getRequestOptions(name, signal));
+      const refreshRead = await this.prepareResourceUse(name, uri, connection);
+      const requestOptions = this.getRequestOptions(name, signal);
+      return await connection.client.readResource(
+        { uri },
+        refreshRead ? { ...requestOptions, cacheMode: "refresh" } : requestOptions,
+      );
     } finally {
       this.decrementInFlight(name);
       this.touch(name);
@@ -1235,6 +1549,7 @@ export class McpServerManager {
       .flatMap(result => result.status === "rejected" ? [result.reason] : [])
       .filter(error => this.containsCleanupFailure(error));
     this.uiStreamListeners.clear();
+    this.resourceUpdatedListeners.clear();
     this.acceptedUrlElicitations.clear();
     this.pendingMetadataPublications.clear();
     this.samplingConfig = undefined;

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,14 @@ export type McpServerRuntimeStatus =
   | "not-connected"
   | "disabled";
 
+export type McpListenState =
+  | "active"
+  | "dropped"
+  | "re-establishing"
+  | "legacy"
+  | "not-listening"
+  | "disconnected";
+
 export interface McpServerStatusSnapshot {
   readonly name: string;
   readonly status: McpServerRuntimeStatus;
@@ -33,6 +41,8 @@ export interface McpServerStatusSnapshot {
   readonly resourceCount?: number;
   readonly failedAgoSeconds?: number;
   readonly disabled: boolean;
+  readonly listenState: McpListenState;
+  readonly catalogStale?: boolean;
 }
 
 export interface McpStatusSnapshot {
@@ -183,6 +193,7 @@ export interface UiServerHandle {
   sendToolResult: (result: CallToolResult) => void;
   sendResultPatch: (result: CallToolResult) => void;
   sendToolCancelled: (reason: string) => void;
+  sendResourceUpdated: (uri: string) => void;
   sendHostContext: (context: UiHostContext) => void;
   /** Get accumulated messages from this session */
   getSessionMessages: () => UiSessionMessages;
@@ -564,9 +575,8 @@ export interface McpSettings {
   approveTools?: boolean | string[];
   disableProxyTool?: boolean;
   /** Freeze direct-tool registration after the initial sync. Automatic metadata updates
-   * (reconnects, lazy-connect, tool-list-changed) won't rebuild the system prompt,
-   * preserving the prompt-cache prefix. The agent rediscovers explicitly via
-   * mcp({ connect: "server" }). Default: false. */
+   * and explicit reconnects won't rebuild the system prompt, preserving the
+   * prompt-cache prefix. Proxy/search/cache metadata still refreshes. Default: false. */
   freezeDirectTools?: boolean;
   autoAuth?: boolean;
   sampling?: boolean;

--- a/ui-resource-handler.ts
+++ b/ui-resource-handler.ts
@@ -57,7 +57,14 @@ export class UiResourceHandler {
               ...(options.onNeedsAuth ? { onNeedsAuth: options.onNeedsAuth } : {}),
             },
             serverName,
-            (connection) => connection.client.readResource({ uri }, this.manager.getRequestOptions(serverName, options.signal)),
+            async (connection) => {
+              const refreshRead = await this.manager.prepareResourceUse?.(serverName, uri, connection);
+              const requestOptions = this.manager.getRequestOptions(serverName, options.signal);
+              return connection.client.readResource(
+                { uri },
+                refreshRead ? { ...requestOptions, cacheMode: "refresh" } : requestOptions,
+              );
+            },
           );
         } finally {
           this.manager.decrementInFlight(serverName);

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -498,9 +498,15 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
                   ...(options.onNeedsAuth ? { onNeedsAuth: options.onNeedsAuth } : {}),
                 },
                 options.serverName,
-                (conn) => conn.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName)),
+                async (conn) => {
+                  await options.manager.ensureListen?.(options.serverName, conn);
+                  return conn.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName));
+                },
               )
-            : await connection.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName));
+            : await (async () => {
+                await options.manager.ensureListen?.(options.serverName, connection);
+                return connection.client.callTool(callArgs, options.manager.getRequestOptions?.(options.serverName));
+              })();
           sendJson(res, 200, { ok: true, result });
         } finally {
           options.manager.decrementInFlight(options.serverName);
@@ -724,6 +730,9 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         },
         sendToolCancelled: (reason: string) => {
           pushEvent("tool-cancelled", { reason });
+        },
+        sendResourceUpdated: (uri: string) => {
+          pushEvent("resource-updated", { uri });
         },
         sendHostContext: (context: UiHostContext) => {
           Object.assign(hostContext, context);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -315,11 +315,13 @@ export async function maybeStartUiSession(
     let active = true;
     let nextStreamSequence = 0;
     let handle: UiServerHandle;
+    const resourceListenerToken = randomUUID();
 
-    const cleanupStreamListener = () => {
+    const cleanupListeners = () => {
       if (streamToken) {
         state.manager.removeUiStreamListener(streamToken);
       }
+      state.manager.removeResourceUpdatedListener?.(resourceListenerToken);
     };
 
     handle = await startUiServer({
@@ -395,7 +397,7 @@ export async function maybeStartUiSession(
 
       onComplete: (reason: string) => {
         active = false;
-        cleanupStreamListener();
+        cleanupListeners();
 
         if (state.uiServer === handle) {
           const messages = handle.getSessionMessages();
@@ -454,6 +456,16 @@ export async function maybeStartUiSession(
         handle.sendResultPatch(withStreamEnvelope(notification.result as CallToolResult, streamId, nextStreamSequence));
       });
     }
+
+    state.manager.registerResourceUpdatedListener?.(
+      resourceListenerToken,
+      request.serverName,
+      request.uiResourceUri,
+      (_serverName, uri) => {
+        if (!active || state.uiServer !== handle) return;
+        handle.sendResourceUpdated(uri);
+      },
+    );
 
     state.uiServer = handle;
 
@@ -555,7 +567,7 @@ export async function maybeStartUiSession(
       },
       close: (reason?: string) => {
         active = false;
-        cleanupStreamListener();
+        cleanupListeners();
         handle.close(reason);
       },
     };


### PR DESCRIPTION
Closes #468.

## Summary
- Track modern `subscriptions/listen` health separately from transport health, watch remote drops, and repair with bounded single-flight relisten at existing activity boundaries.
- Reconcile tools, prompts, and resources after dropped-listen recovery before clearing stale-catalog state; optional prompt/resource confirmation failures keep the replacement listen active and surface `catalog may be stale`.
- Track bounded recent/open resource URIs in `resourceSubscriptions`, force affected resource reads through cache refresh after missed updates, and signal matching open UI sessions with a no-reload `resource-updated` event.
- Preserve legacy notification behavior, request-local progress/MRTR streams, and frozen direct-tool registration semantics.

## Validation
- Fresh review: PASS (`reports/issue-468-followup-review.md`).
- `npx vitest run __tests__/server-manager-modern-listen.test.ts __tests__/direct-tool-host-contract.test.ts __tests__/index-lifecycle.test.ts __tests__/mcp-status.test.ts __tests__/ui-server.test.ts __tests__/ui-streaming.test.ts __tests__/mrtr-sdk-integration.test.ts __tests__/error-signal.test.ts __tests__/ui-resource-handler.test.ts` passed in the issue worktree.
- `npx vitest run __tests__/server-manager-modern-listen.test.ts __tests__/mcp-status.test.ts __tests__/direct-tool-host-contract.test.ts __tests__/ui-resource-handler.test.ts __tests__/ui-server.test.ts __tests__/ui-streaming.test.ts __tests__/index-lifecycle.test.ts` passed in the issue worktree after the optional-catalog follow-up.
- `npm run typecheck` passed in the issue worktree.
- `git diff --check` passed in the issue worktree.
- `npx vitest run --exclude __tests__/interactive-visualizer-server.test.ts` passed in the issue worktree: 109 files, 1379 tests.

Known local artifact note: the unexcluded suite can depend on generated interactive-visualizer dist files in isolated worktrees. CI builds those artifacts before tests.
