### PR TITLE
refactor(panels): use active Pi theme and TUI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime MCP status snapshots now include each server's `directToolCount`, the number of direct tools currently registered with Pi, including resource tools. Thanks to [@FischLu](https://github.com/FischLu) for #482.
 
 ### Changed
+- MCP setup and server panels now use Pi's active theme and TUI components while preserving their existing workflows. (#488)
 - MCP sampling requests now route through Pi's `ModelRegistry.complete`, leaving provider authentication, environment, and base URL handling to the host.
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -106,6 +106,21 @@ describe("commands onboarding", () => {
     expect(loadOnboardingState().sharedConfigHintShown).toBe(true);
   });
 
+  it("passes the active theme into the setup MCP panel", async () => {
+    process.env.HOME = mkdtempSync(join(tmpdir(), "pi-mcp-commands-setup-theme-home-"));
+    const ui = createUi();
+    const { openMcpSetup } = await import("../commands.ts");
+
+    await openMcpSetup(
+      { config: { mcpServers: {} } } as any,
+      {} as any,
+      { hasUI: true, mode: "tui", cwd: process.cwd(), ui } as any,
+    );
+
+    const options = mocks.createMcpSetupPanel.mock.calls.at(-1)?.[2];
+    expect(options.theme).toBe(ui.theme);
+  });
+
   it("passes the active theme into the OAuth MCP panel", async () => {
     const ui = createUi();
     const { openMcpAuthPanel } = await import("../commands.ts");

--- a/__tests__/commands-onboarding.test.ts
+++ b/__tests__/commands-onboarding.test.ts
@@ -49,10 +49,12 @@ describe("commands onboarding", () => {
   });
 
   function createUi() {
+    const theme = { name: "active-test-theme" };
     return {
       notify: vi.fn(),
       setStatus: vi.fn(),
-      custom: vi.fn((renderer: any) => renderer({ requestRender: vi.fn() }, {}, {}, vi.fn())),
+      theme,
+      custom: vi.fn((renderer: any) => renderer({ requestRender: vi.fn() }, theme, {}, vi.fn())),
     };
   }
 
@@ -85,6 +87,7 @@ describe("commands onboarding", () => {
     });
 
     const ui = createUi();
+    const { theme } = ui;
     const { loadMcpConfig } = await import("../config.ts");
     const { openMcpPanel } = await import("../commands.ts");
     const { loadOnboardingState } = await import("../onboarding-state.ts");
@@ -99,7 +102,28 @@ describe("commands onboarding", () => {
     expect(mocks.createMcpPanel).toHaveBeenCalled();
     const options = mocks.createMcpPanel.mock.calls[0]?.[6];
     expect(options.noticeLines[0]).toContain("Using standard MCP config");
+    expect(options.theme).toBe(theme);
     expect(loadOnboardingState().sharedConfigHintShown).toBe(true);
+  });
+
+  it("passes the active theme into the OAuth MCP panel", async () => {
+    const ui = createUi();
+    const { openMcpAuthPanel } = await import("../commands.ts");
+
+    await openMcpAuthPanel({
+      programmaticConfig: false,
+      config: { mcpServers: { sentry: { url: "https://mcp.sentry.dev/mcp", auth: "oauth" } } },
+      manager: { getConnection: () => null },
+      failureTracker: new Map(),
+    } as any, { getFlag: () => undefined } as any, {
+      hasUI: true,
+      mode: "tui",
+      cwd: process.cwd(),
+      ui,
+    } as any);
+
+    const options = mocks.createMcpPanel.mock.calls.at(-1)?.[6];
+    expect(options.theme).toBe(ui.theme);
   });
 
   it("does not present an .agents-only config as canonical shared MCP config", async () => {

--- a/__tests__/mcp-panel-copy-error.test.ts
+++ b/__tests__/mcp-panel-copy-error.test.ts
@@ -3,14 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   copyToClipboard: vi.fn(async (_text: string) => undefined),
   DynamicBorder: class {
-    private readonly color: (text: string) => string;
-
-    constructor(color: (text: string) => string = (text) => text) {
-      this.color = color;
-    }
-
     render(width: number): string[] {
-      return [this.color("─".repeat(Math.max(1, width)))];
+      return ["─".repeat(Math.max(1, width))];
     }
 
     invalidate(): void {}

--- a/__tests__/mcp-panel-copy-error.test.ts
+++ b/__tests__/mcp-panel-copy-error.test.ts
@@ -2,9 +2,25 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   copyToClipboard: vi.fn(async (_text: string) => undefined),
+  DynamicBorder: class {
+    private readonly color: (text: string) => string;
+
+    constructor(color: (text: string) => string = (text) => text) {
+      this.color = color;
+    }
+
+    render(width: number): string[] {
+      return [this.color("─".repeat(Math.max(1, width)))];
+    }
+
+    invalidate(): void {}
+  },
 }));
 
-vi.mock("@earendil-works/pi-coding-agent", () => ({ copyToClipboard: mocks.copyToClipboard }));
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  copyToClipboard: mocks.copyToClipboard,
+  DynamicBorder: mocks.DynamicBorder,
+}));
 
 function stripAnsi(input: string): string {
   return input.replace(/\x1b\[[0-9;]*m/g, "");

--- a/__tests__/mcp-panel-theme.test.ts
+++ b/__tests__/mcp-panel-theme.test.ts
@@ -1,0 +1,106 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpPanel } from "../mcp-panel.ts";
+import { computeServerHash, type MetadataCache } from "../metadata-cache.ts";
+import type { McpConfig, McpPanelCallbacks } from "../types.ts";
+
+function createTheme() {
+  const colors: Record<string, number> = {
+    accent: 31,
+    border: 32,
+    success: 33,
+    warning: 34,
+    muted: 35,
+    dim: 36,
+    error: 37,
+  };
+  const fg = vi.fn((color: string, text: string) => `\x1b[38;5;${colors[color] ?? 38}m${text}\x1b[39m`);
+  const theme = {
+    fg,
+    bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+    italic: (text: string) => `\x1b[3m${text}\x1b[23m`,
+    inverse: (text: string) => `\x1b[7m${text}\x1b[27m`,
+  } as unknown as Theme;
+  return { fg, theme };
+}
+
+function createCallbacks(): McpPanelCallbacks {
+  return {
+    reconnect: async () => true,
+    canAuthenticate: () => true,
+    authenticate: async () => ({ ok: true }),
+    getConnectionStatus: () => "idle",
+    refreshCacheAfterReconnect: () => null,
+  };
+}
+
+function createPanelThemeFixture() {
+  const config: McpConfig = {
+    mcpServers: {
+      github: { command: "node", args: ["server.js"], directTools: ["search"] },
+    },
+  };
+  const cache: MetadataCache = {
+    version: 1,
+    servers: {
+      github: {
+        configHash: computeServerHash(config.mcpServers.github),
+        cachedAt: Date.now(),
+        tools: [{ name: "search", description: "Search repositories" }],
+        resources: [],
+      },
+    },
+  };
+  return { config, cache };
+}
+
+describe("mcp-panel theme and component rendering", () => {
+  it("renders normal MCP rows through the supplied Pi theme", () => {
+    const { fg, theme } = createTheme();
+    const { config, cache } = createPanelThemeFixture();
+    const panel = createMcpPanel(
+      config,
+      cache,
+      new Map(),
+      createCallbacks(),
+      { requestRender: () => {} },
+      () => {},
+      { theme },
+    );
+
+    const lines = panel.render(80);
+    const output = lines.join("\n");
+
+    expect(fg).toHaveBeenCalledWith("border", expect.any(String));
+    expect(fg).toHaveBeenCalledWith("accent", expect.stringContaining(" MCP Servers "));
+    expect(fg).toHaveBeenCalledWith("success", "●");
+    expect(fg).toHaveBeenCalledWith("muted", expect.stringContaining("1/1"));
+    expect(output).not.toContain("\x1b[0m");
+    expect(Math.max(...lines.map((line) => visibleWidth(line)))).toBeLessThanOrEqual(80);
+    panel.dispose();
+  });
+
+  it("keeps auth-only rendering themed without changing the public panel behavior", () => {
+    const { fg, theme } = createTheme();
+    const { config } = createPanelThemeFixture();
+    const panel = createMcpPanel(
+      config,
+      null,
+      new Map(),
+      { ...createCallbacks(), getConnectionStatus: () => "needs-auth" },
+      { requestRender: () => {} },
+      () => {},
+      { authOnly: true, theme },
+    );
+
+    const output = panel.render(80).join("\n");
+
+    expect(output).toContain("MCP OAuth");
+    expect(output).toContain("github");
+    expect(fg).toHaveBeenCalledWith("accent", expect.stringContaining(" MCP OAuth "));
+    expect(fg).toHaveBeenCalledWith("warning", "needs auth");
+    expect(output).not.toContain("\x1b[0m");
+    panel.dispose();
+  });
+});

--- a/__tests__/mcp-setup-panel-theme.test.ts
+++ b/__tests__/mcp-setup-panel-theme.test.ts
@@ -93,4 +93,48 @@ describe("mcp setup panel theme and component rendering", () => {
     expect(Math.max(...lines.map((line) => visibleWidth(line)))).toBeLessThanOrEqual(60);
     panel.dispose();
   });
+
+  it("reapplies active styles to wrapped setup continuation lines", () => {
+    const { theme } = createTheme();
+    const discovery = createDiscovery();
+    const panel = createMcpSetupPanel(
+      discovery,
+      createCallbacks(),
+      {
+        mode: "setup",
+        onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+        theme,
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    const secondaryLines = panel.render(40).filter((line) => [
+      "for this project/team or",
+      "~/.config/mcp/mcp.json for all",
+      "projects. Adopt host imports or",
+      "quick-add RepoPrompt from this",
+      "screen.",
+    ].some((text) => line.includes(text)));
+    expect(secondaryLines).toHaveLength(5);
+    for (const line of secondaryLines) {
+      expect(line).toContain("\x1b[38;5;35m");
+      expect(line).toContain("\x1b[3m");
+    }
+
+    panel.handleInput("\x1b[B");
+    panel.handleInput("\r");
+    const noticeLine = panel.render(40).find((line) => line.includes("to global ~/.config/mcp/mcp.json."));
+    expect(noticeLine).toContain("\x1b[38;5;36m");
+
+    discovery.hasAnyConfig = true;
+    discovery.totalServerCount = 123;
+    discovery.sources = [
+      { id: "shared-project", label: "project shared", path: "/tmp/shared", exists: true, scope: "project", kind: "shared", serverCount: 1 },
+      { id: "pi-project", label: "project Pi", path: "/tmp/pi", exists: true, scope: "project", kind: "pi", serverCount: 1 },
+    ];
+    const summaryLine = panel.render(40).find((line) => line.includes("across 1 shared"));
+    expect(summaryLine).toContain("\x1b[38;5;36m");
+    panel.dispose();
+  });
 });

--- a/__tests__/mcp-setup-panel-theme.test.ts
+++ b/__tests__/mcp-setup-panel-theme.test.ts
@@ -1,0 +1,96 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpSetupPanel, type SetupPanelCallbacks } from "../mcp-setup-panel.ts";
+import type { McpDiscoverySummary } from "../config.ts";
+
+function createTheme() {
+  const colors: Record<string, number> = {
+    accent: 31,
+    border: 32,
+    success: 33,
+    warning: 34,
+    muted: 35,
+    dim: 36,
+    error: 37,
+  };
+  const fg = vi.fn((color: string, text: string) => `\x1b[38;5;${colors[color] ?? 38}m${text}\x1b[39m`);
+  const theme = {
+    fg,
+    bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+    italic: (text: string) => `\x1b[3m${text}\x1b[23m`,
+    inverse: (text: string) => `\x1b[7m${text}\x1b[27m`,
+  } as unknown as Theme;
+  return { fg, theme };
+}
+
+function createDiscovery(): McpDiscoverySummary {
+  return {
+    sources: [],
+    imports: [],
+    hostConfigs: [],
+    hostConfigDiscovery: "off",
+    agentPlugins: [],
+    conflicts: [],
+    hasAnyConfig: false,
+    hasAnyDetectedPaths: false,
+    hasSharedServers: false,
+    hasPiOwnedServers: false,
+    totalServerCount: 0,
+    fingerprint: "test",
+    repoPrompt: { configured: false },
+  };
+}
+
+function createCallbacks(): SetupPanelCallbacks {
+  const preview = {
+    path: "/tmp/mcp.json",
+    existed: false,
+    changed: true,
+    beforeText: "",
+    afterText: "",
+    diffText: "",
+  };
+  return {
+    previewImports: () => preview,
+    previewStarterConfig: () => preview,
+    previewRepoPrompt: () => null,
+    previewKnownServer: () => preview,
+    adoptImports: async () => ({ added: [], path: preview.path }),
+    scaffoldConfig: async () => ({ path: preview.path }),
+    addRepoPrompt: async () => ({ path: preview.path, serverName: "repoprompt" }),
+    addKnownServer: async (preset) => ({ path: preview.path, serverName: preset.name }),
+    openPath: async () => {},
+    markSetupCompleted: () => {},
+  };
+}
+
+describe("mcp setup panel theme and component rendering", () => {
+  it("renders setup content through the active Pi theme", () => {
+    const { fg, theme } = createTheme();
+    const panel = createMcpSetupPanel(
+      createDiscovery(),
+      createCallbacks(),
+      {
+        mode: "setup",
+        onboardingState: { version: 1, sharedConfigHintShown: false, setupCompleted: false },
+        theme,
+      },
+      { requestRender: () => {} },
+      () => {},
+    );
+
+    const lines = panel.render(60);
+    const output = lines.join("\n");
+
+    expect(output).toContain("MCP setup");
+    expect(output).toContain("No MCP config is active yet.");
+    expect(fg).toHaveBeenCalledWith("border", expect.stringContaining("─"));
+    expect(fg).toHaveBeenCalledWith("accent", "MCP setup");
+    expect(fg).toHaveBeenCalledWith("accent", "›");
+    expect(fg).toHaveBeenCalledWith("warning", "No MCP config is active yet.");
+    expect(output).not.toContain("\x1b[0m");
+    expect(Math.max(...lines.map((line) => visibleWidth(line)))).toBeLessThanOrEqual(60);
+    panel.dispose();
+  });
+});

