### PR TITLE
fix(output): reuse host truncation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.
+- MCP output truncation now uses Pi host truncation semantics and formatting while preserving MCP artifact spill behavior.
 - OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
 
 ## [2.32.1] - 2026-09-01

--- a/__tests__/mcp-output-guard.test.ts
+++ b/__tests__/mcp-output-guard.test.ts
@@ -44,12 +44,12 @@ describe("guardMcpOutput", () => {
   });
 
   it("truncates large text output and saves the full output to a file", async () => {
-    const text = Array.from({ length: 20 }, (_, i) => `line-${i} ${"x".repeat(40)}`).join("\n");
+    const text = Array.from({ length: 20 }, (_, i) => `line-${i} ${"x".repeat(100)}`).join("\n");
     const guarded = await guardMcpOutput(
       [{ type: "text", text }],
       {
-        maxBytes: 300,
-        maxLines: 8,
+        maxBytes: 1500,
+        maxLines: 100,
         detailsMaxBytes: 1200,
         rawMcpResult: { content: [{ type: "text", text }], isError: false, structuredContent: { rows: [text] } },
       },
@@ -58,7 +58,15 @@ describe("guardMcpOutput", () => {
     expect(guarded.outputGuard).toMatchObject({
       truncated: true,
       originalLines: 20,
+      totalLines: 20,
+      totalBytes: Buffer.byteLength(text, "utf8"),
+      truncatedBy: "bytes",
+      maxLines: 100,
+      maxBytes: 1500,
+      firstLineExceedsLimit: false,
     });
+    expect(guarded.outputGuard?.outputLines).toBeGreaterThan(0);
+    expect(guarded.outputGuard?.outputBytes).toBeLessThanOrEqual(1500);
     expect(guarded.outputGuard?.fullOutputPath).toBeTruthy();
     expect(guarded.content).toHaveLength(1);
     expect(guarded.content[0]).toMatchObject({ type: "text" });
@@ -304,14 +312,83 @@ describe("guardMcpOutput", () => {
     expect(saved).toBe(text);
   });
 
-  it("truncates on line count alone", async () => {
+  it("reports the delivered preview in the line truncation notice and details", async () => {
     const text = Array.from({ length: 30 }, (_, i) => `entry-${i}`).join("\n");
     const guarded = await guardMcpOutput([{ type: "text", text }], { maxBytes: 10_000, maxLines: 10 });
 
-    expect(guarded.outputGuard).toMatchObject({ truncated: true, originalLines: 30 });
     const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
+    const noticeStart = returnedText.indexOf("\n\n[MCP text output truncated:");
+    expect(noticeStart).toBeGreaterThan(0);
+    const deliveredPreview = returnedText.slice(0, noticeStart);
+
+    expect(guarded.outputGuard).toMatchObject({
+      truncated: true,
+      originalLines: 30,
+      totalLines: 30,
+      totalBytes: Buffer.byteLength(text, "utf8"),
+      truncatedBy: "lines",
+      outputLines: 7,
+      outputBytes: Buffer.byteLength(deliveredPreview, "utf8"),
+      maxLines: 10,
+      maxBytes: 10_000,
+      firstLineExceedsLimit: false,
+    });
+    expect(deliveredPreview.split("\n")).toHaveLength(guarded.outputGuard!.outputLines);
     expect(returnedText).toContain("entry-0");
+    expect(returnedText).not.toContain("entry-7");
     expect(returnedText).not.toContain("entry-29");
+    expect(returnedText).toContain("Truncated: showing 7 of 30 lines (10 line limit)");
+  });
+
+  it("does not count a trailing newline as an additional line", async () => {
+    const text = "a\nb\n";
+    const guarded = await guardMcpOutput([{ type: "text", text }], { maxBytes: 100, maxLines: 2 });
+
+    expect(guarded.content).toEqual([{ type: "text", text }]);
+    expect(guarded.outputGuard).toBeUndefined();
+  });
+
+  it("does not return a partial first line when it exceeds the byte limit", async () => {
+    const text = `${"x".repeat(10)}\nsmall`;
+    const guarded = await guardMcpOutput([{ type: "text", text }], { maxBytes: 5, maxLines: 10 });
+
+    expect(guarded.outputGuard).toMatchObject({
+      truncated: true,
+      truncatedBy: "bytes",
+      totalLines: 2,
+      totalBytes: Buffer.byteLength(text, "utf8"),
+      outputLines: 0,
+      outputBytes: 0,
+      firstLineExceedsLimit: true,
+      maxLines: 10,
+      maxBytes: 5,
+    });
+    expect(guarded.outputGuard?.fullOutputPath).toBeTruthy();
+    const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
+    expect(returnedText).not.toContain("xxxxxxxxxx");
+    expect(returnedText).toContain("First line exceeds 5B limit");
+    expect(await readFile(guarded.outputGuard!.fullOutputPath!, "utf8")).toBe(text);
+  });
+
+  it("omits an oversized multibyte line without returning a partial line", async () => {
+    const text = `first-line\n${"😀".repeat(300)}\nend`;
+    const guarded = await guardMcpOutput([{ type: "text", text }], { maxBytes: 1024, maxLines: 10 });
+
+    expect(guarded.outputGuard).toMatchObject({
+      truncated: true,
+      truncatedBy: "bytes",
+      totalLines: 3,
+      totalBytes: Buffer.byteLength(text, "utf8"),
+      outputLines: 1,
+      outputBytes: Buffer.byteLength("first-line", "utf8"),
+      firstLineExceedsLimit: false,
+      maxLines: 10,
+      maxBytes: 1024,
+    });
+    const returnedText = guarded.content[0].type === "text" ? guarded.content[0].text : "";
+    expect(returnedText).toContain("first-line");
+    expect(returnedText).not.toContain("😀");
+    expect(await readFile(guarded.outputGuard!.fullOutputPath!, "utf8")).toBe(text);
   });
 
   it("keeps prefixes and suffixes inside the saved full output", async () => {

--- a/mcp-output-guard.ts
+++ b/mcp-output-guard.ts
@@ -2,10 +2,17 @@ import { randomBytes } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  type TruncationResult,
+} from "@earendil-works/pi-coding-agent";
 import type { ContentBlock, McpSettings } from "./types.ts";
 
-export const DEFAULT_MCP_OUTPUT_MAX_BYTES = 50 * 1024;
-export const DEFAULT_MCP_OUTPUT_MAX_LINES = 2000;
+export const DEFAULT_MCP_OUTPUT_MAX_BYTES = DEFAULT_MAX_BYTES;
+export const DEFAULT_MCP_OUTPUT_MAX_LINES = DEFAULT_MAX_LINES;
 export const DEFAULT_MCP_DETAILS_MAX_BYTES = 16 * 1024;
 
 const CONTENT_SUMMARY_LIMIT = 20;
@@ -22,6 +29,16 @@ export interface McpOutputGuardDetails {
   returnedBytes: number;
   originalLines: number;
   returnedLines: number;
+  /** Host truncation classification and preview counts for the composed text before the MCP notice is added. */
+  truncatedBy: TruncationResult["truncatedBy"];
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+  lastLinePartial: boolean;
+  firstLineExceedsLimit: boolean;
+  maxLines: number;
+  maxBytes: number;
   /** Number of image content blocks returned untouched alongside the truncated text. */
   imageBlocksPassedThrough?: number;
   fullOutputPath?: string;
@@ -119,26 +136,43 @@ export async function guardMcpOutput(
     .map((block) => (block as { text: string }).text)
     .join("\n");
   const composedOutput = `${prefix}${textOutput}${suffix}`;
-  const stats = textStats(composedOutput);
+  const truncation = truncateHead(composedOutput, { maxBytes, maxLines });
 
   let guardedContent: ContentBlock[] = addAffixes(normalizedContent, prefix, suffix);
   let outputGuard: McpOutputGuardDetails | undefined;
 
-  if (stats.bytes > maxBytes || stats.lines > maxLines) {
+  if (truncation.truncated) {
     const { path: fullOutputPath, error: writeError } = await saveArtifact("output", composedOutput);
-    const notice = formatTruncationNotice(stats, fullOutputPath, writeError);
-    const previewBudget = reserveBudget(maxBytes, maxLines, notice);
-    const preview = truncateHead(composedOutput, previewBudget.maxBytes, previewBudget.maxLines);
+    const initialNotice = formatTruncationNotice(truncation, fullOutputPath, writeError);
+    const previewBudget = reserveBudget(maxBytes, maxLines, initialNotice);
+    const preview = truncateHead(composedOutput, {
+      maxBytes: previewBudget.maxBytes,
+      maxLines: previewBudget.maxLines,
+    });
+    const notice = formatTruncationNotice(
+      { ...truncation, outputLines: preview.outputLines, outputBytes: preview.outputBytes },
+      fullOutputPath,
+      writeError,
+    );
     const finalText = `${preview.content}\n\n${notice}`;
     const finalStats = textStats(finalText);
 
     guardedContent = [{ type: "text" as const, text: finalText }, ...imageBlocks];
     outputGuard = {
       truncated: true,
-      originalBytes: stats.bytes,
+      originalBytes: truncation.totalBytes,
       returnedBytes: finalStats.bytes,
-      originalLines: stats.lines,
+      originalLines: truncation.totalLines,
       returnedLines: finalStats.lines,
+      truncatedBy: truncation.truncatedBy,
+      totalLines: truncation.totalLines,
+      totalBytes: truncation.totalBytes,
+      outputLines: preview.outputLines,
+      outputBytes: preview.outputBytes,
+      lastLinePartial: truncation.lastLinePartial,
+      firstLineExceedsLimit: truncation.firstLineExceedsLimit,
+      maxLines: truncation.maxLines,
+      maxBytes: truncation.maxBytes,
       ...(imageBlocks.length > 0 ? { imageBlocksPassedThrough: imageBlocks.length } : {}),
       ...(fullOutputPath !== undefined ? { fullOutputPath } : {}),
       ...(writeError !== undefined ? { writeError } : {}),
@@ -217,31 +251,6 @@ function reserveBudget(maxBytes: number, maxLines: number, notice: string): { ma
   };
 }
 
-function truncateHead(text: string, maxBytes: number, maxLines: number): { content: string; bytes: number; lines: number } {
-  const lines = text.split("\n");
-  const output: string[] = [];
-  let bytes = 0;
-
-  for (const line of lines) {
-    if (output.length >= maxLines) break;
-    const separatorBytes = output.length > 0 ? 1 : 0;
-    const lineBytes = byteLength(line);
-    if (bytes + separatorBytes + lineBytes > maxBytes) {
-      const remaining = maxBytes - bytes - separatorBytes;
-      if (remaining > 0) {
-        output.push(truncateStringToBytes(line, remaining));
-      }
-      break;
-    }
-    output.push(line);
-    bytes += separatorBytes + lineBytes;
-  }
-
-  const content = output.join("\n");
-  const stats = textStats(content);
-  return { content, bytes: stats.bytes, lines: stats.lines };
-}
-
 function truncateStringToBytes(value: string, maxBytes: number): string {
   if (byteLength(value) <= maxBytes) return value;
   const buffer = Buffer.from(value, "utf8");
@@ -251,11 +260,19 @@ function truncateStringToBytes(value: string, maxBytes: number): string {
 }
 
 function formatTruncationNotice(
-  stats: { bytes: number; lines: number },
+  truncation: TruncationResult,
   fullOutputPath: string | undefined,
   writeError: string | undefined,
 ): string {
-  const base = `[MCP text output truncated: original ${stats.lines.toLocaleString()} lines / ${formatSize(stats.bytes)}.`;
+  let reason: string;
+  if (truncation.firstLineExceedsLimit) {
+    reason = `First line exceeds ${formatSize(truncation.maxBytes)} limit`;
+  } else if (truncation.truncatedBy === "lines") {
+    reason = `Truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${truncation.maxLines} line limit)`;
+  } else {
+    reason = `Truncated: ${truncation.outputLines} lines shown (${formatSize(truncation.maxBytes)} limit)`;
+  }
+  const base = `[MCP text output truncated: original ${truncation.totalLines.toLocaleString()} lines / ${formatSize(truncation.totalBytes)}. ${reason}.`;
   if (fullOutputPath) {
     return `${base} Full text saved to: ${fullOutputPath} — use read with offset/limit or grep to inspect.]`;
   }
@@ -487,10 +504,4 @@ function envKillSwitch(name: string): boolean | undefined {
   if (["0", "false", "no", "off"].includes(value)) return false;
   if (["1", "true", "yes", "on"].includes(value)) return true;
   return undefined;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
 }


### PR DESCRIPTION
## Summary
- reuse Pi host truncation defaults, formatting, and head-truncation semantics for MCP text output
- preserve MCP artifact spill files, image pass-through, affixes, and structured-result bounding
- report delivered preview counts truthfully after reserving space for the MCP notice

Closes #487.

## Validation
- `npx vitest run __tests__/mcp-output-guard.test.ts`
- `npm run typecheck`
- `git diff --check`
