### PR TITLE
fix(approvals): persist session-scoped grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 
 ### Fixed
+- Session-scoped MCP tool approvals and MCP App iframe consent now persist on and restore from the active Pi session branch. (#492)
 - The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.
 - MCP output truncation now uses Pi host truncation semantics and formatting while preserving MCP artifact spill behavior.
 - Exclusive mode now honors an explicit `--mcp-config` override instead of always loading the agent-global configuration. Thanks to [@willem445](https://github.com/willem445) for #496.

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Use `approveTools` when a tool should stay visible but not run without confirmat
 }
 ```
 
-When a matching tool is called from the proxy tool, a direct MCP tool, a resource call, or an MCP UI iframe, Pi asks: **Allow once**, **Allow for session**, or **Deny**. Session approvals are kept in memory only. In headless sessions, matching calls fail closed with an `approval_required` result instead of running. `excludeTools` still removes tools entirely; `approveTools` only gates visible tools at call time.
+When a matching tool is called from the proxy tool, a direct MCP tool, a resource call, or an MCP UI iframe, Pi asks: **Allow once**, **Allow for session**, or **Deny**. **Allow for session** tool grants and MCP UI iframe consent decisions (including denials) persist as non-LLM custom entries on the active Pi session branch and restore on resume or branch navigation. Entries store only server/tool names and deterministic definition/argument hashes; raw arguments, results, and secrets never persist. Tool grants and iframe consent remain separate gates. In headless sessions, matching calls fail closed with an `approval_required` result; denials, abstentions, **Allow once**, and approval-required paths do not create tool grant records. `excludeTools` still removes tools entirely; `approveTools` only gates visible tools at call time.
 
 Permission extensions can broker these decisions by listening on `pi-mcp-adapter:tool-approval-request` and claiming the request synchronously:
 
@@ -457,7 +457,7 @@ pi.events.on(MCP_TOOL_APPROVAL_REQUEST_EVENT, (request: McpToolApprovalRequest) 
 });
 ```
 
-The request includes `serverName`, `originalToolName`, `prefixedToolName`, `args`, `origin`, and optional `signal`. The first synchronous claim wins. `allow_for_session` updates the same in-memory approval cache as the built-in dialog; `deny` blocks the MCP call; `abstain` or no claim preserves the fallback behavior above. Brokered approval runs for every uncached MCP call regardless of `approveTools` configuration, across proxy, direct, `mcpScript`, resource, and iframe origins.
+The request includes `serverName`, `originalToolName`, `prefixedToolName`, `args`, `origin`, and optional `signal`. The first synchronous claim wins. `allow_for_session` updates the same session-scoped approval cache and persistence path as the built-in dialog; `deny` blocks the MCP call; `abstain` or no claim preserves the fallback behavior above. Brokered approval runs for every uncached MCP call regardless of `approveTools` configuration, across proxy, direct, `mcpScript`, resource, and iframe origins.
 
 ### Output Guard
 

--- a/__tests__/consent-manager.test.ts
+++ b/__tests__/consent-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ConsentManager, type ToolConsentMode } from "../consent-manager.ts";
 
 describe("ConsentManager", () => {
@@ -146,6 +146,26 @@ describe("ConsentManager", () => {
       // Neither approved nor denied
       expect(() => manager.ensureApproved("server-a")).toThrow(/approval required/);
       expect(() => manager.ensureApproved("server-b")).toThrow(/approval required/);
+    });
+  });
+
+  describe("session persistence", () => {
+    it("writes tagged iframe decisions and restores without re-emitting", () => {
+      const persist = vi.fn();
+      const manager = new ConsentManager("once-per-server", persist);
+
+      manager.registerDecision("server-a", true);
+      manager.registerDecision("server-a", false);
+      expect(persist.mock.calls.map(([record]) => record)).toEqual([
+        { version: 1, kind: "iframe", decision: "allow", serverName: "server-a" },
+        { version: 1, kind: "iframe", decision: "deny", serverName: "server-a" },
+      ]);
+
+      persist.mockClear();
+      manager.restoreDecision("server-a", true);
+      expect(persist).not.toHaveBeenCalled();
+      expect(manager.requiresPrompt("server-a")).toBe(false);
+      expect(() => manager.ensureApproved("server-a")).not.toThrow();
     });
   });
 });

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCP_STATUS_EVENT } from "../types.ts";
+import { ConsentManager } from "../consent-manager.ts";
+import { MCP_APPROVAL_CUSTOM_TYPE, getToolApprovalIdentity, makeToolApprovalKey } from "../session-approvals.ts";
 
 const mocks = vi.hoisted(() => ({
   initializeMcp: vi.fn(),
@@ -515,6 +517,75 @@ describe("mcpAdapter session lifecycle", () => {
     await sessionStart;
 
     expect(api.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "demo_search" }));
+  });
+
+  it("restores approval state from the active session branch on session_tree", async () => {
+    const sessionManager = {
+      getBranch: vi.fn(),
+    };
+    const state = createState();
+    const tool = {
+      originalName: "search",
+      inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      uiResourceUri: "ui://demo/search",
+    };
+    const identity = getToolApprovalIdentity("demo", tool, { query: "safe" });
+    const branch = [{
+      type: "custom",
+      customType: MCP_APPROVAL_CUSTOM_TYPE,
+      data: {
+        version: 1,
+        kind: "tool",
+        decision: "allow_for_session",
+        serverName: "demo",
+        originalToolName: "search",
+        definitionHash: identity.definitionHash,
+        argsHash: identity.argsHash,
+      },
+    }];
+    sessionManager.getBranch.mockReturnValue(branch);
+    state.sessionManager = sessionManager;
+    state.approvedToolCalls = new Map([["stale", true]]);
+    state.consentManager = new ConsentManager();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    const context = { hasUI: false, sessionManager };
+    await handlers.get("session_start")?.({}, context);
+    await handlers.get("session_tree")?.({}, context);
+
+    expect(state.approvedToolCalls).toEqual(new Map([
+      [makeToolApprovalKey("demo", "search", identity.definitionHash, identity.argsHash), true],
+    ]));
+  });
+
+  it("ignores session_tree events from a stale session manager", async () => {
+    const activeSessionManager = { getBranch: vi.fn().mockReturnValue([]) };
+    const staleSessionManager = { getBranch: vi.fn().mockReturnValue([{
+      type: "custom",
+      customType: MCP_APPROVAL_CUSTOM_TYPE,
+      data: {
+        version: 1,
+        kind: "iframe",
+        decision: "allow",
+        serverName: "stale",
+      },
+    }]) };
+    const state = createState();
+    state.sessionManager = activeSessionManager;
+    state.consentManager = new ConsentManager();
+    mocks.initializeMcp.mockResolvedValue(state);
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, { hasUI: false, sessionManager: activeSessionManager });
+    await handlers.get("session_tree")?.({}, { hasUI: false, sessionManager: staleSessionManager });
+
+    expect(staleSessionManager.getBranch).not.toHaveBeenCalled();
+    expect(state.consentManager.requiresPrompt("stale")).toBe(true);
   });
 
   it("waits for keep-alive convergence before Pi processes the next input", async () => {

--- a/__tests__/session-approvals.test.ts
+++ b/__tests__/session-approvals.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { McpExtensionState } from "../state.ts";
+import { ConsentManager } from "../consent-manager.ts";
+import {
+  MCP_APPROVAL_CUSTOM_TYPE,
+  computeToolArgumentsHash,
+  computeToolDefinitionHash,
+  createSessionApprovalWriter,
+  getToolApprovalIdentity,
+  makeToolApprovalKey,
+  rememberToolApproval,
+  restoreSessionApprovalState,
+  type SessionApprovalEntry,
+} from "../session-approvals.ts";
+
+const tool = {
+  originalName: "search",
+  inputSchema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+  },
+  resourceUri: undefined,
+  uiResourceUri: "ui://demo/search",
+};
+
+function createState(mode: "never" | "once-per-server" | "always" = "once-per-server", persist?: (entry: SessionApprovalEntry) => void): McpExtensionState {
+  return {
+    approvedToolCalls: new Map(),
+    consentManager: new ConsentManager(mode, persist),
+  } as unknown as McpExtensionState;
+}
+
+function custom(data: unknown): unknown {
+  return { type: "custom", customType: MCP_APPROVAL_CUSTOM_TYPE, data };
+}
+
+describe("session approval persistence", () => {
+  it("hashes normalized arguments and the effective tool definition deterministically", () => {
+    expect(computeToolArgumentsHash({ query: "demo", options: { limit: 5, reverse: true } }))
+      .toBe(computeToolArgumentsHash({ options: { reverse: true, limit: 5 }, query: "demo" }));
+    expect(computeToolArgumentsHash({ query: "other" })).not.toBe(computeToolArgumentsHash({ query: "demo" }));
+
+    const sameDefinition = {
+      ...tool,
+      inputSchema: { properties: { query: { type: "string" } }, type: "object" },
+    };
+    expect(computeToolDefinitionHash(tool)).toBe(computeToolDefinitionHash(sameDefinition));
+    expect(computeToolDefinitionHash(tool)).not.toBe(computeToolDefinitionHash({
+      ...tool,
+      inputSchema: { type: "object", properties: { query: { type: "number" } } },
+    }));
+    expect(computeToolDefinitionHash(tool)).not.toBe(computeToolDefinitionHash({ ...tool, resourceUri: "mcp://demo/search" }));
+    expect(computeToolDefinitionHash(tool)).not.toBe(computeToolDefinitionHash({ ...tool, uiResourceUri: "ui://demo/other" }));
+  });
+
+  it("writes only versioned names and hashes through the Pi custom-entry sink", () => {
+    const appendEntry = vi.fn();
+    const writer = createSessionApprovalWriter(appendEntry);
+    const identity = getToolApprovalIdentity("demo", tool, { query: "private" });
+    const record: SessionApprovalEntry = {
+      version: 1,
+      kind: "tool",
+      decision: "allow_for_session",
+      serverName: "demo",
+      originalToolName: tool.originalName,
+      definitionHash: identity.definitionHash,
+      argsHash: identity.argsHash,
+    };
+
+    writer(record);
+
+    expect(appendEntry).toHaveBeenCalledWith(MCP_APPROVAL_CUSTOM_TYPE, record);
+  });
+
+  it("restores only strict records from the active branch and does not re-emit them", () => {
+    const appendEntry = vi.fn();
+    const state = createState("once-per-server", (record) => appendEntry(MCP_APPROVAL_CUSTOM_TYPE, record));
+    state.approvedToolCalls.set("stale", true);
+    state.consentManager.registerDecision("stale-server", true);
+    appendEntry.mockClear();
+
+    const identity = getToolApprovalIdentity("demo", tool, { query: "safe" });
+    const entries = [
+      custom({
+        version: 1,
+        kind: "tool",
+        decision: "allow_for_session",
+        serverName: "demo",
+        originalToolName: tool.originalName,
+        definitionHash: identity.definitionHash,
+        argsHash: identity.argsHash,
+      }),
+      custom({ version: 1, kind: "iframe", decision: "allow", serverName: "demo" }),
+      custom({ version: 1, kind: "iframe", decision: "deny", serverName: "denied" }),
+      custom({ version: 1, kind: "iframe", decision: "allow", serverName: "denied" }),
+      custom({
+        version: 1,
+        kind: "tool",
+        decision: "allow_for_session",
+        serverName: "malformed",
+        originalToolName: "search",
+        definitionHash: identity.definitionHash,
+        argsHash: identity.argsHash,
+        rawArgs: { secret: "must not be accepted" },
+      }),
+      custom({ version: 2, kind: "iframe", decision: "allow", serverName: "unknown-version" }),
+      { type: "custom", customType: "other-extension", data: { allow: true } },
+    ];
+
+    restoreSessionApprovalState(state, entries);
+
+    expect(state.approvedToolCalls).toEqual(new Map([
+      [makeToolApprovalKey("demo", tool.originalName, identity.definitionHash, identity.argsHash), true],
+    ]));
+    expect(() => state.consentManager.ensureApproved("demo")).not.toThrow();
+    expect(() => state.consentManager.ensureApproved("denied")).not.toThrow();
+    expect(() => state.consentManager.ensureApproved("stale-server")).toThrow(/approval required/);
+    expect(appendEntry).not.toHaveBeenCalled();
+  });
+
+  it("replays only the selected session branch", () => {
+    const manager = SessionManager.inMemory("/tmp/pi-mcp-adapter-approvals");
+    const first = getToolApprovalIdentity("demo", tool, { query: "ancestor" });
+    const abandoned = getToolApprovalIdentity("demo", tool, { query: "abandoned" });
+    const selected = getToolApprovalIdentity("demo", tool, { query: "selected" });
+    const record = (identity: typeof first): SessionApprovalEntry => ({
+      version: 1,
+      kind: "tool",
+      decision: "allow_for_session",
+      serverName: "demo",
+      originalToolName: tool.originalName,
+      definitionHash: identity.definitionHash,
+      argsHash: identity.argsHash,
+    });
+
+    const ancestorId = manager.appendCustomEntry(MCP_APPROVAL_CUSTOM_TYPE, record(first));
+    manager.appendCustomEntry(MCP_APPROVAL_CUSTOM_TYPE, record(abandoned));
+    manager.branch(ancestorId);
+    manager.appendCustomEntry(MCP_APPROVAL_CUSTOM_TYPE, record(selected));
+
+    const state = createState();
+    restoreSessionApprovalState(state, manager.getBranch());
+
+    expect(state.approvedToolCalls).toEqual(new Map([
+      [makeToolApprovalKey("demo", tool.originalName, first.definitionHash, first.argsHash), true],
+      [makeToolApprovalKey("demo", tool.originalName, selected.definitionHash, selected.argsHash), true],
+    ]));
+    expect(state.approvedToolCalls.has(makeToolApprovalKey(
+      "demo",
+      tool.originalName,
+      abandoned.definitionHash,
+      abandoned.argsHash,
+    ))).toBe(false);
+  });
+
+  it("restores a persisted grant after reopening the session", () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-mcp-adapter-approvals-"));
+    try {
+      const manager = SessionManager.create(root, join(root, "sessions"));
+      const identity = getToolApprovalIdentity("demo", tool, { query: "persisted" });
+      const record: SessionApprovalEntry = {
+        version: 1,
+        kind: "tool",
+        decision: "allow_for_session",
+        serverName: "demo",
+        originalToolName: tool.originalName,
+        definitionHash: identity.definitionHash,
+        argsHash: identity.argsHash,
+      };
+      manager.appendCustomEntry(MCP_APPROVAL_CUSTOM_TYPE, record);
+      manager.appendMessage({
+        role: "assistant",
+        content: [],
+        api: "openai-completions",
+        provider: "openai",
+        model: "test",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+
+      const resumed = SessionManager.open(manager.getSessionFile()!, join(root, "sessions"));
+      const state = createState();
+      restoreSessionApprovalState(state, resumed.getBranch());
+
+      expect(state.approvedToolCalls).toEqual(new Map([
+        [makeToolApprovalKey("demo", tool.originalName, identity.definitionHash, identity.argsHash), true],
+      ]));
+      const persistedEntry = resumed.getBranch().find(entry => entry.type === "custom");
+      expect(persistedEntry).toMatchObject({
+        type: "custom",
+        customType: MCP_APPROVAL_CUSTOM_TYPE,
+        data: record,
+      });
+      expect(persistedEntry).not.toHaveProperty("data.args");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves always and never consent mode semantics after restore", () => {
+    const always = createState("always");
+    restoreSessionApprovalState(always, [custom({ version: 1, kind: "iframe", decision: "allow", serverName: "demo" })]);
+    expect(always.consentManager.requiresPrompt("demo")).toBe(true);
+    expect(() => always.consentManager.ensureApproved("demo")).toThrow(/approval required/);
+
+    const never = createState("never");
+    restoreSessionApprovalState(never, [custom({ version: 1, kind: "iframe", decision: "deny", serverName: "demo" })]);
+    expect(never.consentManager.requiresPrompt("demo")).toBe(false);
+    expect(() => never.consentManager.ensureApproved("demo")).not.toThrow();
+  });
+
+  it("keeps an explicit in-memory grant when persistence fails", () => {
+    const state = createState();
+    state.persistSessionApproval = vi.fn(() => {
+      throw new Error("no session");
+    });
+    const identity = getToolApprovalIdentity("demo", tool, {});
+
+    rememberToolApproval(state, "demo", tool, {});
+
+    expect(state.approvedToolCalls).toEqual(new Map([
+      [makeToolApprovalKey("demo", tool.originalName, identity.definitionHash, identity.argsHash), true],
+    ]));
+  });
+});

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -9,6 +9,7 @@ import {
   type McpToolApprovalRequest,
   type ToolMetadata,
 } from "../types.ts";
+import type { SessionApprovalEntry } from "../session-approvals.ts";
 
 const tool: ToolMetadata = {
   name: "demo_search-records",
@@ -21,6 +22,7 @@ function createState(options: {
   decision?: "Allow once" | "Allow for session" | "Deny";
   interactive?: boolean;
   broker?: (request: McpToolApprovalRequest) => void;
+  persist?: (record: SessionApprovalEntry) => void;
 } = {}) {
   const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
   const select = vi.fn().mockResolvedValue(options.decision ?? "Allow once");
@@ -46,6 +48,7 @@ function createState(options: {
     promptMetadataLive: new Set(),
     serverInstructions: new Map(),
     approvedToolCalls: new Map<string, true>(),
+    ...(options.persist ? { persistSessionApproval: options.persist } : {}),
     ...(options.broker
       ? { approvalEvents: { emit: vi.fn((channel: string, data: unknown) => {
           expect(channel).toBe(MCP_TOOL_APPROVAL_REQUEST_EVENT);
@@ -161,7 +164,8 @@ describe("tool approval", () => {
   });
 
   it("fails closed headlessly with a structured approval_required result", async () => {
-    const { state, callTool } = createState({ approveTools: true, interactive: false });
+    const persist = vi.fn();
+    const { state, callTool } = createState({ approveTools: true, interactive: false, persist });
 
     const result = await executeCall(state, tool.name, { query: "private" });
 
@@ -173,14 +177,17 @@ describe("tool approval", () => {
     });
     expect(result.content[0].text).toContain("approval-gated");
     expect(callTool).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it("returns approval_denied without throwing or invoking proxy or direct tools", async () => {
-    const proxy = createState({ approveTools: true, decision: "Deny" });
+    const persist = vi.fn();
+    const proxy = createState({ approveTools: true, decision: "Deny", persist });
     await expect(executeCall(proxy.state, tool.name, {})).resolves.toMatchObject({
       details: { error: "approval_denied", server: "demo", tool: "search-records" },
     });
     expect(proxy.callTool).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
 
     const direct = createState({ approveTools: true, decision: "Deny" });
     const execute = createDirectToolExecutor(() => direct.state, () => null, {
@@ -196,18 +203,46 @@ describe("tool approval", () => {
   });
 
   it("caches only Allow for session decisions", async () => {
-    const session = createState({ approveTools: true, decision: "Allow for session" });
+    const persist = vi.fn();
+    const session = createState({ approveTools: true, decision: "Allow for session", persist });
     await ensureToolCallApproved(session.state, "demo", tool, { record: { id: "safe", type: "demo" } }, undefined);
     await ensureToolCallApproved(session.state, "demo", tool, { record: { type: "demo", id: "safe" } }, undefined);
     await ensureToolCallApproved(session.state, "demo", tool, { record: { id: "other", type: "demo" } }, undefined);
     expect(session.select).toHaveBeenCalledTimes(2);
     expect(session.state.approvedToolCalls.size).toBe(2);
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist.mock.calls[0]?.[0]).toMatchObject({
+      version: 1,
+      kind: "tool",
+      decision: "allow_for_session",
+      serverName: "demo",
+      originalToolName: "search-records",
+      definitionHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      argsHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(persist.mock.calls[0]?.[0]).not.toHaveProperty("args");
 
-    const once = createState({ approveTools: true, decision: "Allow once" });
+    const oncePersist = vi.fn();
+    const once = createState({ approveTools: true, decision: "Allow once", persist: oncePersist });
     await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
     await ensureToolCallApproved(once.state, "demo", tool, {}, undefined);
     expect(once.select).toHaveBeenCalledTimes(2);
     expect(once.state.approvedToolCalls.size).toBe(0);
+    expect(oncePersist).not.toHaveBeenCalled();
+  });
+
+  it("invalidates persisted grants when the tool definition changes", async () => {
+    const persist = vi.fn();
+    const session = createState({ approveTools: true, decision: "Allow for session", persist });
+    const args = { query: "safe" };
+
+    await ensureToolCallApproved(session.state, "demo", tool, args, undefined);
+    await ensureToolCallApproved(session.state, "demo", { ...tool, inputSchema: { type: "number" } }, args, undefined);
+    await ensureToolCallApproved(session.state, "demo", { ...tool, inputSchema: tool.inputSchema, uiResourceUri: "ui://demo/other" }, args, undefined);
+
+    expect(session.select).toHaveBeenCalledTimes(3);
+    expect(persist).toHaveBeenCalledTimes(3);
+    expect(new Set(persist.mock.calls.map(([record]) => record.definitionHash)).size).toBe(3);
   });
 
   it("lets a broker allow a gated call without showing the built-in prompt", async () => {
@@ -316,7 +351,8 @@ describe("tool approval", () => {
     const broker = vi.fn((request: McpToolApprovalRequest) => {
       expect(request.claim(() => "allow_for_session")).toBe(true);
     });
-    const { state } = createState({ approveTools: true, broker });
+    const persist = vi.fn();
+    const { state } = createState({ approveTools: true, broker, persist });
 
     await ensureToolCallApproved(state, "demo", tool, {}, undefined);
     await ensureToolCallApproved(state, "demo", tool, {}, undefined);
@@ -324,6 +360,7 @@ describe("tool approval", () => {
 
     expect(broker).toHaveBeenCalledTimes(2);
     expect(state.approvedToolCalls.size).toBe(2);
+    expect(persist).toHaveBeenCalledTimes(2);
   });
 
   it("requires brokers to claim synchronously", async () => {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -5,6 +5,7 @@ import type { McpServerManager } from "../server-manager.ts";
 import type { ConsentManager } from "../consent-manager.ts";
 import type { McpConfig, UiResourceContent } from "../types.ts";
 import type { McpExtensionState } from "../state.ts";
+import { getToolApprovalIdentity, makeToolApprovalKey } from "../session-approvals.ts";
 
 // Helper to make HTTP requests to the server
 async function request(
@@ -976,6 +977,51 @@ describe("UiServer", () => {
         },
       });
       expect(mockClient.callTool).not.toHaveBeenCalled();
+    });
+
+    it("keeps iframe consent separate while hashing the app tool definition", async () => {
+      const inputSchema = { type: "object", properties: { query: { type: "string" } } };
+      const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "called" }] });
+      const manager = createMockManager({
+        getConnection: vi.fn().mockReturnValue({
+          status: "connected",
+          client: { callTool },
+          tools: [{
+            name: "some_tool",
+            inputSchema,
+            _meta: { ui: { visibility: ["app"], resourceUri: "ui://demo/app" } },
+          }],
+          resources: [],
+        }),
+      });
+      const config: McpConfig = {
+        mcpServers: { "test-server": { command: "demo", approveTools: true } },
+      };
+      const state = {
+        config,
+        approvedToolCalls: new Map(),
+        toolMetadata: new Map(),
+        ui: { select: vi.fn().mockResolvedValue("Allow for session") },
+      } as unknown as McpExtensionState;
+      handle = await startUiServer(createServerOptions({ manager, config, state }));
+
+      const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
+        method: "POST",
+        body: {
+          token: handle.sessionToken,
+          params: { name: "some_tool", arguments: { query: "safe" } },
+        },
+      });
+
+      expect(res.body).toEqual({ ok: true, result: { content: [{ type: "text", text: "called" }] } });
+      const identity = getToolApprovalIdentity("test-server", {
+        originalName: "some_tool",
+        inputSchema,
+        uiResourceUri: "ui://demo/app",
+      }, { query: "safe" });
+      expect(state.approvedToolCalls).toEqual(new Map([
+        [makeToolApprovalKey("test-server", "some_tool", identity.definitionHash, identity.argsHash), true],
+      ]));
     });
 
     it("checks consent before calling tool", async () => {

--- a/consent-manager.ts
+++ b/consent-manager.ts
@@ -1,5 +1,6 @@
 import { ConsentError } from "./errors.ts";
 import { logger } from "./logger.ts";
+import type { SessionApprovalWriter } from "./session-approvals.ts";
 
 export type ToolConsentMode = "never" | "once-per-server" | "always";
 
@@ -8,7 +9,10 @@ export class ConsentManager {
   private deniedServers = new Set<string>();
   private log = logger.child({ component: "ConsentManager" });
 
-  constructor(private mode: ToolConsentMode = "once-per-server") {
+  constructor(
+    private mode: ToolConsentMode = "once-per-server",
+    private persistDecision?: SessionApprovalWriter,
+  ) {
     this.log.debug("Initialized", { mode });
   }
 
@@ -24,17 +28,30 @@ export class ConsentManager {
   }
 
   registerDecision(serverName: string, approved: boolean): void {
-    this.deniedServers.delete(serverName);
-    this.approvedServers.delete(serverName);
+    this.applyDecision(serverName, approved);
+    try {
+      this.persistDecision?.({
+        version: 1,
+        kind: "iframe",
+        decision: approved ? "allow" : "deny",
+        serverName,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.log.debug("Failed to persist consent decision", { server: serverName, error: detail });
+    }
+  }
 
-    if (approved) {
-      this.approvedServers.add(serverName);
-      this.log.debug("Consent granted", { server: serverName });
+  /** Apply a persisted decision without writing it back to the session. */
+  restoreDecision(serverName: string, approved: boolean): void {
+    if (this.mode === "always" && approved) {
+      // Restored "always" grants cannot be reused. A later grant still
+      // overrides an earlier denial.
+      this.approvedServers.delete(serverName);
+      this.deniedServers.delete(serverName);
       return;
     }
-
-    this.deniedServers.add(serverName);
-    this.log.debug("Consent denied", { server: serverName });
+    this.applyDecision(serverName, approved);
   }
 
   ensureApproved(serverName: string): void {
@@ -60,5 +77,19 @@ export class ConsentManager {
     this.approvedServers.clear();
     this.deniedServers.clear();
     this.log.debug("Cleared all consent records");
+  }
+
+  private applyDecision(serverName: string, approved: boolean): void {
+    this.deniedServers.delete(serverName);
+    this.approvedServers.delete(serverName);
+
+    if (approved) {
+      this.approvedServers.add(serverName);
+      this.log.debug("Consent granted", { server: serverName });
+      return;
+    }
+
+    this.deniedServers.add(serverName);
+    this.log.debug("Consent denied", { server: serverName });
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import { publishMcpStatusShutdown } from "./mcp-status.ts";
 import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
 import { syncNamespaceProxyTools } from "./namespace-tools.ts";
+import { restoreSessionApprovalState } from "./session-approvals.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
@@ -211,6 +212,20 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     if (flushError) {
       throw flushError;
     }
+  }
+
+  function restoreCurrentSessionApprovals(targetState: McpExtensionState): void {
+    const sessionManager = targetState.sessionManager;
+    if (!sessionManager) return;
+
+    let branch: readonly unknown[] = [];
+    try {
+      branch = sessionManager.getBranch();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: could not read the active session branch for approval restore: ${detail}`);
+    }
+    restoreSessionApprovalState(targetState, branch);
   }
 
   const earlyConfigPath = programmaticConfig
@@ -593,6 +608,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
 
       state = nextState;
+      // Re-read after asynchronous startup so navigation during initialization
+      // cannot restore a stale branch.
+      restoreCurrentSessionApprovals(nextState);
       clearRetainedInitFailure();
       for (const [name, { entry }] of runtimeServers) {
         if (Object.hasOwn(nextState.config.mcpServers, name)) {
@@ -708,6 +726,22 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         await initialization;
       }
     }
+  });
+
+  pi.on("session_tree", (_event, ctx) => {
+    const currentState = state;
+    const owner = currentOwner;
+    if (!currentState || !owner?.isActive() || !currentState.sessionManager) return;
+
+    let sessionManager: ExtensionContext["sessionManager"] | undefined;
+    try {
+      sessionManager = ctx.sessionManager;
+    } catch {
+      return;
+    }
+    if (!sessionManager || sessionManager !== currentState.sessionManager) return;
+
+    restoreCurrentSessionApprovals(currentState);
   });
 
   pi.on("input", async () => {

--- a/init.ts
+++ b/init.ts
@@ -38,6 +38,10 @@ import {
 } from "./runtime-owner.ts";
 import { publishMcpStatusSnapshot } from "./mcp-status.ts";
 import { FAILURE_BACKOFF_MS, getFailureAgeSeconds } from "./failure-backoff.ts";
+import {
+  createSessionApprovalWriter,
+  restoreSessionApprovalState,
+} from "./session-approvals.ts";
 export { getFailureAgeSeconds, getFailureMessage, isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 
 const MAX_FAILURE_MESSAGE_CHARS = 8 * 1024;
@@ -117,6 +121,21 @@ export async function initializeMcp(
   const rawUi = hasUI ? ctx.ui : undefined;
   const modelRegistry = ctx.modelRegistry;
   const initialSignal = ctx.signal;
+  let sessionManager: ExtensionContext["sessionManager"] | undefined;
+  try {
+    sessionManager = ctx.sessionManager;
+  } catch {
+    // Synthetic/load-time contexts may not expose a session manager.
+  }
+  let sessionBranch: readonly unknown[] = [];
+  if (sessionManager) {
+    try {
+      sessionBranch = sessionManager.getBranch();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: could not read the active session branch for approval restore: ${detail}`);
+    }
+  }
   const ui = rawUi ? createOwnedUi(rawUi, owner) : undefined;
   const runtimeSignal = combineAbortSignals(owner.signal, initialSignal);
   const config = options.config !== undefined
@@ -162,7 +181,17 @@ export async function initializeMcp(
   const failureMessages = new Map<string, string>();
   const approvedToolCalls = new Map<string, true>();
   const uiResourceHandler = new UiResourceHandler(manager, config);
-  const consentManager = new ConsentManager("once-per-server");
+  let appendEntry: ((customType: string, data?: unknown) => void) | undefined;
+  try {
+    const candidate = pi.appendEntry;
+    appendEntry = typeof candidate === "function" ? candidate.bind(pi) : undefined;
+  } catch {
+    // Load-time or synthetic APIs may not expose appendEntry yet.
+  }
+  const persistSessionApproval = sessionManager && appendEntry
+    ? createSessionApprovalWriter(appendEntry, () => owner.isActive())
+    : undefined;
+  const consentManager = new ConsentManager("once-per-server", persistSessionApproval);
   const state: McpExtensionState = {
     owner,
     manager,
@@ -180,6 +209,8 @@ export async function initializeMcp(
     failureTracker,
     failureMessages,
     approvedToolCalls,
+    ...(persistSessionApproval !== undefined ? { persistSessionApproval } : {}),
+    ...(sessionManager !== undefined ? { sessionManager } : {}),
     approvalEvents: pi.events,
     uiResourceHandler,
     consentManager,
@@ -209,6 +240,7 @@ export async function initializeMcp(
     },
     ...(options.statusEvents !== undefined ? { statusEvents: options.statusEvents } : {}),
   };
+  if (sessionManager) restoreSessionApprovalState(state, sessionBranch);
   if (ownsOAuthRuntime) owner.addCleanup(() => shutdownOAuth(oauthRuntime));
   manager.setMetadataListChangedListener?.((serverName, reason) => {
     if (!owner.isActive()) return;

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ts-shape.ts",
     "search-ranking.ts",
     "tool-approval.ts",
+    "session-approvals.ts",
     "init.ts",
     "failure-backoff.ts",
     "ui-session.ts",

--- a/session-approvals.ts
+++ b/session-approvals.ts
@@ -1,0 +1,199 @@
+import { createHash } from "node:crypto";
+import type { McpExtensionState } from "./state.ts";
+import type { ToolMetadata } from "./types.ts";
+import { logger } from "./logger.ts";
+
+export const MCP_APPROVAL_CUSTOM_TYPE = "mcp-approval-v1";
+
+export type SessionApprovalEntry =
+  | {
+      version: 1;
+      kind: "tool";
+      decision: "allow_for_session";
+      serverName: string;
+      originalToolName: string;
+      definitionHash: string;
+      argsHash: string;
+    }
+  | {
+      version: 1;
+      kind: "iframe";
+      decision: "allow" | "deny";
+      serverName: string;
+    };
+
+export type SessionApprovalWriter = (record: SessionApprovalEntry) => void;
+
+const TOOL_APPROVAL_KEYS = [
+  "version",
+  "kind",
+  "decision",
+  "serverName",
+  "originalToolName",
+  "definitionHash",
+  "argsHash",
+] as const;
+const IFRAME_APPROVAL_KEYS = ["version", "kind", "decision", "serverName"] as const;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+/** Deterministic serialization used for approval identity hashes. */
+export function stableStringify(value: unknown): string {
+  if (value === null || value === undefined || typeof value !== "object") {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? "undefined" : serialized;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(item => stableStringify(item)).join(",")}]`;
+  }
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map(key => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
+}
+
+export function computeToolArgumentsHash(args: unknown): string {
+  return createHash("sha256").update(stableStringify(args ?? {})).digest("hex");
+}
+
+export function computeToolDefinitionHash(
+  toolMeta: Pick<ToolMetadata, "originalName" | "inputSchema" | "resourceUri" | "uiResourceUri">,
+): string {
+  return createHash("sha256").update(stableStringify({
+    originalName: toolMeta.originalName,
+    inputSchema: toolMeta.inputSchema ?? null,
+    resourceUri: toolMeta.resourceUri ?? null,
+    uiResourceUri: toolMeta.uiResourceUri ?? null,
+  })).digest("hex");
+}
+
+export function makeToolApprovalKey(
+  serverName: string,
+  originalToolName: string,
+  definitionHash: string,
+  argsHash: string,
+): string {
+  return `${serverName}\u0000${originalToolName}\u0000${definitionHash}\u0000${argsHash}`;
+}
+
+export function getToolApprovalIdentity(
+  serverName: string,
+  toolMeta: Pick<ToolMetadata, "originalName" | "inputSchema" | "resourceUri" | "uiResourceUri">,
+  args: unknown,
+): { definitionHash: string; argsHash: string; cacheKey: string } {
+  const definitionHash = computeToolDefinitionHash(toolMeta);
+  const argsHash = computeToolArgumentsHash(args);
+  return {
+    definitionHash,
+    argsHash,
+    cacheKey: makeToolApprovalKey(serverName, toolMeta.originalName, definitionHash, argsHash),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actualKeys = Object.keys(value);
+  return actualKeys.length === keys.length && keys.every(key => Object.hasOwn(value, key));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === "string" && SHA256_HEX.test(value);
+}
+
+function isSessionApprovalEntry(value: unknown): value is SessionApprovalEntry {
+  if (!isRecord(value) || value.version !== 1 || !isNonEmptyString(value.serverName)) return false;
+
+  if (value.kind === "tool") {
+    return hasExactKeys(value, TOOL_APPROVAL_KEYS)
+      && value.decision === "allow_for_session"
+      && isNonEmptyString(value.originalToolName)
+      && isSha256(value.definitionHash)
+      && isSha256(value.argsHash);
+  }
+
+  if (value.kind === "iframe") {
+    return hasExactKeys(value, IFRAME_APPROVAL_KEYS)
+      && (value.decision === "allow" || value.decision === "deny");
+  }
+
+  return false;
+}
+
+function isApprovalCustomEntry(entry: unknown): entry is { type: "custom"; data?: unknown } {
+  return isRecord(entry)
+    && entry.type === "custom"
+    && entry.customType === MCP_APPROVAL_CUSTOM_TYPE;
+}
+
+export function createSessionApprovalWriter(
+  appendEntry: (customType: string, data?: unknown) => void,
+  canAppend: (() => boolean) | undefined = undefined,
+): SessionApprovalWriter {
+  return (record) => {
+    if (canAppend && !canAppend()) return;
+    try {
+      appendEntry(MCP_APPROVAL_CUSTOM_TYPE, record);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.debug(`MCP: failed to persist session approval: ${detail}`);
+    }
+  };
+}
+
+export function rememberToolApproval(
+  state: McpExtensionState,
+  serverName: string,
+  toolMeta: Pick<ToolMetadata, "originalName" | "inputSchema" | "resourceUri" | "uiResourceUri">,
+  args: unknown,
+): void {
+  const { definitionHash, argsHash, cacheKey } = getToolApprovalIdentity(serverName, toolMeta, args);
+  const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
+  if (approvedToolCalls.has(cacheKey)) return;
+
+  approvedToolCalls.set(cacheKey, true);
+  const record: SessionApprovalEntry = {
+    version: 1,
+    kind: "tool",
+    decision: "allow_for_session",
+    serverName,
+    originalToolName: toolMeta.originalName,
+    definitionHash,
+    argsHash,
+  };
+  try {
+    state.persistSessionApproval?.(record);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.debug(`MCP: session approval persistence callback failed: ${detail}`);
+  }
+}
+
+export function restoreSessionApprovalState(
+  state: McpExtensionState,
+  branchEntries: readonly unknown[],
+): void {
+  const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
+  approvedToolCalls.clear();
+  state.consentManager.clear();
+
+  for (const entry of branchEntries) {
+    if (!isApprovalCustomEntry(entry)) continue;
+    if (!isSessionApprovalEntry(entry.data)) continue;
+
+    if (entry.data.kind === "tool") {
+      approvedToolCalls.set(makeToolApprovalKey(
+        entry.data.serverName,
+        entry.data.originalToolName,
+        entry.data.definitionHash,
+        entry.data.argsHash,
+      ), true);
+      continue;
+    }
+
+    state.consentManager.restoreDecision(entry.data.serverName, entry.data.decision === "allow");
+  }
+}

--- a/state.ts
+++ b/state.ts
@@ -7,6 +7,7 @@ import type { ToolMetadata, PromptMetadata, McpConfig, UiSessionMessages, UiStre
 import type { UiResourceHandler } from "./ui-resource-handler.ts";
 import type { McpRuntimeOwner } from "./runtime-owner.ts";
 import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
+import type { SessionApprovalEntry } from "./session-approvals.ts";
 
 export interface CompletedUiSession {
   serverName: string;
@@ -46,8 +47,12 @@ export interface McpExtensionState {
   authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;
   failureMessages: Map<string, string>;
-  /** Session-only approvals keyed by server and original tool name. */
+  /** Session-only approvals keyed by server, tool definition, and arguments. */
   approvedToolCalls: Map<string, true>;
+  /** Optional active-session sink for approval decisions. */
+  persistSessionApproval?: (record: SessionApprovalEntry) => void;
+  /** Session manager used to reject stale session-tree contexts. */
+  sessionManager?: ExtensionContext["sessionManager"];
   /** Shared event bus used by permission extensions to broker MCP approvals. */
   approvalEvents?: ExtensionAPI["events"];
   uiResourceHandler: UiResourceHandler;

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -1,7 +1,8 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { abortable } from "./abort.ts";
 import { combineAbortSignals } from "./runtime-owner.ts";
 import type { McpExtensionState } from "./state.ts";
+import { getToolApprovalIdentity, rememberToolApproval } from "./session-approvals.ts";
 import {
   getToolNameCandidates,
   matchesToolPattern,
@@ -19,18 +20,6 @@ import { sanitizeTerminalText } from "./utils.ts";
 export type ToolCallApprovalResult =
   | { ok: true }
   | { ok: false; reason: "denied" | "approval_required_headless" };
-
-function stableStringify(value: unknown): string {
-  if (value === null || value === undefined || typeof value !== "object") {
-    const serialized = JSON.stringify(value);
-    return serialized === undefined ? "undefined" : serialized;
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(item => stableStringify(item)).join(",")}]`;
-  }
-  const object = value as Record<string, unknown>;
-  return `{${Object.keys(object).sort().map(key => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
-}
 
 export function isToolCallApprovalRequired(
   config: McpConfig,
@@ -148,8 +137,7 @@ export async function ensureToolCallApproved(
   origin: McpToolApprovalOrigin = toolMeta.resourceUri ? "resource" : "proxy",
   approvalMetadata?: ReadonlyMap<string, readonly ToolMetadata[]>,
 ): Promise<ToolCallApprovalResult> {
-  const argsHash = createHash("sha256").update(stableStringify(args ?? {})).digest("hex");
-  const cacheKey = `${serverName}\u0000${toolMeta.originalName}\u0000${argsHash}`;
+  const { cacheKey } = getToolApprovalIdentity(serverName, toolMeta, args);
   const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
   if (approvedToolCalls.has(cacheKey)) {
     return { ok: true };
@@ -158,7 +146,7 @@ export async function ensureToolCallApproved(
   const brokerDecision = await requestBrokerApproval(state, serverName, toolMeta, args, origin, signal);
   if (brokerDecision === "allow_once") return { ok: true };
   if (brokerDecision === "allow_for_session") {
-    approvedToolCalls.set(cacheKey, true);
+    rememberToolApproval(state, serverName, toolMeta, args);
     return { ok: true };
   }
   if (brokerDecision === "deny") return { ok: false, reason: "denied" };
@@ -188,7 +176,7 @@ export async function ensureToolCallApproved(
     return { ok: true };
   }
   if (decision === "Allow for session") {
-    approvedToolCalls.set(cacheKey, true);
+    rememberToolApproval(state, serverName, toolMeta, args);
     return { ok: true };
   }
   return { ok: false, reason: "denied" };

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -2,7 +2,7 @@ import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { buildAllowAttribute } from "./ui-app-bridge-helpers.ts";
+import { buildAllowAttribute, getToolUiResourceUri } from "./ui-app-bridge-helpers.ts";
 import {
   type CallToolRequest,
   type CallToolResult,
@@ -473,11 +473,18 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
           name: callParams.name,
           arguments: normalizedArguments,
         };
+        let uiResourceUri: string | undefined;
+        try {
+          uiResourceUri = getToolUiResourceUri({ _meta: toolDefinition._meta });
+        } catch {
+          // Preserve the endpoint's existing behavior for malformed declarations.
+        }
         const toolMeta = {
           name: callParams.name,
           originalName: callParams.name,
           description: toolDefinition?.description ?? "",
           ...(toolDefinition?.inputSchema !== undefined ? { inputSchema: toolDefinition.inputSchema } : {}),
+          ...(uiResourceUri !== undefined ? { uiResourceUri } : {}),
           ...(uiVisibility !== undefined ? { uiVisibility } : {}),
         };
         const approvalMetadata = new Map(options.state?.toolMetadata);


### PR DESCRIPTION
## Summary
- persist Allow for session MCP tool approvals as versioned `mcp-approval-v1` custom entries on the active Pi session branch
- persist MCP App iframe consent through the same branch-scoped approval replay path while keeping it independent from tool grants
- replay only the active branch on startup/session-tree changes, fail closed for malformed records, and store hashes instead of raw args/results/secrets

Closes #492.

## Validation
- `npm test -- --run __tests__/tool-approval.test.ts __tests__/consent-manager.test.ts __tests__/session-approvals.test.ts __tests__/ui-server.test.ts __tests__/index-lifecycle.test.ts`
- `npm run typecheck`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check origin/main...HEAD`
- fresh read-only review: no issues found