--- a/commands.ts
+++ b/commands.ts
@@ -670,7 +670,7 @@ export async function openMcpPanel(
 
   await new Promise<void>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, keybindings, done) => {
+      (tui, theme, keybindings, done) => {
         return createMcpPanel(config, cache, provenanceMap, callbacks, tui, (result: McpPanelResult) => {
           void (async () => {
             if (!result.cancelled && result.disabledChanges.size > 0) {
@@ -699,7 +699,7 @@ export async function openMcpPanel(
             done(undefined);
             resolve();
           });
-        }, { noticeLines, keybindings });
+        }, { noticeLines, keybindings, theme });
       },
       {
         overlay: true,
@@ -750,13 +750,14 @@ export async function openMcpAuthPanel(
 
   await new Promise<void>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, keybindings, done) => {
+      (tui, theme, keybindings, done) => {
         return createMcpPanel(config, cache, provenanceMap, callbacks, tui, () => {
           done(undefined);
           resolve();
         }, {
           authOnly: true,
           keybindings,
+          theme,
           noticeLines: ["Select an OAuth MCP server and press Enter or ctrl+a to authenticate."],
         });
       },

--- a/commands.ts
+++ b/commands.ts
@@ -556,8 +556,8 @@ export async function openMcpSetup(
 
   return new Promise<PanelFlowResult>((resolve) => {
     ctx.ui.custom(
-      (tui, _theme, keybindings, done) => {
-        return createMcpSetupPanel(discovery, callbacks, { mode, onboardingState, keybindings }, tui, () => {
+      (tui, theme, keybindings, done) => {
+        return createMcpSetupPanel(discovery, callbacks, { mode, onboardingState, keybindings, theme }, tui, () => {
           done(undefined);
           resolve({ configChanged });
         });

--- a/mcp-panel-theme.ts
+++ b/mcp-panel-theme.ts
@@ -1,4 +1,60 @@
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
+
+/**
+ * A width-aware frame shared by the MCP panel views.
+ *
+ * DynamicBorder owns the horizontal sizing; the panel supplies the corners so
+ * each view can retain its existing frame shape without hand-building a
+ * border-width-dependent ANSI line.
+ */
+export class McpPanelFrame implements Component {
+  private readonly border: DynamicBorder;
+
+  constructor(
+    private readonly theme: McpPanelTheme,
+    private readonly left: string,
+    private readonly right: string,
+    private readonly title?: string,
+  ) {
+    this.border = new DynamicBorder((text: string) => this.theme.border(text));
+  }
+
+  render(width: number): string[] {
+    if (width <= 0) return [];
+    if (width === 1) return [truncateToWidth(this.theme.border(this.left), width, "", false)];
+
+    const innerWidth = width - 2;
+    if (this.title !== undefined) {
+      const titleText = truncateToWidth(` ${this.title} `, innerWidth, "", false);
+      const borderLength = Math.max(0, innerWidth - visibleWidth(titleText));
+      const leftLength = Math.floor(borderLength / 2);
+      const rightLength = borderLength - leftLength;
+      return [
+        this.theme.border(this.left) +
+          this.renderBorderSegment(leftLength) +
+          this.theme.title(titleText) +
+          this.renderBorderSegment(rightLength) +
+          this.theme.border(this.right),
+      ];
+    }
+
+    return [
+      this.theme.border(this.left) +
+        this.renderBorderSegment(innerWidth) +
+        this.theme.border(this.right),
+    ];
+  }
+
+  invalidate(): void {
+    this.border.invalidate();
+  }
+
+  private renderBorderSegment(width: number): string {
+    if (width <= 0) return "";
+    return this.border.render(width)[0] ?? "";
+  }
+}
 
 /**
  * Semantic styles shared by the MCP panels.

--- a/mcp-panel-theme.ts
+++ b/mcp-panel-theme.ts
@@ -1,0 +1,70 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Semantic styles shared by the MCP panels.
+ *
+ * The adapter deliberately keeps the panel roles independent from Pi's theme
+ * token names. This lets the panel preserve its existing hierarchy while
+ * consuming the active host theme, and gives the setup panel a small boundary
+ * to adopt in its follow-up migration.
+ */
+export interface McpPanelTheme {
+  border(text: string): string;
+  title(text: string): string;
+  selected(text: string): string;
+  direct(text: string): string;
+  needsAuth(text: string): string;
+  placeholder(text: string): string;
+  description(text: string): string;
+  hint(text: string): string;
+  confirm(text: string): string;
+  cancel(text: string): string;
+  bold(text: string): string;
+  italic(text: string): string;
+  inverse(text: string): string;
+}
+
+const identity = (text: string): string => text;
+
+const PLAIN_THEME: McpPanelTheme = {
+  border: identity,
+  title: identity,
+  selected: identity,
+  direct: identity,
+  needsAuth: identity,
+  placeholder: identity,
+  description: identity,
+  hint: identity,
+  confirm: identity,
+  cancel: identity,
+  bold: identity,
+  italic: identity,
+  inverse: identity,
+};
+
+/**
+ * Build panel styles from the theme supplied to `ctx.ui.custom()`.
+ *
+ * When the panel is constructed directly (for example by an integration test
+ * or an older embedding), plain text remains a safe fallback. No ANSI palette
+ * is owned by the adapter anymore.
+ */
+export function createMcpPanelTheme(theme?: Theme): McpPanelTheme {
+  if (!theme) return PLAIN_THEME;
+
+  return {
+    border: (text) => theme.fg("border", text),
+    title: (text) => theme.fg("accent", text),
+    selected: (text) => theme.fg("accent", text),
+    direct: (text) => theme.fg("success", text),
+    needsAuth: (text) => theme.fg("warning", text),
+    placeholder: (text) => theme.fg("dim", text),
+    description: (text) => theme.fg("muted", text),
+    hint: (text) => theme.fg("dim", text),
+    confirm: (text) => theme.fg("success", text),
+    cancel: (text) => theme.fg("error", text),
+    bold: (text) => theme.bold(text),
+    italic: (text) => theme.italic(text),
+    inverse: (text) => theme.inverse(text),
+  };
+}

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -301,15 +301,11 @@ class McpPanelView implements Component {
   }
 
   private addRow(content: string, innerWidth: number): void {
-    this.addText(this.row(content, innerWidth));
+    this.container.addChild(new Text(this.row(content, innerWidth), 0, 0));
   }
 
   private addRule(left: string, right: string): void {
     this.container.addChild(new McpPanelFrame(this.theme, left, right));
-  }
-
-  private addText(content: string): void {
-    this.container.addChild(new Text(content, 0, 0));
   }
 
   private row(content: string, innerWidth: number): string {

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,63 +1,13 @@
-import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { copyToClipboard } from "@earendil-works/pi-coding-agent";
+import { Container, Text, matchesKey, truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import { copyToClipboard, DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
+import { createMcpPanelTheme, type McpPanelTheme } from "./mcp-panel-theme.ts";
 import { getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
 import { sanitizeTerminalText, stripOscSequences } from "./utils.ts";
 import { isServerCacheValid, type MetadataCache, type ServerCacheEntry, type CachedTool } from "./metadata-cache.ts";
 import { isUiToolVisibleToModel } from "./ui-tool-visibility.ts";
-
-interface PanelTheme {
-  border: string;
-  title: string;
-  selected: string;
-  direct: string;
-  needsAuth: string;
-  placeholder: string;
-  description: string;
-  hint: string;
-  confirm: string;
-  cancel: string;
-}
-
-const DEFAULT_THEME: PanelTheme = {
-  border: "2",
-  title: "2",
-  selected: "36",
-  direct: "32",
-  needsAuth: "33",
-  placeholder: "2;3",
-  description: "2",
-  hint: "2",
-  confirm: "32",
-  cancel: "31",
-};
-
-function fg(code: string, text: string): string {
-  if (!code) return text;
-  return `\x1b[${code}m${text}\x1b[0m`;
-}
-
-const RAINBOW_COLORS = [
-  "38;2;178;129;214",
-  "38;2;215;135;175",
-  "38;2;254;188;56",
-  "38;2;228;192;15",
-  "38;2;137;210;129",
-  "38;2;0;175;175",
-  "38;2;23;143;185",
-];
-
-function rainbowProgress(filled: number, total: number): string {
-  const dots: string[] = [];
-  for (let i = 0; i < total; i++) {
-    const color = RAINBOW_COLORS[i % RAINBOW_COLORS.length];
-    if (!color) continue;
-    dots.push(fg(color, i < filled ? "●" : "○"));
-  }
-  return dots.join(" ");
-}
 
 function fuzzyScore(query: string, text: string): number {
   const lq = query.toLowerCase();
@@ -150,6 +100,390 @@ interface VisibleItem {
   toolIndex?: number;
 }
 
+interface McpPanelViewState {
+  noticeLines: readonly string[];
+  servers: readonly ServerState[];
+  visibleItems: readonly VisibleItem[];
+  cursorIndex: number;
+  nameQuery: string;
+  descSearchActive: boolean;
+  descQuery: string;
+  dirty: boolean;
+  confirmingDiscard: boolean;
+  discardSelected: number;
+  importNotice: string | null;
+  authNotice: string | null;
+  authInFlight: string | null;
+  authOnly: boolean;
+  saveLabel: string | null;
+}
+
+/** A panel-specific rule that delegates horizontal sizing to Pi's border component. */
+class McpPanelRule implements Component {
+  private readonly border: DynamicBorder;
+
+  constructor(
+    private readonly theme: McpPanelTheme,
+    private readonly left: string,
+    private readonly right: string,
+    private readonly title?: string,
+  ) {
+    this.border = new DynamicBorder((text: string) => this.theme.border(text));
+  }
+
+  render(width: number): string[] {
+    if (width <= 0) return [];
+    if (width === 1) return [truncateToWidth(this.theme.border(this.left), width, "", false)];
+
+    const innerWidth = width - 2;
+    if (this.title !== undefined) {
+      const titleText = truncateToWidth(` ${this.title} `, innerWidth, "", false);
+      const borderLength = Math.max(0, innerWidth - visibleWidth(titleText));
+      const leftLength = Math.floor(borderLength / 2);
+      const rightLength = borderLength - leftLength;
+      return [
+        this.theme.border(this.left) +
+          this.renderBorderSegment(leftLength) +
+          this.theme.title(titleText) +
+          this.renderBorderSegment(rightLength) +
+          this.theme.border(this.right),
+      ];
+    }
+
+    return [
+      this.theme.border(this.left) +
+        this.renderBorderSegment(innerWidth) +
+        this.theme.border(this.right),
+    ];
+  }
+
+  invalidate(): void {
+    this.border.invalidate();
+  }
+
+  private renderBorderSegment(width: number): string {
+    if (width <= 0) return "";
+    return this.border.render(width)[0] ?? "";
+  }
+}
+
+/**
+ * The themed MCP view. It owns only component composition and formatting;
+ * input routing and callbacks remain on McpPanel.
+ */
+class McpPanelView implements Component {
+  private readonly container = new Container();
+
+  constructor(
+    private readonly getState: () => McpPanelViewState,
+    private readonly theme: McpPanelTheme,
+  ) {}
+
+  render(width: number): string[] {
+    const panelWidth = Math.max(0, width);
+    const innerWidth = Math.max(0, panelWidth - 2);
+    const state = this.getState();
+    this.container.clear();
+
+    const title = state.authOnly ? "MCP OAuth" : "MCP Servers";
+    this.container.addChild(new McpPanelRule(this.theme, "╭", "╮", title));
+    this.addRow("", innerWidth);
+
+    const cursor = this.theme.selected("│");
+    const searchIcon = this.theme.border("◎");
+    if (state.descSearchActive) {
+      this.addRow(`${searchIcon}  ${this.theme.needsAuth("desc:")} ${state.descQuery}${cursor}`, innerWidth);
+    } else if (state.nameQuery) {
+      this.addRow(`${searchIcon}  ${state.nameQuery}${cursor}`, innerWidth);
+    } else {
+      this.addRow(`${searchIcon}  ${this.theme.placeholder(this.theme.italic("search..."))}`, innerWidth);
+    }
+
+    this.addRow("", innerWidth);
+    if (state.noticeLines.length > 0) {
+      for (const notice of state.noticeLines) {
+        this.addRow(this.theme.hint(this.theme.italic(sanitizeDisplayText(notice))), innerWidth);
+      }
+      this.addRow("", innerWidth);
+    }
+    this.addRule("├", "┤");
+
+    if (state.servers.length === 0) {
+      this.addRow("", innerWidth);
+      this.addRow(
+        this.theme.hint(
+          this.theme.italic(
+            state.authOnly ? "No OAuth-capable MCP servers configured." : "No MCP servers configured.",
+          ),
+        ),
+        innerWidth,
+      );
+      this.addRow("", innerWidth);
+    } else {
+      const maxVisible = McpPanel.MAX_VISIBLE;
+      const total = state.visibleItems.length;
+      const startIndex = Math.max(
+        0,
+        Math.min(state.cursorIndex - Math.floor(maxVisible / 2), total - maxVisible),
+      );
+      const endIndex = Math.min(startIndex + maxVisible, total);
+
+      this.addRow("", innerWidth);
+
+      for (let index = startIndex; index < endIndex; index++) {
+        const item = state.visibleItems[index];
+        if (!item) continue;
+        const isCursor = index === state.cursorIndex;
+        const server = state.servers[item.serverIndex];
+        if (!server) continue;
+
+        if (item.type === "server") {
+          this.addRow(this.renderServerRow(state, server, isCursor), innerWidth);
+          if (isCursor && server.connectionStatus === "failed" && server.failureMessage) {
+            for (const line of this.wrapText(sanitizeDisplayText(server.failureMessage), innerWidth - 6)) {
+              this.addRow(`    ${this.theme.cancel(line)}`, innerWidth);
+            }
+          }
+        } else if (item.toolIndex !== undefined) {
+          const tool = server.tools[item.toolIndex];
+          if (tool) this.addRow(this.renderToolRow(tool, isCursor, innerWidth), innerWidth);
+        }
+      }
+
+      this.addRow("", innerWidth);
+
+      if (total > maxVisible) {
+        const progress = Math.round(((state.cursorIndex + 1) / total) * 10);
+        this.addRow(
+          `${this.progressDots(progress, 10)}  ${this.theme.hint(`${state.cursorIndex + 1}/${total}`)}`,
+          innerWidth,
+        );
+        this.addRow("", innerWidth);
+      }
+
+      if (state.importNotice) {
+        this.addRow(this.theme.needsAuth(this.theme.italic(sanitizeDisplayText(state.importNotice))), innerWidth);
+        this.addRow("", innerWidth);
+      }
+      if (state.authNotice) {
+        this.addRow(this.theme.needsAuth(this.theme.italic(sanitizeDisplayText(state.authNotice))), innerWidth);
+        this.addRow("", innerWidth);
+      }
+    }
+
+    this.addRule("├", "┤");
+    this.addRow("", innerWidth);
+
+    if (state.confirmingDiscard) {
+      const discardButton = state.discardSelected === 0
+        ? this.theme.inverse(this.theme.bold(this.theme.cancel("  Discard  ")))
+        : this.theme.hint("  Discard  ");
+      const keepButton = state.discardSelected === 1
+        ? this.theme.inverse(this.theme.bold(this.theme.confirm("  Keep & Close  ")))
+        : this.theme.hint("  Keep & Close  ");
+      this.addRow(`Discard unsaved changes?  ${discardButton}   ${keepButton}`, innerWidth);
+    } else if (state.authOnly) {
+      this.addRow(this.theme.description("select a server to authenticate"), innerWidth);
+    } else {
+      let directCount = 0;
+      let directTokens = 0;
+      for (const server of state.servers) {
+        directCount += server.directCount;
+        directTokens += server.directTokens;
+      }
+      const stats = directCount > 0
+        ? `${directCount} direct  ~${directTokens.toLocaleString()} tokens`
+        : "no direct tools";
+      this.addRow(
+        this.theme.description(stats + (state.dirty ? this.theme.needsAuth("  (unsaved)") : "")),
+        innerWidth,
+      );
+    }
+
+    this.addRow("", innerWidth);
+    const hints = state.authOnly
+      ? [
+          this.theme.italic("↑↓") + " navigate",
+          this.theme.italic("⏎") + " auth",
+          this.theme.italic("ctrl+a") + " auth",
+          this.theme.italic("esc") + " clear/close",
+          this.theme.italic("ctrl+c") + " quit",
+        ]
+      : [
+          this.theme.italic("↑↓") + " navigate",
+          this.theme.italic("space") + " toggle",
+          this.theme.italic("⏎") + " expand/auth",
+          this.theme.italic("ctrl+a") + " auth",
+          this.theme.italic("ctrl+r") + " reconnect",
+          this.theme.italic("ctrl+d") + " disable/enable",
+          ...(this.selectedServerHasFailureMessage(state) ? [this.theme.italic("ctrl+y") + " copy error"] : []),
+          this.theme.italic("?") + " desc search",
+          ...(state.saveLabel ? [this.theme.italic(state.saveLabel) + " save"] : []),
+          this.theme.italic("esc") + " clear/close",
+          this.theme.italic("ctrl+c") + " quit",
+        ];
+    const gap = "  ";
+    const gapWidth = 2;
+    const maxWidth = innerWidth - 2;
+    let currentLine = "";
+    let currentWidth = 0;
+    for (const hint of hints) {
+      const hintWidth = visibleWidth(hint);
+      const needed = currentWidth === 0 ? hintWidth : gapWidth + hintWidth;
+      if (currentWidth > 0 && currentWidth + needed > maxWidth) {
+        this.addRow(this.theme.hint(currentLine), innerWidth);
+        currentLine = hint;
+        currentWidth = hintWidth;
+      } else {
+        currentLine += (currentWidth > 0 ? gap : "") + hint;
+        currentWidth += needed;
+      }
+    }
+    if (currentLine) this.addRow(this.theme.hint(currentLine), innerWidth);
+
+    this.addRule("╰", "╯");
+    return this.container.render(panelWidth);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+
+  private addRow(content: string, innerWidth: number): void {
+    this.addText(this.row(content, innerWidth));
+  }
+
+  private addRule(left: string, right: string): void {
+    this.container.addChild(new McpPanelRule(this.theme, left, right));
+  }
+
+  private addText(content: string): void {
+    this.container.addChild(new Text(content, 0, 0));
+  }
+
+  private row(content: string, innerWidth: number): string {
+    const fitted = truncateToWidth(" " + sanitizeRowContent(content), innerWidth, "…", true);
+    return this.theme.border("│") + fitted + this.theme.border("│");
+  }
+
+  private progressDots(filled: number, total: number): string {
+    const dots: string[] = [];
+    for (let index = 0; index < total; index++) {
+      if (index < filled) {
+        dots.push(this.theme.direct("●"));
+      } else {
+        dots.push(this.theme.hint("○"));
+      }
+    }
+    return dots.join(" ");
+  }
+
+  private renderServerRow(state: McpPanelViewState, server: ServerState, isCursor: boolean): string {
+    const expandIcon = server.expanded ? "▾" : "▸";
+    const prefix = isCursor
+      ? this.theme.selected(expandIcon)
+      : this.theme.border(server.expanded ? expandIcon : "·");
+
+    const serverName = sanitizeDisplayText(server.name);
+    const importKind = sanitizeDisplayText(server.importKind ?? "import");
+    const name = isCursor
+      ? this.theme.bold(this.theme.selected(serverName))
+      : serverName;
+    const importLabel = server.source === "import" ? this.theme.description(` (${importKind})`) : "";
+    const statusLabel = this.renderConnectionStatus(state, server);
+
+    if (!server.hasCachedData && !state.authOnly) {
+      return `${prefix}   ${name}${importLabel}  ${this.theme.description("(not cached)")}${statusLabel}`;
+    }
+
+    const directCount = server.directCount;
+    const totalCount = server.tools.length;
+    let toggleIcon = this.theme.description("○");
+    if (directCount === totalCount && totalCount > 0) {
+      toggleIcon = this.theme.direct("●");
+    } else if (directCount > 0) {
+      toggleIcon = this.theme.needsAuth("◐");
+    }
+
+    let toolInfo = "";
+    if (totalCount > 0) {
+      toolInfo = `${directCount}/${totalCount}`;
+      if (directCount > 0) toolInfo += `  ~${server.directTokens.toLocaleString()}`;
+      toolInfo = this.theme.description(toolInfo);
+    }
+
+    return `${prefix} ${toggleIcon} ${name}${importLabel}  ${toolInfo}${statusLabel}`;
+  }
+
+  private selectedServerHasFailureMessage(state: McpPanelViewState): boolean {
+    const item = state.visibleItems[state.cursorIndex];
+    if (!item) return false;
+    const server = state.servers[item.serverIndex];
+    return server?.connectionStatus === "failed" && !!server.failureMessage;
+  }
+
+  private wrapText(text: string, width: number): string[] {
+    const max = Math.max(8, width);
+    const words = text.split(/\s+/).filter(Boolean);
+    const lines: string[] = [];
+    let current = "";
+    const splitLongWord = (word: string): string => {
+      let rest = word;
+      while (visibleWidth(rest) > max) {
+        let take = "";
+        let index = 0;
+        while (index < rest.length && visibleWidth(take + rest.charAt(index)) <= max) {
+          take += rest.charAt(index);
+          index++;
+        }
+        if (!take) take = rest.charAt(0);
+        lines.push(take);
+        rest = rest.slice(take.length);
+      }
+      return rest;
+    };
+
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (visibleWidth(candidate) <= max) {
+        current = candidate;
+      } else {
+        if (current) lines.push(current);
+        current = splitLongWord(word);
+      }
+    }
+    if (current) lines.push(current);
+    return lines.length > 0 ? lines : [text];
+  }
+
+  private renderConnectionStatus(state: McpPanelViewState, server: ServerState): string {
+    if (state.authInFlight === server.name) return `  ${this.theme.needsAuth("authenticating")}`;
+    if (server.disabled) return `  ${this.theme.description("disabled")}`;
+    if (server.connectionStatus === "needs-auth") return `  ${this.theme.needsAuth("needs auth")}`;
+    if (server.connectionStatus === "connecting") return `  ${this.theme.needsAuth("connecting")}`;
+    if (server.connectionStatus === "failed") return `  ${this.theme.cancel("failed")}`;
+    if (state.authOnly && server.connectionStatus === "connected") return `  ${this.theme.direct("connected")}`;
+    if (state.authOnly) return `  ${this.theme.description("idle")}`;
+    return "";
+  }
+
+  private renderToolRow(tool: ToolState, isCursor: boolean, innerWidth: number): string {
+    const toggleIcon = tool.isDirect ? this.theme.direct("●") : this.theme.description("○");
+    const cursor = isCursor ? this.theme.selected("▸") : " ";
+    const toolName = sanitizeDisplayText(tool.name);
+    const description = sanitizeDisplayText(tool.description);
+    const name = isCursor ? this.theme.bold(this.theme.selected(toolName)) : toolName;
+
+    const prefixLength = 7 + visibleWidth(toolName);
+    const maxDescriptionLength = Math.max(0, innerWidth - prefixLength - 8);
+    const descriptionText = maxDescriptionLength > 5 && description
+      ? this.theme.description(`— ${truncateToWidth(description, maxDescriptionLength, "…")}`)
+      : "";
+
+    return `  ${cursor} ${toggleIcon} ${name} ${descriptionText}`;
+  }
+}
+
 class McpPanel {
   private noticeLines: string[];
   private prefix: ToolPrefix;
@@ -167,11 +501,12 @@ class McpPanel {
   private inactivityTimeout: ReturnType<typeof setTimeout> | null = null;
   private visibleItems: VisibleItem[] = [];
   private tui: { requestRender(): void };
-  private t = DEFAULT_THEME;
+  private readonly theme: McpPanelTheme;
+  private readonly view: McpPanelView;
   private authOnly: boolean;
   private keys: PanelKeys;
 
-  private static readonly MAX_VISIBLE = 12;
+  static readonly MAX_VISIBLE = 12;
   private static readonly INACTIVITY_MS = 60_000;
 
   constructor(
@@ -181,12 +516,14 @@ class McpPanel {
     private callbacks: McpPanelCallbacks,
     tui: { requestRender(): void },
     private done: (result: McpPanelResult) => void,
-    options: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings } = {},
+    options: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings; theme?: Theme } = {},
   ) {
     this.tui = tui;
     this.noticeLines = options.noticeLines ?? [];
     this.authOnly = options.authOnly === true;
     this.keys = createPanelKeys(options.keybindings);
+    this.theme = createMcpPanelTheme(options.theme);
+    this.view = new McpPanelView(() => this.getViewState(), this.theme);
     this.prefix = config.settings?.toolPrefix ?? "server";
 
     for (const [serverName, definition] of Object.entries(config.mcpServers)) {
@@ -770,282 +1107,33 @@ class McpPanel {
     this.updateDirty();
   }
 
-  render(width: number): string[] {
-    const innerW = width - 2;
-    const lines: string[] = [];
-    const t = this.t;
-    const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
-    const italic = (s: string) => `\x1b[3m${s}\x1b[23m`;
-    const inverse = (s: string) => `\x1b[7m${s}\x1b[27m`;
-
-    const row = (content: string) =>
-      fg(t.border, "│") + truncateToWidth(" " + sanitizeRowContent(content), innerW, "…", true) + fg(t.border, "│");
-    const emptyRow = () => fg(t.border, "│") + " ".repeat(innerW) + fg(t.border, "│");
-    const divider = () => fg(t.border, "├" + "─".repeat(innerW) + "┤");
-
-    const titleText = this.authOnly ? " MCP OAuth " : " MCP Servers ";
-    const borderLen = innerW - visibleWidth(titleText);
-    const leftB = Math.floor(borderLen / 2);
-    const rightB = borderLen - leftB;
-    lines.push(fg(t.border, "╭" + "─".repeat(leftB)) + fg(t.title, titleText) + fg(t.border, "─".repeat(rightB) + "╮"));
-
-    lines.push(emptyRow());
-
-    const cursor = fg(t.selected, "│");
-    const searchIcon = fg(t.border, "◎");
-    if (this.descSearchActive) {
-      lines.push(row(`${searchIcon}  ${fg(t.needsAuth, "desc:")} ${this.descQuery}${cursor}`));
-    } else if (this.nameQuery) {
-      lines.push(row(`${searchIcon}  ${this.nameQuery}${cursor}`));
-    } else {
-      lines.push(row(`${searchIcon}  ${fg(t.placeholder, italic("search..."))}`));
-    }
-
-    lines.push(emptyRow());
-    if (this.noticeLines.length > 0) {
-      for (const notice of this.noticeLines) {
-        lines.push(row(fg(t.hint, italic(sanitizeDisplayText(notice)))));
-      }
-      lines.push(emptyRow());
-    }
-    lines.push(divider());
-
-    if (this.servers.length === 0) {
-      lines.push(emptyRow());
-      lines.push(row(fg(t.hint, italic(this.authOnly ? "No OAuth-capable MCP servers configured." : "No MCP servers configured."))));
-      lines.push(emptyRow());
-    } else {
-      const maxVis = McpPanel.MAX_VISIBLE;
-      const total = this.visibleItems.length;
-      const startIdx = Math.max(0, Math.min(this.cursorIndex - Math.floor(maxVis / 2), total - maxVis));
-      const endIdx = Math.min(startIdx + maxVis, total);
-
-      lines.push(emptyRow());
-
-      for (let i = startIdx; i < endIdx; i++) {
-        const item = this.visibleItems[i];
-        if (!item) continue;
-        const isCursor = i === this.cursorIndex;
-        const server = this.servers[item.serverIndex];
-        if (!server) continue;
-
-        if (item.type === "server") {
-          lines.push(row(this.renderServerRow(server, isCursor)));
-          if (isCursor && server.connectionStatus === "failed" && server.failureMessage) {
-            for (const line of this.wrapText(sanitizeDisplayText(server.failureMessage), innerW - 6)) {
-              lines.push(row(`    ${fg(t.cancel, line)}`));
-            }
-          }
-        } else if (item.toolIndex !== undefined) {
-          const tool = server.tools[item.toolIndex];
-          if (tool) lines.push(row(this.renderToolRow(tool, isCursor, innerW)));
-        }
-      }
-
-      lines.push(emptyRow());
-
-      if (total > maxVis) {
-        const prog = Math.round(((this.cursorIndex + 1) / total) * 10);
-        lines.push(row(`${rainbowProgress(prog, 10)}  ${fg(t.hint, `${this.cursorIndex + 1}/${total}`)}`));
-        lines.push(emptyRow());
-      }
-
-      if (this.importNotice) {
-        lines.push(row(fg(t.needsAuth, italic(sanitizeDisplayText(this.importNotice)))));
-        lines.push(emptyRow());
-      }
-      if (this.authNotice) {
-        lines.push(row(fg(t.needsAuth, italic(sanitizeDisplayText(this.authNotice)))));
-        lines.push(emptyRow());
-      }
-    }
-
-    lines.push(divider());
-    lines.push(emptyRow());
-
-    if (this.confirmingDiscard) {
-      const discardBtn = this.discardSelected === 0
-        ? inverse(bold(fg(t.cancel, "  Discard  ")))
-        : fg(t.hint, "  Discard  ");
-      const keepBtn = this.discardSelected === 1
-        ? inverse(bold(fg(t.confirm, "  Keep & Close  ")))
-        : fg(t.hint, "  Keep & Close  ");
-      lines.push(row(`Discard unsaved changes?  ${discardBtn}   ${keepBtn}`));
-    } else {
-      if (this.authOnly) {
-        lines.push(row(fg(t.description, "select a server to authenticate")));
-      } else {
-        let directCount = 0;
-        let directTokens = 0;
-        for (const server of this.servers) {
-          directCount += server.directCount;
-          directTokens += server.directTokens;
-        }
-        const stats =
-          directCount > 0 ? `${directCount} direct  ~${directTokens.toLocaleString()} tokens` : "no direct tools";
-        lines.push(row(fg(t.description, stats + (this.dirty ? fg(t.needsAuth, "  (unsaved)") : ""))));
-      }
-    }
-
-    lines.push(emptyRow());
-    const saveLabel = this.keys.saveLabel();
-    const hints = this.authOnly
-      ? [
-          italic("↑↓") + " navigate",
-          italic("⏎") + " auth",
-          italic("ctrl+a") + " auth",
-          italic("esc") + " clear/close",
-          italic("ctrl+c") + " quit",
-        ]
-      : [
-          italic("↑↓") + " navigate",
-          italic("space") + " toggle",
-          italic("⏎") + " expand/auth",
-          italic("ctrl+a") + " auth",
-          italic("ctrl+r") + " reconnect",
-          italic("ctrl+d") + " disable/enable",
-          ...(this.selectedServerHasFailureMessage() ? [italic("ctrl+y") + " copy error"] : []),
-          italic("?") + " desc search",
-          ...(saveLabel ? [italic(saveLabel) + " save"] : []),
-          italic("esc") + " clear/close",
-          italic("ctrl+c") + " quit",
-        ];
-    const gap = "  ";
-    const gapW = 2;
-    const maxW = innerW - 2;
-    let curLine = "";
-    let curW = 0;
-    for (const hint of hints) {
-      const hw = visibleWidth(hint);
-      const needed = curW === 0 ? hw : gapW + hw;
-      if (curW > 0 && curW + needed > maxW) {
-        lines.push(row(fg(t.hint, curLine)));
-        curLine = hint;
-        curW = hw;
-      } else {
-        curLine += (curW > 0 ? gap : "") + hint;
-        curW += needed;
-      }
-    }
-    if (curLine) lines.push(row(fg(t.hint, curLine)));
-
-    lines.push(fg(t.border, "╰" + "─".repeat(innerW) + "╯"));
-
-    return lines;
-  }
-
-  private renderServerRow(server: ServerState, isCursor: boolean): string {
-    const t = this.t;
-    const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
-
-    const expandIcon = server.expanded ? "▾" : "▸";
-    const prefix = isCursor ? fg(t.selected, expandIcon) : fg(t.border, server.expanded ? expandIcon : "·");
-
-    const serverName = sanitizeDisplayText(server.name);
-    const importKind = sanitizeDisplayText(server.importKind ?? "import");
-    const nameStr = isCursor ? bold(fg(t.selected, serverName)) : serverName;
-    const importLabel = server.source === "import" ? fg(t.description, ` (${importKind})`) : "";
-    const statusLabel = this.renderConnectionStatus(server);
-
-    if (!server.hasCachedData && !this.authOnly) {
-      return `${prefix}   ${nameStr}${importLabel}  ${fg(t.description, "(not cached)")}${statusLabel}`;
-    }
-
-    const directCount = server.directCount;
-    const totalCount = server.tools.length;
-    let toggleIcon = fg(t.description, "○");
-    if (directCount === totalCount && totalCount > 0) {
-      toggleIcon = fg(t.direct, "●");
-    } else if (directCount > 0) {
-      toggleIcon = fg(t.needsAuth, "◐");
-    }
-
-    let toolInfo = "";
-    if (totalCount > 0) {
-      toolInfo = `${directCount}/${totalCount}`;
-      if (directCount > 0) {
-        toolInfo += `  ~${server.directTokens.toLocaleString()}`;
-      }
-      toolInfo = fg(t.description, toolInfo);
-    }
-
-    return `${prefix} ${toggleIcon} ${nameStr}${importLabel}  ${toolInfo}${statusLabel}`;
-  }
-
-  private selectedServerHasFailureMessage(): boolean {
-    const item = this.visibleItems[this.cursorIndex];
-    if (!item) return false;
-    const server = this.servers[item.serverIndex];
-    return server?.connectionStatus === "failed" && !!server.failureMessage;
-  }
-
-  private wrapText(text: string, width: number): string[] {
-    const max = Math.max(8, width);
-    const words = text.split(/\s+/).filter(Boolean);
-    const lines: string[] = [];
-    let current = "";
-    const splitLongWord = (word: string): string => {
-      let rest = word;
-      while (visibleWidth(rest) > max) {
-        let take = "";
-        let index = 0;
-        while (index < rest.length && visibleWidth(take + rest.charAt(index)) <= max) {
-          take += rest.charAt(index);
-          index++;
-        }
-        if (!take) take = rest.charAt(0);
-        lines.push(take);
-        rest = rest.slice(take.length);
-      }
-      return rest;
+  private getViewState(): McpPanelViewState {
+    return {
+      noticeLines: this.noticeLines,
+      servers: this.servers,
+      visibleItems: this.visibleItems,
+      cursorIndex: this.cursorIndex,
+      nameQuery: this.nameQuery,
+      descSearchActive: this.descSearchActive,
+      descQuery: this.descQuery,
+      dirty: this.dirty,
+      confirmingDiscard: this.confirmingDiscard,
+      discardSelected: this.discardSelected,
+      importNotice: this.importNotice,
+      authNotice: this.authNotice,
+      authInFlight: this.authInFlight,
+      authOnly: this.authOnly,
+      saveLabel: this.keys.saveLabel(),
     };
-
-    for (const word of words) {
-      const candidate = current ? `${current} ${word}` : word;
-      if (visibleWidth(candidate) <= max) {
-        current = candidate;
-      } else {
-        if (current) lines.push(current);
-        current = splitLongWord(word);
-      }
-    }
-    if (current) lines.push(current);
-    return lines.length > 0 ? lines : [text];
   }
 
-  private renderConnectionStatus(server: ServerState): string {
-    const t = this.t;
-    if (this.authInFlight === server.name) return `  ${fg(t.needsAuth, "authenticating")}`;
-    if (server.disabled) return `  ${fg(t.description, "disabled")}`;
-    if (server.connectionStatus === "needs-auth") return `  ${fg(t.needsAuth, "needs auth")}`;
-    if (server.connectionStatus === "connecting") return `  ${fg(t.needsAuth, "connecting")}`;
-    if (server.connectionStatus === "failed") return `  ${fg(t.cancel, "failed")}`;
-    if (this.authOnly && server.connectionStatus === "connected") return `  ${fg(t.direct, "connected")}`;
-    if (this.authOnly) return `  ${fg(t.description, "idle")}`;
-    return "";
+  render(width: number): string[] {
+    return this.view.render(width);
   }
 
-  private renderToolRow(tool: ToolState, isCursor: boolean, innerW: number): string {
-    const t = this.t;
-    const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
-
-    const toggleIcon = tool.isDirect ? fg(t.direct, "●") : fg(t.description, "○");
-    const cursor = isCursor ? fg(t.selected, "▸") : " ";
-    const toolName = sanitizeDisplayText(tool.name);
-    const description = sanitizeDisplayText(tool.description);
-    const nameStr = isCursor ? bold(fg(t.selected, toolName)) : toolName;
-
-    const prefixLen = 7 + visibleWidth(toolName);
-    const maxDescLen = Math.max(0, innerW - prefixLen - 8);
-    const descStr =
-      maxDescLen > 5 && description
-        ? fg(t.description, "— " + truncateToWidth(description, maxDescLen, "…"))
-        : "";
-
-    return `  ${cursor} ${toggleIcon} ${nameStr} ${descStr}`;
+  invalidate(): void {
+    this.view.invalidate();
   }
-
-  invalidate(): void {}
 
   dispose(): void {
     this.cleanup();
@@ -1059,7 +1147,7 @@ export function createMcpPanel(
   callbacks: McpPanelCallbacks,
   tui: { requestRender(): void },
   done: (result: McpPanelResult) => void,
-  options?: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings },
+  options?: { noticeLines?: string[]; authOnly?: boolean; keybindings?: PanelKeybindings; theme?: Theme },
 ): McpPanel & { dispose(): void } {
   return new McpPanel(config, cache, provenance, callbacks, tui, done, options ?? {});
 }

--- a/mcp-panel.ts
+++ b/mcp-panel.ts
@@ -1,7 +1,7 @@
 import { Container, Text, matchesKey, truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
-import { copyToClipboard, DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import { copyToClipboard, type Theme } from "@earendil-works/pi-coding-agent";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
-import { createMcpPanelTheme, type McpPanelTheme } from "./mcp-panel-theme.ts";
+import { createMcpPanelTheme, McpPanelFrame, type McpPanelTheme } from "./mcp-panel-theme.ts";
 import { getToolNameCandidates, isServerDisabled, isToolAllowed, resolveToolPrefix } from "./types.ts";
 import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance, ToolPrefix } from "./types.ts";
 import { resourceNameToToolName } from "./resource-tools.ts";
@@ -118,55 +118,6 @@ interface McpPanelViewState {
   saveLabel: string | null;
 }
 
-/** A panel-specific rule that delegates horizontal sizing to Pi's border component. */
-class McpPanelRule implements Component {
-  private readonly border: DynamicBorder;
-
-  constructor(
-    private readonly theme: McpPanelTheme,
-    private readonly left: string,
-    private readonly right: string,
-    private readonly title?: string,
-  ) {
-    this.border = new DynamicBorder((text: string) => this.theme.border(text));
-  }
-
-  render(width: number): string[] {
-    if (width <= 0) return [];
-    if (width === 1) return [truncateToWidth(this.theme.border(this.left), width, "", false)];
-
-    const innerWidth = width - 2;
-    if (this.title !== undefined) {
-      const titleText = truncateToWidth(` ${this.title} `, innerWidth, "", false);
-      const borderLength = Math.max(0, innerWidth - visibleWidth(titleText));
-      const leftLength = Math.floor(borderLength / 2);
-      const rightLength = borderLength - leftLength;
-      return [
-        this.theme.border(this.left) +
-          this.renderBorderSegment(leftLength) +
-          this.theme.title(titleText) +
-          this.renderBorderSegment(rightLength) +
-          this.theme.border(this.right),
-      ];
-    }
-
-    return [
-      this.theme.border(this.left) +
-        this.renderBorderSegment(innerWidth) +
-        this.theme.border(this.right),
-    ];
-  }
-
-  invalidate(): void {
-    this.border.invalidate();
-  }
-
-  private renderBorderSegment(width: number): string {
-    if (width <= 0) return "";
-    return this.border.render(width)[0] ?? "";
-  }
-}
-
 /**
  * The themed MCP view. It owns only component composition and formatting;
  * input routing and callbacks remain on McpPanel.
@@ -186,7 +137,7 @@ class McpPanelView implements Component {
     this.container.clear();
 
     const title = state.authOnly ? "MCP OAuth" : "MCP Servers";
-    this.container.addChild(new McpPanelRule(this.theme, "╭", "╮", title));
+    this.container.addChild(new McpPanelFrame(this.theme, "╭", "╮", title));
     this.addRow("", innerWidth);
 
     const cursor = this.theme.selected("│");
@@ -354,7 +305,7 @@ class McpPanelView implements Component {
   }
 
   private addRule(left: string, right: string): void {
-    this.container.addChild(new McpPanelRule(this.theme, left, right));
+    this.container.addChild(new McpPanelFrame(this.theme, left, right));
   }
 
   private addText(content: string): void {
@@ -501,7 +452,6 @@ class McpPanel {
   private inactivityTimeout: ReturnType<typeof setTimeout> | null = null;
   private visibleItems: VisibleItem[] = [];
   private tui: { requestRender(): void };
-  private readonly theme: McpPanelTheme;
   private readonly view: McpPanelView;
   private authOnly: boolean;
   private keys: PanelKeys;
@@ -522,8 +472,7 @@ class McpPanel {
     this.noticeLines = options.noticeLines ?? [];
     this.authOnly = options.authOnly === true;
     this.keys = createPanelKeys(options.keybindings);
-    this.theme = createMcpPanelTheme(options.theme);
-    this.view = new McpPanelView(() => this.getViewState(), this.theme);
+    this.view = new McpPanelView(() => this.getViewState(), createMcpPanelTheme(options.theme));
     this.prefix = config.settings?.toolPrefix ?? "server";
 
     for (const [serverName, definition] of Object.entries(config.mcpServers)) {

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -1,38 +1,16 @@
-import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { Container, Text, matchesKey, truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { createMcpPanelTheme, McpPanelFrame, type McpPanelTheme } from "./mcp-panel-theme.ts";
 import { createPanelKeys, type PanelKeybindings, type PanelKeys } from "./panel-keys.ts";
 import type { ImportKind } from "./types.ts";
 import { getConfigDirName } from "./agent-dir.ts";
 import { KNOWN_SERVER_PRESETS, type ConfigWritePreview, type KnownServerPreset, type McpDiscoverySummary, type SharedConfigTarget } from "./config.ts";
 import type { McpOnboardingState } from "./onboarding-state.ts";
 
-interface SetupTheme {
-  border: string;
-  title: string;
-  selected: string;
-  hint: string;
-  success: string;
-  warning: string;
-  muted: string;
-}
-
-const DEFAULT_THEME: SetupTheme = {
-  border: "2",
-  title: "36",
-  selected: "32",
-  hint: "2",
-  success: "32",
-  warning: "33",
-  muted: "2;3",
-};
-
 const MIN_PANEL_WIDTH = 24;
 const COMPACT_WIDTH = 60;
 const COMPACT_ACTION_ROWS = 7;
 const DESKTOP_PREVIEW_WIDTH = 74;
-
-function fg(code: string, text: string): string {
-  return code ? `\x1b[${code}m${text}\x1b[0m` : text;
-}
 
 function wrapText(text: string, width: number): string[] {
   if (width <= 8) return [text];
@@ -69,6 +47,7 @@ export interface SetupPanelOptions {
   mode: "empty" | "setup";
   onboardingState: McpOnboardingState;
   keybindings?: PanelKeybindings;
+  theme?: Theme;
 }
 
 type Screen = "empty" | "setup" | "imports" | "paths";
@@ -93,6 +72,347 @@ interface Action {
   target?: SharedConfigTarget;
 }
 
+interface McpSetupPanelViewState {
+  screen: Screen;
+  actionCursor: number;
+  importCursor: number;
+  pathCursor: number;
+  sharedConfigTarget: SharedConfigTarget;
+  selectedImports: ReadonlySet<ImportKind>;
+  busy: boolean;
+  notice: { text: string; tone: "success" | "warning" | "muted" } | null;
+  onboardingState: McpOnboardingState;
+  discovery: McpDiscoverySummary;
+  actions: readonly Action[];
+  detectedPaths: readonly string[];
+}
+
+/**
+ * The setup view owns component composition and display formatting. The panel
+ * below remains the controller for input routing, async actions, and timers.
+ */
+class McpSetupPanelView implements Component {
+  private readonly container = new Container();
+
+  constructor(
+    private readonly getState: () => McpSetupPanelViewState,
+    private readonly callbacks: SetupPanelCallbacks,
+    private readonly theme: McpPanelTheme,
+  ) {}
+
+  render(width: number): string[] {
+    const panelWidth = Math.max(MIN_PANEL_WIDTH, width);
+    const innerWidth = panelWidth - 2;
+    const contentWidth = this.contentWidth(innerWidth);
+    const state = this.getState();
+    this.container.clear();
+
+    this.addFrame("┌", "┐", panelWidth);
+    this.addRow(this.theme.title("MCP setup"), innerWidth);
+    for (const line of wrapText(this.discoverySummaryLine(state), contentWidth)) {
+      this.addRow(line, innerWidth);
+    }
+    for (const line of wrapText(this.theme.description(this.theme.italic(this.secondarySummaryLine(state))), contentWidth)) {
+      this.addRow(line, innerWidth);
+    }
+    this.addRow("", innerWidth);
+
+    if (state.notice) {
+      const tone = state.notice.tone === "success"
+        ? this.theme.confirm
+        : state.notice.tone === "warning"
+          ? this.theme.needsAuth
+          : this.theme.hint;
+      for (const line of wrapText(tone(state.notice.text), contentWidth)) {
+        this.addRow(line, innerWidth);
+      }
+      this.addRow("", innerWidth);
+    }
+
+    this.addFrame("├", "┤", panelWidth);
+    if (state.screen === "imports") {
+      for (const line of this.renderImports(state, innerWidth)) this.addRow(line, innerWidth);
+    } else if (state.screen === "paths") {
+      for (const line of this.renderPaths(state, innerWidth)) this.addRow(line, innerWidth);
+    } else {
+      for (const line of this.renderActions(state, innerWidth)) this.addRow(line, innerWidth);
+    }
+    this.addFrame("└", "┘", panelWidth);
+    return this.container.render(panelWidth);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+
+  private addFrame(left: string, right: string, width: number): void {
+    this.container.addChild(new McpPanelFrame(this.theme, left, right));
+  }
+
+  private addRow(content: string, innerWidth: number): void {
+    this.container.addChild(new Text(this.padLine(content, innerWidth), 0, 0));
+  }
+
+  private renderActions(state: McpSetupPanelViewState, innerWidth: number): string[] {
+    const lines: string[] = [];
+    const actions = state.actions;
+    const compact = innerWidth < COMPACT_WIDTH;
+    const { start, end } = compact
+      ? this.visibleActionRange(actions.length, state.actionCursor)
+      : { start: 0, end: actions.length };
+
+    if (start > 0) {
+      lines.push(this.theme.description(`… ${start} more above`));
+    }
+    for (let index = start; index < end; index++) {
+      const action = actions[index];
+      if (!action) continue;
+      if (action.id === "select-shared-target" && (index === start || actions[index - 1]?.id !== "select-shared-target")) {
+        lines.push(this.theme.title("Choose where new shared servers go"));
+      }
+      if (action.id === "add-known-server" && (index === start || actions[index - 1]?.id !== "add-known-server")) {
+        lines.push(this.theme.title(`Add a known server to ${this.sharedTargetLabel(state)}`));
+      }
+      const selected = index === state.actionCursor;
+      const cursor = selected ? this.theme.selected("›") : " ";
+      lines.push(`${cursor} ${truncateToWidth(action.label, this.contentWidth(innerWidth) - 2)}`);
+    }
+    if (end < actions.length) {
+      lines.push(this.theme.description(`… ${actions.length - end} more below`));
+    }
+    lines.push("");
+
+    const preview = this.getActionPreview(state, actions[state.actionCursor], this.previewWidth(innerWidth));
+    lines.push(...preview);
+    lines.push("");
+    const hint = compact ? "Enter select · Esc back" : "Enter selects, Esc goes back, Ctrl+C closes.";
+    lines.push(this.theme.description(hint));
+    return lines;
+  }
+
+  private renderImports(state: McpSetupPanelViewState, innerWidth: number): string[] {
+    const lines: string[] = [];
+    lines.push("Select compatibility imports. Space toggles, Enter saves, Esc goes back.");
+    lines.push("");
+    for (let index = 0; index < state.discovery.imports.length; index++) {
+      const entry = state.discovery.imports[index];
+      if (!entry) continue;
+      const selected = state.selectedImports.has(entry.kind) ? "[x]" : "[ ]";
+      const cursor = index === state.importCursor ? this.theme.selected("›") : " ";
+      lines.push(`${cursor} ${selected} ${entry.kind}  ${entry.path}`);
+    }
+    lines.push("");
+    const selected = state.discovery.imports
+      .filter((entry) => state.selectedImports.has(entry.kind))
+      .map((entry) => entry.kind);
+    const preview = this.callbacks.previewImports(selected);
+    lines.push(...this.formatWritePreview("Compatibility import write preview", preview, [], this.previewWidth(innerWidth)));
+    return lines;
+  }
+
+  private renderPaths(state: McpSetupPanelViewState, innerWidth: number): string[] {
+    const lines: string[] = [];
+    lines.push("Select a detected config path to open. Enter opens it, Esc goes back.");
+    lines.push("");
+    for (let index = 0; index < state.detectedPaths.length; index++) {
+      const path = state.detectedPaths[index];
+      const cursor = index === state.pathCursor ? this.theme.selected("›") : " ";
+      if (path !== undefined) lines.push(`${cursor} ${path}`);
+    }
+    return lines;
+  }
+
+  private discoverySummaryLine(state: McpSetupPanelViewState): string {
+    if (!state.discovery.hasAnyConfig) {
+      return this.theme.needsAuth(state.onboardingState.setupCompleted
+        ? "No MCP servers are active right now."
+        : "No MCP config is active yet.");
+    }
+
+    if (state.discovery.totalServerCount === 0 && (state.discovery.imports.length > 0 || !!state.discovery.repoPrompt.executablePath)) {
+      return this.theme.needsAuth("Pi found MCP-related setup options, but none are active in Pi yet.");
+    }
+
+    const shared = state.discovery.sources.filter((source) => source.kind === "shared" && source.serverCount > 0).length;
+    const piOwned = state.discovery.sources.filter((source) => source.kind === "pi" && source.serverCount > 0).length;
+    return this.theme.hint(`Detected ${state.discovery.totalServerCount} configured servers across ${shared} shared and ${piOwned} Pi-owned source${shared + piOwned === 1 ? "" : "s"}.`);
+  }
+
+  private secondarySummaryLine(state: McpSetupPanelViewState): string {
+    const hostNote = state.discovery.hostConfigs.length > 0
+      ? ` Host discovery is ${state.discovery.hostConfigDiscovery}; ${state.discovery.hostConfigs.length} host source${state.discovery.hostConfigs.length === 1 ? "" : "s"} detected.`
+      : "";
+    const conflictNote = state.discovery.conflicts.length > 0
+      ? ` ${state.discovery.conflicts.length} same-name conflict${state.discovery.conflicts.length === 1 ? "" : "s"} reported.`
+      : "";
+    if (!state.discovery.hasAnyConfig) {
+      return `Add shared servers to .mcp.json for this project/team or ~/.config/mcp/mcp.json for all projects. Adopt host imports or quick-add RepoPrompt from this screen.${hostNote}${conflictNote}`;
+    }
+    if (state.discovery.totalServerCount === 0 && state.discovery.imports.length > 0) {
+      return `Detected ${state.discovery.imports.length} compatibility import source${state.discovery.imports.length === 1 ? "" : "s"}. Adopt them into Pi or inspect the underlying files.${hostNote}${conflictNote}`;
+    }
+    return `Use .mcp.json for project/team servers or ~/.config/mcp/mcp.json for all projects. Pi-owned files are for compatibility imports and adapter-specific overrides, not another normal setup path.${hostNote}${conflictNote}`;
+  }
+
+  private visibleActionRange(total: number, cursor: number): { start: number; end: number } {
+    if (total <= COMPACT_ACTION_ROWS) return { start: 0, end: total };
+    const half = Math.floor(COMPACT_ACTION_ROWS / 2);
+    const start = Math.min(Math.max(0, cursor - half), Math.max(0, total - COMPACT_ACTION_ROWS));
+    return { start, end: Math.min(total, start + COMPACT_ACTION_ROWS) };
+  }
+
+  private contentWidth(innerWidth: number): number {
+    return Math.max(8, innerWidth - 4);
+  }
+
+  private previewWidth(innerWidth: number): number {
+    return Math.max(12, Math.min(DESKTOP_PREVIEW_WIDTH, this.contentWidth(innerWidth)));
+  }
+
+  private sharedTargetLabel(state: McpSetupPanelViewState): string {
+    return state.sharedConfigTarget === "project" ? "project .mcp.json" : "global ~/.config/mcp/mcp.json";
+  }
+
+  private getActionPreview(state: McpSetupPanelViewState, action?: Action, previewW = DESKTOP_PREVIEW_WIDTH): string[] {
+    switch (action?.id) {
+      case "run-setup":
+        return this.formatPreview([
+          "Run setup to adopt host-specific imports, inspect detected paths, and scaffold a minimal `.mcp.json` if needed.",
+        ], previewW);
+      case "adopt-imports":
+        return this.formatWritePreview(
+          "Compatibility import write preview",
+          this.callbacks.previewImports(state.discovery.imports
+            .filter((entry) => state.selectedImports.has(entry.kind))
+            .map((entry) => entry.kind)),
+          [
+            `Detected imports: ${state.discovery.imports.map((entry) => `${entry.kind} (${entry.serverCount} servers)`).join(", ")}`,
+            "Selected imports are written into the Pi agent dir config as Pi-owned compatibility state.",
+          ],
+          previewW,
+        );
+      case "select-shared-target":
+        return this.formatPreview([
+          action.target === "project" ? "Project target: .mcp.json" : "Global target: ~/.config/mcp/mcp.json",
+          "Known server presets and starter configs will be written to the selected normal MCP setup path.",
+          "Pi-owned mcp.json files remain compatibility and adapter-only override state.",
+        ], previewW);
+      case "view-example":
+        return this.formatPreview([
+          "Example shared `.mcp.json`:",
+          "{",
+          '  "mcpServers": {',
+          '    "chrome-devtools": {',
+          '      "command": "npx",',
+          '      "args": ["-y", "chrome-devtools-mcp@1.6.0"]',
+          "    }",
+          "  }",
+          "}",
+          "",
+          "Use Scaffold selected config when you want a safe empty shell instead of a live example server.",
+        ], previewW);
+      case "show-precedence":
+        return this.formatPreview([
+          "Recommended shared config:",
+          "  project/team: .mcp.json",
+          "  all projects: ~/.config/mcp/mcp.json",
+          "",
+          "Advanced compatibility and Pi-owned layers:",
+          "  host imports, .agents files, package MCP manifests, and Pi overrides",
+          "",
+          "Read order (later entries win):",
+          "0. detected host configs (opt-in lowest-precedence fallback)",
+          "1. ~/.config/mcp/mcp.json",
+          "2. ~/.agents/mcp.json",
+          "3. ~/.agents/mcp/mcp.json",
+          "4. <Pi agent dir>/mcp.json",
+          "5. .mcp.json",
+          `6. ${getConfigDirName()}/mcp.json`,
+          `Host discovery: ${state.discovery.hostConfigDiscovery}. Conflicts reported: ${state.discovery.conflicts.length}.`,
+          ...state.discovery.conflicts.slice(0, 8).map((conflict) =>
+            `${conflict.serverName}: ${conflict.sources.map((source) => source.path).join(" -> ")} (winner: ${conflict.winner.path})`,
+          ),
+          "Pi writes compatibility imports and adapter-only overrides to Pi-owned files.",
+        ], previewW);
+      case "open-paths":
+        return this.formatPreview(state.detectedPaths.length > 0
+          ? ["Detected paths:", ...state.detectedPaths]
+          : ["No config paths were detected."], previewW);
+      case "add-repoprompt": {
+        const repoPrompt = state.discovery.repoPrompt;
+        const preview = this.callbacks.previewRepoPrompt(state.sharedConfigTarget);
+        if (!preview) {
+          return this.formatPreview(["RepoPrompt is not available to add from this setup screen."], previewW);
+        }
+        return this.formatWritePreview(
+          "RepoPrompt write preview",
+          preview,
+          [
+            `Executable: ${repoPrompt.executablePath ?? "not found"}`,
+            `Target: ${this.sharedTargetLabel(state)}`,
+            `Server name: ${repoPrompt.serverName ?? "repoprompt"}`,
+          ],
+          previewW,
+        );
+      }
+      case "add-known-server": {
+        const preset = action.preset;
+        if (!preset) return this.formatPreview(["Known server preset is unavailable."], previewW);
+        return this.formatWritePreview(
+          `${preset.name} write preview`,
+          this.callbacks.previewKnownServer(preset, state.sharedConfigTarget),
+          [preset.summary, `Target: ${this.sharedTargetLabel(state)}`],
+          previewW,
+        );
+      }
+      case "scaffold-shared-config":
+        return this.formatWritePreview(
+          `${this.sharedTargetLabel(state)} starter write preview`,
+          this.callbacks.previewStarterConfig(state.sharedConfigTarget),
+          [
+            "This writes a minimal config at the selected normal MCP setup path.",
+            "It intentionally avoids adding a fake placeholder server that would fail on first reload.",
+          ],
+          previewW,
+        );
+      case "close":
+      default:
+        return this.formatPreview(["Close the setup flow."], previewW);
+    }
+  }
+
+  private formatPreview(lines: string[], width = DESKTOP_PREVIEW_WIDTH): string[] {
+    const preview: string[] = [];
+    for (const line of lines) preview.push(...wrapText(line, width));
+    return preview;
+  }
+
+  private formatWritePreview(title: string, preview: ConfigWritePreview, intro: string[] = [], width = DESKTOP_PREVIEW_WIDTH): string[] {
+    const lines: string[] = [];
+    for (const line of intro) lines.push(...wrapText(line, width));
+    if (intro.length > 0) lines.push("");
+    lines.push(...wrapText(`${title}: ${preview.path}`, width));
+    lines.push(...wrapText(preview.existed ? "Existing file detected. Showing exact before/after diff." : "New file will be created. Showing exact content diff.", width));
+    lines.push("");
+    const diffLines = preview.diffText.split("\n");
+    const maxLines = 18;
+    const shown = diffLines.slice(0, maxLines);
+    for (const line of shown) lines.push(...wrapText(line, width));
+    if (diffLines.length > maxLines) {
+      lines.push(...wrapText(`… ${diffLines.length - maxLines} more diff line${diffLines.length - maxLines === 1 ? "" : "s"}`, width));
+    }
+    return lines;
+  }
+
+  private padLine(text: string, innerWidth: number): string {
+    const inset = 2;
+    const contentWidth = Math.max(0, innerWidth - inset * 2);
+    const fitted = truncateToWidth(text, contentWidth, "…", true);
+    const padding = Math.max(0, contentWidth - visibleWidth(fitted));
+    return `${this.theme.border("│")}${" ".repeat(inset)}${fitted}${" ".repeat(padding)}${" ".repeat(inset)}${this.theme.border("│")}`;
+  }
+}
+
 export class McpSetupPanel {
   private screen: Screen;
   private actionCursor = 0;
@@ -103,7 +423,8 @@ export class McpSetupPanel {
   private busy = false;
   private notice: { text: string; tone: "success" | "warning" | "muted" } | null = null;
   private tui: { requestRender(): void };
-  private t = DEFAULT_THEME;
+  private readonly theme: McpPanelTheme;
+  private readonly view: McpSetupPanelView;
   private keys: PanelKeys;
   private inactivityTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly INACTIVITY_MS = 60_000;
@@ -117,6 +438,8 @@ export class McpSetupPanel {
   ) {
     this.tui = tui;
     this.keys = createPanelKeys(options.keybindings);
+    this.theme = createMcpPanelTheme(options.theme);
+    this.view = new McpSetupPanelView(() => this.getViewState(), callbacks, this.theme);
     this.screen = options.mode;
     for (const entry of discovery.imports) {
       this.selectedImports.add(entry.kind);
@@ -386,308 +709,30 @@ export class McpSetupPanel {
     }
   }
 
+  private getViewState(): McpSetupPanelViewState {
+    return {
+      screen: this.screen,
+      actionCursor: this.actionCursor,
+      importCursor: this.importCursor,
+      pathCursor: this.pathCursor,
+      sharedConfigTarget: this.sharedConfigTarget,
+      selectedImports: this.selectedImports,
+      busy: this.busy,
+      notice: this.notice,
+      onboardingState: this.options.onboardingState,
+      discovery: this.discovery,
+      actions: this.getActions(),
+      detectedPaths: this.getDetectedPaths(),
+    };
+  }
+
   render(width: number): string[] {
-    const panelW = Math.max(MIN_PANEL_WIDTH, width);
-    const innerW = panelW - 2;
-    const contentW = this.contentWidth(innerW);
-    const lines: string[] = [];
-    const border = fg(this.t.border, "─".repeat(innerW));
-    lines.push(`┌${border}┐`);
-    lines.push(this.padLine(fg(this.t.title, "MCP setup"), innerW));
-    for (const line of wrapText(this.discoverySummaryLine(), contentW)) {
-      lines.push(this.padLine(line, innerW));
-    }
-    for (const line of wrapText(this.secondarySummaryLine(), contentW)) {
-      lines.push(this.padLine(fg(this.t.muted, line), innerW));
-    }
-    lines.push(this.padLine("", innerW));
-
-    if (this.notice) {
-      const tone = this.notice.tone === "success" ? this.t.success : this.notice.tone === "warning" ? this.t.warning : this.t.hint;
-      for (const line of wrapText(this.notice.text, contentW)) {
-        lines.push(this.padLine(fg(tone, line), innerW));
-      }
-      lines.push(this.padLine("", innerW));
-    }
-
-    lines.push(`├${border}┤`);
-
-    if (this.screen === "imports") {
-      lines.push(...this.renderImports(innerW));
-    } else if (this.screen === "paths") {
-      lines.push(...this.renderPaths(innerW));
-    } else {
-      lines.push(...this.renderActions(innerW));
-    }
-
-    lines.push(`└${border}┘`);
-    return lines;
+    return this.view.render(width);
   }
 
-  private renderActions(innerW: number): string[] {
-    const lines: string[] = [];
-    const actions = this.getActions();
-    const compact = innerW < COMPACT_WIDTH;
-    const { start, end } = compact
-      ? this.visibleActionRange(actions.length)
-      : { start: 0, end: actions.length };
-
-    if (start > 0) {
-      lines.push(this.padLine(fg(this.t.muted, `… ${start} more above`), innerW));
-    }
-    for (let index = start; index < end; index++) {
-      const action = actions[index];
-      if (!action) continue;
-      if (action.id === "select-shared-target" && (index === start || actions[index - 1]?.id !== "select-shared-target")) {
-        lines.push(this.padLine(fg(this.t.title, "Choose where new shared servers go"), innerW));
-      }
-      if (action.id === "add-known-server" && (index === start || actions[index - 1]?.id !== "add-known-server")) {
-        lines.push(this.padLine(fg(this.t.title, `Add a known server to ${this.sharedTargetLabel()}`), innerW));
-      }
-      const selected = index === this.actionCursor;
-      const cursor = selected ? fg(this.t.selected, "›") : " ";
-      lines.push(this.padLine(`${cursor} ${truncateToWidth(action.label, this.contentWidth(innerW) - 2)}`, innerW));
-    }
-    if (end < actions.length) {
-      lines.push(this.padLine(fg(this.t.muted, `… ${actions.length - end} more below`), innerW));
-    }
-    lines.push(this.padLine("", innerW));
-
-    const preview = this.getActionPreview(this.getSelectedAction(), this.previewWidth(innerW));
-    for (const line of preview) {
-      lines.push(this.padLine(line, innerW));
-    }
-    lines.push(this.padLine("", innerW));
-    const hint = compact ? "Enter select · Esc back" : "Enter selects, Esc goes back, Ctrl+C closes.";
-    lines.push(this.padLine(fg(this.t.muted, hint), innerW));
-    return lines;
+  invalidate(): void {
+    this.view.invalidate();
   }
-
-  private renderImports(innerW: number): string[] {
-    const lines: string[] = [];
-    lines.push(this.padLine("Select compatibility imports. Space toggles, Enter saves, Esc goes back.", innerW));
-    lines.push(this.padLine("", innerW));
-    for (let index = 0; index < this.discovery.imports.length; index++) {
-      const entry = this.discovery.imports[index];
-      if (!entry) continue;
-      const selected = this.selectedImports.has(entry.kind) ? "[x]" : "[ ]";
-      const cursor = index === this.importCursor ? fg(this.t.selected, "›") : " ";
-      lines.push(this.padLine(`${cursor} ${selected} ${entry.kind}  ${entry.path}`, innerW));
-    }
-    lines.push(this.padLine("", innerW));
-    const selected = this.discovery.imports.filter((entry) => this.selectedImports.has(entry.kind)).map((entry) => entry.kind);
-    const preview = this.callbacks.previewImports(selected);
-    for (const line of this.formatWritePreview("Compatibility import write preview", preview, [], this.previewWidth(innerW))) {
-      lines.push(this.padLine(line, innerW));
-    }
-    return lines;
-  }
-
-  private renderPaths(innerW: number): string[] {
-    const lines: string[] = [];
-    lines.push(this.padLine("Select a detected config path to open. Enter opens it, Esc goes back.", innerW));
-    lines.push(this.padLine("", innerW));
-    const paths = this.getDetectedPaths();
-    for (let index = 0; index < paths.length; index++) {
-      const cursor = index === this.pathCursor ? fg(this.t.selected, "›") : " ";
-      const path = paths[index];
-      if (path !== undefined) lines.push(this.padLine(`${cursor} ${path}`, innerW));
-    }
-    return lines;
-  }
-
-  private discoverySummaryLine(): string {
-    if (!this.discovery.hasAnyConfig) {
-      return fg(this.t.warning, this.options.onboardingState.setupCompleted
-        ? "No MCP servers are active right now."
-        : "No MCP config is active yet.");
-    }
-
-    if (this.discovery.totalServerCount === 0 && (this.discovery.imports.length > 0 || !!this.discovery.repoPrompt.executablePath)) {
-      return fg(this.t.warning, "Pi found MCP-related setup options, but none are active in Pi yet.");
-    }
-
-    const shared = this.discovery.sources.filter((source) => source.kind === "shared" && source.serverCount > 0).length;
-    const piOwned = this.discovery.sources.filter((source) => source.kind === "pi" && source.serverCount > 0).length;
-    return fg(this.t.hint, `Detected ${this.discovery.totalServerCount} configured servers across ${shared} shared and ${piOwned} Pi-owned source${shared + piOwned === 1 ? "" : "s"}.`);
-  }
-
-  private secondarySummaryLine(): string {
-    const hostNote = this.discovery.hostConfigs.length > 0
-      ? ` Host discovery is ${this.discovery.hostConfigDiscovery}; ${this.discovery.hostConfigs.length} host source${this.discovery.hostConfigs.length === 1 ? "" : "s"} detected.`
-      : "";
-    const conflictNote = this.discovery.conflicts.length > 0
-      ? ` ${this.discovery.conflicts.length} same-name conflict${this.discovery.conflicts.length === 1 ? "" : "s"} reported.`
-      : "";
-    if (!this.discovery.hasAnyConfig) {
-      return `Add shared servers to .mcp.json for this project/team or ~/.config/mcp/mcp.json for all projects. Adopt host imports or quick-add RepoPrompt from this screen.${hostNote}${conflictNote}`;
-    }
-    if (this.discovery.totalServerCount === 0 && this.discovery.imports.length > 0) {
-      return `Detected ${this.discovery.imports.length} compatibility import source${this.discovery.imports.length === 1 ? "" : "s"}. Adopt them into Pi or inspect the underlying files.${hostNote}${conflictNote}`;
-    }
-    return `Use .mcp.json for project/team servers or ~/.config/mcp/mcp.json for all projects. Pi-owned files are for compatibility imports and adapter-specific overrides, not another normal setup path.${hostNote}${conflictNote}`;
-  }
-
-  private visibleActionRange(total: number): { start: number; end: number } {
-    if (total <= COMPACT_ACTION_ROWS) return { start: 0, end: total };
-    const half = Math.floor(COMPACT_ACTION_ROWS / 2);
-    const start = Math.min(Math.max(0, this.actionCursor - half), Math.max(0, total - COMPACT_ACTION_ROWS));
-    return { start, end: Math.min(total, start + COMPACT_ACTION_ROWS) };
-  }
-
-  private contentWidth(innerW: number): number {
-    return Math.max(8, innerW - 4);
-  }
-
-  private previewWidth(innerW: number): number {
-    return Math.max(12, Math.min(DESKTOP_PREVIEW_WIDTH, this.contentWidth(innerW)));
-  }
-
-  private getActionPreview(action?: Action, previewW = DESKTOP_PREVIEW_WIDTH): string[] {
-    switch (action?.id) {
-      case "run-setup":
-        return this.formatPreview([
-          "Run setup to adopt host-specific imports, inspect detected paths, and scaffold a minimal `.mcp.json` if needed.",
-        ], previewW);
-      case "adopt-imports":
-        return this.formatWritePreview(
-          "Compatibility import write preview",
-          this.callbacks.previewImports(this.discovery.imports.filter((entry) => this.selectedImports.has(entry.kind)).map((entry) => entry.kind)),
-          [
-            `Detected imports: ${this.discovery.imports.map((entry) => `${entry.kind} (${entry.serverCount} servers)`).join(", ")}`,
-            "Selected imports are written into the Pi agent dir config as Pi-owned compatibility state.",
-          ],
-          previewW,
-        );
-      case "select-shared-target":
-        return this.formatPreview([
-          action.target === "project" ? "Project target: .mcp.json" : "Global target: ~/.config/mcp/mcp.json",
-          "Known server presets and starter configs will be written to the selected normal MCP setup path.",
-          "Pi-owned mcp.json files remain compatibility and adapter-only override state.",
-        ], previewW);
-      case "view-example":
-        return this.formatPreview([
-          "Example shared `.mcp.json`:",
-          "{",
-          '  "mcpServers": {',
-          '    "chrome-devtools": {',
-          '      "command": "npx",',
-          '      "args": ["-y", "chrome-devtools-mcp@1.6.0"]',
-          "    }",
-          "  }",
-          "}",
-          "",
-          "Use Scaffold selected config when you want a safe empty shell instead of a live example server.",
-        ], previewW);
-      case "show-precedence":
-        return this.formatPreview([
-          "Recommended shared config:",
-          "  project/team: .mcp.json",
-          "  all projects: ~/.config/mcp/mcp.json",
-          "",
-          "Advanced compatibility and Pi-owned layers:",
-          "  host imports, .agents files, package MCP manifests, and Pi overrides",
-          "",
-          "Read order (later entries win):",
-          "0. detected host configs (opt-in lowest-precedence fallback)",
-          "1. ~/.config/mcp/mcp.json",
-          "2. ~/.agents/mcp.json",
-          "3. ~/.agents/mcp/mcp.json",
-          "4. <Pi agent dir>/mcp.json",
-          "5. .mcp.json",
-          `6. ${getConfigDirName()}/mcp.json`,
-          `Host discovery: ${this.discovery.hostConfigDiscovery}. Conflicts reported: ${this.discovery.conflicts.length}.`,
-          ...this.discovery.conflicts.slice(0, 8).map((conflict) =>
-            `${conflict.serverName}: ${conflict.sources.map((source) => source.path).join(" -> ")} (winner: ${conflict.winner.path})`,
-          ),
-          "Pi writes compatibility imports and adapter-only overrides to Pi-owned files."
-        ], previewW);
-      case "open-paths":
-        return this.formatPreview(this.getDetectedPaths().length > 0
-          ? ["Detected paths:", ...this.getDetectedPaths()]
-          : ["No config paths were detected."], previewW);
-      case "add-repoprompt": {
-        const repoPrompt = this.discovery.repoPrompt;
-        const preview = this.callbacks.previewRepoPrompt(this.sharedConfigTarget);
-        if (!preview) {
-          return this.formatPreview(["RepoPrompt is not available to add from this setup screen."], previewW);
-        }
-        return this.formatWritePreview(
-          "RepoPrompt write preview",
-          preview,
-          [
-            `Executable: ${repoPrompt.executablePath ?? "not found"}`,
-            `Target: ${this.sharedTargetLabel()}`,
-            `Server name: ${repoPrompt.serverName ?? "repoprompt"}`,
-          ],
-          previewW,
-        );
-      }
-      case "add-known-server": {
-        const preset = action.preset;
-        if (!preset) return this.formatPreview(["Known server preset is unavailable."], previewW);
-        return this.formatWritePreview(
-          `${preset.name} write preview`,
-          this.callbacks.previewKnownServer(preset, this.sharedConfigTarget),
-          [preset.summary, `Target: ${this.sharedTargetLabel()}`],
-          previewW,
-        );
-      }
-      case "scaffold-shared-config":
-        return this.formatWritePreview(
-          `${this.sharedTargetLabel()} starter write preview`,
-          this.callbacks.previewStarterConfig(this.sharedConfigTarget),
-          [
-            "This writes a minimal config at the selected normal MCP setup path.",
-            "It intentionally avoids adding a fake placeholder server that would fail on first reload.",
-          ],
-          previewW,
-        );
-      case "close":
-      default:
-        return this.formatPreview(["Close the setup flow."], previewW);
-    }
-  }
-
-  private formatPreview(lines: string[], width = DESKTOP_PREVIEW_WIDTH): string[] {
-    const preview: string[] = [];
-    for (const line of lines) {
-      preview.push(...wrapText(line, width));
-    }
-    return preview;
-  }
-
-  private formatWritePreview(title: string, preview: ConfigWritePreview, intro: string[] = [], width = DESKTOP_PREVIEW_WIDTH): string[] {
-    const lines: string[] = [];
-    for (const line of intro) {
-      lines.push(...wrapText(line, width));
-    }
-    if (intro.length > 0) lines.push("");
-    lines.push(...wrapText(`${title}: ${preview.path}`, width));
-    lines.push(...wrapText(preview.existed ? "Existing file detected. Showing exact before/after diff." : "New file will be created. Showing exact content diff.", width));
-    lines.push("");
-    const diffLines = preview.diffText.split("\n");
-    const maxLines = 18;
-    const shown = diffLines.slice(0, maxLines);
-    for (const line of shown) {
-      lines.push(...wrapText(line, width));
-    }
-    if (diffLines.length > maxLines) {
-      lines.push(...wrapText(`… ${diffLines.length - maxLines} more diff line${diffLines.length - maxLines === 1 ? "" : "s"}`, width));
-    }
-    return lines;
-  }
-
-  private padLine(text: string, innerW: number): string {
-    const inset = 2;
-    const contentW = Math.max(0, innerW - inset * 2);
-    const fitted = truncateToWidth(text, contentW, "…", true);
-    const plainWidth = visibleWidth(fitted);
-    const padding = Math.max(0, contentW - plainWidth);
-    return `│${" ".repeat(inset)}${fitted}${" ".repeat(padding)}${" ".repeat(inset)}│`;
-  }
-
-  invalidate(): void {}
 
   dispose(): void {
     this.cleanup();

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -116,11 +116,12 @@ class McpSetupPanelView implements Component {
     this.addRow("", innerWidth);
 
     if (state.notice) {
-      const tone = state.notice.tone === "success"
-        ? this.theme.confirm
-        : state.notice.tone === "warning"
-          ? this.theme.needsAuth
-          : this.theme.hint;
+      let tone = this.theme.hint;
+      if (state.notice.tone === "success") {
+        tone = this.theme.confirm;
+      } else if (state.notice.tone === "warning") {
+        tone = this.theme.needsAuth;
+      }
       for (const line of wrapText(tone(state.notice.text), contentWidth)) {
         this.addRow(line, innerWidth);
       }

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -105,7 +105,7 @@ class McpSetupPanelView implements Component {
     const state = this.getState();
     this.container.clear();
 
-    this.addFrame("┌", "┐", panelWidth);
+    this.addFrame("┌", "┐");
     this.addRow(this.theme.title("MCP setup"), innerWidth);
     for (const line of wrapText(this.discoverySummaryLine(state), contentWidth)) {
       this.addRow(line, innerWidth);
@@ -127,15 +127,15 @@ class McpSetupPanelView implements Component {
       this.addRow("", innerWidth);
     }
 
-    this.addFrame("├", "┤", panelWidth);
+    this.addFrame("├", "┤");
     if (state.screen === "imports") {
       for (const line of this.renderImports(state, innerWidth)) this.addRow(line, innerWidth);
     } else if (state.screen === "paths") {
-      for (const line of this.renderPaths(state, innerWidth)) this.addRow(line, innerWidth);
+      for (const line of this.renderPaths(state)) this.addRow(line, innerWidth);
     } else {
       for (const line of this.renderActions(state, innerWidth)) this.addRow(line, innerWidth);
     }
-    this.addFrame("└", "┘", panelWidth);
+    this.addFrame("└", "┘");
     return this.container.render(panelWidth);
   }
 
@@ -143,7 +143,7 @@ class McpSetupPanelView implements Component {
     this.container.invalidate();
   }
 
-  private addFrame(left: string, right: string, width: number): void {
+  private addFrame(left: string, right: string): void {
     this.container.addChild(new McpPanelFrame(this.theme, left, right));
   }
 
@@ -208,7 +208,7 @@ class McpSetupPanelView implements Component {
     return lines;
   }
 
-  private renderPaths(state: McpSetupPanelViewState, innerWidth: number): string[] {
+  private renderPaths(state: McpSetupPanelViewState): string[] {
     const lines: string[] = [];
     lines.push("Select a detected config path to open. Enter opens it, Esc goes back.");
     lines.push("");

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -67,7 +67,6 @@ type ActionId =
 interface Action {
   id: ActionId;
   label: string;
-  description: string;
   preset?: KnownServerPreset;
   target?: SharedConfigTarget;
 }
@@ -79,7 +78,6 @@ interface McpSetupPanelViewState {
   pathCursor: number;
   sharedConfigTarget: SharedConfigTarget;
   selectedImports: ReadonlySet<ImportKind>;
-  busy: boolean;
   notice: { text: string; tone: "success" | "warning" | "muted" } | null;
   onboardingState: McpOnboardingState;
   discovery: McpDiscoverySummary;
@@ -423,7 +421,6 @@ export class McpSetupPanel {
   private busy = false;
   private notice: { text: string; tone: "success" | "warning" | "muted" } | null = null;
   private tui: { requestRender(): void };
-  private readonly theme: McpPanelTheme;
   private readonly view: McpSetupPanelView;
   private keys: PanelKeys;
   private inactivityTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -438,8 +435,7 @@ export class McpSetupPanel {
   ) {
     this.tui = tui;
     this.keys = createPanelKeys(options.keybindings);
-    this.theme = createMcpPanelTheme(options.theme);
-    this.view = new McpSetupPanelView(() => this.getViewState(), callbacks, this.theme);
+    this.view = new McpSetupPanelView(() => this.getViewState(), callbacks, createMcpPanelTheme(options.theme));
     this.screen = options.mode;
     for (const entry of discovery.imports) {
       this.selectedImports.add(entry.kind);
@@ -465,30 +461,30 @@ export class McpSetupPanel {
   private getActions(): Action[] {
     const actions: Action[] = [];
     if (this.screen === "empty") {
-      actions.push({ id: "run-setup", label: "Run setup", description: "Inspect detected configs, adopt imports, and scaffold a minimal `.mcp.json`." });
+      actions.push({ id: "run-setup", label: "Run setup" });
     }
     if (this.discovery.imports.length > 0) {
-      actions.push({ id: "adopt-imports", label: "Adopt detected compatibility imports", description: `Choose which host-specific MCP configs Pi should import into its own override file. ${this.discovery.imports.length} source${this.discovery.imports.length === 1 ? "" : "s"} found.` });
+      actions.push({ id: "adopt-imports", label: "Adopt detected compatibility imports" });
     }
     actions.push(
-      { id: "select-shared-target", label: `${this.sharedConfigTarget === "project" ? "●" : "○"} Add to this project (.mcp.json)`, description: "Write new shared MCP servers to the project/team config.", target: "project" },
-      { id: "select-shared-target", label: `${this.sharedConfigTarget === "global" ? "●" : "○"} Add globally (~/.config/mcp/mcp.json)`, description: "Write new shared MCP servers to your all-projects config.", target: "global" },
+      { id: "select-shared-target", label: `${this.sharedConfigTarget === "project" ? "●" : "○"} Add to this project (.mcp.json)`, target: "project" },
+      { id: "select-shared-target", label: `${this.sharedConfigTarget === "global" ? "●" : "○"} Add globally (~/.config/mcp/mcp.json)`, target: "global" },
     );
-    actions.push({ id: "view-example", label: "View example shared config", description: "Preview a working shared MCP config you can paste or adapt." });
+    actions.push({ id: "view-example", label: "View example shared config" });
     if (!this.selectedSharedConfigExists()) {
-      actions.push({ id: "scaffold-shared-config", label: `Scaffold ${this.sharedTargetLabel()}`, description: "Write a minimal config at the selected normal MCP setup path, then reload Pi." });
+      actions.push({ id: "scaffold-shared-config", label: `Scaffold ${this.sharedTargetLabel()}` });
     }
-    actions.push({ id: "show-precedence", label: "Explain config precedence", description: "Show the read order and where Pi writes compatibility settings." });
+    actions.push({ id: "show-precedence", label: "Explain config precedence" });
     if (this.getDetectedPaths().length > 0) {
-      actions.push({ id: "open-paths", label: "Open detected config paths", description: "Browse the actual config files that Pi discovered on this machine." });
+      actions.push({ id: "open-paths", label: "Open detected config paths" });
     }
     for (const preset of KNOWN_SERVER_PRESETS) {
-      actions.push({ id: "add-known-server", label: preset.name, description: preset.summary, preset });
+      actions.push({ id: "add-known-server", label: preset.name, preset });
     }
     if (!this.discovery.repoPrompt.configured && this.discovery.repoPrompt.executablePath && this.discovery.repoPrompt.targetPath && this.discovery.repoPrompt.entry && this.discovery.repoPrompt.serverName) {
-      actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to selected shared config", description: "Write a standard MCP entry for RepoPrompt to the selected normal setup path, then reload MCP in-session." });
+      actions.push({ id: "add-repoprompt", label: "Add RepoPrompt to selected shared config" });
     }
-    actions.push({ id: "close", label: "Close", description: "Exit the onboarding flow." });
+    actions.push({ id: "close", label: "Close" });
     return actions;
   }
 
@@ -507,11 +503,6 @@ export class McpSetupPanel {
   private selectedSharedConfigExists(): boolean {
     const sourceId = this.sharedConfigTarget === "project" ? "shared-project" : "shared-global";
     return this.discovery.sources.some((source) => source.id === sourceId && source.exists);
-  }
-
-  private getSelectedAction(): Action | undefined {
-    const actions = this.getActions();
-    return actions[this.actionCursor];
   }
 
   handleInput(data: string): void {
@@ -558,7 +549,7 @@ export class McpSetupPanel {
       return;
     }
     if (this.keys.selectConfirm(data)) {
-      const selected = this.getSelectedAction();
+      const selected = actions[this.actionCursor];
       if (selected) void this.runAction(selected);
     }
   }
@@ -717,7 +708,6 @@ export class McpSetupPanel {
       pathCursor: this.pathCursor,
       sharedConfigTarget: this.sharedConfigTarget,
       selectedImports: this.selectedImports,
-      busy: this.busy,
       notice: this.notice,
       onboardingState: this.options.onboardingState,
       discovery: this.discovery,

--- a/mcp-setup-panel.ts
+++ b/mcp-setup-panel.ts
@@ -107,11 +107,15 @@ class McpSetupPanelView implements Component {
 
     this.addFrame("┌", "┐");
     this.addRow(this.theme.title("MCP setup"), innerWidth);
-    for (const line of wrapText(this.discoverySummaryLine(state), contentWidth)) {
-      this.addRow(line, innerWidth);
+    let discoveryTone = this.theme.hint;
+    if (!state.discovery.hasAnyConfig || (state.discovery.totalServerCount === 0 && (state.discovery.imports.length > 0 || !!state.discovery.repoPrompt.executablePath))) {
+      discoveryTone = this.theme.needsAuth;
     }
-    for (const line of wrapText(this.theme.description(this.theme.italic(this.secondarySummaryLine(state))), contentWidth)) {
-      this.addRow(line, innerWidth);
+    for (const line of wrapText(this.discoverySummaryLine(state), contentWidth)) {
+      this.addRow(discoveryTone(line), innerWidth);
+    }
+    for (const line of wrapText(this.secondarySummaryLine(state), contentWidth)) {
+      this.addRow(this.theme.description(this.theme.italic(line)), innerWidth);
     }
     this.addRow("", innerWidth);
 
@@ -122,8 +126,8 @@ class McpSetupPanelView implements Component {
       } else if (state.notice.tone === "warning") {
         tone = this.theme.needsAuth;
       }
-      for (const line of wrapText(tone(state.notice.text), contentWidth)) {
-        this.addRow(line, innerWidth);
+      for (const line of wrapText(state.notice.text, contentWidth)) {
+        this.addRow(tone(line), innerWidth);
       }
       this.addRow("", innerWidth);
     }
@@ -223,18 +227,18 @@ class McpSetupPanelView implements Component {
 
   private discoverySummaryLine(state: McpSetupPanelViewState): string {
     if (!state.discovery.hasAnyConfig) {
-      return this.theme.needsAuth(state.onboardingState.setupCompleted
+      return state.onboardingState.setupCompleted
         ? "No MCP servers are active right now."
-        : "No MCP config is active yet.");
+        : "No MCP config is active yet.";
     }
 
     if (state.discovery.totalServerCount === 0 && (state.discovery.imports.length > 0 || !!state.discovery.repoPrompt.executablePath)) {
-      return this.theme.needsAuth("Pi found MCP-related setup options, but none are active in Pi yet.");
+      return "Pi found MCP-related setup options, but none are active in Pi yet.";
     }
 
     const shared = state.discovery.sources.filter((source) => source.kind === "shared" && source.serverCount > 0).length;
     const piOwned = state.discovery.sources.filter((source) => source.kind === "pi" && source.serverCount > 0).length;
-    return this.theme.hint(`Detected ${state.discovery.totalServerCount} configured servers across ${shared} shared and ${piOwned} Pi-owned source${shared + piOwned === 1 ? "" : "s"}.`);
+    return `Detected ${state.discovery.totalServerCount} configured servers across ${shared} shared and ${piOwned} Pi-owned source${shared + piOwned === 1 ? "" : "s"}.`;
   }
 
   private secondarySummaryLine(state: McpSetupPanelViewState): string {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "mcp-callback-server.ts",
     "mcp-auth-flow.ts",
     "mcp-panel.ts",
+    "mcp-panel-theme.ts",
     "panel-keys.ts",
     "mcp-trace.ts",
     "logger.ts",


### PR DESCRIPTION
## Summary
Migrate the MCP server/auth and setup panels to Pi theme styles and shared TUI component views. Preserve the current layout, hierarchical rows, search, scrolling, actions, custom keybindings, and non-TUI behavior. Wrapped setup text keeps its styling on every display line.

Closes #488.

## Validation
- 14 focused panel, command, and lifecycle test files: 167 tests passed.
- Typecheck and public build passed.
- Public exports: 2 tests passed; package dry-run passed.
- Independent review completed; its wrapped-text styling finding was fixed with a red/green rendered-output regression.
- Diff hygiene and clean worktree verified.

No new controls, dependency upgrades, or visual redesign.