### PR TITLE
fix(ui): serve MCP Apps through sandbox proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Hardened MCP 2026 multi-round input flows across proxy, direct, resource, and UI-resource calls, with actionable no-UI errors and cancellation cleanup.
 - Hardened MCP 2026-07-28 catalog listens with visible drop/recovery state, bounded re-listen on activity, resource update signals for open UIs, and quiet metadata/cache refreshes. (#468)
+- MCP App views now load through a separate loopback sandbox proxy origin so storage APIs work without exposing host session capabilities. Thanks to [@drewbitt](https://github.com/drewbitt) for #480.
 - Implicit OAuth now reuses URL-bound stored credentials while preserving anonymous fallback. Thanks to [@wilt00](https://github.com/wilt00) for #471.
 - Per-server proxy lists now distinguish cached lazy tools from servers that need authentication while preserving active failure backoff. Thanks to [@inattendu](https://github.com/inattendu) for PR #474.
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -17,6 +17,7 @@ function createMinimalInput(overrides: Partial<HostHtmlTemplateInput> = {}): Hos
     allowAttribute: "",
     requireToolConsent: false,
     cacheToolConsent: true,
+    sandboxProxyUrl: "http://localhost:9876/sandbox",
     ...overrides,
   };
 }
@@ -53,9 +54,8 @@ describe("buildHostHtmlTemplate", () => {
       const html = buildHostHtmlTemplate(createMinimalInput());
 
       expect(html).toContain('<iframe id="mcp-app"');
-      expect(html).toContain('sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads"');
+      expect(html).toContain('sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin"');
       expect(html).not.toContain("allow-popups-to-escape-sandbox");
-      expect(html).not.toContain("allow-same-origin");
       expect(html).toContain('referrerpolicy="no-referrer"');
     });
 
@@ -63,8 +63,29 @@ describe("buildHostHtmlTemplate", () => {
       const html = buildHostHtmlTemplate(createMinimalInput());
 
       expect(html).toContain("new PostMessageTransport(iframe.contentWindow, iframe.contentWindow)");
-      expect(html).toContain("if (event.source !== iframe.contentWindow) return;");
+      expect(html).toContain("if (event.source !== iframe.contentWindow || event.origin !== sandboxProxyOrigin) return;");
+      expect(html).toContain("event.source === iframe.contentWindow && event.origin !== sandboxProxyOrigin");
       expect(html).not.toContain("new PostMessageTransport(iframe.contentWindow, null)");
+    });
+
+    it("loads provider HTML only after the proxy ready handshake", () => {
+      const html = buildHostHtmlTemplate(createMinimalInput({
+        resource: {
+          uri: "ui://test/widget",
+          html: "<p>provider</p>",
+          meta: {
+            csp: { resourceDomains: ["https://cdn.example.com"] },
+            permissions: { clipboardWrite: {} },
+          },
+        },
+      }));
+
+      expect(html).toContain("bridge.onsandboxready = async () => {");
+      expect(html).toContain('fetch("/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN)');
+      expect(html).toContain("bridge.sendSandboxResourceReady({");
+      expect(html).toContain("sandbox: INNER_SANDBOX");
+      expect(html).toContain('"https://cdn.example.com"');
+      expect(html).toContain('"clipboardWrite"');
     });
 
     it("includes control buttons", () => {
@@ -105,8 +126,10 @@ describe("buildHostHtmlTemplate", () => {
 
       expect(html).toContain('const SESSION_TOKEN = "secret-session-token"');
       expect(html).toContain('const UI_RESOURCE_TOKEN = "app-resource-token"');
-      expect(html).toContain('iframe.src = "/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN)');
-      expect(html).not.toContain('iframe.src = "/ui-app?session="');
+      expect(html).toContain('const SANDBOX_PROXY_URL = "http://localhost:9876/sandbox"');
+      expect(html).toContain('iframe.src = SANDBOX_PROXY_URL');
+      expect(html).not.toContain('iframe.src = "/ui-app?resource="');
+      expect(html).not.toContain("http://localhost:9876/sandbox?session=");
     });
 
     it("injects tool arguments", () => {

--- a/__tests__/sandbox-proxy-template.test.ts
+++ b/__tests__/sandbox-proxy-template.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSandboxProxyCsp,
+  buildSandboxProxyHtml,
+  SANDBOX_INNER_SANDBOX,
+  SANDBOX_PROXY_SANDBOX,
+} from "../sandbox-proxy-template.ts";
+
+describe("sandbox proxy template", () => {
+  it("uses a safe sandbox policy with a distinct parent origin", () => {
+    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377" });
+
+    expect(html).toContain('<iframe id="mcp-app"');
+    expect(html).toContain(`sandbox="${SANDBOX_INNER_SANDBOX}"`);
+    expect(html).toContain('const EXPECTED_PARENT_ORIGIN = "http://localhost:8377"');
+    expect(html).toContain("event.source === window.parent && event.origin === EXPECTED_PARENT_ORIGIN");
+    expect(html).toContain("event.source === innerFrame.contentWindow && event.origin === window.location.origin");
+    expect(html).toContain("document.write(injectCsp(params.html, buildResourceCsp(params.csp)))");
+    expect(html).not.toContain("allow-popups-to-escape-sandbox");
+    expect(html).not.toContain("SESSION_TOKEN");
+    expect(html).not.toContain("UI_RESOURCE_TOKEN");
+  });
+
+  it("relays only validated parent/inner messages and reserves sandbox messages", () => {
+    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377" });
+
+    expect(html).toContain("data.method === SANDBOX_RESOURCE_READY_METHOD");
+    expect(html).toContain("data.method === SANDBOX_PROXY_READY_METHOD");
+    expect(html).toContain('data.method.startsWith("ui/notifications/sandbox-")');
+    expect(html).toContain("postToInner(data)");
+    expect(html).toContain("postToParent(data)");
+    expect(html).toContain("window.parent.postMessage(data, EXPECTED_PARENT_ORIGIN)");
+    expect(html).toContain("innerFrame.contentWindow.postMessage(data, window.location.origin)");
+  });
+
+  it("keeps proxy and inner CSP sandboxing distinct from raw resource policy", () => {
+    expect(SANDBOX_PROXY_SANDBOX).toContain("allow-same-origin");
+    expect(buildSandboxProxyCsp()).toContain(`sandbox ${SANDBOX_PROXY_SANDBOX}`);
+    expect(buildSandboxProxyCsp()).toContain("script-src 'unsafe-inline'");
+    expect(buildSandboxProxyCsp()).toContain("frame-src 'self'");
+    expect(buildSandboxProxyCsp()).not.toContain("allow-popups-to-escape-sandbox");
+    expect(buildSandboxProxyCsp()).not.toContain("connect-src *");
+  });
+
+  it("escapes the injected parent origin as JavaScript data", () => {
+    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377/<script>\u2028" });
+
+    expect(html).not.toContain("<script>\u2028");
+    expect(html).toContain("\\u003cscript\\u003e");
+    expect(html).toContain("\\u2028");
+  });
+});

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -246,6 +246,51 @@ describe("UiServer", () => {
         body: { token: handle.sessionToken, params: {} },
       })).status).toBe(404);
     });
+
+    it("does not resolve a handle after completion races sandbox proxy startup", async () => {
+      const tempServer = http.createServer();
+      await new Promise<void>((resolve) => tempServer.listen(0, "127.0.0.1", resolve));
+      const freePort = (tempServer.address() as { port: number }).port;
+      await new Promise<void>((resolve, reject) => tempServer.close((error) => error ? reject(error) : resolve()));
+
+      const realCreateServer = http.createServer.bind(http);
+      const createServerSpy = vi.spyOn(http, "createServer");
+      let createdServers = 0;
+      let finishProxyListen: (() => void) | undefined;
+      createServerSpy.mockImplementation(((...args: Parameters<typeof http.createServer>) => {
+        const created = realCreateServer(...args);
+        createdServers += 1;
+        if (createdServers === 2) {
+          const realListen = created.listen.bind(created);
+          vi.spyOn(created, "listen").mockImplementation(((...listenArgs: unknown[]) => {
+            const callback = typeof listenArgs.at(-1) === "function" ? listenArgs.pop() as () => void : undefined;
+            finishProxyListen = () => callback?.();
+            return realListen(...listenArgs as [number, string]);
+          }) as http.Server["listen"]);
+        }
+        return created;
+      }) as typeof http.createServer);
+
+      try {
+        const startup = startUiServer(createServerOptions({
+          port: freePort,
+          sessionToken: "startup-race-token",
+        }));
+
+        await vi.waitFor(() => expect(finishProxyListen).toBeTypeOf("function"));
+        const complete = await request(`http://localhost:${freePort}/proxy/ui/complete`, {
+          method: "POST",
+          body: { token: "startup-race-token", params: { reason: "done" } },
+        });
+
+        expect(complete.status).toBe(200);
+        finishProxyListen?.();
+        await expect(startup).rejects.toThrow("UI session completed before sandbox proxy was ready");
+      } finally {
+        createServerSpy.mockRestore();
+        handle = null;
+      }
+    });
   });
 
   describe("GET /", () => {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -188,6 +188,8 @@ describe("UiServer", () => {
       expect(handle.port).toBeGreaterThanOrEqual(8377);
       expect(handle.port).toBeLessThanOrEqual(8396);
       expect(handle.url).toContain(`http://localhost:${handle.port}`);
+      expect(handle.proxyPort).not.toBe(handle.port);
+      expect(handle.proxyUrl).toBe(`http://localhost:${handle.proxyPort}/sandbox`);
       expect(handle.sessionToken).toBeTruthy();
     });
 
@@ -218,6 +220,31 @@ describe("UiServer", () => {
 
       expect(handle.serverName).toBe("my-server");
       expect(handle.toolName).toBe("my_tool");
+    });
+
+    it("serves a tokenless second-origin sandbox proxy", async () => {
+      handle = await startUiServer(createServerOptions());
+
+      const res = await request(handle.proxyUrl);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expect(res.headers["content-security-policy"]).toContain(
+        "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin",
+      );
+      expect(res.headers["content-security-policy"]).not.toContain("allow-popups-to-escape-sandbox");
+      expect(res.body).toContain(`const EXPECTED_PARENT_ORIGIN = "http://localhost:${handle.port}"`);
+      expect(res.body).toContain("ui/notifications/sandbox-proxy-ready");
+      expect(res.body).toContain("event.source === window.parent && event.origin === EXPECTED_PARENT_ORIGIN");
+      expect(res.body).toContain("event.source === innerFrame.contentWindow && event.origin === window.location.origin");
+      expect(res.body).not.toContain(handle.sessionToken);
+      expect(res.body).not.toContain("UI_RESOURCE_TOKEN");
+
+      expect((await request(`${handle.proxyUrl}/ui-app`)).status).toBe(404);
+      expect((await request(`${handle.proxyUrl}/proxy/ui/heartbeat`, {
+        method: "POST",
+        body: { token: handle.sessionToken, params: {} },
+      })).status).toBe(404);
     });
   });
 
