### PR TITLE
feat: add allowlisted confidential MCP workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added the reviewed `dps-catalog-local-upload:v1` confidential workflow for trusted extensions that must broker sensitive MCP calls without exposing their results to model-facing tools or protocol traces. (#146)
+
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the reviewed `dps-catalog-local-upload:v1` confidential workflow for trusted extensions that must broker sensitive MCP calls without exposing their results to model-facing tools or protocol traces. (#146)
 
+### Changed
+- Reserved the unpublished `2.32.0` package version for this workflow API and its strict approval/argument contract.
+
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ But the MCP ecosystem has useful stuff - databases, browsers, APIs. This adapter
 ## Install
 
 ```bash
-pi install npm:pi-mcp-adapter
+pi install npm:pi-mcp-adapter@2.32.0
 ```
 
 Restart Pi after installation.
@@ -209,12 +209,22 @@ const result = await workflow.call("presign_file_upload", {
 });
 ```
 
+The broker accepts only the exact scalar fields shown above: bounded catalog
+identifiers/locales, a canonical basename ending in lowercase `.pdf` or
+`.xlsx`, and an integer `size_bytes` from 1 through 100 MiB. Confirmation accepts
+only its safe upload identifier plus the same store, filename, and locale;
+objects, arrays, byte buffers, paths, and extra/missing fields are rejected
+before any MCP connection or call.
+
 This allowlist is intentionally not a generic raw-MCP API: it binds to the
 configured `eproduct-catalog` server and only the `presign_file_upload` and
 `confirm_file_upload` tools. Those tools are added to `excludeTools` before
 metadata/direct/namespace surfaces are built and remain hidden across session
 restarts. The workflow handle is still required for any trusted call; disposing
-that handle never re-exposes the sensitive tools to the model. The adapter reuses the existing
+that handle never re-exposes the sensitive tools to the model. Calls reuse the
+normal approval broker (including broker denials and headless approval-required
+failures), validate the complete per-tool argument contract before connecting,
+and never invoke the MCP manager after a denial. The adapter reuses the existing
 connection and OAuth state, suppresses protocol tracing for the call, and
 returns provider failures only as stable, non-sensitive error codes. The
 trusted extension owns the safe projection; the adapter never renders or emits
@@ -225,8 +235,8 @@ accepts enumerated operator-owned roots and relative paths, streams a reopened
 read-only file to the presigned R2 URL, and projects only file/slot metadata.
 It must be installed only after an adapter release containing this API. The
 release/install order is: merge adapter PR, run its public build and tests,
-create the operator-approved `v*` release through deploy-control, update the
-Pi package, then link the `agus-skills` extension. Do not copy presigned URLs
+create the operator-approved `v2.32.0` release through deploy-control, update the
+Pi package to `npm:pi-mcp-adapter@2.32.0`, then link the `agus-skills` extension. Do not copy presigned URLs
 into commands, logs, traces, issues, or chat. Rollback is the inverse: stop
 using the local-upload extension, restore the previous Pi adapter package and
 remove the extension symlink; no catalog rows or already-confirmed files are
@@ -536,7 +546,7 @@ The bundled `mcp-scripting` skill is a separate Pi package resource. To hide tha
 ```json
 {
   "packages": [
-    { "source": "npm:pi-mcp-adapter", "skills": [] }
+    { "source": "npm:pi-mcp-adapter@2.32.0", "skills": [] }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -185,6 +185,53 @@ Cross-extension registration uses Pi's shared event bus and does not require a r
 
 Runtime registrations are session scoped and never written to config files. Duplicate server names fail closed against configured servers and other registrations. Registered servers use the normal lazy connection, OAuth, approval, and shutdown behavior, but they are proxy-tool-only and their tools become visible at the next tool sync. To change a definition, dispose the registration and register again.
 
+### Confidential local-upload workflow
+
+The package exposes one reviewed, versioned in-process workflow for trusted Pi
+extensions that must handle a sensitive MCP response without putting it in a
+model-visible result or transcript:
+
+```ts
+import {
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+  registerMcpConfidentialWorkflow,
+} from "pi-mcp-adapter";
+
+const workflow = registerMcpConfidentialWorkflow({
+  pi,
+  workflow: MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+});
+const result = await workflow.call("presign_file_upload", {
+  store_id: "lehrermaterial",
+  locale: "de",
+  filename: "lesson.pdf",
+  size_bytes: 1234,
+});
+```
+
+This allowlist is intentionally not a generic raw-MCP API: it binds to the
+configured `eproduct-catalog` server and only the `presign_file_upload` and
+`confirm_file_upload` tools. Those tools are added to `excludeTools` before
+metadata/direct/namespace surfaces are built and remain hidden across session
+restarts. The workflow handle is still required for any trusted call; disposing
+that handle never re-exposes the sensitive tools to the model. The adapter reuses the existing
+connection and OAuth state, suppresses protocol tracing for the call, and
+returns provider failures only as stable, non-sensitive error codes. The
+trusted extension owns the safe projection; the adapter never renders or emits
+the raw `CallToolResult`.
+
+`dps-catalog-local-upload` in `agus-skills` is the only current consumer. It
+accepts enumerated operator-owned roots and relative paths, streams a reopened
+read-only file to the presigned R2 URL, and projects only file/slot metadata.
+It must be installed only after an adapter release containing this API. The
+release/install order is: merge adapter PR, run its public build and tests,
+create the operator-approved `v*` release through deploy-control, update the
+Pi package, then link the `agus-skills` extension. Do not copy presigned URLs
+into commands, logs, traces, issues, or chat. Rollback is the inverse: stop
+using the local-upload extension, restore the previous Pi adapter package and
+remove the extension symlink; no catalog rows or already-confirmed files are
+deleted by rollback.
+
 ### SDK configuration
 
 Use `createMcpAdapter` when an SDK or server integration already owns its MCP configuration:

--- a/__tests__/confidential-workflow.test.ts
+++ b/__tests__/confidential-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
   McpConfidentialError,
 } from "../confidential-workflow.ts";
+import { MCP_TOOL_APPROVAL_REQUEST_EVENT, type McpToolApprovalRequest } from "../types.ts";
 
 function createState(overrides: Record<string, unknown> = {}) {
   const owner = { signal: new AbortController().signal };
@@ -44,7 +45,12 @@ describe("confidential MCP workflow boundary", () => {
       state,
       "eproduct-catalog",
       "presign_file_upload",
-      {},
+      {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
       controller.signal,
     )).rejects.toMatchObject({ code: "aborted" });
     expect(state.manager.callTool).not.toHaveBeenCalled();
@@ -101,6 +107,154 @@ describe("confidential MCP workflow boundary", () => {
       .rejects.toMatchObject({ code: "invalid_request" });
   });
 
+  it("reuses the normal approval broker and fails closed before manager.callTool", async () => {
+    const requests: McpToolApprovalRequest[] = [];
+    const state = createState({
+      config: {
+        mcpServers: {
+          "eproduct-catalog": {
+            url: "https://catalog.example/mcp",
+            approveTools: true,
+          },
+        },
+      },
+      approvalEvents: {
+        emit: vi.fn((channel: string, request: unknown) => {
+          expect(channel).toBe(MCP_TOOL_APPROVAL_REQUEST_EVENT);
+          const approvalRequest = request as McpToolApprovalRequest;
+          requests.push(approvalRequest);
+          expect(Object.isFrozen(approvalRequest.args)).toBe(true);
+          expect(approvalRequest.claim(() => "deny")).toBe(true);
+        }),
+      },
+    });
+
+    await expect(executeConfidentialToolCall(
+      state,
+      "eproduct-catalog",
+      "presign_file_upload",
+      {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
+    )).rejects.toMatchObject({ code: "approval_denied" });
+    expect(requests[0]).toMatchObject({
+      serverName: "eproduct-catalog",
+      originalToolName: "presign_file_upload",
+      args: {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
+      origin: "proxy",
+    });
+    expect(state.manager.callTool).not.toHaveBeenCalled();
+
+    const headless = createState({
+      config: {
+        mcpServers: {
+          "eproduct-catalog": {
+            url: "https://catalog.example/mcp",
+            approveTools: true,
+          },
+        },
+      },
+    });
+    await expect(executeConfidentialToolCall(
+      headless,
+      "eproduct-catalog",
+      "presign_file_upload",
+      {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
+    )).rejects.toMatchObject({ code: "approval_required" });
+    expect(headless.manager.callTool).not.toHaveBeenCalled();
+
+    const allowed = createState({
+      config: {
+        mcpServers: {
+          "eproduct-catalog": {
+            url: "https://catalog.example/mcp",
+            approveTools: true,
+          },
+        },
+      },
+      approvalEvents: {
+        emit: vi.fn((_channel: string, request: unknown) => {
+          expect((request as McpToolApprovalRequest).claim(() => "allow_once")).toBe(true);
+        }),
+      },
+    });
+    await expect(executeConfidentialToolCall(
+      allowed,
+      "eproduct-catalog",
+      "presign_file_upload",
+      {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
+    )).resolves.toBeDefined();
+    expect(allowed.manager.callTool).toHaveBeenCalledOnce();
+  });
+
+  it("validates the complete catalog broker argument contract before connecting", async () => {
+    const state = createState({
+      config: { mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } } },
+    });
+    const valid = {
+      store_id: "lehrermaterial",
+      locale: "de",
+      filename: "lesson.pdf",
+      size_bytes: 12,
+    };
+    const invalidPresignArgs: unknown[] = [
+      {},
+      { ...valid, store_id: "../catalog" },
+      { ...valid, locale: "de/../en" },
+      { ...valid, filename: "/tmp/lesson.pdf" },
+      { ...valid, filename: "lesson.PDF" },
+      { ...valid, size_bytes: "12" },
+      { ...valid, size_bytes: 0 },
+      { ...valid, size_bytes: 100 * 1024 * 1024 + 1 },
+      { ...valid, size_bytes: Number.NaN },
+      new Uint8Array([1, 2, 3]),
+      [valid],
+    ];
+
+    for (const args of invalidPresignArgs) {
+      await expect(executeConfidentialToolCall(
+        state,
+        "eproduct-catalog",
+        "presign_file_upload",
+        args as Record<string, unknown>,
+      )).rejects.toMatchObject({ code: "invalid_request" });
+    }
+
+    const invalidConfirmArgs: unknown[] = [
+      { upload_id: "upload/1", store_id: "lehrermaterial", filename: "lesson.pdf", locale: "de" },
+      { upload_id: "upload-1", store_id: "lehrermaterial", filename: "lesson.pdf", locale: "de", path: "hidden" },
+      { upload_id: "upload-1", store_id: "lehrermaterial", filename: "lesson.pdf", locale: { value: "de" } },
+    ];
+    for (const args of invalidConfirmArgs) {
+      await expect(executeConfidentialToolCall(
+        state,
+        "eproduct-catalog",
+        "confirm_file_upload",
+        args as Record<string, unknown>,
+      )).rejects.toMatchObject({ code: "invalid_request" });
+    }
+    expect(state.manager.connect).not.toHaveBeenCalled();
+    expect(state.manager.callTool).not.toHaveBeenCalled();
+  });
+
   it("does not copy upstream connection errors into the broker error", async () => {
     const state = createState({
       config: { mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } } },
@@ -112,10 +266,20 @@ describe("confidential MCP workflow boundary", () => {
       state,
       "eproduct-catalog",
       "presign_file_upload",
-      {},
+      {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      },
     )).rejects.toMatchObject({ code: "call_failed" });
     try {
-      await executeConfidentialToolCall(state, "eproduct-catalog", "presign_file_upload", {});
+      await executeConfidentialToolCall(state, "eproduct-catalog", "presign_file_upload", {
+        store_id: "lehrermaterial",
+        locale: "de",
+        filename: "lesson.pdf",
+        size_bytes: 12,
+      });
     } catch (error) {
       expect(error).toBeInstanceOf(McpConfidentialError);
       expect(String(error)).not.toContain("private.example");

--- a/__tests__/confidential-workflow.test.ts
+++ b/__tests__/confidential-workflow.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyConfidentialToolFilters,
+  createConfidentialCallExecutor,
+  getConfidentialWorkflowSpec,
+  executeConfidentialToolCall,
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+  McpConfidentialError,
+} from "../confidential-workflow.ts";
+
+function createState(overrides: Record<string, unknown> = {}) {
+  const owner = { signal: new AbortController().signal };
+  return {
+    owner,
+    config: { mcpServers: { catalog: { url: "https://catalog.example/mcp" } } },
+    manager: {
+      getConnection: vi.fn(() => ({ status: "connected" })),
+      connect: vi.fn(),
+      callTool: vi.fn(async () => ({
+        content: [{ type: "text", text: "{\"url\":\"https://private.example/upload\"}" }],
+      })),
+    },
+    ...overrides,
+  } as any;
+}
+
+describe("confidential MCP workflow boundary", () => {
+  it("exposes only the reviewed catalog workflow allowlist", () => {
+    expect(getConfidentialWorkflowSpec(MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD)).toEqual({
+      serverName: "eproduct-catalog",
+      tools: ["presign_file_upload", "confirm_file_upload"],
+    });
+    expect(getConfidentialWorkflowSpec("arbitrary-workflow")).toBeUndefined();
+  });
+
+  it("maps an already-aborted trusted call to a stable error", async () => {
+    const state = createState({
+      config: { mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } } },
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(executeConfidentialToolCall(
+      state,
+      "eproduct-catalog",
+      "presign_file_upload",
+      {},
+      controller.signal,
+    )).rejects.toMatchObject({ code: "aborted" });
+    expect(state.manager.callTool).not.toHaveBeenCalled();
+  });
+
+  it("adds tool exclusions without changing the MCP server transport definition", () => {
+    const config = {
+      mcpServers: {
+        catalog: { url: "https://catalog.example/mcp", headers: { "X-Test": "ok" } },
+      },
+    };
+
+    applyConfidentialToolFilters(config, {
+      catalog: ["presign_file_upload", "confirm_file_upload"],
+    });
+
+    expect(config.mcpServers.catalog).toEqual({
+      url: "https://catalog.example/mcp",
+      headers: { "X-Test": "ok" },
+      excludeTools: ["presign_file_upload", "confirm_file_upload"],
+    });
+  });
+
+  it("only calls tools explicitly registered by the trusted workflow", async () => {
+    const state = createState({
+      config: { mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } } },
+    });
+    const executor = createConfidentialCallExecutor(
+      () => state,
+      (server, tool) => server === "eproduct-catalog" && tool === "presign_file_upload",
+    );
+
+    const result = await executor.callTool("eproduct-catalog", "presign_file_upload", {
+      store_id: "store",
+      locale: "de",
+      filename: "lesson.pdf",
+      size_bytes: 12,
+    });
+    expect(result.content).toHaveLength(1);
+    expect(state.manager.callTool).toHaveBeenCalledWith(
+      "eproduct-catalog",
+      "presign_file_upload",
+      expect.objectContaining({ filename: "lesson.pdf" }),
+      expect.anything(),
+    );
+
+    await expect(executor.callTool("eproduct-catalog", "confirm_file_upload", {}))
+      .rejects.toMatchObject({ code: "tool_not_registered" });
+    await expect(executeConfidentialToolCall(state, "eproduct-catalog", "list_products", {}))
+      .rejects.toMatchObject({ code: "tool_not_registered" });
+    await expect(executeConfidentialToolCall(state, "eproduct-catalog", "presign_file_upload", {
+      bytes: "never accepted",
+    }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+  });
+
+  it("does not copy upstream connection errors into the broker error", async () => {
+    const state = createState({
+      config: { mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } } },
+    });
+    state.manager.getConnection.mockReturnValue(undefined);
+    state.manager.connect.mockRejectedValue(new Error("https://private.example/signed?token=secret"));
+
+    await expect(executeConfidentialToolCall(
+      state,
+      "eproduct-catalog",
+      "presign_file_upload",
+      {},
+    )).rejects.toMatchObject({ code: "call_failed" });
+    try {
+      await executeConfidentialToolCall(state, "eproduct-catalog", "presign_file_upload", {});
+    } catch (error) {
+      expect(error).toBeInstanceOf(McpConfidentialError);
+      expect(String(error)).not.toContain("private.example");
+      expect(String(error)).not.toContain("secret");
+    }
+  });
+});

--- a/__tests__/mcp-trace.test.ts
+++ b/__tests__/mcp-trace.test.ts
@@ -4,6 +4,7 @@ import {
   createMcpTraceEvent,
   isMcpTraceEnabled,
   McpTraceWriter,
+  runWithoutMcpTrace,
   wrapTransportWithMcpTrace,
 } from "../mcp-trace.ts";
 
@@ -136,6 +137,45 @@ describe("MCP protocol tracing", () => {
     underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/ping", params: {} });
     await wrapped.send({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
     expect(incoming).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses all protocol events for confidential internal work", async () => {
+    const record = vi.fn();
+    const sent = vi.fn(async () => undefined);
+    const incoming = vi.fn();
+    const underlying = fakeTransport({ send: sent });
+    const wrapped = wrapTransportWithMcpTrace(underlying, "private", "stdio", { record });
+    wrapped.onmessage = incoming;
+
+    await runWithoutMcpTrace(async () => {
+      underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/ping", params: {} });
+      await wrapped.send({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { secret: "never traced" } });
+    });
+
+    expect(incoming).toHaveBeenCalledOnce();
+    expect(sent).toHaveBeenCalledOnce();
+    expect(record).not.toHaveBeenCalled();
+
+    // A real transport may deliver a response from a socket callback after the
+    // AsyncLocalStorage scope has ended; its request id remains suppressed.
+    underlying.onmessage?.({ jsonrpc: "2.0", id: 1, result: { url: "https://private.example/signed" } });
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it("suppresses uncorrelated notifications while confidential work is pending", async () => {
+    const record = vi.fn();
+    const incoming = vi.fn();
+    const underlying = fakeTransport();
+    const wrapped = wrapTransportWithMcpTrace(underlying, "private", "stdio", { record });
+    wrapped.onmessage = incoming;
+    let release!: () => void;
+    const pending = runWithoutMcpTrace(() => new Promise<void>(resolve => { release = resolve; }));
+
+    underlying.onmessage?.({ jsonrpc: "2.0", method: "notifications/message", params: { text: "private" } });
+    expect(incoming).toHaveBeenCalledOnce();
+    expect(record).not.toHaveBeenCalled();
+    release();
+    await pending;
   });
 
   it("keeps transport behavior when onmessage cannot be redefined", async () => {

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8")) as {
+  version?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   files?: string[];
@@ -22,6 +23,10 @@ const hostPeerPackages = {
 };
 
 describe("package.json files", () => {
+  it("reserves the next unpublished semver for the confidential workflow API", () => {
+    expect(packageJson.version).toBe("2.32.0");
+  });
+
   it("exports source entry points and plain Node host helpers", () => {
     expect(packageJson.types).toBe("./index.ts");
     expect(packageJson.exports).toMatchObject({

--- a/__tests__/runtime-register.test.ts
+++ b/__tests__/runtime-register.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   initializeMcp: vi.fn(),
   updateStatusBar: vi.fn(),
+  updateServerMetadata: vi.fn(),
   flushMetadataCache: vi.fn(),
   notifyToolMetadataUpdated: vi.fn(),
   initializeOAuth: vi.fn().mockResolvedValue(undefined),
@@ -45,6 +46,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../init.ts", () => ({
   initializeMcp: mocks.initializeMcp,
   updateStatusBar: mocks.updateStatusBar,
+  updateServerMetadata: mocks.updateServerMetadata,
   flushMetadataCache: mocks.flushMetadataCache,
   notifyToolMetadataUpdated: mocks.notifyToolMetadataUpdated,
 }));
@@ -226,6 +228,61 @@ describe("runtime MCP server registration", () => {
       url: "https://event.test/mcp",
       directTools: false,
     });
+  });
+
+  it("registers only the allowlisted catalog workflow and hides its tools", async () => {
+    const state = createState();
+    state.config.mcpServers = {
+      "eproduct-catalog": {
+        url: "https://catalog.example/mcp",
+        excludeTools: ["presign_file_upload", "confirm_file_upload"],
+      },
+    };
+    state.manager.getConnection.mockReturnValue({ status: "connected" });
+    state.toolMetadata.set("eproduct-catalog", [
+      { originalName: "presign_file_upload", name: "catalog_presign", description: "private" },
+      { originalName: "confirm_file_upload", name: "catalog_confirm", description: "private" },
+      { originalName: "list_products", name: "catalog_list", description: "visible" },
+    ]);
+    mocks.loadMcpConfig.mockReturnValue({
+      mcpServers: { "eproduct-catalog": { url: "https://catalog.example/mcp" } },
+    });
+    mocks.initializeMcp.mockResolvedValue(state);
+    const {
+      default: mcpAdapter,
+      MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+      registerMcpConfidentialWorkflow,
+    } = await import("../index.ts");
+    const events = createEventBus();
+    const { api: adapterApi, handlers } = createPi(events);
+    const { api: consumerApi } = createPi(events);
+    mcpAdapter(adapterApi);
+    await handlers.get("session_start")?.({}, {});
+    await settle();
+
+    const workflow = registerMcpConfidentialWorkflow({
+      pi: consumerApi,
+      workflow: MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+    });
+
+    expect(state.config.mcpServers["eproduct-catalog"].excludeTools).toEqual([
+      "presign_file_upload",
+      "confirm_file_upload",
+    ]);
+    expect(mocks.updateServerMetadata).toHaveBeenCalledWith(state, "eproduct-catalog");
+    expect(state.toolMetadata.get("eproduct-catalog")).toEqual([
+      { originalName: "list_products", name: "catalog_list", description: "visible" },
+    ]);
+    await expect(workflow.call("list_products", {})).rejects.toMatchObject({ code: "tool_not_registered" });
+    expect(() => registerMcpConfidentialWorkflow({
+      pi: consumerApi,
+      workflow: "not-reviewed" as never,
+    })).toThrow(/invalid_request/);
+    await workflow.dispose();
+    expect(state.config.mcpServers["eproduct-catalog"].excludeTools).toEqual([
+      "presign_file_upload",
+      "confirm_file_upload",
+    ]);
   });
 
   it("returns event registration failures in the mutable result", async () => {

--- a/__tests__/server-manager-runtime-owner.test.ts
+++ b/__tests__/server-manager-runtime-owner.test.ts
@@ -26,6 +26,9 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     });
     this.listTools = vi.fn(async () => ({ tools: [] }));
     this.listResources = vi.fn(async () => ({ resources: [] }));
+    this.callTool = vi.fn(async (request: any) => ({
+      content: [{ type: "text", text: JSON.stringify({ tool: request.name }) }],
+    }));
     this.close = vi.fn(async () => undefined);
     mocks.clients.push(this);
   }),
@@ -132,6 +135,22 @@ describe("MCP manager owner races", () => {
 
     await expect(connecting).rejects.toThrow("MCP connection setup failed");
     expect(mocks.clients[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("executes trusted calls through the connected client with request cancellation", async () => {
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager("/tmp/session");
+    await manager.connect("demo", { command: "node", args: ["server.js"] });
+    const signal = new AbortController().signal;
+
+    const result = await manager.callTool("demo", "private_tool", { value: "safe" }, signal);
+
+    expect(result).toMatchObject({ content: [{ type: "text" }] });
+    expect(mocks.clients[0].callTool).toHaveBeenCalledWith(
+      { name: "private_tool", arguments: { value: "safe" } },
+      expect.objectContaining({ signal }),
+    );
+    expect(manager.getConnection("demo")?.inFlight).toBe(0);
   });
 
   it("rejects connections after terminal manager shutdown", async () => {

--- a/confidential-workflow.ts
+++ b/confidential-workflow.ts
@@ -3,7 +3,13 @@ import type { McpExtensionState } from "./state.ts";
 import { throwIfAborted } from "./abort.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import { runWithoutMcpTrace } from "./mcp-trace.ts";
-import { isServerDisabled } from "./types.ts";
+import {
+  formatToolName,
+  isServerDisabled,
+  resolveToolPrefix,
+  type ToolMetadata,
+} from "./types.ts";
+import { ensureToolCallApproved } from "./tool-approval.ts";
 
 /**
  * The confidential bridge is deliberately an allowlist, not a general-purpose
@@ -36,6 +42,87 @@ const CONFIDENTIAL_TOOL_ARGUMENT_KEYS: Readonly<Record<string, ReadonlySet<strin
   confirm_file_upload: new Set(["upload_id", "store_id", "filename", "locale"]),
 });
 
+const CONFIDENTIAL_STORE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,29}$/;
+const CONFIDENTIAL_LOCALE_PATTERN = /^[a-z]{2,3}(?:-[a-z]{2,4})?$/;
+const CONFIDENTIAL_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\.(?:pdf|xlsx)$/;
+const CONFIDENTIAL_UPLOAD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const CONFIDENTIAL_MAX_FILENAME_LENGTH = 256;
+const CONFIDENTIAL_MAX_FILE_SIZE = 100 * 1024 * 1024;
+const CONFIDENTIAL_CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    const keys = Reflect.ownKeys(value);
+    return keys.every((key) => {
+      if (typeof key !== "string") return false;
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      return descriptor !== undefined &&
+        Object.hasOwn(descriptor, "value") &&
+        descriptor.enumerable === true;
+    });
+  } catch {
+    return false;
+  }
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: ReadonlySet<string>): boolean {
+  try {
+    const keys = Reflect.ownKeys(value);
+    return keys.length === expected.size &&
+      keys.every((key) => typeof key === "string" && expected.has(key));
+  } catch {
+    return false;
+  }
+}
+
+function isSafeBoundedString(value: unknown, pattern: RegExp, maximum: number): value is string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maximum &&
+    !CONFIDENTIAL_CONTROL_CHARACTER_PATTERN.test(value) &&
+    pattern.test(value);
+}
+
+function validateConfidentialArguments(
+  toolName: string,
+  args: unknown,
+): Record<string, unknown> {
+  if (!isPlainRecord(args)) fail("invalid_request");
+  const expectedKeys = CONFIDENTIAL_TOOL_ARGUMENT_KEYS[toolName];
+  if (!expectedKeys || !hasExactKeys(args, expectedKeys)) fail("invalid_request");
+
+  const values = Object.fromEntries(Object.keys(args).map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(args, key);
+    return [key, descriptor && "value" in descriptor ? descriptor.value : undefined];
+  }));
+  if (toolName === "presign_file_upload") {
+    if (!isSafeBoundedString(values.store_id, CONFIDENTIAL_STORE_PATTERN, 30) ||
+      !isSafeBoundedString(values.locale, CONFIDENTIAL_LOCALE_PATTERN, 8) ||
+      !isSafeBoundedString(values.filename, CONFIDENTIAL_FILENAME_PATTERN, CONFIDENTIAL_MAX_FILENAME_LENGTH) ||
+      Number.isSafeInteger(values.size_bytes) === false ||
+      (values.size_bytes as number) < 1 ||
+      (values.size_bytes as number) > CONFIDENTIAL_MAX_FILE_SIZE ||
+      /[\\/]/.test(values.filename)) {
+      fail("invalid_request");
+    }
+  } else if (
+    !isSafeBoundedString(values.upload_id, CONFIDENTIAL_UPLOAD_ID_PATTERN, 128) ||
+    !isSafeBoundedString(values.store_id, CONFIDENTIAL_STORE_PATTERN, 30) ||
+    !isSafeBoundedString(values.filename, CONFIDENTIAL_FILENAME_PATTERN, CONFIDENTIAL_MAX_FILENAME_LENGTH) ||
+    !isSafeBoundedString(values.locale, CONFIDENTIAL_LOCALE_PATTERN, 8) ||
+    /[\\/]/.test(values.filename)
+  ) {
+    fail("invalid_request");
+  }
+
+  // Approval handlers are other extensions. Keep their preview immutable so
+  // a handler cannot rewrite the validated payload before the MCP call.
+  return Object.freeze(values) as Record<string, unknown>;
+}
+
 /** Return the immutable allowlist entry for the one supported trusted workflow. */
 export function getConfidentialWorkflowSpec(
   name: string,
@@ -53,6 +140,8 @@ export type McpConfidentialErrorCode =
   | "server_disabled"
   | "server_not_connected"
   | "auth_required"
+  | "approval_denied"
+  | "approval_required"
   | "aborted"
   | "call_failed";
 
@@ -101,9 +190,10 @@ function isAbortLike(error: unknown, signal: AbortSignal | undefined): boolean {
 
 /**
  * Execute one registered confidential MCP operation without going through the
- * model-facing proxy/direct-tool execution path. No result guard, renderer,
- * approval event, UI session, metadata publication, normal MCP trace, or
- * provider error is returned by this function.
+ * model-facing proxy/direct-tool execution path. Approval is handled by the
+ * existing broker contract with validated arguments. No result guard, renderer,
+ * UI session, metadata publication, normal MCP trace, or provider error is
+ * returned by this function.
  */
 export async function executeConfidentialToolCall(
   state: McpExtensionState,
@@ -121,13 +211,6 @@ export async function executeConfidentialToolCall(
       toolName as typeof MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS[number],
     )
   ) fail("tool_not_registered");
-  if (args !== undefined && (
-    typeof args !== "object" ||
-    args === null ||
-    Array.isArray(args) ||
-    Object.keys(args).some(key => !CONFIDENTIAL_TOOL_ARGUMENT_KEYS[toolName]?.has(key))
-  )) fail("invalid_request");
-
   const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
   try {
     throwIfAborted(ownedSignal);
@@ -135,9 +218,37 @@ export async function executeConfidentialToolCall(
     fail("aborted");
   }
 
+  const normalizedArgs = validateConfidentialArguments(toolName, args);
+
   const definition = state.config.mcpServers[serverName];
   if (!definition) fail("server_not_found");
   if (isServerDisabled(definition)) fail("server_disabled");
+
+  const toolMeta: ToolMetadata = {
+    name: formatToolName(toolName, serverName, resolveToolPrefix(definition, state.config.settings?.toolPrefix)),
+    originalName: toolName,
+    description: `Confidential workflow tool ${toolName}`,
+  };
+  let approval: Awaited<ReturnType<typeof ensureToolCallApproved>>;
+  try {
+    approval = await ensureToolCallApproved(
+      state,
+      serverName,
+      toolMeta,
+      normalizedArgs,
+      ownedSignal,
+      "proxy",
+      new Map([[serverName, [toolMeta]]]),
+    );
+  } catch (error) {
+    if (isAbortLike(error, ownedSignal)) fail("aborted");
+    // Approval handlers are extension-owned, but an unexpected handler/UI
+    // failure must not expose its error or accidentally authorize the call.
+    fail("call_failed");
+  }
+  if (!approval.ok) {
+    fail(approval.reason === "denied" ? "approval_denied" : "approval_required");
+  }
 
   let connection = state.manager.getConnection(serverName);
   try {
@@ -158,7 +269,7 @@ export async function executeConfidentialToolCall(
 
   try {
     return await runWithoutMcpTrace(() =>
-      state.manager.callTool(serverName, toolName, args, ownedSignal)
+      state.manager.callTool(serverName, toolName, normalizedArgs, ownedSignal)
     );
   } catch (error) {
     if (isAbortLike(error, ownedSignal)) throw new McpConfidentialError("aborted");

--- a/confidential-workflow.ts
+++ b/confidential-workflow.ts
@@ -1,0 +1,221 @@
+import type { CallToolResult } from "@modelcontextprotocol/client";
+import type { McpExtensionState } from "./state.ts";
+import { throwIfAborted } from "./abort.ts";
+import { combineAbortSignals } from "./runtime-owner.ts";
+import { runWithoutMcpTrace } from "./mcp-trace.ts";
+import { isServerDisabled } from "./types.ts";
+
+/**
+ * The confidential bridge is deliberately an allowlist, not a general-purpose
+ * raw MCP escape hatch. Add a workflow here only when its safe projection and
+ * owning extension have been reviewed together.
+ */
+export const MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD =
+  "dps-catalog-local-upload:v1" as const;
+
+export type McpConfidentialWorkflowName =
+  typeof MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD;
+
+export const MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS = Object.freeze([
+  "presign_file_upload",
+  "confirm_file_upload",
+]) as readonly ["presign_file_upload", "confirm_file_upload"];
+
+export interface ConfidentialWorkflowSpec {
+  readonly serverName: "eproduct-catalog";
+  readonly tools: typeof MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS;
+}
+
+const CATALOG_LOCAL_UPLOAD_SPEC: ConfidentialWorkflowSpec = Object.freeze({
+  serverName: "eproduct-catalog",
+  tools: MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS,
+});
+
+const CONFIDENTIAL_TOOL_ARGUMENT_KEYS: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
+  presign_file_upload: new Set(["store_id", "locale", "filename", "size_bytes"]),
+  confirm_file_upload: new Set(["upload_id", "store_id", "filename", "locale"]),
+});
+
+/** Return the immutable allowlist entry for the one supported trusted workflow. */
+export function getConfidentialWorkflowSpec(
+  name: string,
+): ConfidentialWorkflowSpec | undefined {
+  if (name !== MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD) return undefined;
+  return CATALOG_LOCAL_UPLOAD_SPEC;
+}
+
+/** Stable, non-sensitive errors exposed by the confidential bridge. */
+export type McpConfidentialErrorCode =
+  | "invalid_request"
+  | "workflow_not_registered"
+  | "tool_not_registered"
+  | "server_not_found"
+  | "server_disabled"
+  | "server_not_connected"
+  | "auth_required"
+  | "aborted"
+  | "call_failed";
+
+export class McpConfidentialError extends Error {
+  readonly code: McpConfidentialErrorCode;
+
+  constructor(code: McpConfidentialErrorCode) {
+    super(`Confidential MCP operation failed (${code})`);
+    this.name = "McpConfidentialError";
+    this.code = code;
+  }
+}
+
+/**
+ * The raw SDK result is available only to trusted extension code. A workflow
+ * implementation must project it before returning anything from a model-facing
+ * tool. This type is intentionally not part of any registered Pi tool schema.
+ */
+export type McpConfidentialCallResult = CallToolResult;
+
+/** Trusted extension handle returned by the fixed, versioned allowlist. */
+export interface McpConfidentialWorkflow {
+  readonly name: McpConfidentialWorkflowName;
+  readonly serverName: "eproduct-catalog";
+  call(
+    toolName: string,
+    args?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<McpConfidentialCallResult>;
+  dispose(): Promise<void>;
+}
+
+export type McpConfidentialWorkflowRegistrationResult =
+  | { ok: true; workflow: McpConfidentialWorkflow }
+  | { ok: false; error: McpConfidentialError };
+
+function fail(code: McpConfidentialErrorCode): never {
+  throw new McpConfidentialError(code);
+}
+
+function isAbortLike(error: unknown, signal: AbortSignal | undefined): boolean {
+  if (signal?.aborted) return true;
+  return error instanceof Error &&
+    (error.name === "AbortError" || error.name === "TimeoutError");
+}
+
+/**
+ * Execute one registered confidential MCP operation without going through the
+ * model-facing proxy/direct-tool execution path. No result guard, renderer,
+ * approval event, UI session, metadata publication, normal MCP trace, or
+ * provider error is returned by this function.
+ */
+export async function executeConfidentialToolCall(
+  state: McpExtensionState,
+  serverName: string,
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  signal?: AbortSignal,
+): Promise<McpConfidentialCallResult> {
+  if (typeof serverName !== "string" || typeof toolName !== "string" || !serverName.trim() || !toolName.trim()) {
+    fail("invalid_request");
+  }
+  if (
+    serverName !== CATALOG_LOCAL_UPLOAD_SPEC.serverName ||
+    !MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS.includes(
+      toolName as typeof MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS[number],
+    )
+  ) fail("tool_not_registered");
+  if (args !== undefined && (
+    typeof args !== "object" ||
+    args === null ||
+    Array.isArray(args) ||
+    Object.keys(args).some(key => !CONFIDENTIAL_TOOL_ARGUMENT_KEYS[toolName]?.has(key))
+  )) fail("invalid_request");
+
+  const ownedSignal = combineAbortSignals(state.owner?.signal, signal);
+  try {
+    throwIfAborted(ownedSignal);
+  } catch {
+    fail("aborted");
+  }
+
+  const definition = state.config.mcpServers[serverName];
+  if (!definition) fail("server_not_found");
+  if (isServerDisabled(definition)) fail("server_disabled");
+
+  let connection = state.manager.getConnection(serverName);
+  try {
+    if (!connection || connection.status === "closed") {
+      connection = await runWithoutMcpTrace(() =>
+        state.manager.connect(serverName, definition, ownedSignal)
+      );
+    }
+  } catch (error) {
+    if (isAbortLike(error, ownedSignal)) throw new McpConfidentialError("aborted");
+    // Deliberately drop the provider error. It can contain URLs, headers, or
+    // response bodies and must never become a transcript-visible error.
+    fail("call_failed");
+  }
+
+  if (connection.status === "needs-auth") fail("auth_required");
+  if (connection.status !== "connected") fail("server_not_connected");
+
+  try {
+    return await runWithoutMcpTrace(() =>
+      state.manager.callTool(serverName, toolName, args, ownedSignal)
+    );
+  } catch (error) {
+    if (isAbortLike(error, ownedSignal)) throw new McpConfidentialError("aborted");
+    // Never preserve the raw CallToolResult or provider exception on failure.
+    fail("call_failed");
+  }
+}
+
+/** Apply trusted workflow exclusions to a freshly loaded adapter config. */
+export function applyConfidentialToolFilters(
+  config: { mcpServers: Record<string, { excludeTools?: string[] }> },
+  tools: Record<string, string[]> | undefined,
+): void {
+  if (!tools) return;
+  for (const [serverName, names] of Object.entries(tools)) {
+    const definition = config.mcpServers[serverName];
+    if (!definition || !Array.isArray(names) || names.length === 0) continue;
+    const excluded = new Set(definition.excludeTools ?? []);
+    for (const toolName of names) {
+      if (typeof toolName === "string" && toolName.trim()) {
+        excluded.add(toolName.trim());
+      }
+    }
+    const nextExcluded = [...excluded];
+    if (
+      Array.isArray(definition.excludeTools) &&
+      definition.excludeTools.length === nextExcluded.length &&
+      definition.excludeTools.every((toolName, index) => toolName === nextExcluded[index])
+    ) continue;
+    config.mcpServers[serverName] = { ...definition, excludeTools: nextExcluded };
+  }
+}
+
+export interface ConfidentialCallExecutor {
+  callTool(
+    serverName: string,
+    toolName: string,
+    args: Record<string, unknown> | undefined,
+    signal?: AbortSignal,
+  ): Promise<McpConfidentialCallResult>;
+}
+
+/**
+ * Build the executor used by the adapter's in-process broker. Keeping this
+ * boundary small lets tests prove authorization and error redaction without
+ * starting a Pi session.
+ */
+export function createConfidentialCallExecutor(
+  getState: () => McpExtensionState | null,
+  isRegistered: (serverName: string, toolName: string) => boolean,
+): ConfidentialCallExecutor {
+  return {
+    async callTool(serverName, toolName, args, signal) {
+      if (!isRegistered(serverName, toolName)) fail("tool_not_registered");
+      const state = getState();
+      if (!state) fail("server_not_connected");
+      return executeConfidentialToolCall(state, serverName, toolName, args, signal);
+    },
+  };
+}

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import type { TSchema } from "typebox";
 import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, authenticateServer, logoutServer, manageBearerToken, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { cloneMcpConfig, loadMcpConfig, writeProjectServerDisabledOverride } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, prepareDirectToolArguments, resolveDirectTools } from "./direct-tools.ts";
-import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
+import { flushMetadataCache, initializeMcp, updateServerMetadata, updateStatusBar } from "./init.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
@@ -22,9 +22,30 @@ import { publishMcpStatusShutdown } from "./mcp-status.ts";
 import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
 import { syncNamespaceProxyTools } from "./namespace-tools.ts";
+import {
+  applyConfidentialToolFilters,
+  createConfidentialCallExecutor,
+  getConfidentialWorkflowSpec,
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS,
+  McpConfidentialError,
+  type McpConfidentialWorkflow,
+  type McpConfidentialWorkflowName,
+  type McpConfidentialWorkflowRegistrationResult,
+} from "./confidential-workflow.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
+export {
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD,
+  MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS,
+  McpConfidentialError,
+  type McpConfidentialCallResult,
+  type McpConfidentialWorkflow,
+  type McpConfidentialWorkflowName,
+  type McpConfidentialWorkflowRegistrationResult,
+  type McpConfidentialErrorCode,
+} from "./confidential-workflow.ts";
 export {
   namespaceProxyName,
   parseMcpReference,
@@ -55,6 +76,16 @@ export interface McpServerRegistration {
 
 export const MCP_RUNTIME_REGISTER_EVENT = "pi-mcp-adapter:runtime-register:v1" as const;
 export const MCP_RUNTIME_REGISTER_VERSION = 1 as const;
+
+/** Versioned in-process bridge for the fixed trusted workflow allowlist. */
+export const MCP_CONFIDENTIAL_WORKFLOW_EVENT = "pi-mcp-adapter:confidential-workflow:v1" as const;
+export const MCP_CONFIDENTIAL_WORKFLOW_VERSION = 1 as const;
+
+export interface McpConfidentialWorkflowRequest {
+  version: typeof MCP_CONFIDENTIAL_WORKFLOW_VERSION;
+  workflow: string;
+  result?: McpConfidentialWorkflowRegistrationResult;
+}
 
 export const MCP_RUNTIME_SNAPSHOT_EVENT = "pi-mcp-adapter:runtime-snapshot:v1" as const;
 export const MCP_RUNTIME_SNAPSHOT_VERSION = 1 as const;
@@ -90,6 +121,7 @@ export interface McpRuntimeSnapshotRequest {
 // Fast path for callers that share the adapter's module and ExtensionAPI.
 const runtimeRegistrars = new WeakMap<ExtensionAPI, (name: string, definition: ServerEntry) => McpServerRegistration>();
 const runtimeSnapshotters = new WeakMap<ExtensionAPI, (name: string) => McpRuntimeServerSnapshot>();
+const confidentialWorkflowRegistrars = new WeakMap<ExtensionAPI, (workflow: string) => McpConfidentialWorkflow>();
 
 async function awaitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof INIT_WAIT_TIMED_OUT> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -236,6 +268,158 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   // survive session restarts within this install and die with the process.
   const runtimeServers = new Map<string, { definition: ServerEntry; entry: ServerEntry }>();
 
+  type ConfidentialRegistration = {
+    id: string;
+    workflow: McpConfidentialWorkflowName;
+    serverName: string;
+    tools: ReadonlySet<string>;
+  };
+  const confidentialRegistrations = new Map<string, ConfidentialRegistration>();
+  const confidentialTools = new Map<string, Set<string>>();
+  const confidentialManagedConfigs = new Map<McpConfig, Map<string, Set<string>>>();
+  let nextConfidentialWorkflowId = 1;
+
+  const baseConfidentialToolExclusions: Record<string, string[]> = {
+    "eproduct-catalog": [...MCP_CONFIDENTIAL_WORKFLOW_CATALOG_LOCAL_UPLOAD_TOOLS],
+  };
+
+  function confidentialToolsSnapshot(): Record<string, string[]> {
+    const snapshot = Object.fromEntries(
+      Object.entries(baseConfidentialToolExclusions).map(([serverName, tools]) => [serverName, [...tools]]),
+    ) as Record<string, string[]>;
+    for (const [serverName, tools] of confidentialTools) {
+      const merged = new Set(snapshot[serverName] ?? []);
+      for (const toolName of tools) merged.add(toolName);
+      snapshot[serverName] = [...merged];
+    }
+    return snapshot;
+  }
+
+  function addConfidentialFilters(config: McpConfig): void {
+    let additionsByServer = confidentialManagedConfigs.get(config);
+    if (!additionsByServer) {
+      additionsByServer = new Map();
+      confidentialManagedConfigs.set(config, additionsByServer);
+    }
+    for (const [serverName, tools] of confidentialTools) {
+      const definition = config.mcpServers[serverName];
+      if (!definition) continue;
+      const excluded = new Set(definition.excludeTools ?? []);
+      const additions = additionsByServer.get(serverName) ?? new Set<string>();
+      for (const toolName of tools) {
+        if (!excluded.has(toolName)) {
+          excluded.add(toolName);
+          additions.add(toolName);
+        }
+      }
+      additionsByServer.set(serverName, additions);
+      config.mcpServers[serverName] = {
+        ...definition,
+        excludeTools: [...excluded],
+      };
+    }
+  }
+
+  function removeConfidentialFilters(): void {
+    for (const [config, additionsByServer] of confidentialManagedConfigs) {
+      for (const [serverName, additions] of additionsByServer) {
+        if (confidentialTools.has(serverName)) continue;
+        const definition = config.mcpServers[serverName];
+        if (!definition) continue;
+        const excluded = new Set(definition.excludeTools ?? []);
+        for (const toolName of additions) excluded.delete(toolName);
+        config.mcpServers[serverName] = excluded.size > 0
+          ? { ...definition, excludeTools: [...excluded] }
+          : (() => {
+              const { excludeTools: _excludeTools, ...withoutExcludes } = definition;
+              return withoutExcludes;
+            })();
+        additionsByServer.delete(serverName);
+      }
+    }
+  }
+
+  function hideConfidentialMetadata(serverName: string): void {
+    if (!state) return;
+    const hidden = new Set(confidentialToolsSnapshot()[serverName] ?? []);
+    const metadata = state.toolMetadata.get(serverName);
+    if (hidden.size === 0 || !metadata) return;
+    state.toolMetadata.set(
+      serverName,
+      metadata.filter((tool) => !hidden.has(tool.originalName) && !hidden.has(tool.name)),
+    );
+  }
+
+  function refreshConfidentialSurface(serverName: string): void {
+    if (!state) return;
+    const connection = state.manager.getConnection(serverName);
+    if (connection?.status === "connected") updateServerMetadata(state, serverName);
+    hideConfidentialMetadata(serverName);
+    syncToolSurface();
+    updateStatusBar(state);
+  }
+
+  function applyConfidentialWorkflowRegistration(workflowName: string): McpConfidentialWorkflow {
+    const spec = getConfidentialWorkflowSpec(workflowName);
+    const registeredName = workflowName as McpConfidentialWorkflowName;
+    if (!spec) throw new McpConfidentialError("invalid_request");
+    const effectiveConfig = state?.config ?? earlyConfig;
+    if (!Object.hasOwn(effectiveConfig.mcpServers, spec.serverName) || !effectiveConfig.mcpServers[spec.serverName]) {
+      throw new McpConfidentialError("server_not_found");
+    }
+
+    const id = `confidential-${nextConfidentialWorkflowId++}`;
+    const registration: ConfidentialRegistration = {
+      id,
+      workflow: registeredName,
+      serverName: spec.serverName,
+      tools: new Set(spec.tools),
+    };
+    confidentialRegistrations.set(id, registration);
+    const hidden = confidentialTools.get(spec.serverName) ?? new Set<string>();
+    for (const toolName of spec.tools) hidden.add(toolName);
+    confidentialTools.set(spec.serverName, hidden);
+    addConfidentialFilters(earlyConfig);
+    if (sessionConfig) addConfidentialFilters(sessionConfig);
+    if (state) {
+      addConfidentialFilters(state.config);
+      refreshConfidentialSurface(spec.serverName);
+    }
+
+    const executor = createConfidentialCallExecutor(
+      () => state,
+      (candidateServer, toolName) => confidentialTools.get(candidateServer)?.has(toolName) === true
+        && confidentialRegistrations.has(id)
+        && confidentialRegistrations.get(id)?.tools.has(toolName) === true,
+    );
+    let disposed = false;
+    return {
+      name: registeredName,
+      serverName: spec.serverName,
+      call: async (toolName, args, signal) => {
+        if (disposed) throw new McpConfidentialError("workflow_not_registered");
+        if (typeof toolName !== "string" || !registration.tools.has(toolName)) {
+          throw new McpConfidentialError("tool_not_registered");
+        }
+        return executor.callTool(spec.serverName, toolName, args, signal);
+      },
+      dispose: async () => {
+        if (disposed) return;
+        disposed = true;
+        confidentialRegistrations.delete(id);
+        const remaining = new Set<string>();
+        for (const active of confidentialRegistrations.values()) {
+          if (active.serverName !== spec.serverName) continue;
+          for (const toolName of active.tools) remaining.add(toolName);
+        }
+        if (remaining.size > 0) confidentialTools.set(spec.serverName, remaining);
+        else confidentialTools.delete(spec.serverName);
+        removeConfidentialFilters();
+        refreshConfidentialSurface(spec.serverName);
+      },
+    };
+  }
+
   // Mirrors init's per-server lifecycle registration so runtime servers get
   // idle cleanup and keep-alive health recovery like configured servers.
   function attachRuntimeServerLifecycle(targetState: McpExtensionState, name: string, definition: ServerEntry): void {
@@ -378,6 +562,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   function syncToolSurface(ctx?: ExtensionContext): void {
     const config = state?.config ?? earlyConfig;
+    applyConfidentialToolFilters(config, confidentialToolsSnapshot());
     const cache = loadMetadataCache();
     const result = syncDirectTools(config, cache);
     syncProxyTool(config, cache, result.specs);
@@ -503,6 +688,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   };
   runtimeRegistrars.set(pi, registerRuntimeServer);
   runtimeSnapshotters.set(pi, getRuntimeServerSnapshot);
+  confidentialWorkflowRegistrars.set(pi, applyConfidentialWorkflowRegistration);
   pi.events.on(MCP_RUNTIME_REGISTER_EVENT, (rawRequest: unknown) => {
     if (typeof rawRequest !== "object" || rawRequest === null || Array.isArray(rawRequest)) return;
     const request = rawRequest as McpRuntimeRegistrationRequest;
@@ -531,6 +717,28 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       request.result = { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     }
   });
+  pi.events.on(MCP_CONFIDENTIAL_WORKFLOW_EVENT, (rawRequest: unknown) => {
+    if (typeof rawRequest !== "object" || rawRequest === null || Array.isArray(rawRequest)) return;
+    const request = rawRequest as McpConfidentialWorkflowRequest;
+    if (request.result !== undefined) return;
+    if (request.version !== MCP_CONFIDENTIAL_WORKFLOW_VERSION || typeof request.workflow !== "string") {
+      request.result = { ok: false, error: new McpConfidentialError("invalid_request") };
+      return;
+    }
+    try {
+      request.result = {
+        ok: true,
+        workflow: applyConfidentialWorkflowRegistration(request.workflow),
+      };
+    } catch (error) {
+      request.result = {
+        ok: false,
+        error: error instanceof McpConfidentialError
+          ? error
+          : new McpConfidentialError("invalid_request"),
+      };
+    }
+  });
 
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
 
@@ -541,6 +749,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
   function startInitialization(ctx: ExtensionContext, owner: McpRuntimeOwner, oauthRuntime: McpOAuthRuntime, generation: number, staleReason: string): Promise<void> {
     owner.addCleanup(() => cleanupMaterializedBinaryResources(owner.signal));
+    const hiddenTools = confidentialToolsSnapshot();
     const promise = initializeMcp(pi, ctx, owner, {
       ...(programmaticConfig || options.configPath !== undefined
         ? {
@@ -548,6 +757,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
             ...(sessionConfig !== undefined ? { config: sessionConfig } : {}),
           }
         : {}),
+      ...(Object.keys(hiddenTools).length > 0 ? { confidentialToolExclusions: hiddenTools } : {}),
       oauthRuntime,
     });
     initPromise = promise;
@@ -563,6 +773,10 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
 
       state = nextState;
+      // A workflow may register while initialization is already in flight. The
+      // captured startup config can therefore predate the current exclusions;
+      // reapply them before any live metadata reaches a model-facing surface.
+      applyConfidentialToolFilters(nextState.config, confidentialToolsSnapshot());
       clearRetainedInitFailure();
       for (const [name, { entry }] of runtimeServers) {
         if (Object.hasOwn(nextState.config.mcpServers, name)) {
@@ -1222,6 +1436,12 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
   }
 
+  applyConfidentialToolFilters(earlyConfig, baseConfidentialToolExclusions);
+  addConfidentialFilters(earlyConfig);
+  if (sessionConfig) {
+    applyConfidentialToolFilters(sessionConfig, baseConfidentialToolExclusions);
+    addConfidentialFilters(sessionConfig);
+  }
   const initialDirectResult = syncDirectTools(earlyConfig, earlyCache);
   syncProxyTool(earlyConfig, earlyCache, initialDirectResult.specs);
   // Register namespace-proxy tools eagerly so tool-groups/slow-mode can validate
@@ -1264,6 +1484,31 @@ export function registerMcpServer(options: { pi: ExtensionAPI; name: string; def
   }
   if (!request.result.ok) throw request.result.error;
   return request.result.registration;
+}
+
+/**
+ * Register one reviewed trusted workflow from the adapter's fixed allowlist.
+ * The returned handle is the only supported way for that extension to call
+ * the hidden MCP tools; raw results stay in process memory for safe projection.
+ */
+export function registerMcpConfidentialWorkflow(options: {
+  pi: ExtensionAPI;
+  workflow: McpConfidentialWorkflowName;
+}): McpConfidentialWorkflow {
+  const { pi, workflow } = options;
+  const register = confidentialWorkflowRegistrars.get(pi);
+  if (register) return register(workflow);
+  const request: McpConfidentialWorkflowRequest = {
+    version: MCP_CONFIDENTIAL_WORKFLOW_VERSION,
+    workflow,
+  };
+  pi.events.emit(MCP_CONFIDENTIAL_WORKFLOW_EVENT, request);
+  if (!request.result) {
+    throw new McpConfidentialError("workflow_not_registered");
+  }
+  const registrationResult = request.result;
+  if (!registrationResult.ok) throw registrationResult.error;
+  return registrationResult.workflow;
 }
 
 /**

--- a/init.ts
+++ b/init.ts
@@ -38,6 +38,7 @@ import {
 } from "./runtime-owner.ts";
 import { publishMcpStatusSnapshot } from "./mcp-status.ts";
 import { FAILURE_BACKOFF_MS, getFailureAgeSeconds } from "./failure-backoff.ts";
+import { applyConfidentialToolFilters } from "./confidential-workflow.ts";
 export { getFailureAgeSeconds, getFailureMessage, isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 const MAX_FAILURE_MESSAGE_CHARS = 8 * 1024;
@@ -96,6 +97,8 @@ export function isTuiMode(ctx: Pick<ExtensionContext, "hasUI" | "mode">): boolea
 }
 
 type McpInitializationOptions = McpAdapterOptions & {
+  /** Adapter-internal exclusions retained across session initialization. */
+  confidentialToolExclusions?: Record<string, string[]>;
   oauthRuntime?: McpOAuthRuntime;
   statusEvents?: McpExtensionState["statusEvents"];
 };
@@ -122,6 +125,7 @@ export async function initializeMcp(
   const config = options.config !== undefined
     ? cloneMcpConfig(options.config)
     : loadMcpConfig(configPath, cwd);
+  applyConfidentialToolFilters(config, options.confidentialToolExclusions);
   const authStorageOptions = getAuthStorageOptions(config.settings?.oauthDir, cwd);
 
   const ownsOAuthRuntime = options.oauthRuntime === undefined;

--- a/mcp-trace.ts
+++ b/mcp-trace.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { Buffer } from "node:buffer";
 import { dirname, isAbsolute, resolve } from "node:path";
@@ -7,6 +8,36 @@ import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/cli
 export const MCP_TRACE_SCHEMA_VERSION = 1;
 export const DEFAULT_MCP_TRACE_MAX_BYTES = 256 * 1024;
 export const DEFAULT_MCP_TRACE_MAX_EVENTS = 10_000;
+
+interface TraceSuppressionContext {
+  readonly suppress: true;
+}
+
+const traceSuppression = new AsyncLocalStorage<TraceSuppressionContext>();
+let activeSuppressedOperations = 0;
+
+/** Run trusted internal work without creating protocol trace events. */
+export function runWithoutMcpTrace<T>(operation: () => T): T {
+  activeSuppressedOperations += 1;
+  let result: T;
+  try {
+    result = traceSuppression.run({ suppress: true }, operation);
+  } catch (error) {
+    activeSuppressedOperations -= 1;
+    throw error;
+  }
+  if (result && typeof (result as { then?: unknown }).then === "function") {
+    return Promise.resolve(result).finally(() => {
+      activeSuppressedOperations -= 1;
+    }) as T;
+  }
+  activeSuppressedOperations -= 1;
+  return result;
+}
+
+function isMcpTraceSuppressed(): boolean {
+  return activeSuppressedOperations > 0 || traceSuppression.getStore()?.suppress === true;
+}
 
 export type McpTraceDirection = "outbound" | "inbound";
 export type McpTraceTransport = "stdio" | "unix-socket" | "sse" | "streamable-http" | "unknown";
@@ -242,6 +273,30 @@ export function wrapTransportWithMcpTrace(
   let messageHandler = transport.onmessage;
   let tracedMessageHandler: Transport["onmessage"];
   const originalSend = transport.send;
+  // AsyncLocalStorage follows the outbound send, but an SDK transport can
+  // deliver notifications or responses from socket callbacks created before
+  // that context. The global operation counter suppresses uncorrelated events
+  // while trusted work is pending; retain only request IDs after it settles so
+  // late responses remain absent without retaining payloads or URLs.
+  const suppressedRequestIds = new Set<string>();
+  const requestIdKey = (message: JSONRPCMessage): string | undefined => {
+    if (!("id" in message)) return undefined;
+    if (typeof message.id === "string") return `s:${message.id}`;
+    if (typeof message.id === "number" && Number.isFinite(message.id)) return `n:${message.id}`;
+    return undefined;
+  };
+  const shouldSuppressMessage = (message: JSONRPCMessage): boolean => {
+    const requestId = requestIdKey(message);
+    if (isMcpTraceSuppressed()) {
+      if (requestId !== undefined && "method" in message) suppressedRequestIds.add(requestId);
+      if (requestId !== undefined && !("method" in message)) suppressedRequestIds.delete(requestId);
+      return true;
+    }
+    if (requestId !== undefined && !("method" in message) && suppressedRequestIds.delete(requestId)) {
+      return true;
+    }
+    return false;
+  };
   const record = (event: McpTraceEvent): void => {
     try {
       observer.record(event);
@@ -261,7 +316,9 @@ export function wrapTransportWithMcpTrace(
         messageHandler = handler;
         tracedMessageHandler = handler
           ? ((message: JSONRPCMessage, extra?: MessageExtraInfo) => {
-              record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
+              if (!shouldSuppressMessage(message)) {
+                record(createMcpTraceEvent("inbound", server, transportKind, message, "received"));
+              }
               handler(message, extra);
             })
           : undefined;
@@ -276,18 +333,34 @@ export function wrapTransportWithMcpTrace(
   transport.send = async (message: JSONRPCMessage, options?: Parameters<Transport["send"]>[1]) => {
     const started = performance.now();
     const messages = Array.isArray(message) ? message : [message];
+    const suppressOutbound = isMcpTraceSuppressed();
+    if (suppressOutbound) {
+      for (const item of messages) {
+        const requestId = requestIdKey(item);
+        if (requestId !== undefined && "method" in item) suppressedRequestIds.add(requestId);
+      }
+    }
     try {
       await originalSend.call(transport, message, options);
       for (const item of messages) {
+        if (suppressOutbound || shouldSuppressMessage(item)) continue;
         record(createMcpTraceEvent("outbound", server, transportKind, item, "sent", {
           durationMs: performance.now() - started,
         }));
       }
     } catch (error) {
       for (const item of messages) {
-        record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
-          durationMs: performance.now() - started,
-        }));
+        const requestId = requestIdKey(item);
+        if (suppressOutbound) {
+          // Keep the id: a transport may reject locally after handing the
+          // request to a socket, which can still deliver a late response.
+          continue;
+        }
+        if (!shouldSuppressMessage(item)) {
+          record(createMcpTraceEvent("outbound", server, transportKind, item, "error", {
+            durationMs: performance.now() - started,
+          }));
+        }
       }
       throw error;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-mcp-adapter",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-mcp-adapter",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/client": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-mcp-adapter",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "MCP (Model Context Protocol) adapter extension for Pi coding agent",
   "type": "module",
   "types": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "direct-tools.ts",
     "namespace-tools.ts",
     "mcp-references.ts",
+    "confidential-workflow.ts",
     "commands.ts",
     "prompts.ts",
     "onboarding-state.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -8,6 +8,7 @@ import {
   SSEClientTransport,
   StreamableHTTPClientTransport,
   UnauthorizedError,
+  type CallToolResult,
   type GetPromptResult,
   type ListToolsResult,
   type ReadResourceResult,
@@ -1449,6 +1450,41 @@ export class McpServerManager {
 
   removeUiStreamListener(streamToken: string): void {
     this.uiStreamListeners.delete(streamToken);
+  }
+
+  /**
+   * Call a tool for trusted adapter code without exposing the result through
+   * the model-facing execution path. The caller owns authorization and safe
+   * projection; this method only manages the connection's activity counters
+   * and request-scoped cancellation.
+   */
+  async callTool(
+    name: string,
+    toolName: string,
+    args?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<CallToolResult> {
+    const connection = this.connections.get(name);
+    if (!connection || connection.status !== "connected") {
+      throw new Error(`Server "${name}" is not connected`);
+    }
+
+    const ownedSignal = combineAbortSignals(this.runtimeSignal, signal);
+    throwIfAborted(ownedSignal);
+    try {
+      this.touch(name);
+      this.incrementInFlight(name);
+      return await abortable(
+        connection.client.callTool(
+          { name: toolName, ...(args ? { arguments: args } : {}) },
+          this.getRequestOptions(name, ownedSignal),
+        ),
+        ownedSignal,
+      ) as CallToolResult;
+    } finally {
+      this.decrementInFlight(name);
+      this.touch(name);
+    }
   }
 
   async getPrompt(


### PR DESCRIPTION
## Summary
- add an allowlisted confidential workflow broker that reuses existing MCP/OAuth sessions
- suppress raw workflow responses from tool results and traces
- allow model-visible tool filtering so sensitive presign/confirm tools stay hidden
- validate server, tool and argument allowlists with stable sanitized errors

## Verification
- `npm run typecheck`
- `npm run test:public-exports`
- 34 focused Vitest checks across confidential workflow, trace, runtime registration and server ownership
- staged secret scan passed

## Context
Required by https://github.com/dpscompany/eproduct-sender/issues/146. No release or installation is included.