### PR TITLE
Clarify MCP setup UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `/mcp setup` now lets users choose project `.mcp.json` or global `~/.config/mcp/mcp.json` as the write target for new shared MCP servers, while identifying Pi-owned files and compatibility inputs as advanced layers. The bundled `mcp-scripting` skill is manual-only by default. Thanks to [@w-winter](https://github.com/w-winter) for #477.
+
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The adapter reads standard MCP files automatically. No extra setup needed if you
 
 | You already have... | What happens |
 |---------------------|--------------|
-| `.mcp.json` or `~/.config/mcp/mcp.json` | Pi uses it immediately. The first time you open `/mcp`, you'll see a short heads-up explaining which file Pi detected and that Pi only writes adapter-specific overrides to its own files. |
+| `.mcp.json` or `~/.config/mcp/mcp.json` | Pi uses it immediately. Use `.mcp.json` for project/team sharing and `~/.config/mcp/mcp.json` for all projects. The first time you open `/mcp`, you'll see a short heads-up explaining which file Pi detected and that Pi only writes adapter-specific overrides to its own files. |
 | Host-specific configs (Cursor, Claude Code, Codex, etc.) but no standard MCP files | Run `/mcp setup` to adopt those host configs into Pi. The setup flow shows exactly what it found, lets you pick which ones to import, and previews the exact file changes before writing. |
-| Nothing configured yet | Run `/mcp setup` to scaffold a minimal `.mcp.json`, add a curated known server, quick-add RepoPrompt, or inspect what the adapter discovered on your machine. |
+| Nothing configured yet | Run `/mcp setup`, choose project `.mcp.json` or global `~/.config/mcp/mcp.json`, then scaffold a minimal config, add a curated known server, quick-add RepoPrompt, or inspect what the adapter discovered on your machine. |
 
 If you prefer the terminal, you can also run `pi-mcp-adapter init` after install to scan for host-specific configs and add missing compatibility imports to the Pi agent dir (`~/.pi/agent/mcp.json` by default, or `$PI_CODING_AGENT_DIR/mcp.json` when set).
 
@@ -53,16 +53,16 @@ Preferred project config: `.mcp.json`
 }
 ```
 
-Preferred user-global shared config: `~/.config/mcp/mcp.json`. Pi also reads the tool-agnostic global paths `~/.agents/mcp.json` and `~/.agents/mcp/mcp.json`.
+Preferred user-global shared config: `~/.config/mcp/mcp.json` (for all projects). Pi also reads the tool-agnostic global paths `~/.agents/mcp.json` and `~/.agents/mcp/mcp.json` as compatibility inputs.
 
-Pi also reads Pi-owned override files for settings and host-specific compatibility:
+Pi-owned files are not additional normal setup choices. They hold Pi-specific settings, compatibility imports, and adapter-only overrides:
 
 - `<Pi agent dir>/mcp.json` — Pi global override (`~/.pi/agent/mcp.json` by default)
 - `.pi/mcp.json` — Pi project override
 
-Host-specific configs are detected and shown by `/mcp setup` and `pi-mcp-adapter init`, but they are not loaded automatically. The normal `/mcp` panel does not scan host-specific files when `settings.hostConfigDiscovery` is `"off"`. To explicitly opt in to host-config fallback discovery, set `settings.hostConfigDiscovery` to `"on"` or run `pi-mcp-adapter init --discover-host-configs`. The default is `"off"`; `"prompt"` is available for integrations that want detection without activation. Host configs are lower precedence than every shared and Pi-owned source, and `/mcp setup` continues to offer explicit import adoption. Discovery reports source paths, provenance, and same-name conflicts; it never writes to external host files or silently launches commands from them.
+Host-specific configs are detected and shown by `/mcp setup` and `pi-mcp-adapter init`, but they are compatibility inputs rather than normal setup paths and are not loaded automatically. The normal `/mcp` panel does not scan host-specific files when `settings.hostConfigDiscovery` is `"off"`. To explicitly opt in to host-config fallback discovery, set `settings.hostConfigDiscovery` to `"on"` or run `pi-mcp-adapter init --discover-host-configs`. The default is `"off"`; `"prompt"` is available for integrations that want detection without activation. Host configs are lower precedence than every shared and Pi-owned source, and `/mcp setup` continues to offer explicit import adoption. Discovery reports source paths, provenance, and same-name conflicts; it never writes to external host files or silently launches commands from them.
 
-Precedence is:
+Precedence is (later entries win):
 
 1. `~/.config/mcp/mcp.json`
 2. `~/.agents/mcp.json`
@@ -484,7 +484,7 @@ Set `"outputGuard": false` — or the env kill switch `MCP_OUTPUT_GUARD=0` — t
 
 For multi-call MCP work, write ordinary JavaScript: discover, inspect, call, loop, filter, chain, or fan out, then return one result. Run that code with the default-on `mcpScript` tool. For a single MCP call, search, describe, status check, or auth action, use `mcp` instead. Set `settings.scriptMode` to `false` to hide the scripting tool.
 
-The bundled `mcp-scripting` skill is a separate Pi package resource. To hide that skill while keeping the adapter extension installed, replace the package entry in Pi settings with the object form and disable package skills:
+The bundled `mcp-scripting` skill is a separate Pi package resource and is manual-only by default, so its description is not added to the model's automatic skill context. Use `/skill:mcp-scripting` when you want its detailed workflow. To remove the manual skill command as well while keeping the adapter extension and `mcpScript` tool installed, replace the package entry in Pi settings with the object form and disable package skills:
 
 ```json
 {
@@ -630,7 +630,7 @@ When you change direct-tool toggles in `/mcp`, the extension updates direct tool
 
 **Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers and toggle tools between direct and proxy from the same overlay. For OAuth, press Enter on a server that needs auth or `ctrl+a` on any OAuth server. The Save action defaults to `ctrl+s` and can be remapped with the `mcp.panel.save` keybinding.
 
-**Guided first-run setup:** Run `/mcp setup` to inspect detected shared MCP files, adopt compatibility imports from other hosts, open discovered config paths, preview exact before/after file diffs for writes, scaffold a minimal project `.mcp.json`, add a curated known server (DeepWiki, Context7, Notion, GitHub, or Chrome DevTools), or quick-add RepoPrompt into a standard/shared MCP file.
+**Guided first-run setup:** Run `/mcp setup` to choose the normal write target for new shared servers — project `.mcp.json` or global `~/.config/mcp/mcp.json` — inspect detected shared MCP files, adopt compatibility imports from other hosts, open discovered config paths, preview exact before/after file diffs for writes, scaffold a minimal selected config, add a curated known server (DeepWiki, Context7, Notion, GitHub, or Chrome DevTools), or quick-add RepoPrompt into a standard/shared MCP file.
 
 **Subagent integration:** If you use the subagent extension, agents can request direct MCP tools in their frontmatter with `mcp:server-name` syntax. See the subagent README for details.
 
@@ -712,7 +712,7 @@ Supported compatibility imports: `cursor`, `claude-code`, `claude-desktop`, `ope
 
 ### Project Config
 
-Prefer `.mcp.json` for project-local shared MCP config. Use `.pi/mcp.json` only when you need a Pi-specific project override. Project files override both user-global shared MCP config and Pi global overrides.
+Prefer `.mcp.json` for project-local shared MCP config and `~/.config/mcp/mcp.json` for user-global shared MCP config. Use `.pi/mcp.json` only when you need a Pi-specific project override. Project files override both user-global shared MCP config and Pi global overrides.
 
 ## Usage
 

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -100,6 +100,84 @@ describe("commands onboarding", () => {
     const options = mocks.createMcpPanel.mock.calls[0]?.[6];
     expect(options.noticeLines[0]).toContain("Using standard MCP config");
     expect(loadOnboardingState().sharedConfigHintShown).toBe(true);
+  });
+
+  it("does not present an .agents-only config as canonical shared MCP config", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-commands-agents-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-commands-agents-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+
+    writeJson(join(home, ".agents", "mcp.json"), {
+      mcpServers: {
+        compatibilityServer: { command: "compatibility" },
+      },
+    });
+
+    const ui = createUi();
+    const { loadMcpConfig } = await import("../config.ts");
+    const { openMcpPanel } = await import("../commands.ts");
+
+    await openMcpPanel({
+      config: loadMcpConfig(),
+      manager: { getConnection: () => null },
+      toolMetadata: new Map(),
+      failureTracker: new Map(),
+    } as any, { getFlag: () => undefined } as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
+
+    expect(mocks.createMcpPanel).toHaveBeenCalled();
+    const options = mocks.createMcpPanel.mock.calls[0]?.[6];
+    expect(options.noticeLines).toEqual([]);
+  });
+
+  it("writes known-server setup choices to the selected global shared config", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-commands-global-target-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-commands-global-target-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    mocks.createMcpSetupPanel.mockImplementationOnce((_discovery, callbacks, _options, _tui, done) => {
+      void callbacks.addKnownServer({ id: "demo", name: "Demo", summary: "Demo server", entry: { command: "demo" } }, "global")
+        .then(() => done());
+      return { dispose() {} };
+    });
+
+    const ui = createUi();
+    const { openMcpSetup } = await import("../commands.ts");
+
+    const result = await openMcpSetup({ config: { mcpServers: {} } } as any, {} as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
+
+    expect(result.configChanged).toBe(true);
+    expect(JSON.parse(readFileSync(join(home, ".config", "mcp", "mcp.json"), "utf-8"))).toEqual({
+      mcpServers: {
+        demo: { command: "demo" },
+      },
+    });
+  });
+
+  it("writes RepoPrompt setup choices to the selected global shared config", async () => {
+    const home = mkdtempSync(join(tmpdir(), "pi-mcp-commands-repoprompt-global-home-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-mcp-commands-repoprompt-global-project-"));
+    process.env.HOME = home;
+    process.chdir(project);
+    writeFileSync(join(project, "package.json"), "{}\n", "utf-8");
+    writeJson(join(home, "RepoPrompt", "repoprompt_cli"), {});
+    mocks.createMcpSetupPanel.mockImplementationOnce((_discovery, callbacks, _options, _tui, done) => {
+      void callbacks.addRepoPrompt("global").then(() => done());
+      return { dispose() {} };
+    });
+
+    const ui = createUi();
+    const { openMcpSetup } = await import("../commands.ts");
+
+    const result = await openMcpSetup({ config: { mcpServers: {} } } as any, {} as any, { hasUI: true, mode: "tui", ui, cwd: process.cwd() } as any);
+
+    expect(result.configChanged).toBe(true);
+    expect(existsSync(join(project, ".mcp.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(join(home, ".config", "mcp", "mcp.json"), "utf-8"))).toEqual({
+      mcpServers: {
+        repoprompt: { command: join(home, "RepoPrompt", "repoprompt_cli"), args: [], lifecycle: "lazy" },
+      },
+    });
   });
 
   it("does not inspect host-specific configs when opening the MCP panel", async () => {

--- a/__tests__/commands-status-failure.test.ts
+++ b/__tests__/commands-status-failure.test.ts
@@ -27,7 +27,11 @@ describe("MCP status failure reasons", () => {
       expect.stringContaining("demo: failed 7s ago — stderr says server failed"),
       "info",
     );
-    expect(ui.notify.mock.calls[0][0]).not.toContain("https://secret.invalid/status");
+    const output = ui.notify.mock.calls[0][0];
+    expect(output).toContain(".mcp.json for this project/team");
+    expect(output).toContain("~/.config/mcp/mcp.json for all projects");
+    expect(output).toContain("Pi-owned files hold compatibility imports and adapter-specific overrides");
+    expect(output).not.toContain("https://secret.invalid/status");
   });
 
   it("uses known metadata during reconnect filtering", async () => {

--- a/__tests__/mcp-panel-keybindings.test.ts
+++ b/__tests__/mcp-panel-keybindings.test.ts
@@ -79,13 +79,13 @@ function createSetupCallbacks(): SetupPanelCallbacks {
   const preview = { path: "/tmp/x", existed: false, changed: true, beforeText: "", afterText: "", diffText: "" };
   return {
     previewImports: () => preview,
-    previewStarterProject: () => preview,
+    previewStarterConfig: () => preview,
     previewRepoPrompt: () => null,
     previewKnownServer: () => preview,
     adoptImports: async () => ({ added: [], path: "/tmp/x" }),
-    scaffoldProjectConfig: vi.fn(async () => ({ path: "/tmp/x" })),
-    addRepoPrompt: async () => ({ path: "/tmp/x", serverName: "repoprompt" }),
-    addKnownServer: async (preset) => ({ path: "/tmp/x", serverName: preset.name }),
+    scaffoldConfig: vi.fn(async () => ({ path: "/tmp/x" })),
+    addRepoPrompt: vi.fn(async () => ({ path: "/tmp/x", serverName: "repoprompt" })),
+    addKnownServer: vi.fn(async (preset) => ({ path: "/tmp/x", serverName: preset.name })),
     openPath: async () => {},
     markSetupCompleted: () => {},
   };
@@ -258,12 +258,41 @@ describe("mcp-setup-panel custom keybindings", () => {
       () => {},
     );
 
-    // Actions for this discovery: view-example, scaffold-project, show-precedence, close.
+    // Select global target, then scaffold the selected normal config path.
     panel.handleInput(CTRL_N);
+    panel.handleInput(ENTER);
+    panel.handleInput(CTRL_N);
+    panel.handleInput(CTRL_N);
+    await Promise.resolve();
+    await Promise.resolve();
     panel.handleInput(ENTER);
     await Promise.resolve();
     await Promise.resolve();
-    expect(callbacks.scaffoldProjectConfig).toHaveBeenCalledTimes(1);
+    expect(callbacks.scaffoldConfig).toHaveBeenCalledWith("global");
+    panel.dispose();
+  });
+
+  it("adds known servers to the selected shared config target", async () => {
+    const callbacks = createSetupCallbacks();
+    const panel = createMcpSetupPanel(
+      createEmptyDiscovery(),
+      callbacks,
+      {
+        mode: "setup",
+        onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    panel.handleInput(DOWN);
+    panel.handleInput(ENTER);
+    for (let i = 0; i < 4; i += 1) panel.handleInput(DOWN);
+    panel.handleInput(ENTER);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(callbacks.addKnownServer).toHaveBeenCalledWith(expect.objectContaining({ id: "deepwiki" }), "global");
     panel.dispose();
   });
 
@@ -279,7 +308,7 @@ describe("mcp-setup-panel custom keybindings", () => {
       () => {},
     );
 
-    // Actions for this discovery: view-example, scaffold-project, show-precedence, known presets, close.
+    // Actions include target selection, scaffold-selected, known presets, close.
     panel.handleInput(DOWN);
     panel.handleInput(DOWN);
     panel.handleInput(DOWN);
@@ -288,7 +317,7 @@ describe("mcp-setup-panel custom keybindings", () => {
 
     expect(Math.max(...lines.map((line) => visibleWidth(line)))).toBeLessThanOrEqual(37);
     expect(output).toContain("DeepWiki");
-    expect(output).toContain("write preview");
+    expect(output).toContain("starter write");
     expect(output).toContain("Enter select");
     panel.dispose();
   });
@@ -305,11 +334,17 @@ describe("mcp-setup-panel custom keybindings", () => {
       () => {},
     );
 
-    // Actions for this discovery: view-example, scaffold-project, show-precedence, close.
+    // Actions include target selection, view-example, scaffold-selected, show-precedence, close.
+    panel.handleInput(DOWN);
+    panel.handleInput(DOWN);
     panel.handleInput(DOWN);
     panel.handleInput(DOWN);
     const output = panel.render(100).join("\n");
 
+    expect(output).toContain("Recommended shared config:");
+    expect(output).toContain("project/team: .mcp.json");
+    expect(output).toContain("all projects: ~/.config/mcp/mcp.json");
+    expect(output).toContain("Advanced compatibility and Pi-owned layers:");
     expect(output).toContain("Read order (later entries win):");
     expect(output).toContain("0. detected host configs (opt-in lowest-precedence fallback)");
     expect(output).toContain("2. ~/.agents/mcp.json");
@@ -336,6 +371,8 @@ describe("mcp-setup-panel custom keybindings", () => {
         () => {},
       );
 
+      panel.handleInput(DOWN);
+      panel.handleInput(DOWN);
       panel.handleInput(DOWN);
       panel.handleInput(DOWN);
       const output = panel.render(100).join("\n");

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -22,6 +22,11 @@ const hostPeerPackages = {
 };
 
 describe("package.json files", () => {
+  it("keeps the bundled MCP scripting skill available for manual use only", () => {
+    const skill = readFileSync(join(repoRoot, "skills", "mcp-scripting", "SKILL.md"), "utf-8");
+    expect(skill).toMatch(/^disable-model-invocation:\s*true\s*$/m);
+  });
+
   it("exports source entry points and plain Node host helpers", () => {
     expect(packageJson.types).toBe("./index.ts");
     expect(packageJson.exports).toMatchObject({

--- a/commands.ts
+++ b/commands.ts
@@ -4,17 +4,18 @@ import type { McpExtensionState } from "./state.ts";
 import { isServerDisabled, type McpAuthResult, type McpConfig, type McpPanelCallbacks, type McpPanelResult, type ImportKind } from "./types.ts";
 import {
   ensureCompatibilityImports,
+  getSharedConfigPath,
   getMcpDiscoverySummary,
   getMcpStandardConfigSummary,
-  getProjectConfigPath,
   type KnownServerPreset,
+  type SharedConfigTarget,
   getServerProvenance,
   previewCompatibilityImports,
   previewSharedServerEntry,
-  previewStarterProjectConfig,
+  previewStarterSharedConfig,
   writeDirectToolsConfig,
   writeSharedServerEntry,
-  writeStarterProjectConfig,
+  writeStarterSharedConfig,
 } from "./config.ts";
 import { markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateMetadataCache, updateStatusBar, getFailureAgeSeconds, getFailureMessage, clearFailure, recordFailure } from "./init.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
@@ -48,6 +49,13 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
   if (!ctx.hasUI) return;
 
   const lines: string[] = ["MCP Server Status:", ""];
+  if (!state.programmaticConfig) {
+    lines.push(
+      "Shared MCP config: .mcp.json for this project/team or ~/.config/mcp/mcp.json for all projects.",
+      "Pi-owned files hold compatibility imports and adapter-specific overrides.",
+      "",
+    );
+  }
 
   for (const name of Object.keys(state.config.mcpServers)) {
     const definition = state.config.mcpServers[name];
@@ -98,7 +106,7 @@ export async function showStatus(state: McpExtensionState, ctx: ExtensionContext
 
   if (Object.keys(state.config.mcpServers).length === 0) {
     lines.push("No MCP servers configured");
-    lines.push("Run /mcp setup to adopt imports or scaffold a starter .mcp.json");
+    lines.push("Run /mcp setup to add a server to .mcp.json or ~/.config/mcp/mcp.json");
   }
 
   ctx.ui.notify(lines.join("\n"), "info");
@@ -464,16 +472,18 @@ export interface PanelFlowResult {
 function buildSharedConfigNoticeLines(configOverridePath: string | undefined, cwd: string): { lines: string[]; fingerprint: string | null } {
   const discovery = getMcpStandardConfigSummary(configOverridePath, cwd);
   const onboardingState = loadOnboardingState();
-  if (!discovery.hasSharedServers || onboardingState.sharedConfigHintShown) {
+  const sharedSources = discovery.sources.filter((source) =>
+    (source.id === "shared-project" || source.id === "shared-global") && source.serverCount > 0,
+  );
+  if (sharedSources.length === 0 || onboardingState.sharedConfigHintShown) {
     return { lines: [], fingerprint: null };
   }
 
-  const sharedSources = discovery.sources.filter((source) => source.kind === "shared" && source.serverCount > 0);
   const sourceList = sharedSources.map((source) => source.path).join(", ");
   return {
     lines: [
       `Using standard MCP config from ${sourceList}.`,
-      "Pi only writes compatibility imports and adapter-specific overrides into Pi-owned files when needed.",
+      "Use .mcp.json for project/team config or ~/.config/mcp/mcp.json for all projects. Pi only writes compatibility imports and adapter-specific overrides into Pi-owned files when needed.",
     ],
     fingerprint: discovery.fingerprint,
   };
@@ -504,34 +514,34 @@ export async function openMcpSetup(
 
   const callbacks = {
     previewImports: (imports: ImportKind[]) => previewCompatibilityImports(imports, configOverridePath),
-    previewStarterProject: () => previewStarterProjectConfig(ctx.cwd),
-    previewRepoPrompt: () => {
+    previewStarterConfig: (target: SharedConfigTarget) => previewStarterSharedConfig(target, ctx.cwd),
+    previewRepoPrompt: (target: SharedConfigTarget) => {
       const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd, options).repoPrompt;
       if (!repoPrompt.entry || !repoPrompt.targetPath || !repoPrompt.serverName) return null;
-      return previewSharedServerEntry(repoPrompt.targetPath, repoPrompt.serverName, repoPrompt.entry);
+      return previewSharedServerEntry(getSharedConfigPath(target, ctx.cwd), repoPrompt.serverName, repoPrompt.entry);
     },
-    previewKnownServer: (preset: KnownServerPreset) => previewSharedServerEntry(getProjectConfigPath(ctx.cwd), preset.id, preset.entry),
+    previewKnownServer: (preset: KnownServerPreset, target: SharedConfigTarget) => previewSharedServerEntry(getSharedConfigPath(target, ctx.cwd), preset.id, preset.entry),
     adoptImports: async (imports: ImportKind[]) => {
       const result = ensureCompatibilityImports(imports, configOverridePath);
       if (result.added.length > 0) configChanged = true;
       return result;
     },
-    scaffoldProjectConfig: async () => {
-      const path = writeStarterProjectConfig(ctx.cwd);
+    scaffoldConfig: async (target: SharedConfigTarget) => {
+      const path = writeStarterSharedConfig(target, ctx.cwd);
       configChanged = true;
       return { path };
     },
-    addRepoPrompt: async () => {
+    addRepoPrompt: async (target: SharedConfigTarget) => {
       const repoPrompt = getMcpDiscoverySummary(configOverridePath, ctx.cwd, options).repoPrompt;
       if (!repoPrompt.entry || !repoPrompt.targetPath || !repoPrompt.serverName) {
         throw new Error("RepoPrompt is not available to add from this setup screen.");
       }
-      const path = writeSharedServerEntry(repoPrompt.targetPath, repoPrompt.serverName, repoPrompt.entry);
+      const path = writeSharedServerEntry(getSharedConfigPath(target, ctx.cwd), repoPrompt.serverName, repoPrompt.entry);
       configChanged = true;
       return { path, serverName: repoPrompt.serverName };
     },
-    addKnownServer: async (preset: KnownServerPreset) => {
-      const path = writeSharedServerEntry(getProjectConfigPath(ctx.cwd), preset.id, preset.entry);
+    addKnownServer: async (preset: KnownServerPreset, target: SharedConfigTarget) => {
+      const path = writeSharedServerEntry(getSharedConfigPath(target, ctx.cwd), preset.id, preset.entry);
       configChanged = true;
       return { path, serverName: preset.name };
     },

--- a/config.ts
+++ b/config.ts
@@ -175,6 +175,8 @@ export interface ConfigWritePreview {
   diffText: string;
 }
 
+export type SharedConfigTarget = "project" | "global";
+
 export function getPiGlobalConfigPath(overridePath?: string): string {
   return overridePath ? resolve(overridePath) : getAgentPath("mcp.json");
 }
@@ -189,6 +191,10 @@ export function getProjectConfigPath(cwd = process.cwd()): string {
 
 export function getProjectPiConfigPath(cwd = process.cwd()): string {
   return resolve(cwd, getConfigDirName(), PROJECT_PI_CONFIG_NAME);
+}
+
+export function getSharedConfigPath(target: SharedConfigTarget, cwd = process.cwd()): string {
+  return target === "project" ? getProjectConfigPath(cwd) : getGenericGlobalConfigPath();
 }
 
 export function getConfigDiscoveryPaths(overridePath?: string, cwd = process.cwd()): ConfigDiscoveryPath[] {
@@ -1159,17 +1165,25 @@ export function buildStarterProjectConfig(): McpConfig {
   };
 }
 
-export function previewStarterProjectConfig(cwd = process.cwd()): ConfigWritePreview {
-  const targetPath = getProjectConfigPath(cwd);
+export function previewStarterSharedConfig(target: SharedConfigTarget, cwd = process.cwd()): ConfigWritePreview {
+  const targetPath = getSharedConfigPath(target, cwd);
   const nextRaw = { mcpServers: buildStarterProjectConfig().mcpServers };
   return buildConfigWritePreview(targetPath, nextRaw);
 }
 
-export function writeStarterProjectConfig(cwd = process.cwd()): string {
-  const targetPath = getProjectConfigPath(cwd);
+export function writeStarterSharedConfig(target: SharedConfigTarget, cwd = process.cwd()): string {
+  const targetPath = getSharedConfigPath(target, cwd);
   const raw = { mcpServers: buildStarterProjectConfig().mcpServers };
   writeRawConfigObject(targetPath, raw);
   return targetPath;
+}
+
+export function previewStarterProjectConfig(cwd = process.cwd()): ConfigWritePreview {
+  return previewStarterSharedConfig("project", cwd);
+}
+
+export function writeStarterProjectConfig(cwd = process.cwd()): string {
+  return writeStarterSharedConfig("project", cwd);
 }
 
 export function previewSharedServerEntry(filePath: string, serverName: string, entry: ServerEntry): ConfigWritePreview {

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -2,7 +2,7 @@ import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tu
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import type { ImportKind } from "./types.ts";
 import { getConfigDirName } from "./agent-dir.ts";
-import { KNOWN_SERVER_PRESETS, type ConfigWritePreview, type KnownServerPreset, type McpDiscoverySummary } from "./config.ts";
+import { KNOWN_SERVER_PRESETS, type ConfigWritePreview, type KnownServerPreset, type McpDiscoverySummary, type SharedConfigTarget } from "./config.ts";
 import type { McpOnboardingState } from "./onboarding-state.ts";
 
 interface SetupTheme {
@@ -54,13 +54,13 @@ function wrapText(text: string, width: number): string[] {
 
 export interface SetupPanelCallbacks {
   previewImports: (imports: ImportKind[]) => ConfigWritePreview;
-  previewStarterProject: () => ConfigWritePreview;
-  previewRepoPrompt: () => ConfigWritePreview | null;
-  previewKnownServer: (preset: KnownServerPreset) => ConfigWritePreview;
+  previewStarterConfig: (target: SharedConfigTarget) => ConfigWritePreview;
+  previewRepoPrompt: (target: SharedConfigTarget) => ConfigWritePreview | null;
+  previewKnownServer: (preset: KnownServerPreset, target: SharedConfigTarget) => ConfigWritePreview;
   adoptImports: (imports: ImportKind[]) => Promise<{ added: ImportKind[]; path: string }>;
-  scaffoldProjectConfig: () => Promise<{ path: string }>;
-  addRepoPrompt: () => Promise<{ path: string; serverName: string }>;
-  addKnownServer: (preset: KnownServerPreset) => Promise<{ path: string; serverName: string }>;
+  scaffoldConfig: (target: SharedConfigTarget) => Promise<{ path: string }>;
+  addRepoPrompt: (target: SharedConfigTarget) => Promise<{ path: string; serverName: string }>;
+  addKnownServer: (preset: KnownServerPreset, target: SharedConfigTarget) => Promise<{ path: string; serverName: string }>;
   openPath: (path: string) => Promise<void>;
   markSetupCompleted: () => void;
 }
@@ -75,13 +75,14 @@ type Screen = "empty" | "setup" | "imports" | "paths";
 
 type ActionId =
   | "run-setup"
+  | "select-shared-target"
   | "adopt-imports"
   | "view-example"
   | "show-precedence"
   | "open-paths"
   | "add-repoprompt"
   | "add-known-server"
-  | "scaffold-project"
+  | "scaffold-shared-config"
   | "close";
 
 interface Action {
@@ -89,6 +90,7 @@ interface Action {
   label: string;
   description: string;
   preset?: KnownServerPreset;
+  target?: SharedConfigTarget;
 }
 
 export class McpSetupPanel {
@@ -96,6 +98,7 @@ export class McpSetupPanel {
   private actionCursor = 0;
   private importCursor = 0;
   private pathCursor = 0;
+  private sharedConfigTarget: SharedConfigTarget = "project";
   private selectedImports = new Set<ImportKind>();
   private busy = false;
   private notice: { text: string; tone: "success" | "warning" | "muted" } | null = null;
@@ -144,9 +147,13 @@ export class McpSetupPanel {
     if (this.discovery.imports.length > 0) {
       actions.push({ id: "adopt-imports", label: "Adopt detected compatibility imports", description: `Choose which host-specific MCP configs Pi should import into its own override file. ${this.discovery.imports.length} source${this.discovery.imports.length === 1 ? "" : "s"} found.` });
     }
-    actions.push({ id: "view-example", label: "View example `.mcp.json`", description: "Preview a working shared MCP config you can paste or adapt." });
-    if (!this.discovery.sources.some((source) => source.id === "shared-project" && source.exists)) {
-      actions.push({ id: "scaffold-project", label: "Scaffold project `.mcp.json`", description: "Write a minimal project config using the standard shared MCP file path, then reload Pi." });
+    actions.push(
+      { id: "select-shared-target", label: `${this.sharedConfigTarget === "project" ? "●" : "○"} Add to this project (.mcp.json)`, description: "Write new shared MCP servers to the project/team config.", target: "project" },
+      { id: "select-shared-target", label: `${this.sharedConfigTarget === "global" ? "●" : "○"} Add globally (~/.config/mcp/mcp.json)`, description: "Write new shared MCP servers to your all-projects config.", target: "global" },
+    );
+    actions.push({ id: "view-example", label: "View example shared config", description: "Preview a working shared MCP config you can paste or adapt." });
+    if (!this.selectedSharedConfigExists()) {
+      actions.push({ id: "scaffold-shared-config", label: `Scaffold ${this.sharedTargetLabel()}`, description: "Write a minimal config at the selected normal MCP setup path, then reload Pi." });
     }
     actions.push({ id: "show-precedence", label: "Explain config precedence", description: "Show the read order and where Pi writes compatibility settings." });
     if (this.getDetectedPaths().length > 0) {
@@ -156,7 +163,7 @@ export class McpSetupPanel {
       actions.push({ id: "add-known-server", label: preset.name, description: preset.summary, preset });
     }
     if (!this.discovery.repoPrompt.configured && this.discovery.repoPrompt.executablePath && this.discovery.repoPrompt.targetPath && this.discovery.repoPrompt.entry && this.discovery.repoPrompt.serverName) {
-      actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to shared MCP config", description: "Write a standard MCP entry for RepoPrompt to the recommended shared target, then reload MCP in-session." });
+      actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to selected shared config", description: "Write a standard MCP entry for RepoPrompt to the selected normal setup path, then reload MCP in-session." });
     }
     actions.push({ id: "close", label: "Close", description: "Exit the onboarding flow." });
     return actions;
@@ -168,6 +175,15 @@ export class McpSetupPanel {
       ...this.discovery.imports.map((entry) => entry.path),
     ];
     return [...new Set(paths)];
+  }
+
+  private sharedTargetLabel(): string {
+    return this.sharedConfigTarget === "project" ? "project .mcp.json" : "global ~/.config/mcp/mcp.json";
+  }
+
+  private selectedSharedConfigExists(): boolean {
+    const sourceId = this.sharedConfigTarget === "project" ? "shared-project" : "shared-global";
+    return this.discovery.sources.some((source) => source.id === sourceId && source.exists);
   }
 
   private getSelectedAction(): Action | undefined {
@@ -293,9 +309,15 @@ export class McpSetupPanel {
       this.tui.requestRender();
       return;
     }
-    if (action.id === "scaffold-project") {
+    if (action.id === "select-shared-target" && action.target) {
+      this.sharedConfigTarget = action.target;
+      this.notice = { text: `New shared servers will be written to ${this.sharedTargetLabel()}.`, tone: "muted" };
+      this.tui.requestRender();
+      return;
+    }
+    if (action.id === "scaffold-shared-config") {
       await this.runBusy(async () => {
-        const result = await this.callbacks.scaffoldProjectConfig();
+        const result = await this.callbacks.scaffoldConfig(this.sharedConfigTarget);
         this.callbacks.markSetupCompleted();
         this.notice = { text: `Wrote starter config to ${result.path}. Pi will reload after this panel closes.`, tone: "success" };
       });
@@ -303,7 +325,7 @@ export class McpSetupPanel {
     }
     if (action.id === "add-repoprompt") {
       await this.runBusy(async () => {
-        const result = await this.callbacks.addRepoPrompt();
+        const result = await this.callbacks.addRepoPrompt(this.sharedConfigTarget);
         this.callbacks.markSetupCompleted();
         this.notice = { text: `Added ${result.serverName} to ${result.path}. Pi will reload after this panel closes.`, tone: "success" };
       });
@@ -312,7 +334,7 @@ export class McpSetupPanel {
     if (action.id === "add-known-server" && action.preset) {
       const preset = action.preset;
       await this.runBusy(async () => {
-        const result = await this.callbacks.addKnownServer(preset);
+        const result = await this.callbacks.addKnownServer(preset, this.sharedConfigTarget);
         this.callbacks.markSetupCompleted();
         this.notice = { text: `Added ${result.serverName} to ${result.path}. Pi will reload after this panel closes.`, tone: "success" };
       });
@@ -416,8 +438,11 @@ export class McpSetupPanel {
     for (let index = start; index < end; index++) {
       const action = actions[index];
       if (!action) continue;
+      if (action.id === "select-shared-target" && (index === start || actions[index - 1]?.id !== "select-shared-target")) {
+        lines.push(this.padLine(fg(this.t.title, "Choose where new shared servers go"), innerW));
+      }
       if (action.id === "add-known-server" && (index === start || actions[index - 1]?.id !== "add-known-server")) {
-        lines.push(this.padLine(fg(this.t.title, "Add a known server"), innerW));
+        lines.push(this.padLine(fg(this.t.title, `Add a known server to ${this.sharedTargetLabel()}`), innerW));
       }
       const selected = index === this.actionCursor;
       const cursor = selected ? fg(this.t.selected, "›") : " ";
@@ -495,12 +520,12 @@ export class McpSetupPanel {
       ? ` ${this.discovery.conflicts.length} same-name conflict${this.discovery.conflicts.length === 1 ? "" : "s"} reported.`
       : "";
     if (!this.discovery.hasAnyConfig) {
-      return `Create a shared .mcp.json, adopt host imports, or quick-add RepoPrompt from this screen.${hostNote}${conflictNote}`;
+      return `Add shared servers to .mcp.json for this project/team or ~/.config/mcp/mcp.json for all projects. Adopt host imports or quick-add RepoPrompt from this screen.${hostNote}${conflictNote}`;
     }
     if (this.discovery.totalServerCount === 0 && this.discovery.imports.length > 0) {
       return `Detected ${this.discovery.imports.length} compatibility import source${this.discovery.imports.length === 1 ? "" : "s"}. Adopt them into Pi or inspect the underlying files.${hostNote}${conflictNote}`;
     }
-    return `Shared MCP files are preferred. Pi-owned files are only for compatibility imports and adapter-specific overrides.${hostNote}${conflictNote}`;
+    return `Use .mcp.json for project/team servers or ~/.config/mcp/mcp.json for all projects. Pi-owned files are for compatibility imports and adapter-specific overrides, not another normal setup path.${hostNote}${conflictNote}`;
   }
 
   private visibleActionRange(total: number): { start: number; end: number } {
@@ -534,6 +559,12 @@ export class McpSetupPanel {
           ],
           previewW,
         );
+      case "select-shared-target":
+        return this.formatPreview([
+          action.target === "project" ? "Project target: .mcp.json" : "Global target: ~/.config/mcp/mcp.json",
+          "Known server presets and starter configs will be written to the selected normal MCP setup path.",
+          "Pi-owned mcp.json files remain compatibility and adapter-only override state.",
+        ], previewW);
       case "view-example":
         return this.formatPreview([
           "Example shared `.mcp.json`:",
@@ -546,10 +577,17 @@ export class McpSetupPanel {
           "  }",
           "}",
           "",
-          "Use Scaffold project `.mcp.json` when you want a safe empty shell instead of a live example server.",
+          "Use Scaffold selected config when you want a safe empty shell instead of a live example server.",
         ], previewW);
       case "show-precedence":
         return this.formatPreview([
+          "Recommended shared config:",
+          "  project/team: .mcp.json",
+          "  all projects: ~/.config/mcp/mcp.json",
+          "",
+          "Advanced compatibility and Pi-owned layers:",
+          "  host imports, .agents files, package MCP manifests, and Pi overrides",
+          "",
           "Read order (later entries win):",
           "0. detected host configs (opt-in lowest-precedence fallback)",
           "1. ~/.config/mcp/mcp.json",
@@ -570,7 +608,7 @@ export class McpSetupPanel {
           : ["No config paths were detected."], previewW);
       case "add-repoprompt": {
         const repoPrompt = this.discovery.repoPrompt;
-        const preview = this.callbacks.previewRepoPrompt();
+        const preview = this.callbacks.previewRepoPrompt(this.sharedConfigTarget);
         if (!preview) {
           return this.formatPreview(["RepoPrompt is not available to add from this setup screen."], previewW);
         }
@@ -579,7 +617,7 @@ export class McpSetupPanel {
           preview,
           [
             `Executable: ${repoPrompt.executablePath ?? "not found"}`,
-            `Target: ${repoPrompt.targetPath ?? "n/a"}`,
+            `Target: ${this.sharedTargetLabel()}`,
             `Server name: ${repoPrompt.serverName ?? "repoprompt"}`,
           ],
           previewW,
@@ -590,17 +628,17 @@ export class McpSetupPanel {
         if (!preset) return this.formatPreview(["Known server preset is unavailable."], previewW);
         return this.formatWritePreview(
           `${preset.name} write preview`,
-          this.callbacks.previewKnownServer(preset),
-          [preset.summary],
+          this.callbacks.previewKnownServer(preset, this.sharedConfigTarget),
+          [preset.summary, `Target: ${this.sharedTargetLabel()}`],
           previewW,
         );
       }
-      case "scaffold-project":
+      case "scaffold-shared-config":
         return this.formatWritePreview(
-          "Starter project `.mcp.json` write preview",
-          this.callbacks.previewStarterProject(),
+          `${this.sharedTargetLabel()} starter write preview`,
+          this.callbacks.previewStarterConfig(this.sharedConfigTarget),
           [
-            "This writes a minimal `.mcp.json` in the current project using the shared MCP layout.",
+            "This writes a minimal config at the selected normal MCP setup path.",
             "It intentionally avoids adding a fake placeholder server that would fail on first reload.",
           ],
           previewW,

--- a/skills/mcp-scripting/SKILL.md
+++ b/skills/mcp-scripting/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-scripting
 description: Write mcpScript JavaScript for discovering, inspecting, and calling MCP tools.
+disable-model-invocation: true
 ---
 
 # MCP scripting


### PR DESCRIPTION
## Summary

- make `/mcp setup` choose the normal write target for new shared servers: project `.mcp.json` or global `~/.config/mcp/mcp.json`
- wire starter config, known-server presets, and RepoPrompt writes/previews through that selected target
- label Pi-owned files, `.agents` configs, host imports, and package manifests as compatibility or override layers
- make the bundled `mcp-scripting` skill manual-only by default with `disable-model-invocation: true`

Closes #477.

Thanks to [@w-winter](https://github.com/w-winter) for the UX improvement idea.

## Validation

- `npm test -- --run __tests__/commands-onboarding.test.ts __tests__/mcp-panel-keybindings.test.ts __tests__/commands-status-failure.test.ts __tests__/package-manifest.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review after amendment: No issues found.
