### PR TITLE
fix(oauth): bound SDK auth requests with a timeout and wire abort signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OAuth loopback redirects can use `{port}` with `localhost`, `127.0.0.1`, or `::1` when a provider permits RFC 8252 dynamic ports. Thanks to [@nrutman](https://github.com/nrutman) for PR #483.
 - Runtime MCP status snapshots now include each server's `directToolCount`, the number of direct tools currently registered with Pi, including resource tools. Thanks to [@FischLu](https://github.com/FischLu) for #482.
 
+### Fixed
+- OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
+
 ## [2.32.1] - 2026-09-01
 
 ### Fixed

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -782,6 +782,7 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.sdkAuth).toHaveBeenNthCalledWith(2, expect.anything(), {
       serverUrl: "https://api.example.com/mcp",
       authorizationCode: "manual-code",
+      fetchFn: expect.any(Function),
     });
     expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(mocks.waitForCallback.mock.calls[0][0]);
     expect(getOAuthState("browser-fail")).toBeUndefined();
@@ -799,6 +800,7 @@ describe("mcp-auth-flow explicit auth", () => {
         expect(options).toEqual({
           serverUrl: "https://api.example.com/mcp",
           authorizationCode: "pasted-code",
+          fetchFn: expect.any(Function),
         });
         return "AUTHORIZED";
       });
@@ -1080,12 +1082,14 @@ describe("mcp-auth-flow explicit auth", () => {
       serverUrl: "https://api.example.com/mcp",
       resourceMetadataUrl: new URL(resourceMetadataUrl),
       scope: "mcp:read",
+      fetchFn: expect.any(Function),
     });
     expect(mocks.sdkAuth).toHaveBeenNthCalledWith(2, expect.anything(), {
       serverUrl: "https://api.example.com/mcp",
       authorizationCode: "auth-code",
       resourceMetadataUrl: new URL(resourceMetadataUrl),
       scope: "mcp:read",
+      fetchFn: expect.any(Function),
     });
     expect(mocks.cancelPendingCallback).toHaveBeenCalledWith(oauthState);
     expect(getOAuthState("direct-complete")).toBeUndefined();
@@ -1111,11 +1115,13 @@ describe("mcp-auth-flow explicit auth", () => {
     expect(mocks.sdkAuth).toHaveBeenNthCalledWith(1, expect.anything(), {
       serverUrl: "https://api.example.com/mcp",
       scope: "session:role:MCP_ROLE",
+      fetchFn: expect.any(Function),
     });
     expect(mocks.sdkAuth).toHaveBeenNthCalledWith(2, expect.anything(), {
       serverUrl: "https://api.example.com/mcp",
       authorizationCode: "auth-code",
       scope: "session:role:MCP_ROLE",
+      fetchFn: expect.any(Function),
     });
   });
 

--- a/mcp-auth-flow-timeout.test.ts
+++ b/mcp-auth-flow-timeout.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert"
+import { createServer } from "node:http"
+import { after, before, describe, it } from "node:test"
+
+import {
+  initializeOAuth,
+  shutdownOAuth,
+  startAuth,
+} from "./mcp-auth-flow.ts"
+import {
+  clearAllCredentials,
+  resetTestAuthSecretStore,
+} from "./mcp-auth.ts"
+
+// A stalling authorization server proves the OAuth flow's outbound requests are
+// timeout-bounded. Without the bound, the metadata fetch below would hang until
+// the OS TCP timeout.
+describe("OAuth flow request timeout", () => {
+  const serverName = "oauth-timeout"
+  let origin = ""
+  let serverUrl = ""
+  const previousTimeoutMs = process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS
+
+  const server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", origin || "http://127.0.0.1")
+
+    if (request.method === "POST" && requestUrl.pathname === "/mcp") {
+      response.writeHead(401, {
+        "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+      })
+      response.end()
+      return
+    }
+
+    if (request.method === "GET" && requestUrl.pathname === "/.well-known/oauth-protected-resource") {
+      response.writeHead(200, { "Content-Type": "application/json" })
+      response.end(JSON.stringify({
+        resource: serverUrl,
+        authorization_servers: [origin],
+      }))
+      return
+    }
+
+    // Authorization-server metadata never responds; this is the stall the flow
+    // must not wait on.
+    if (request.method === "GET" && [
+      "/.well-known/oauth-authorization-server",
+      "/.well-known/openid-configuration",
+    ].includes(requestUrl.pathname)) {
+      return
+    }
+
+    response.writeHead(404)
+    response.end()
+  })
+
+  before(async () => {
+    process.env.PI_MCP_ADAPTER_TEST_AUTH_STORE = "memory"
+    process.env.PI_MCP_ADAPTER_DISABLE_AUTH_CACHE = "1"
+    process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS = "200"
+    resetTestAuthSecretStore()
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port")
+    origin = `http://127.0.0.1:${address.port}`
+    serverUrl = `${origin}/mcp`
+    await initializeOAuth()
+  })
+
+  after(async () => {
+    if (previousTimeoutMs === undefined) {
+      delete process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS
+    } else {
+      process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS = previousTimeoutMs
+    }
+    await shutdownOAuth()
+    clearAllCredentials(serverName)
+    resetTestAuthSecretStore()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  })
+
+  it("rejects when authorization-server metadata stalls, instead of hanging", async () => {
+    const startedAt = Date.now()
+    await assert.rejects(
+      () => startAuth(serverName, serverUrl, { url: serverUrl, auth: "oauth" }),
+    )
+    const elapsedMs = Date.now() - startedAt
+    assert.ok(
+      elapsedMs < 5_000,
+      `startAuth should have rejected at the request timeout, took ${elapsedMs}ms`,
+    )
+  })
+})

