### PR TITLE
fix(oauth): re-register stale clients after refresh failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP output truncation now uses Pi host truncation semantics and formatting while preserving MCP artifact spill behavior.
 - Exclusive mode now honors an explicit `--mcp-config` override instead of always loading the agent-global configuration. Thanks to [@willem445](https://github.com/willem445) for #496.
 - OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
+- OAuth redirect URI mismatches now preserve refreshable credentials and re-register stale dynamic clients after `invalid_grant`. Thanks to [@CharlesMcMillan](https://github.com/CharlesMcMillan) for PR #495.
 
 ## [2.32.1] - 2026-09-01
 

--- a/__tests__/mcp-auth-flow-client-credentials.test.ts
+++ b/__tests__/mcp-auth-flow-client-credentials.test.ts
@@ -599,6 +599,8 @@ describe("mcp-auth-flow explicit auth", () => {
 
   it("re-registers dynamic OAuth clients when cached redirect URIs are stale", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      expect(await provider.clientInformation()).toEqual({ client_id: "stale-client", client_secret: "stale-secret", redirect_uris: ["http://localhost:19876/callback"] });
+      await provider.invalidateCredentials("tokens");
       expect(await provider.clientInformation()).toBeUndefined();
       await provider.saveClientInformation({
         client_id: "fresh-client",
@@ -629,9 +631,9 @@ describe("mcp-auth-flow explicit auth", () => {
     const stored = getAuthForUrl("stale-redirect", "https://api.example.com/mcp");
     expect(stored?.clientInfo?.clientId).toBe("fresh-client");
     expect(stored?.clientInfo?.redirectUris).toEqual(["http://localhost:3118/callback"]);
-    expect(stored?.tokens).toBeUndefined();
-    expect(stored?.codeVerifier).toBeUndefined();
-    expect(stored?.oauthState).not.toBe("old-state");
+    expect(stored?.tokens?.refreshToken).toBe("old-refresh");
+    expect(stored?.codeVerifier).toBe("old-verifier");
+    expect(stored?.oauthState).toBe("old-state");
     expect(mocks.ensureCallbackServer).toHaveBeenCalledWith(expect.objectContaining({
       strictPort: true,
       port: 3118,
@@ -644,6 +646,8 @@ describe("mcp-auth-flow explicit auth", () => {
 
   it("re-registers dynamic OAuth clients when cached redirect URI metadata is missing", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      expect(await provider.clientInformation()).toEqual({ client_id: "legacy-client", client_secret: "legacy-secret" });
+      await provider.invalidateCredentials("tokens");
       expect(await provider.clientInformation()).toBeUndefined();
       await provider.saveClientInformation({
         client_id: "fresh-client",
@@ -670,11 +674,13 @@ describe("mcp-auth-flow explicit auth", () => {
     const stored = getAuthForUrl("missing-redirect-metadata", "https://api.example.com/mcp");
     expect(stored?.clientInfo?.clientId).toBe("fresh-client");
     expect(stored?.clientInfo?.redirectUris).toEqual(["http://localhost:19876/callback"]);
-    expect(stored?.tokens).toBeUndefined();
+    expect(stored?.tokens?.refreshToken).toBe("old-refresh");
   });
 
   it("re-registers dynamic OAuth clients when cached redirect URI metadata is malformed", async () => {
     mocks.sdkAuth.mockImplementationOnce(async (provider) => {
+      expect(await provider.clientInformation()).toEqual({ client_id: "legacy-client", client_secret: "legacy-secret" });
+      await provider.invalidateCredentials("tokens");
       expect(await provider.clientInformation()).toBeUndefined();
       await provider.saveClientInformation({
         client_id: "fresh-client",
@@ -704,7 +710,7 @@ describe("mcp-auth-flow explicit auth", () => {
     const stored = getAuthForUrl("malformed-redirect-metadata", "https://api.example.com/mcp");
     expect(stored?.clientInfo?.clientId).toBe("fresh-client");
     expect(stored?.clientInfo?.redirectUris).toEqual(["http://localhost:19876/callback"]);
-    expect(stored?.tokens).toBeUndefined();
+    expect(stored?.tokens?.refreshToken).toBe("old-refresh");
   });
 
   it("refreshes expired tokens even when cached dynamic redirect URIs are stale", async () => {

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -523,5 +523,61 @@ describe("mcp-auth-flow", () => {
       assert.strictEqual(config.clientName, "Custom MCP")
       assert.strictEqual(config.clientUri, "https://example.com/custom")
     })
+
+    it("should preserve tokens on a stale redirect URI when a refresh token exists", async () => {
+      const serverName = "redirect-mismatch-refresh-test"
+      const serverUrl = "https://redirect-mismatch-refresh.example.com/mcp"
+      // A client registered against an older ephemeral loopback port.
+      await updateClientInfo(serverName, {
+        clientId: "registered-client",
+        redirectUris: ["http://localhost:1/callback"],
+      }, serverUrl)
+      await updateTokens(serverName, {
+        accessToken: "expired-access",
+        refreshToken: "stored-refresh",
+        expiresAt: Date.now() / 1000 - 3600,
+      }, serverUrl)
+
+      // startAuth binds a fresh ephemeral port, so the stored redirect URI does
+      // not match. The flow then proceeds to discovery, which fails for this
+      // fake server — but the mismatch decision has already been made.
+      await assert.rejects(async () => await startAuth(serverName, serverUrl, {
+        url: serverUrl,
+        auth: "oauth",
+      }))
+
+      const entry = await getAuthForUrl(serverName, serverUrl)
+      assert.strictEqual(entry?.tokens?.refreshToken, "stored-refresh")
+      assert.strictEqual(entry?.tokens?.accessToken, "expired-access")
+      assert.strictEqual(entry?.clientInfo?.clientId, "registered-client")
+
+      clearAllCredentials(serverName)
+    })
+
+    it("should re-register the client on a stale redirect URI when no refresh token exists", async () => {
+      const serverName = "redirect-mismatch-interactive-test"
+      const serverUrl = "https://redirect-mismatch-interactive.example.com/mcp"
+      await updateClientInfo(serverName, {
+        clientId: "registered-client",
+        redirectUris: ["http://localhost:1/callback"],
+      }, serverUrl)
+      await updateTokens(serverName, {
+        accessToken: "expired-access",
+        expiresAt: Date.now() / 1000 - 3600,
+      }, serverUrl)
+
+      await assert.rejects(async () => await startAuth(serverName, serverUrl, {
+        url: serverUrl,
+        auth: "oauth",
+      }))
+
+      // With no refresh token the interactive leg is unavoidable, so the stale
+      // client registration is dropped to force re-registration on the new port.
+      const entry = await getAuthForUrl(serverName, serverUrl)
+      assert.strictEqual(entry?.clientInfo, undefined)
+
+      clearAllCredentials(serverName)
+    })
+
   })
 })

--- a/mcp-auth-flow.test.ts
+++ b/mcp-auth-flow.test.ts
@@ -541,7 +541,7 @@ describe("mcp-auth-flow", () => {
       // startAuth binds a fresh ephemeral port, so the stored redirect URI does
       // not match. The flow then proceeds to discovery, which fails for this
       // fake server — but the mismatch decision has already been made.
-      await assert.rejects(async () => await startAuth(serverName, serverUrl, {
+      await assert.rejects(() => startAuth(serverName, serverUrl, {
         url: serverUrl,
         auth: "oauth",
       }))
@@ -566,7 +566,7 @@ describe("mcp-auth-flow", () => {
         expiresAt: Date.now() / 1000 - 3600,
       }, serverUrl)
 
-      await assert.rejects(async () => await startAuth(serverName, serverUrl, {
+      await assert.rejects(() => startAuth(serverName, serverUrl, {
         url: serverUrl,
         auth: "oauth",
       }))
@@ -578,6 +578,5 @@ describe("mcp-auth-flow", () => {
 
       clearAllCredentials(serverName)
     })
-
   })
 })

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -31,7 +31,6 @@ import {
   hasStoredTokens,
   clearAllCredentials,
   clearClientInfo,
-  clearTokens,
   clearCodeVerifier,
   getOAuthState,
   clearOAuthState,
@@ -527,9 +526,11 @@ export async function startAuth(
         await clearOAuthState(serverName, authStorageOptions)
       } else {
         const redirectUris = storedAuth.clientInfo.redirectUris
-        if (!Array.isArray(redirectUris) || !redirectUris.includes(authProvider.redirectUrl ?? "")) {
+        if ((!Array.isArray(redirectUris) || !redirectUris.includes(authProvider.redirectUrl ?? ""))
+          && !storedAuth.tokens.refreshToken) {
+          // A stale redirect URI only blocks the interactive leg; refresh does
+          // not send redirect_uri, so keep refresh-capable credentials intact.
           clearClientInfo(serverName, authStorageOptions)
-          clearTokens(serverName, authStorageOptions)
           clearCodeVerifier(serverName, authStorageOptions)
           await clearOAuthState(serverName, authStorageOptions)
         }

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -526,8 +526,9 @@ export async function startAuth(
         await clearOAuthState(serverName, authStorageOptions)
       } else {
         const redirectUris = storedAuth.clientInfo.redirectUris
-        if ((!Array.isArray(redirectUris) || !redirectUris.includes(authProvider.redirectUrl ?? ""))
-          && !storedAuth.tokens.refreshToken) {
+        const redirectUriMatches = Array.isArray(redirectUris)
+          && redirectUris.includes(authProvider.redirectUrl ?? "")
+        if (!redirectUriMatches && !storedAuth.tokens.refreshToken) {
           // A stale redirect URI only blocks the interactive leg; refresh does
           // not send redirect_uri, so keep refresh-capable credentials intact.
           clearClientInfo(serverName, authStorageOptions)

--- a/mcp-local-oauth-flow.test.ts
+++ b/mcp-local-oauth-flow.test.ts
@@ -14,6 +14,8 @@ import {
   getAuthForUrl,
   getTestAuthSecretStoreEntries,
   resetTestAuthSecretStore,
+  updateClientInfo,
+  updateTokens,
 } from "./mcp-auth.ts"
 import { waitForCallback } from "./mcp-callback-server.ts"
 
@@ -23,6 +25,8 @@ describe("local OAuth authorization-code flow", () => {
   let serverUrl = ""
   let authorizationRequest: URL | undefined
   let tokenRequest: URLSearchParams | undefined
+  const registrationRedirectUris: string[][] = []
+  const refreshTokenRequests: URLSearchParams[] = []
   const authServer = createServer(async (request, response) => {
     const requestUrl = new URL(request.url ?? "/", origin || "http://127.0.0.1")
 
@@ -53,6 +57,7 @@ describe("local OAuth authorization-code flow", () => {
         issuer: origin,
         authorization_endpoint: `${origin}/authorize`,
         token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
         response_types_supported: ["code"],
         code_challenge_methods_supported: ["S256"],
         token_endpoint_auth_methods_supported: ["none"],
@@ -61,10 +66,31 @@ describe("local OAuth authorization-code flow", () => {
       return
     }
 
+    if (request.method === "POST" && requestUrl.pathname === "/register") {
+      let body = ""
+      for await (const chunk of request) body += chunk
+      const metadata = JSON.parse(body) as { redirect_uris?: string[] }
+      const redirectUris = metadata.redirect_uris ?? []
+      registrationRedirectUris.push(redirectUris)
+      response.writeHead(201, { "Content-Type": "application/json" })
+      response.end(JSON.stringify({
+        client_id: "new-dynamic-client",
+        redirect_uris: redirectUris,
+      }))
+      return
+    }
+
     if (request.method === "POST" && requestUrl.pathname === "/token") {
       let body = ""
       for await (const chunk of request) body += chunk
       tokenRequest = new URLSearchParams(body)
+      if (tokenRequest.get("grant_type") === "refresh_token"
+        && tokenRequest.get("refresh_token") === "revoked-refresh") {
+        refreshTokenRequests.push(tokenRequest)
+        response.writeHead(400, { "Content-Type": "application/json" })
+        response.end(JSON.stringify({ error: "invalid_grant" }))
+        return
+      }
       response.writeHead(200, { "Content-Type": "application/json" })
       response.end(JSON.stringify({
         access_token: "example-access-token",
@@ -167,5 +193,43 @@ describe("local OAuth authorization-code flow", () => {
     assert.ok(secureStorePayload.includes("example-refresh-token"))
     assert.ok(!secureStorePayload.includes(codeVerifier))
     assert.ok(!secureStorePayload.includes(state))
+  })
+
+  it("re-registers a stale dynamic client after a refresh invalid_grant", async () => {
+    const refreshServerName = "local-oauth-redirect-refresh"
+    const staleRedirectUri = "http://127.0.0.1:1/callback"
+    await updateClientInfo(refreshServerName, {
+      clientId: "stale-dynamic-client",
+      redirectUris: [staleRedirectUri],
+    }, serverUrl)
+    await updateTokens(refreshServerName, {
+      accessToken: "expired-access-token",
+      refreshToken: "revoked-refresh",
+      expiresAt: Date.now() / 1000 - 60,
+    }, serverUrl)
+
+    const registrationCount = registrationRedirectUris.length
+    refreshTokenRequests.length = 0
+    const { authorizationUrl } = await startAuth(refreshServerName, serverUrl, {
+      url: serverUrl,
+      auth: "oauth",
+      oauth: { redirectUri: "http://127.0.0.1:{port}/callback" },
+    })
+    const fallbackAuthorizationRequest = new URL(authorizationUrl)
+
+    assert.strictEqual(refreshTokenRequests.length, 1)
+    assert.strictEqual(registrationRedirectUris.length, registrationCount + 1)
+    const registeredRedirectUri = registrationRedirectUris[registrationRedirectUris.length - 1]?.[0]
+    assert.ok(registeredRedirectUri)
+    assert.notStrictEqual(registeredRedirectUri, staleRedirectUri)
+    assert.strictEqual(fallbackAuthorizationRequest.searchParams.get("client_id"), "new-dynamic-client")
+    assert.strictEqual(
+      fallbackAuthorizationRequest.searchParams.get("redirect_uri"),
+      registeredRedirectUri,
+    )
+
+    const stored = await getAuthForUrl(refreshServerName, serverUrl)
+    assert.strictEqual(stored?.clientInfo?.clientId, "new-dynamic-client")
+    clearAllCredentials(refreshServerName)
   })
 })

--- a/mcp-oauth-provider.ts
+++ b/mcp-oauth-provider.ts
@@ -256,6 +256,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   private flowState: string | undefined
   private invalidatedAccessToken: string | undefined
   private invalidatedClientId: string | undefined
+  private staleRedirectClientId: string | undefined
   private lastObservedClientId: string | undefined
   private lastSavedAccessToken: string | undefined
   private pendingAuthAccessToken: string | undefined
@@ -288,6 +289,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     this.active = false
     this.invalidatedAccessToken = undefined
     this.invalidatedClientId = undefined
+    this.staleRedirectClientId = undefined
     this.lastObservedClientId = undefined
     this.lastSavedAccessToken = undefined
     this.pendingAuthAccessToken = undefined
@@ -435,6 +437,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.flowClientInfo = clientInfo
         updateClientInfo(this.serverName, clientInfo, this.serverUrl, this.storageOptions)
       }
+      // Keep a stale dynamic registration available for its refresh attempt,
+      // but suppress it if that attempt invalidates the token and auth falls
+      // back to an interactive flow. The next clientInformation() call then
+      // makes the SDK register the current callback URI.
+      const redirectUriIsStale = this.redirectUrl !== undefined
+        && (!Array.isArray(clientInfo.redirectUris) || !clientInfo.redirectUris.includes(this.redirectUrl))
+      this.staleRedirectClientId = redirectUriIsStale ? clientInfo.clientId : undefined
       // Return all registration metadata and the local issuer extension.
       // This keeps the SDK OAuth view and the stored issuer binding consistent.
       this.lastObservedClientId = clientInfo.clientId
@@ -657,6 +666,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.flowState = undefined
         this.invalidatedAccessToken = undefined
         this.invalidatedClientId = undefined
+        this.staleRedirectClientId = undefined
         this.lastObservedClientId = undefined
         this.lastSavedAccessToken = undefined
         this.pendingAuthAccessToken = undefined
@@ -679,6 +689,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.invalidatedAccessToken = this.pendingAuthAccessToken ?? this.lastSavedAccessToken
         this.lastSavedAccessToken = undefined
         this.pendingAuthAccessToken = undefined
+        if (this.staleRedirectClientId !== undefined) {
+          this.invalidatedClientId = this.staleRedirectClientId
+        }
         invalidateAuthEntryCache(this.serverName)
         break
       case "verifier":


### PR DESCRIPTION
## Summary
- preserves PR #495's refreshable OAuth credentials when only the loopback redirect URI is stale
- re-registers stale dynamic clients after `invalid_grant` so fallback interactive auth uses the current callback URI
- adds a local OAuth regression covering refresh failure followed by dynamic registration

Supersedes #495.

Thanks to [@CharlesMcMillan](https://github.com/CharlesMcMillan) for PR #495.

## Validation
- `npm run test:oauth`
- `npm run typecheck`
- `git diff --check`
