### PR TITLE
fix(deps): refresh locked fast-uri to patched 3.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session-scoped MCP tool approvals and MCP App iframe consent now persist on and restore from the active Pi session branch. (#492)
 - The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.
 - MCP output truncation now uses Pi host truncation semantics and formatting while preserving MCP artifact spill behavior.
+- The repository lockfile now pins Ajv's transitive `fast-uri` dependency to patched 3.1.7, avoiding the stale 3.1.5 advisory finding. Thanks to [@escuelallenquen](https://github.com/escuelallenquen) for #513.
 - Exclusive mode now honors an explicit `--mcp-config` override instead of always loading the agent-global configuration. Thanks to [@willem445](https://github.com/willem445) for #496.
 - OAuth discovery, dynamic registration, token exchange, and token refresh requests now have a timeout and honor cancellation instead of hanging the agent on stalled providers. Thanks to [@west-david](https://github.com/west-david) for #485 and PR #486.
 - OAuth redirect URI mismatches now preserve refreshable credentials and re-register stale dynamic clients after `invalid_grant`. Thanks to [@CharlesMcMillan](https://github.com/CharlesMcMillan) for PR #495.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5089,9 +5089,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Refresh only the repository lock entry for fast-uri from 3.1.5 to patched 3.1.7, within the existing Ajv dependency range. No manifest override, direct dependency, or API changes.

Closes #513. Thanks to [@escuelallenquen](https://github.com/escuelallenquen) for the report.

## Validation
- Owned npm ci installs resolve Ajv 8.20.0 with fast-uri 3.1.7.
- Registry version, URL and integrity verified.
- JSON-schema/elicitation tests: 21 passed; typecheck passed.
- Fresh dependency review found no issues.
- npm audit --omit=dev reports no fast-uri finding and zero high findings. An unrelated moderate qs finding remains; this is not a fully clean-audit claim.

## Consumer scope
Published adapter tarballs contain no lockfile. Fresh installs already resolve the patched compatible version; an existing consumer root lock pinned to 3.1.5 must be refreshed separately. Nested adapter overrides would not enforce consumer-root resolution. This lock update does not rewrite SDK-bundled dependency bytes.