--- a/mcp-auth-flow-timeout.test.ts
+++ b/mcp-auth-flow-timeout.test.ts
@@ -93,4 +93,31 @@ describe("OAuth flow request timeout", () => {
       `startAuth should have rejected at the request timeout, took ${elapsedMs}ms`,
     )
   })
+
+  it("ignores malformed numeric-looking timeout overrides", async () => {
+    process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS = "1e999"
+    const originalTimeout = AbortSignal.timeout
+    const observedTimeouts: number[] = []
+    Object.defineProperty(AbortSignal, "timeout", {
+      configurable: true,
+      value(milliseconds: number) {
+        observedTimeouts.push(milliseconds)
+        return originalTimeout.call(AbortSignal, 50)
+      },
+    })
+
+    try {
+      await assert.rejects(
+        () => startAuth(`${serverName}-malformed`, serverUrl, { url: serverUrl, auth: "oauth" }),
+      )
+    } finally {
+      Object.defineProperty(AbortSignal, "timeout", {
+        configurable: true,
+        value: originalTimeout,
+      })
+      process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS = "200"
+    }
+
+    assert.equal(observedTimeouts[0], 30_000)
+  })
 })

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -315,11 +315,12 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
 
 /** Default timeout for each outbound HTTP request the SDK issues during OAuth. */
 const DEFAULT_OAUTH_REQUEST_TIMEOUT_MS = 30_000
