### PR TITLE
refactor(sampling): use model registry completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OAuth loopback redirects can use `{port}` with `localhost`, `127.0.0.1`, or `::1` when a provider permits RFC 8252 dynamic ports. Thanks to [@nrutman](https://github.com/nrutman) for PR #483.
 - Runtime MCP status snapshots now include each server's `directToolCount`, the number of direct tools currently registered with Pi, including resource tools. Thanks to [@FischLu](https://github.com/FischLu) for #482.
 
+### Changed
+- MCP sampling requests now route through Pi's `ModelRegistry.complete`, leaving provider authentication, environment, and base URL handling to the host.
+
 ### Fixed
 - OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
 

--- a/__tests__/sampling-handler.test.ts
+++ b/__tests__/sampling-handler.test.ts
@@ -1,14 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Model } from "@earendil-works/pi-ai";
 import type { CreateMessageRequest, ModelPreferences } from "@modelcontextprotocol/client";
 import type { SamplingHandlerOptions } from "../sampling-handler.ts";
 
 const mocks = vi.hoisted(() => ({
   complete: vi.fn(),
-}));
-
-vi.mock("@earendil-works/pi-ai/compat", () => ({
-  complete: mocks.complete,
 }));
 
 const usage = {
@@ -60,7 +56,7 @@ function createOptions(overrides: Partial<SamplingHandlerOptions> = {}): Samplin
     autoApprove: true,
     modelRegistry: {
       getAvailable: vi.fn(() => [model]),
-      getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key", headers: { "x-test": "1" } })),
+      complete: mocks.complete,
     },
     getCurrentModel: vi.fn(() => undefined),
     getSignal: vi.fn(() => undefined),
@@ -121,8 +117,6 @@ describe("sampling handler", () => {
         ],
       },
       {
-        apiKey: "key",
-        headers: { "x-test": "1" },
         maxTokens: 50,
         temperature: 0.2,
         metadata: { locale: "fr" },
@@ -169,7 +163,7 @@ describe("sampling handler", () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [haiku, opus]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     }, { hints: [{ name: "haiku" }] });
@@ -181,7 +175,7 @@ describe("sampling handler", () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [haiku, opus]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     }, { hints: [{ name: " HAIKU " }] });
@@ -193,7 +187,7 @@ describe("sampling handler", () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [geminiFlash, opus]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     }, { hints: [{ name: "2.5 Flash" }] });
@@ -205,7 +199,7 @@ describe("sampling handler", () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [geminiFlash, opus]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     }, { hints: [{ name: "google/gemini" }] });
@@ -217,7 +211,7 @@ describe("sampling handler", () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [haiku, geminiFlash, opus]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     }, { hints: [{ name: "gemini" }, { name: "haiku" }] });
@@ -225,30 +219,26 @@ describe("sampling handler", () => {
     expect(mocks.complete.mock.calls[0][0]).toBe(geminiFlash);
   });
 
-  it("falls back when hinted models do not have configured auth", async () => {
-    const getApiKeyAndHeaders = vi.fn(async (candidate: Model<Api>) => {
-      if (candidate.id === "claude-haiku") return { ok: false, error: "missing key" };
-      return { ok: true, apiKey: "key" };
-    });
+  it("propagates completion errors without falling back to another candidate", async () => {
+    const complete = vi.fn().mockRejectedValue(new Error("Provider is not configured: anthropic"));
 
-    await runBasicSampling({
+    await expect(runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [haiku, opus]),
-        getApiKeyAndHeaders,
+        complete,
       },
       getCurrentModel: vi.fn(() => opus),
-    }, { hints: [{ name: "haiku" }] });
+    }, { hints: [{ name: "haiku" }] })).rejects.toThrow("Provider is not configured: anthropic");
 
-    expect(getApiKeyAndHeaders).toHaveBeenNthCalledWith(1, haiku);
-    expect(getApiKeyAndHeaders).toHaveBeenNthCalledWith(2, opus);
-    expect(mocks.complete.mock.calls[0][0]).toBe(opus);
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete.mock.calls[0][0]).toBe(haiku);
   });
 
   it("preserves current-model-first selection when no hints are provided", async () => {
     await runBasicSampling({
       modelRegistry: {
         getAvailable: vi.fn(() => [haiku]),
-        getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "key" })),
+        complete: mocks.complete,
       },
       getCurrentModel: vi.fn(() => opus),
     });

