### PR TITLE
Use stored OAuth credentials for implicit auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)
+- Implicit OAuth now reuses URL-bound stored credentials while preserving anonymous fallback. Thanks to [@wilt00](https://github.com/wilt00) for #471.
 
 ## [2.31.0] - 2026-08-28
 

--- a/__tests__/server-manager-auth-cache-recovery-integration.test.ts
+++ b/__tests__/server-manager-auth-cache-recovery-integration.test.ts
@@ -106,22 +106,31 @@ describe("auth cache recovery with the real OAuth provider", () => {
     await expectProviderReloadsOnce(capturedProvider(), "new");
   });
 
-  it("evicts only after the second, provider-backed implicit OAuth 401", async () => {
+  it("uses stored credentials for an implicit OAuth connection and evicts after a 401", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     saveAuthEntry("implicit", { tokens: { accessToken: "old" } }, SERVER_URL);
     expect(getAuthEntry("implicit")?.tokens?.accessToken).toBe("old");
     writeBehindTheCache("implicit", "new");
-    mocks.connectSteps.push(
-      () => { throw unauthorized(); },
-      () => { throw unauthorized(); },
-    );
+    mocks.connectSteps.push(() => { throw unauthorized(); });
 
     const connection = await new McpServerManager().connect("implicit", { url: SERVER_URL });
 
     expect(connection.status).toBe("needs-auth");
-    expect(mocks.transports).toHaveLength(2);
-    expect(mocks.transports[0]?.options.authProvider).toBeUndefined();
+    expect(mocks.transports).toHaveLength(1);
+    expect(mocks.transports[0]?.options.authProvider).toBeDefined();
     await expectProviderReloadsOnce(capturedProvider(), "new");
+  });
+
+  it("invalidates a stale absent cache before using newly stored implicit OAuth credentials", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    expect(getAuthEntry("appearing")?.tokens).toBeUndefined();
+    writeBehindTheCache("appearing", "new");
+
+    const manager = new McpServerManager();
+    await manager.connect("appearing", { url: SERVER_URL });
+
+    const provider = capturedProvider();
+    expect(await provider.tokens?.()).toMatchObject({ access_token: "new" });
   });
 
   it("keeps concurrent recovery connects single-flight", async () => {

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -1,8 +1,13 @@
 import { SdkErrorCode, SdkHttpError } from "@modelcontextprotocol/client";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getAuthEntryFilePath, resetTestAuthSecretStore, saveAuthEntry } from "../mcp-auth.ts";
 
 type OAuthProviderLike = {
   redirectUrl?: string;
+  tokens?: () => Promise<unknown>;
   clientMetadata?: {
     redirect_uris?: string[];
     client_name?: string;
@@ -80,11 +85,13 @@ describe("McpServerManager HTTP bearer auth", () => {
     MCP_TEST_BEARER_TOKEN: process.env.MCP_TEST_BEARER_TOKEN,
     MCP_TEST_BEARER_TOKEN_ENV: process.env.MCP_TEST_BEARER_TOKEN_ENV,
     MCP_TEST_URL: process.env.MCP_TEST_URL,
+    MCP_OAUTH_DIR: process.env.MCP_OAUTH_DIR,
     PI_MCP_ADAPTER_TEST_AUTH_STORE: process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE,
   };
 
   beforeEach(() => {
     process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "memory";
+    resetTestAuthSecretStore();
     mocks.afterConnect = undefined;
     mocks.clients.length = 0;
     mocks.connectErrors.length = 0;
@@ -100,6 +107,7 @@ describe("McpServerManager HTTP bearer auth", () => {
         process.env[key] = value;
       }
     }
+    resetTestAuthSecretStore();
   });
 
 
@@ -291,6 +299,49 @@ describe("McpServerManager HTTP bearer auth", () => {
 
     expect(mocks.httpTransports.at(-1)!.options.requestInit?.headers?.["X-Goog-Api-Key"]).toBe("api-key");
     expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
+  });
+
+  it("uses URL-bound stored OAuth tokens before implicit authentication is challenged", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    saveAuthEntry("stored", { tokens: { accessToken: "stored-token" } }, "https://example.test/mcp");
+
+    const manager = new McpServerManager();
+    await manager.connect("stored", { url: "https://example.test/mcp" });
+
+    const authProvider = mocks.httpTransports.at(-1)!.options.authProvider;
+    expect(authProvider).toBeDefined();
+    expect(await authProvider!.tokens?.()).toMatchObject({ access_token: "stored-token" });
+  });
+
+  it("keeps implicit OAuth deferred when the credential store is unavailable", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "unavailable";
+
+    const manager = new McpServerManager();
+    await manager.connect("anonymous", { url: "https://example.test/mcp" });
+
+    expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
+  });
+
+  it("keeps implicit OAuth deferred when stored credentials are malformed", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const authDir = mkdtempSync(join(tmpdir(), "pi-mcp-implicit-auth-"));
+    const previousAuthDir = process.env.MCP_OAUTH_DIR;
+    process.env.MCP_OAUTH_DIR = authDir;
+    try {
+      const filePath = getAuthEntryFilePath("malformed");
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, JSON.stringify({ tokens: { refreshToken: "missing-access-token" } }));
+
+      const manager = new McpServerManager();
+      await manager.connect("malformed", { url: "https://example.test/mcp" });
+
+      expect(mocks.httpTransports.at(-1)!.options.authProvider).toBeUndefined();
+    } finally {
+      if (previousAuthDir === undefined) delete process.env.MCP_OAUTH_DIR;
+      else process.env.MCP_OAUTH_DIR = previousAuthDir;
+      rmSync(authDir, { recursive: true, force: true });
+    }
   });
 
   it("passes the per-request header command fetch to Streamable HTTP and SSE", async () => {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -40,7 +40,7 @@ import { logger } from "./logger.ts";
 import { RESOURCE_MIME_TYPE } from "./ui-app-bridge-helpers.ts";
 import { McpOAuthProvider } from "./mcp-oauth-provider.ts";
 import { extractOAuthConfig, supportsOAuth, type McpOAuthRuntime } from "./mcp-auth-flow.ts";
-import { invalidateAuthEntryCache, type AuthStorageOptions } from "./mcp-auth.ts";
+import { inspectAuthForUrl, invalidateAuthEntryCache, type AuthStorageOptions } from "./mcp-auth.ts";
 import { getBearerTokenForUrl } from "./mcp-bearer-store.ts";
 import { registerSamplingHandler, type ServerSamplingConfig } from "./sampling-handler.ts";
 import {
@@ -75,6 +75,7 @@ const abortCleanupPromises = new WeakMap<object, Promise<void>>();
 type HttpAuthProviderState =
   | { status: "disabled" }
   | { status: "implicit-deferred" }
+  | { status: "implicit-stored"; provider: McpOAuthProvider }
   | { status: "explicit"; provider: McpOAuthProvider }
   | { status: "implicit-challenged"; provider: McpOAuthProvider };
 
@@ -1228,11 +1229,26 @@ export class McpServerManager {
       this.oauthRuntime?.signal,
     );
 
-    // Explicit OAuth checks secure storage immediately. Implicit OAuth defers
-    // provider construction until the server proves authentication is needed.
+    // Explicit OAuth checks secure storage immediately. Implicit OAuth keeps
+    // anonymous servers provider-free unless URL-bound credentials are already
+    // stored, so an unavailable credential store does not break anonymous use.
+    let implicitStoredAuth: ReturnType<typeof inspectAuthForUrl> | undefined;
+    if (definition.auth === undefined && supportsOAuth(definition)) {
+      try {
+        implicitStoredAuth = inspectAuthForUrl(serverName, serverUrl, this.authStorageOptions);
+      } catch {
+        // Implicit preflight is opportunistic; malformed records must not block
+        // an otherwise anonymous-capable server from connecting.
+      }
+    }
+    const hasImplicitStoredTokens = implicitStoredAuth?.status === "present"
+      && implicitStoredAuth.entry.tokens !== undefined;
+    if (hasImplicitStoredTokens) invalidateAuthEntryCache(serverName);
     let authState: HttpAuthProviderState = supportsOAuth(definition)
       ? definition.auth === undefined
-        ? { status: "implicit-deferred" }
+        ? hasImplicitStoredTokens
+          ? { status: "implicit-stored", provider: createAuthProvider() }
+          : { status: "implicit-deferred" }
         : { status: "explicit", provider: createAuthProvider() }
       : { status: "disabled" };
 


### PR DESCRIPTION
## Summary

- Use URL-bound stored OAuth credentials on the first implicit OAuth HTTP connection.
- Preserve anonymous-first behavior when no stored token exists or credential storage is unavailable.
- Add regressions for stored implicit credentials, stale absent auth cache recovery, and anonymous fallback.

Closes #471.

## Validation

- `npm test -- --run __tests__/server-manager-http-auth.test.ts __tests__/server-manager-auth-cache-recovery-integration.test.ts`
- `npm run typecheck`
- `git diff --check`