+const MAX_OAUTH_REQUEST_TIMEOUT_MS = 2_147_483_647
 
 function resolveOAuthRequestTimeoutMs(): number {
   const raw = process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS
-  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OAUTH_REQUEST_TIMEOUT_MS
+  const parsed = raw === undefined ? Number.NaN : Number(raw)
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= MAX_OAUTH_REQUEST_TIMEOUT_MS ? parsed : DEFAULT_OAUTH_REQUEST_TIMEOUT_MS
 }
 
 /**

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -313,6 +313,29 @@ async function probeAuthDiscovery(serverUrl: string, definition?: ServerEntry, s
   }
 }
 
+/** Default timeout for each outbound HTTP request the SDK issues during OAuth. */
+const DEFAULT_OAUTH_REQUEST_TIMEOUT_MS = 30_000
+
+function resolveOAuthRequestTimeoutMs(): number {
+  const raw = process.env.PI_MCP_OAUTH_REQUEST_TIMEOUT_MS
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OAUTH_REQUEST_TIMEOUT_MS
+}
+
+/**
+ * fetch bound to both the owning runtime/options signal and a per-request
+ * timeout. The MCP SDK issues discovery, dynamic client registration,
+ * token-exchange, and refresh requests through this during OAuth; without a
+ * bound timeout a stalled endpoint hangs until the OS TCP timeout (~2 minutes).
+ */
+function authFetch(signal: AbortSignal | undefined): (url: string | URL, init?: RequestInit) => Promise<Response> {
+  return (url, init) => {
+    const timeoutSignal = AbortSignal.timeout(resolveOAuthRequestTimeoutMs())
+    const combined = combineAbortSignals(signal, timeoutSignal, init?.signal ?? undefined)
+    return fetch(url, { ...init, ...(combined ? { signal: combined } : {}) })
+  }
+}
+
 type OAuthRedirectTarget =
   | {
     mode: "local"
@@ -436,7 +459,7 @@ export async function startAuth(
     try {
       const discovery = applyOAuthConfig(await probeAuthDiscovery(serverUrl, definition, signal), config)
       throwIfAborted(signal)
-      const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+      const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery, fetchFn: authFetch(signal) }), signal)
       throwIfAborted(signal)
       if (result !== "AUTHORIZED") {
         throw new UnauthorizedError("Failed to authorize")
@@ -516,7 +539,7 @@ export async function startAuth(
 
     const discovery = applyOAuthConfig(await probeAuthDiscovery(serverUrl, definition, signal), config)
     throwIfAborted(signal)
-    const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery }), signal)
+    const result = await abortable(runSdkAuth(authProvider, { serverUrl, ...discovery, fetchFn: authFetch(signal) }), signal)
     throwIfAborted(signal)
     if (result === "AUTHORIZED") {
       authProvider.deactivate()
@@ -854,6 +877,7 @@ export async function completeAuth(
       authorizationCode: code,
       ...(iss !== undefined ? { iss } : {}),
       ...pendingAuth.discovery,
+      fetchFn: authFetch(signal),
     }), signal)
     throwIfAborted(signal)
     if (result !== "AUTHORIZED") {
@@ -1047,6 +1071,7 @@ export async function getValidToken(
           serverUrl,
           ...discovery,
           ...(options.skipIssuerMetadataValidation === true ? { skipIssuerMetadataValidation: true } : {}),
+          fetchFn: authFetch(signal),
         }), signal)
         throwIfAborted(signal)
         if (result !== "AUTHORIZED") {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:public-exports": "npm run build:public && node --test public-exports.test.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test --test-concurrency=1 oauth-public-api.test.ts mcp-auth.test.ts mcp-auth-flow.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts mcp-local-oauth-flow.test.ts",
+    "test:oauth": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test --test-concurrency=1 oauth-public-api.test.ts mcp-auth.test.ts mcp-auth-flow.test.ts mcp-auth-flow-timeout.test.ts mcp-callback-server.test.ts mcp-oauth-provider.test.ts mcp-local-oauth-flow.test.ts",
     "test:oauth-provider": "PI_MCP_ADAPTER_TEST_AUTH_STORE=memory PI_MCP_ADAPTER_DISABLE_AUTH_CACHE=1 node --import tsx --test mcp-oauth-provider.test.ts",
     "test:conformance": "bash conformance/run.sh"
   },


### PR DESCRIPTION
Fixes #485.

## What

The OAuth flow (`startAuth`, `completeAuth`, and `getValidToken` refresh) called `runSdkAuth(...)` without a `fetchFn`, so the MCP SDK's OAuth HTTP requests used bare global `fetch` with no timeout or abort signal. A stalled discovery, dynamic registration, token exchange, or token refresh endpoint could hang until the OS TCP timeout and freeze the agent turn.

## Change

- Adds an `authFetch(signal)` helper in `mcp-auth-flow.ts` that bounds each SDK OAuth request with `AbortSignal.timeout(...)`.
- Combines the owning runtime/options signal, the SDK request signal, and the timeout signal so cancellation aborts the in-flight request.
- Defaults to `30_000` ms and accepts `PI_MCP_OAUTH_REQUEST_TIMEOUT_MS` only when it is a whole positive safe integer within Node's timer range.
- Passes `fetchFn: authFetch(signal)` into `runSdkAuth(...)` for authorization startup, callback completion, client credentials, and token refresh.
- Adds `mcp-auth-flow-timeout.test.ts` coverage for stalled metadata and malformed timeout overrides, and registers it in `test:oauth`.
- Adds changelog credit for [@west-david](https://github.com/west-david).

## Testing

- `npm run typecheck`
- `npm run test:oauth` — 148/148
- `npx vitest run __tests__/mcp-auth-flow-client-credentials.test.ts` — 48/48
- `git diff --check`

Fresh reviews found no remaining issues on the final head.