@@ -1515,6 +1542,18 @@ describe("UiServer", () => {
       handle.close();
 
       expect(onComplete).toHaveBeenCalledWith("closed");
+    });
+
+    it("closes both host and sandbox proxy listeners", async () => {
+      handle = await startUiServer(createServerOptions());
+      const hostUrl = handle.url;
+      const proxyUrl = handle.proxyUrl;
+
+      handle.close("manual-close");
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      await expect(request(hostUrl)).rejects.toThrow();
+      await expect(request(proxyUrl)).rejects.toThrow();
     });
   });
 

--- a/__tests__/ui-viewer-none.test.ts
+++ b/__tests__/ui-viewer-none.test.ts
@@ -98,6 +98,11 @@ describe("remote MCP UI viewers", () => {
     expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("This looks like a remote session"), "info");
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("SSH: run `ssh -L"), "info");
+    const handle = state.uiServer;
+    expect(state.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining(`-L ${handle.proxyPort}:127.0.0.1:${handle.proxyPort}`),
+      "info",
+    );
 
     runtime?.close("test-cleanup");
   });
@@ -172,6 +177,11 @@ describe("MCP_UI_VIEWER=none", () => {
     expect(glimpseMocks.isGlimpseAvailable).not.toHaveBeenCalled();
     expect(glimpseMocks.openGlimpseWindow).not.toHaveBeenCalled();
     expect(state.ui.notify).toHaveBeenCalledWith(expect.stringContaining("MCP UI window suppressed"), "info");
+    const handle = state.uiServer;
+    expect(state.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining(`-L ${handle.proxyPort}:127.0.0.1:${handle.proxyPort}`),
+      "info",
+    );
     expect(state.ui.notify).toHaveBeenCalledWith(expect.not.stringContaining("Tool still ran"), "info");
 
     runtime?.close("test-cleanup");

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -3,6 +3,8 @@ import type { UiHostContext, UiResourceContent, UiResourceCsp } from "./types.ts
 // Use locally bundled AppBridge to avoid CDN Zod bundling issues
 const DEFAULT_APP_BRIDGE_MODULE_URL = "/app-bridge.bundle.js";
 const APP_SANDBOX = "allow-scripts allow-forms allow-modals allow-popups allow-downloads";
+const APP_PROXY_SANDBOX = `${APP_SANDBOX} allow-same-origin`;
+const APP_INNER_SANDBOX = APP_PROXY_SANDBOX;
 
 export interface HostHtmlTemplateInput {
   sessionToken: string;
@@ -16,6 +18,7 @@ export interface HostHtmlTemplateInput {
   cacheToolConsent: boolean;
   hostContext?: UiHostContext;
   appBridgeModuleUrl?: string;
+  sandboxProxyUrl: string;
 }
 
 export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
@@ -31,6 +34,9 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
   const requireToolConsent = safeInlineJSON(input.requireToolConsent);
   const cacheToolConsent = safeInlineJSON(input.cacheToolConsent);
   const moduleUrl = safeInlineJSON(input.appBridgeModuleUrl ?? DEFAULT_APP_BRIDGE_MODULE_URL);
+  const sandboxProxyUrl = safeInlineJSON(input.sandboxProxyUrl);
+  const resourceCsp = safeInlineJSON(input.resource.meta.csp);
+  const resourcePermissions = safeInlineJSON(input.resource.meta.permissions);
 
   return `<!doctype html>
 <html lang="en">
@@ -112,7 +118,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     </div>
   </header>
   <main>
-    <iframe id="mcp-app" sandbox="${APP_SANDBOX}" referrerpolicy="no-referrer"></iframe>
+    <iframe id="mcp-app" sandbox="${APP_PROXY_SANDBOX}" referrerpolicy="no-referrer"></iframe>
   </main>
   <div class="overlay" id="error-overlay">
     <div class="panel">
@@ -138,6 +144,10 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const ALLOW_ATTRIBUTE = ${allowAttribute};
     const REQUIRE_TOOL_CONSENT = ${requireToolConsent};
     const CACHE_TOOL_CONSENT = ${cacheToolConsent};
+    const SANDBOX_PROXY_URL = ${sandboxProxyUrl};
+    const RESOURCE_CSP = ${resourceCsp};
+    const RESOURCE_PERMISSIONS = ${resourcePermissions};
+    const INNER_SANDBOX = ${safeInlineJSON(APP_INNER_SANDBOX)};
     const STREAM_CONTEXT_KEY = "pi-mcp-adapter/stream";
     const STREAM_PATCH_METHOD = "notifications/pi-mcp-adapter/ui-result-patch";
 
@@ -148,6 +158,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const errorOverlay = document.getElementById("error-overlay");
     const completionOverlay = document.getElementById("completion-overlay");
     const errorMessage = document.getElementById("error-message");
+    const sandboxProxyOrigin = new URL(SANDBOX_PROXY_URL).origin;
 
     document.getElementById("server-name").textContent = SERVER_NAME;
     document.getElementById("tool-name").textContent = TOOL_NAME;
@@ -205,9 +216,40 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const bridge = new AppBridge(
       null,
       { name: "pi", version: "1.0.0" },
-      { serverTools: {}, openLinks: {}, logging: {}, updateModelContext: {}, message: {} },
+      {
+        serverTools: {},
+        openLinks: {},
+        logging: {},
+        updateModelContext: {},
+        message: {},
+        sandbox: {
+          ...(RESOURCE_CSP ? { csp: RESOURCE_CSP } : {}),
+          ...(RESOURCE_PERMISSIONS ? { permissions: RESOURCE_PERMISSIONS } : {}),
+        },
+      },
       { hostContext: HOST_CONTEXT }
     );
+
+    let sandboxResourceSent = false;
+    bridge.onsandboxready = async () => {
+      if (sandboxResourceSent) return;
+      sandboxResourceSent = true;
+      try {
+        const response = await fetch("/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN), {
+          headers: { Accept: "text/html" },
+        });
+        if (!response.ok) throw new Error("UI resource request failed: HTTP " + response.status);
+        const html = await response.text();
+        await bridge.sendSandboxResourceReady({
+          html,
+          sandbox: INNER_SANDBOX,
+          ...(RESOURCE_CSP ? { csp: RESOURCE_CSP } : {}),
+          ...(RESOURCE_PERMISSIONS ? { permissions: RESOURCE_PERMISSIONS } : {}),
+        });
+      } catch (error) {
+        showError("Failed to load MCP App resource: " + String(error));
+      }
+    };
 
     bridge.oncalltool = async (params) => {
       if (!consentGranted) {
@@ -240,7 +282,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     // Also listen for raw postMessage events with custom types (notify, prompt, intent, etc.)
     // These bypass the AppBridge protocol but are used by some MCP UI implementations
     window.addEventListener("message", async (event) => {
-      if (event.source !== iframe.contentWindow) return;
+      if (event.source !== iframe.contentWindow || event.origin !== sandboxProxyOrigin) return;
       const data = event.data;
       if (!data || typeof data !== "object") return;
       
@@ -304,6 +346,12 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     }
 
     // Connect bridge BEFORE loading iframe to ensure we're listening when the app sends ui/initialize
+    const sandboxMessageGuard = (event) => {
+      if (event.source === iframe.contentWindow && event.origin !== sandboxProxyOrigin) {
+        event.stopImmediatePropagation();
+      }
+    };
+    window.addEventListener("message", sandboxMessageGuard, true);
     try {
       const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow);
       await bridge.connect(transport);
@@ -315,7 +363,7 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     const iframeLoaded = new Promise((resolve) => {
       iframe.onload = resolve;
     });
-    iframe.src = "/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN);
+    iframe.src = SANDBOX_PROXY_URL;
     await iframeLoaded;
 
     const eventSource = new EventSource("/events?session=" + encodeURIComponent(SESSION_TOKEN));
@@ -446,7 +494,9 @@ function sanitizeCspDomains(domains: unknown): string[] {
 }
 
 function safeInlineJSON(value: unknown): string {
-  return JSON.stringify(value)
+  const json = JSON.stringify(value);
+  if (json === undefined) return "undefined";
+  return json
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
     .replace(/&/g, "\\u0026")

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "mcp-status.ts",
     "metadata-cache.ts",
     "host-html-template.ts",
+    "sandbox-proxy-template.ts",
     "ui-resource-handler.ts",
     "consent-manager.ts",
     "ui-server.ts",

--- a/sandbox-proxy-template.ts
+++ b/sandbox-proxy-template.ts
@@ -1,5 +1,3 @@
-import type { UiResourceCsp, UiResourcePermissions } from "./types.ts";
-
 /**
  * The proxy is served from a different loopback origin than the trusted host.
  * `allow-same-origin` is safe here because this document never contains the
@@ -217,9 +215,3 @@ function safeInlineJSON(value: unknown): string {
     .replace(/\u2028/g, "\\u2028")
     .replace(/\u2029/g, "\\u2029");
 }
-
-// Keep the metadata shape visible to type-aware consumers of this helper.
-export type SandboxProxyResourceMetadata = {
-  csp?: UiResourceCsp;
-  permissions?: UiResourcePermissions;
-};

--- a/sandbox-proxy-template.ts
+++ b/sandbox-proxy-template.ts
@@ -1,0 +1,225 @@
+import type { UiResourceCsp, UiResourcePermissions } from "./types.ts";
+
+/**
+ * The proxy is served from a different loopback origin than the trusted host.
+ * `allow-same-origin` is safe here because this document never contains the
+ * host's session capability; provider HTML is loaded into the nested frame.
+ */
+export const SANDBOX_PROXY_SANDBOX =
+  "allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin";
+export const SANDBOX_INNER_SANDBOX = SANDBOX_PROXY_SANDBOX;
+export const SANDBOX_PROXY_PATH = "/sandbox";
+
+export interface SandboxProxyTemplateInput {
+  parentOrigin: string;
+}
+
+/**
+ * Build the static document used by the trusted, second-origin sandbox proxy.
+ * The only per-session value is the exact origin of the parent host.
+ */
+export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string {
+  const parentOrigin = safeInlineJSON(input.parentOrigin);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MCP App Sandbox</title>
+  <style>
+    html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: transparent; }
+    iframe { display: block; width: 100%; height: 100%; border: 0; }
+  </style>
+</head>
+<body>
+  <iframe id="mcp-app" title="MCP App" sandbox="${SANDBOX_INNER_SANDBOX}" referrerpolicy="no-referrer"></iframe>
+  <script>
+    const EXPECTED_PARENT_ORIGIN = ${parentOrigin};
+    const SANDBOX_PROXY_READY_METHOD = "ui/notifications/sandbox-proxy-ready";
+    const SANDBOX_RESOURCE_READY_METHOD = "ui/notifications/sandbox-resource-ready";
+    const INNER_SANDBOX = ${safeInlineJSON(SANDBOX_INNER_SANDBOX)};
+    const MAX_PENDING_MESSAGES = 64;
+    const innerFrame = document.getElementById("mcp-app");
+    const pendingToInner = [];
+    let innerReady = false;
+
+    const isObject = (value) => value !== null && typeof value === "object";
+    const isMessageFromParent = (event) =>
+      event.source === window.parent && event.origin === EXPECTED_PARENT_ORIGIN;
+    const isMessageFromInner = (event) =>
+      event.source === innerFrame.contentWindow && event.origin === window.location.origin;
+
+    const postToParent = (data) => {
+      window.parent.postMessage(data, EXPECTED_PARENT_ORIGIN);
+    };
+
+    const postToInner = (data) => {
+      if (!innerReady || !innerFrame.contentWindow) {
+        if (pendingToInner.length < MAX_PENDING_MESSAGES) pendingToInner.push(data);
+        return;
+      }
+      innerFrame.contentWindow.postMessage(data, window.location.origin);
+    };
+
+    const flushPendingMessages = () => {
+      if (!innerFrame.contentWindow) return;
+      innerReady = true;
+      for (const data of pendingToInner.splice(0)) {
+        innerFrame.contentWindow.postMessage(data, window.location.origin);
+      }
+    };
+
+    const sanitizeDomains = (domains) => {
+      if (!Array.isArray(domains)) return [];
+      return [...new Set(domains.filter((domain) =>
+        typeof domain === "string" &&
+        domain.length > 0 &&
+        /^[\\x21-\\x7E]+$/.test(domain) &&
+        !/[;'\"]/.test(domain),
+      ))];
+    };
+
+    const toDirective = (name, trustedSources, domains) =>
+      name + " " + [...new Set([...trustedSources, ...domains])].join(" ");
+
+    const buildResourceCsp = (csp) => {
+      const resourceDomains = sanitizeDomains(csp?.resourceDomains);
+      const connectDomains = sanitizeDomains(csp?.connectDomains);
+      const frameDomains = sanitizeDomains(csp?.frameDomains);
+      const baseUriDomains = sanitizeDomains(csp?.baseUriDomains);
+      return [
+        "default-src 'none'",
+        "sandbox " + INNER_SANDBOX,
+        toDirective("script-src", ["'self'", "'unsafe-inline'"], resourceDomains),
+        toDirective("style-src", ["'self'", "'unsafe-inline'"], resourceDomains),
+        toDirective("font-src", ["'self'"], resourceDomains),
+        toDirective("img-src", ["'self'", "data:"], resourceDomains),
+        toDirective("media-src", ["'self'", "data:"], resourceDomains),
+        connectDomains.length > 0 ? "connect-src " + connectDomains.join(" ") : "connect-src 'none'",
+        frameDomains.length > 0 ? "frame-src " + frameDomains.join(" ") : "frame-src 'none'",
+        "worker-src 'none'",
+        "object-src 'none'",
+        baseUriDomains.length > 0 ? "base-uri " + baseUriDomains.join(" ") : "base-uri 'self'",
+      ].join("; ");
+    };
+
+    const escapeAttribute = (value) => value
+      .replace(/&/g, "&amp;")
+      .replace(/\"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+
+    const injectCsp = (html, csp) => {
+      const meta = '<meta http-equiv="Content-Security-Policy" content="' + escapeAttribute(csp) + '">';
+      const head = html.match(/<head(?:\\s[^>]*)?>/i);
+      if (head && head.index !== undefined) {
+        const end = head.index + head[0].length;
+        return html.slice(0, end) + meta + html.slice(end);
+      }
+      return meta + html;
+    };
+
+    const safeSandbox = (requested) => {
+      const requestedTokens = typeof requested === "string" ? requested.split(/\\s+/) : [];
+      const allowedTokens = new Set(INNER_SANDBOX.split(" "));
+      const tokens = requestedTokens.filter((token) => allowedTokens.has(token));
+      // Provider HTML needs both script execution and a real proxy-origin
+      // storage context. Never accept popup escape or top-navigation tokens.
+      return [...new Set([
+        "allow-scripts",
+        "allow-same-origin",
+        ...tokens,
+      ])].filter((token) => allowedTokens.has(token)).join(" ");
+    };
+
+    const buildAllowAttribute = (permissions) => {
+      if (!isObject(permissions) || Array.isArray(permissions)) return "";
+      const allowed = [];
+      if (permissions.camera) allowed.push("camera");
+      if (permissions.microphone) allowed.push("microphone");
+      if (permissions.geolocation) allowed.push("geolocation");
+      if (permissions.clipboardWrite) allowed.push("clipboard-write");
+      return allowed.join("; ");
+    };
+
+    const loadResource = (params) => {
+      if (!isObject(params) || typeof params.html !== "string" || !innerFrame.contentDocument) return;
+      innerFrame.setAttribute("sandbox", safeSandbox(params.sandbox));
+      const allow = buildAllowAttribute(params.permissions);
+      if (allow) innerFrame.setAttribute("allow", allow);
+      else innerFrame.removeAttribute("allow");
+      innerReady = false;
+      const document = innerFrame.contentDocument;
+      document.open();
+      document.write(injectCsp(params.html, buildResourceCsp(params.csp)));
+      document.close();
+      flushPendingMessages();
+    };
+
+    window.addEventListener("message", (event) => {
+      if (isMessageFromParent(event)) {
+        const data = event.data;
+        if (!isObject(data)) return;
+        if (data.method === SANDBOX_RESOURCE_READY_METHOD) {
+          loadResource(data.params);
+          return;
+        }
+        if (data.method === SANDBOX_PROXY_READY_METHOD) return;
+        if (typeof data.method === "string" && data.method.startsWith("ui/notifications/sandbox-")) return;
+        postToInner(data);
+        return;
+      }
+
+      if (!isMessageFromInner(event)) return;
+      const data = event.data;
+      if (!isObject(data)) return;
+      if (typeof data.method === "string" && data.method.startsWith("ui/notifications/sandbox-")) return;
+      postToParent(data);
+    });
+
+    postToParent({
+      jsonrpc: "2.0",
+      method: SANDBOX_PROXY_READY_METHOD,
+      params: {},
+    });
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * CSP for the proxy document itself. It contains only the inline relay script
+ * and a nested about:blank frame; provider policy is applied separately after
+ * the host sends the resource-ready notification.
+ */
+export function buildSandboxProxyCsp(): string {
+  return [
+    "default-src 'none'",
+    "script-src 'unsafe-inline'",
+    "style-src 'unsafe-inline'",
+    "frame-src 'self'",
+    "connect-src 'none'",
+    "worker-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    `sandbox ${SANDBOX_PROXY_SANDBOX}`,
+  ].join("; ");
+}
+
+function safeInlineJSON(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) return "undefined";
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+// Keep the metadata shape visible to type-aware consumers of this helper.
+export type SandboxProxyResourceMetadata = {
+  csp?: UiResourceCsp;
+  permissions?: UiResourcePermissions;
+};

--- a/types.ts
+++ b/types.ts
@@ -183,6 +183,9 @@ export type UiDisplayMode = "inline" | "fullscreen" | "pip";
 export interface UiServerHandle {
   url: string;
   port: number;
+  /** URL of the second-origin MCP Apps sandbox proxy. */
+  proxyUrl: string;
+  proxyPort: number;
   sessionToken: string;
   serverName: string;
   toolName: string;

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -12,6 +12,11 @@ import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
 import { formatAuthRequiredMessage, normalizeToolArguments } from "./utils.ts";
 import { buildHostHtmlTemplate, buildCspMetaContent } from "./host-html-template.ts";
+import {
+  buildSandboxProxyCsp,
+  buildSandboxProxyHtml,
+  SANDBOX_PROXY_PATH,
+} from "./sandbox-proxy-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
 import type { McpExtensionState } from "./state.ts";
@@ -99,6 +104,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
   const eventLog: Array<{ id: number; name: string; payload: unknown }> = [];
   let latestCheckpointEventId: number | undefined;
   let streamSummary: UiStreamSummary | undefined;
+  let server: http.Server | null = null;
+  let sandboxProxyServer: http.Server | null = null;
+  let sandboxProxyUrl: string | null = null;
+  let closeTimer: NodeJS.Timeout | null = null;
+  let listenersClosed = false;
 
   // Track messages from UI for retrieval
   const sessionMessages: UiSessionMessages = {
@@ -266,6 +276,32 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     watchdog = null;
   };
 
+  const closeListeners = () => {
+    if (listenersClosed) return;
+    listenersClosed = true;
+    stopWatchdog();
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+    try {
+      server?.close();
+    } catch {}
+    try {
+      sandboxProxyServer?.close();
+    } catch {}
+    closeSse();
+  };
+
+  const scheduleListenerClose = () => {
+    if (closeTimer || listenersClosed) return;
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      closeListeners();
+    }, 20);
+    closeTimer.unref();
+  };
+
   const markCompleted = (reason: string) => {
     if (completed) return;
     log.debug("Session completed", { reason });
@@ -273,9 +309,10 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     completed = true;
     stopWatchdog();
     options.onComplete?.(reason);
+    scheduleListenerClose();
   };
 
-  const server = http.createServer(async (req, res) => {
+  const hostServer = http.createServer(async (req, res) => {
     try {
       const method = req.method || "GET";
       const hostHeader = req.headers.host;
@@ -302,6 +339,10 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         }
         if (!validateTokenQuery(url, sessionToken, res)) return;
         touchHeartbeat();
+        if (!sandboxProxyUrl) {
+          sendText(res, 503, "Sandbox proxy is not ready");
+          return;
+        }
 
         const html = buildHostHtmlTemplate({
           sessionToken,
@@ -314,6 +355,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           requireToolConsent: options.consentManager.requiresPrompt(options.serverName),
           cacheToolConsent: options.consentManager.shouldCacheConsent(),
           hostContext,
+          sandboxProxyUrl,
         });
 
         res.writeHead(200, {
@@ -620,12 +662,6 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           : "done";
         markCompleted(reason);
         sendJson(res, 200, { ok: true, result: {} });
-        setTimeout(() => {
-          try {
-            server.close();
-          } catch {}
-          closeSse();
-        }, 20).unref();
         return;
       }
 
@@ -647,6 +683,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       sendJson(res, status, { ok: false, error: wrapped.message });
     }
   });
+  server = hostServer;
 
   if (options.initialResultPromise) {
     options.initialResultPromise.then(
@@ -662,10 +699,6 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     if (completed) return;
     if (Date.now() - lastHeartbeatAt <= ABANDONED_GRACE_MS) return;
     markCompleted("stale");
-    try {
-      server.close();
-    } catch {}
-    closeSse();
   }, WATCHDOG_INTERVAL_MS);
   watchdog.unref();
 
@@ -673,13 +706,79 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     const candidates = resolvePortCandidates(options.port);
     let candidateIndex = 0;
 
+    const startSandboxProxy = (parentOrigin: string): Promise<number> => {
+      const proxy = http.createServer((req, res) => {
+        try {
+          const method = req.method || "GET";
+          const hostHeader = req.headers.host;
+          const url = new URL(req.url || "/", `http://${hostHeader || "127.0.0.1"}`);
+          if (hostHeader !== undefined && !isAllowedHost(url.hostname)) {
+            sendText(res, 403, "Invalid host");
+            return;
+          }
+
+          if (method === "HEAD" && url.pathname === SANDBOX_PROXY_PATH) {
+            res.writeHead(200, {
+              "Content-Type": "text/html; charset=utf-8",
+              "Cache-Control": "no-store",
+              "Content-Security-Policy": buildSandboxProxyCsp(),
+            });
+            res.end();
+            return;
+          }
+
+          if (method === "GET" && url.pathname === SANDBOX_PROXY_PATH) {
+            res.writeHead(200, {
+              "Content-Type": "text/html; charset=utf-8",
+              "Cache-Control": "no-store",
+              "Content-Security-Policy": buildSandboxProxyCsp(),
+              "Referrer-Policy": "no-referrer",
+              "X-Content-Type-Options": "nosniff",
+            });
+            res.end(buildSandboxProxyHtml({ parentOrigin }));
+            return;
+          }
+
+          sendJson(res, 404, { ok: false, error: "Not found" });
+        } catch (error) {
+          sendJson(res, 500, { ok: false, error: error instanceof Error ? error.message : String(error) });
+        }
+      });
+      sandboxProxyServer = proxy;
+
+      return new Promise((resolveProxy, rejectProxy) => {
+        const onError = (error: NodeJS.ErrnoException) => {
+          proxy.off("listening", onListening);
+          rejectProxy(error);
+        };
+        const onListening = () => {
+          proxy.off("error", onError);
+          const address = proxy.address();
+          if (!address || typeof address === "string") {
+            rejectProxy(new ServerError("invalid sandbox proxy address"));
+            return;
+          }
+          resolveProxy(address.port);
+        };
+        proxy.once("error", onError);
+        proxy.listen(0, "127.0.0.1", onListening);
+      });
+    };
+
     const listen = () => {
-      server.once("error", onError);
-      server.listen(candidates[candidateIndex], "127.0.0.1", onListening);
+      const candidate = candidates[candidateIndex];
+      if (candidate === undefined) {
+        const error = new ServerError("no UI server port candidates available");
+        closeListeners();
+        reject(error);
+        return;
+      }
+      hostServer.once("error", onError);
+      hostServer.listen(candidate, "127.0.0.1", onListening);
     };
 
     const onError = (error: NodeJS.ErrnoException) => {
-      server.off("listening", onListening);
+      hostServer.off("listening", onListening);
       if (error.code === "EADDRINUSE" && candidateIndex < candidates.length - 1) {
         candidateIndex += 1;
         listen();
@@ -687,6 +786,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       }
       log.error("Failed to start server", error);
       const port = candidates[candidateIndex];
+      closeListeners();
       reject(new ServerError(error.message, {
         ...(port !== undefined ? { port } : {}),
         cause: error,
@@ -694,55 +794,66 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     };
 
     const onListening = () => {
-      server.off("error", onError);
-      const address = server.address();
+      hostServer.off("error", onError);
+      const address = hostServer.address();
       if (!address || typeof address === "string") {
         const err = new ServerError("invalid address");
         log.error("Invalid server address", err);
+        closeListeners();
         reject(err);
         return;
       }
 
-      log.debug("Server started", { port: address.port });
-      rememberMoshiDiscoveryPort(address.port);
+      const parentOrigin = `http://localhost:${address.port}`;
+      void startSandboxProxy(parentOrigin).then((proxyPort) => {
+        sandboxProxyUrl = `http://localhost:${proxyPort}${SANDBOX_PROXY_PATH}`;
+        log.debug("Servers started", { port: address.port, proxyPort });
+        rememberMoshiDiscoveryPort(address.port);
 
-      const handle: UiServerHandle = {
-        url: `http://localhost:${address.port}/?session=${sessionToken}`,
-        port: address.port,
-        sessionToken,
-        serverName: options.serverName,
-        toolName: options.toolName,
-        close: (reason?: string) => {
-          markCompleted(reason ?? "closed");
-          try {
-            server.close();
-          } catch {}
-          closeSse();
-        },
-        sendToolInput: (args: Record<string, unknown>) => {
-          pushEvent("tool-input", { arguments: args });
-        },
-        sendToolResult: (result: CallToolResult) => {
-          pushEvent("tool-result", result);
-        },
-        sendResultPatch: (result: CallToolResult) => {
-          pushEvent("result-patch", result);
-        },
-        sendToolCancelled: (reason: string) => {
-          pushEvent("tool-cancelled", { reason });
-        },
-        sendResourceUpdated: (uri: string) => {
-          pushEvent("resource-updated", { uri });
-        },
-        sendHostContext: (context: UiHostContext) => {
-          Object.assign(hostContext, context);
-          pushEvent("host-context", context);
-        },
-        getSessionMessages: () => ({ ...sessionMessages }),
-        getStreamSummary: () => streamSummary ? { ...streamSummary, phases: [...streamSummary.phases] } : undefined,
-      };
+        const handle: UiServerHandle = {
+          url: `http://localhost:${address.port}/?session=${sessionToken}`,
+          port: address.port,
+          proxyUrl: sandboxProxyUrl,
+          proxyPort,
+          sessionToken,
+          serverName: options.serverName,
+          toolName: options.toolName,
+          close: (reason?: string) => {
+            markCompleted(reason ?? "closed");
+            closeListeners();
+          },
+          sendToolInput: (args: Record<string, unknown>) => {
+            pushEvent("tool-input", { arguments: args });
+          },
+          sendToolResult: (result: CallToolResult) => {
+            pushEvent("tool-result", result);
+          },
+          sendResultPatch: (result: CallToolResult) => {
+            pushEvent("result-patch", result);
+          },
+          sendToolCancelled: (reason: string) => {
+            pushEvent("tool-cancelled", { reason });
+          },
+          sendResourceUpdated: (uri: string) => {
+            pushEvent("resource-updated", { uri });
+          },
+          sendHostContext: (context: UiHostContext) => {
+            Object.assign(hostContext, context);
+            pushEvent("host-context", context);
+          },
+          getSessionMessages: () => ({ ...sessionMessages }),
+          getStreamSummary: () => streamSummary ? { ...streamSummary, phases: [...streamSummary.phases] } : undefined,
+        };
 
-      resolve(handle);
+        resolve(handle);
+      }).catch((error) => {
+        log.error("Failed to start sandbox proxy", error instanceof Error ? error : undefined);
+        closeListeners();
+        const wrapped = error instanceof ServerError
+          ? error
+          : new ServerError(error instanceof Error ? error.message : String(error), { cause: error });
+        reject(wrapped);
+      });
     };
 
     listen();

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -806,6 +806,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
       const parentOrigin = `http://localhost:${address.port}`;
       void startSandboxProxy(parentOrigin).then((proxyPort) => {
+        if (completed || listenersClosed) {
+          closeListeners();
+          reject(new ServerError("UI session completed before sandbox proxy was ready"));
+          return;
+        }
         sandboxProxyUrl = `http://localhost:${proxyPort}${SANDBOX_PROXY_PATH}`;
         log.debug("Servers started", { port: address.port, proxyPort });
         rememberMoshiDiscoveryPort(address.port);

--- a/ui-session.ts
+++ b/ui-session.ts
@@ -173,7 +173,7 @@ function probeMoshiGateway(): Promise<boolean> {
   });
 }
 
-function remoteAccessHint(opts: { url: string; port: number; moshi: boolean; openError: string | null; openedOnHost?: boolean }): string {
+function remoteAccessHint(opts: { url: string; port: number; proxyPort: number; moshi: boolean; openError: string | null; openedOnHost?: boolean }): string {
   const lines = [
     opts.openError !== null
       ? "Couldn't open MCP UI here. Open it from your own device:"
@@ -186,10 +186,12 @@ function remoteAccessHint(opts: { url: string; port: number; moshi: boolean; ope
     lines.push(`Browser launch failed: ${opts.openError}`);
   }
   if (opts.moshi) {
-    lines.push("Moshi: tap the preview button in the terminal title bar and pick this MCP UI server.");
+    lines.push(
+      `Moshi: tap the preview button in the terminal title bar and pick this MCP UI server (it must reach ports ${opts.port} and ${opts.proxyPort}).`,
+    );
   }
   lines.push(
-    `SSH: run \`ssh -L ${opts.port}:127.0.0.1:${opts.port} <this-host>\` on your local machine, then open the URL above.`,
+    `SSH: run \`ssh -L ${opts.port}:127.0.0.1:${opts.port} -L ${opts.proxyPort}:127.0.0.1:${opts.proxyPort} <this-host>\` on your local machine, then open the URL above.`,
     "mosh can't forward ports - run that ssh command in a separate terminal.",
   );
   return lines.join("\n");
@@ -479,7 +481,11 @@ export async function maybeStartUiSession(
     if (uiSuppressed) {
       viewer = "suppressed";
       windowOpen = false;
-      state.ui?.notify(`MCP UI window suppressed (MCP_UI_VIEWER=${viewerPref}). Open manually: ${handle.url}`, "info");
+      state.ui?.notify(
+        `MCP UI window suppressed (MCP_UI_VIEWER=${viewerPref}). Open manually: ${handle.url}\n` +
+        `If this session is remote, run ssh -L ${handle.port}:127.0.0.1:${handle.port} -L ${handle.proxyPort}:127.0.0.1:${handle.proxyPort} <this-host> first.`,
+        "info",
+      );
       log.info("Suppressing MCP UI window (MCP_UI_VIEWER=" + viewerPref + ")", { url: handle.url });
     } else {
       const remoteLikely = remoteByEnv || await hasActiveRemoteLogin();
@@ -487,6 +493,7 @@ export async function maybeStartUiSession(
         state.ui?.notify(remoteAccessHint({
           url: handle.url,
           port: handle.port,
+          proxyPort: handle.proxyPort,
           moshi: await probeMoshiGateway(),
           openError,
           openedOnHost,


### PR DESCRIPTION
## Summary
- serve MCP App views through a second loopback sandbox proxy origin so browser storage APIs work
- keep host session/resource capabilities on the host origin only, with the proxy serving only tokenless sandbox HTML
- add focused coverage for the two-origin host/proxy split, token isolation, CSP/sandbox policy, dual-listener cleanup, and remote two-port guidance

Closes #480.

## Validation
- `npm test -- --run __tests__/host-html-template.test.ts __tests__/sandbox-proxy-template.test.ts __tests__/ui-server.test.ts __tests__/ui-integration.test.ts __tests__/ui-viewer-none.test.ts`
- `npm run typecheck`
- `npm run test:public-exports`
- `git diff --check origin/main...HEAD`
- manual browser probe confirmed host/proxy origins differ and inner app storage APIs work

## Notes
Full `npm test` still hits the existing local baseline failures from missing generated interactive-visualizer artifacts, plus one request-header cleanup flake that passes in isolation.
