### PR TITLE
fix(package): support Pi 0.85 peer resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 
 ### Fixed
+- The optional `@earendil-works/pi-ai` peer now supports Pi 0.85 alongside 0.84.1, avoiding npm resolution conflicts. Thanks to [@dyld-w](https://github.com/dyld-w) for #507.
 - Session-scoped MCP tool approvals and MCP App iframe consent now persist on and restore from the active Pi session branch. (#492)
 - The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.
 - MCP output truncation now uses Pi host truncation semantics and formatting while preserving MCP artifact spill behavior.

--- a/__tests__/package-manifest.test.ts
+++ b/__tests__/package-manifest.test.ts
@@ -16,7 +16,7 @@ const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf
 };
 
 const hostPeerPackages = {
-  "@earendil-works/pi-ai": { peer: "^0.84.1", dev: "0.84.1" },
+  "@earendil-works/pi-ai": { peer: "^0.84.1 || ^0.85.0", dev: "0.84.1" },
   "@earendil-works/pi-tui": { peer: "*", dev: "0.84.1" },
   "typebox": { peer: "*", dev: "1.3.3" },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1 || ^0.85.0",
         "@earendil-works/pi-tui": "*",
         "typebox": "*",
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.84.1 || ^0.85.0",
     "@earendil-works/pi-tui": "*",
     "typebox": "*",
     "zod": "^3.25.0 || ^4.0.0"


### PR DESCRIPTION
## Summary
Allow the optional Pi AI peer to resolve either ^0.84.1 or ^0.85.0. Keep the existing dev pin and update matching lock metadata and manifest coverage.

Closes #507. Thanks to [@dyld-w](https://github.com/dyld-w) for reporting and investigating this.

## Validation
- Reproduced ERESOLVE before the change; isolated packed-package consumers resolve Pi AI 0.84.1 and 0.85.0 after it.
- Typecheck and focused sampling tests passed against both dependency sets.
- Current-base manifest/sampling tests, typecheck, public exports and package dry-run passed.
- Fresh packaging review found no issues; rebase retained the same four-line metadata change.

Pi 0.85 coding-agent has a separate missing pi-server dependency in its modular SDK. Root-import probes supplied that package only in disposable fixtures; this PR adds no adapter runtime workaround.