### PR TITLE
fix(panel): avoid false cached reconnect state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP sampling requests now route through Pi's `ModelRegistry.complete`, leaving provider authentication, environment, and base URL handling to the host.
 
 ### Fixed
+- The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.
 - OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
 
 ## [2.32.1] - 2026-09-01

--- a/__tests__/mcp-panel-rendering.test.ts
+++ b/__tests__/mcp-panel-rendering.test.ts
@@ -226,6 +226,71 @@ describe("mcp-panel rendering", () => {
     panel.dispose();
   });
 
+  it("does not report cached data when reconnect returns no cache entry", async () => {
+    const config: McpConfig = {
+      mcpServers: {
+        example: { command: "mock" },
+      },
+    };
+    let connectionStatus: "idle" | "connected" = "idle";
+    const callbacks: McpPanelCallbacks = {
+      ...createCallbacks(),
+      reconnect: async () => {
+        connectionStatus = "connected";
+        return true;
+      },
+      getConnectionStatus: () => connectionStatus,
+      refreshCacheAfterReconnect: () => null,
+    };
+    const panel = createMcpPanel(config, null, new Map(), callbacks, { requestRender: () => {} }, () => {});
+
+    panel.handleInput("\x12");
+    await Promise.resolve();
+
+    expect(stripAnsi(panel.render(100).join("\n"))).toContain("example  (not cached)");
+    panel.dispose();
+  });
+
+  it("shows zero-TTL metadata after reconnect but not when the panel is reopened", async () => {
+    const config: McpConfig = {
+      mcpServers: {
+        example: { command: "mock" },
+      },
+    };
+    const cache: MetadataCache = { version: 1, servers: {} };
+    const refreshedEntry = {
+      configHash: computeServerHash(config.mcpServers.example),
+      cachedAt: Date.now(),
+      ttlMs: 0,
+      tools: [{ name: "search" }],
+      resources: [],
+    };
+    let connectionStatus: "idle" | "connected" = "idle";
+    const callbacks: McpPanelCallbacks = {
+      ...createCallbacks(),
+      reconnect: async () => {
+        connectionStatus = "connected";
+        return true;
+      },
+      getConnectionStatus: () => connectionStatus,
+      refreshCacheAfterReconnect: () => refreshedEntry,
+    };
+    const panel = createMcpPanel(config, cache, new Map(), callbacks, { requestRender: () => {} }, () => {});
+
+    panel.handleInput("\x12");
+    await Promise.resolve();
+
+    const currentOutput = stripAnsi(panel.render(100).join("\n"));
+    expect(currentOutput).toContain("example  0/1");
+    expect(currentOutput).not.toContain("(not cached)");
+    panel.dispose();
+
+    const reopenedPanel = createMcpPanel(config, cache, new Map(), callbacks, { requestRender: () => {} }, () => {});
+    const reopenedOutput = stripAnsi(reopenedPanel.render(100).join("\n"));
+    expect(reopenedOutput).toContain("example  (not cached)");
+    reopenedPanel.dispose();
+  });
+
   it("keeps dirty changes and closes when Keep & Close is confirmed", () => {
     const config = createConfig();
     const done = vi.fn<(result: McpPanelResult) => void>();

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -599,8 +599,8 @@ class McpPanel {
           this.cache ??= { version: 1, servers: {} };
           this.cache.servers[server.name] = entry;
           this.rebuildServerTools(server, entry);
+          server.hasCachedData = true;
         }
-        server.hasCachedData = true;
       }
       if (options.afterAuth) {
         this.authNotice = connected && server.connectionStatus === "connected"


### PR DESCRIPTION
## Summary
- keep `/mcp` reconnects from marking a server cached when cache reload returns no entry
- add focused panel coverage for the null-refresh edge and explicit zero-TTL reopen behavior
- leave `.agents` config aliases, zero-TTL policy, and the #488 TUI migration unchanged

Closes #497.

Thanks to [@fyq163](https://github.com/fyq163) for #497.

## Validation
- `npx vitest run __tests__/mcp-panel-rendering.test.ts __tests__/mcp-panel-exclude-tools.test.ts __tests__/metadata-cache-ttl.test.ts`
- `npm run typecheck`
- `git diff --check`
