### PR TITLE
fix(proxy): make the per-server status note say what is actually wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)
 - Implicit OAuth now reuses URL-bound stored credentials while preserving anonymous fallback. Thanks to [@wilt00](https://github.com/wilt00) for #471.
+- Per-server proxy lists now distinguish cached lazy tools from servers that need authentication while preserving active failure backoff. Thanks to [@inattendu](https://github.com/inattendu) for PR #474.
 
 ## [2.31.0] - 2026-08-28
 

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -189,11 +189,23 @@ describe("proxy discovery", () => {
     state.manager.getConnection = () => ({ status: "needs-auth" }) as any;
 
     expect(executeSearch(state, "demo").details).toMatchObject({ count: 2 });
-    expect(executeList(state, "demo").details).toMatchObject({ mode: "list", count: 2 });
+    const list = executeList(state, "demo");
+    expect(list.details).toMatchObject({ mode: "list", count: 2 });
+    expect(list.content[0].text).toContain(
+      'demo (2 tools (needs auth — run mcp({ action: "auth-start", server: "demo" }))):',
+    );
     expect(executeStatus(state).details).toMatchObject({
       totalTools: 2,
       servers: [expect.objectContaining({ name: "demo", status: "needs-auth", toolCount: 2 })],
     });
+  });
+
+  it("explains when a lazy server's tools come from cache", () => {
+    const result = executeList(createState(), "demo");
+
+    expect(result.content[0].text).toContain(
+      'demo (2 tools (lazy: tools from cache, not connected yet — mcp({ connect: "demo" }) to connect)):',
+    );
   });
 
   it("suggests the matching tool for a prefix-mangled describe name", () => {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -777,19 +777,15 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
     };
   }
 
-  // Faithful per-server status note. "not connected" alone reads as an outage
-  // while the tools listed below are real and the connection is simply lazy
-  // (tools served from cache). Distinguish auth, failure and plain laziness so
-  // the caller knows which remedy applies.
+  // "not connected" alone reads as an outage while the tools listed below are
+  // real and the connection is simply lazy (tools served from cache).
+  // Distinguish auth from plain laziness so the caller knows which remedy applies.
   let cachedNote = "";
   if (connection?.status !== "connected") {
     if (connection?.status === "needs-auth") {
       cachedNote = ` (needs auth — run mcp({ action: "auth-start", server: "${server}" }))`;
     } else {
-      const failedAgo = getFailureAgeSeconds(state, server);
-      cachedNote = failedAgo !== null
-        ? ` (failing — last failure ${failedAgo}s ago; see mcp({}) status)`
-        : ` (lazy: tools from cache, not connected yet — mcp({ connect: "${server}" }) to connect)`;
+      cachedNote = ` (lazy: tools from cache, not connected yet — mcp({ connect: "${server}" }) to connect)`;
     }
   }
   let text = `${server} (${toolNames.length} tools${cachedNote}):\n\n`;

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -777,7 +777,21 @@ export function executeList(state: McpExtensionState, server: string): ProxyTool
     };
   }
 
-  const cachedNote = connection?.status === "connected" ? "" : " (not connected, cached)";
+  // Faithful per-server status note. "not connected" alone reads as an outage
+  // while the tools listed below are real and the connection is simply lazy
+  // (tools served from cache). Distinguish auth, failure and plain laziness so
+  // the caller knows which remedy applies.
+  let cachedNote = "";
+  if (connection?.status !== "connected") {
+    if (connection?.status === "needs-auth") {
+      cachedNote = ` (needs auth — run mcp({ action: "auth-start", server: "${server}" }))`;
+    } else {
+      const failedAgo = getFailureAgeSeconds(state, server);
+      cachedNote = failedAgo !== null
+        ? ` (failing — last failure ${failedAgo}s ago; see mcp({}) status)`
+        : ` (lazy: tools from cache, not connected yet — mcp({ connect: "${server}" }) to connect)`;
+    }
+  }
   let text = `${server} (${toolNames.length} tools${cachedNote}):\n\n`;
 
   const descMap = new Map<string, string>();


### PR DESCRIPTION
## Problem

`mcp({ server })` rendered cached tools for lazy or auth-required servers as `(not connected, cached)`. That makes a healthy lazy server look like an outage, and it gives no remedy when the server needs OAuth.

## Fix

Reuse the state distinctions the adapter already tracks for the reachable per-server cached-tool list states:

- `needs-auth` → `(needs auth — run mcp({ action: "auth-start", server: "..." }))`
- ordinary lazy cached metadata → `(lazy: tools from cache, not connected yet — mcp({ connect: "..." }) to connect)`

Active failure backoff keeps the existing fail-closed behavior: failed servers do not advertise cached tools in the list.

## Verification

- `npm test -- --run __tests__/proxy-modes-discovery.test.ts __tests__/proxy-modes-instructions.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh read-only review: no issues found