--- a/sampling-handler.ts
+++ b/sampling-handler.ts
@@ -1,5 +1,4 @@
-import { complete } from "@earendil-works/pi-ai/compat";
-import type { Api, AssistantMessage, Message, Model, ProviderHeaders, TextContent } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Message, Model, TextContent } from "@earendil-works/pi-ai";
 import { truncateAtWord } from "./utils.ts";
 import { throwIfAborted } from "./abort.ts";
 import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
@@ -13,7 +12,7 @@ import {
 } from "@modelcontextprotocol/client";
 
 export type SamplingUIContext = Pick<ExtensionUIContext, "confirm">;
-export type SamplingModelRegistry = Pick<ModelRegistry, "getAvailable" | "getApiKeyAndHeaders">;
+export type SamplingModelRegistry = Pick<ModelRegistry, "getAvailable" | "complete">;
 
 export interface SamplingHandlerOptions {
   serverName: string;
@@ -57,7 +56,7 @@ export async function handleSamplingRequest(
   }
 
   const messages = params.messages.map(convertSamplingMessage);
-  const { model, apiKey, headers } = await resolveSamplingModel(options, params.modelPreferences);
+  const model = resolveSamplingModel(options, params.modelPreferences);
   throwIfAborted(signal);
   await confirmSampling(
     options,
@@ -66,15 +65,13 @@ export async function handleSamplingRequest(
   );
   throwIfAborted(signal);
 
-  const result = await complete(
+  const result = await options.modelRegistry.complete(
     model,
     {
       ...(params.systemPrompt !== undefined ? { systemPrompt: params.systemPrompt } : {}),
       messages,
     },
     {
-      ...(apiKey !== undefined ? { apiKey } : {}),
-      ...(headers !== undefined ? { headers } : {}),
       maxTokens: params.maxTokens,
       ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       ...(params.metadata !== undefined ? { metadata: params.metadata as Record<string, unknown> } : {}),
@@ -124,14 +121,10 @@ function messageText(message: Message): string {
   }).join("\n");
 }
 
-async function resolveSamplingModel(
+function resolveSamplingModel(
   options: SamplingHandlerOptions,
   modelPreferences: ModelPreferences | undefined,
-): Promise<{
-  model: Model<Api>;
-  apiKey?: string;
-  headers?: ProviderHeaders;
-}> {
+): Model<Api> {
   const candidates: Model<Api>[] = [];
   const availableModels = options.modelRegistry.getAvailable();
 
@@ -153,26 +146,10 @@ async function resolveSamplingModel(
     addSamplingCandidate(candidates, model);
   }
 
-  const errors: string[] = [];
   const signal = options.getSignal();
-  for (const model of candidates) {
-    throwIfAborted(signal);
-    const auth = await options.modelRegistry.getApiKeyAndHeaders(model);
-    throwIfAborted(signal);
-    if (auth.ok === false) {
-      errors.push(`${model.provider}/${model.id}: ${auth.error}`);
-      continue;
-    }
-    return {
-      model,
-      ...(auth.apiKey !== undefined ? { apiKey: auth.apiKey } : {}),
-      ...(auth.headers !== undefined ? { headers: auth.headers } : {}),
-    };
-  }
-
-  if (errors.length > 0) {
-    throw new Error(`No configured auth for MCP sampling model. ${errors.join("; ")}`);
-  }
+  throwIfAborted(signal);
+  const model = candidates[0];
+  if (model) return model;
   throw new Error("No Pi model is available for MCP sampling");
 }
 


### PR DESCRIPTION
## Summary
- route MCP sampling completions through Pi's `ModelRegistry.complete`
- remove adapter-owned auth/header preflight for sampling requests
- preserve model selection, approval, message conversion, and completion error propagation

Closes #489.

## Validation
- `npx vitest run __tests__/sampling-handler.test.ts __tests__/server-manager-sampling.test.ts __tests__/package-manifest.test.ts`
- `npm run typecheck`
- `git diff --check`
