### PR TITLE
fix(deps): refresh locked qs to patched 6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Early MCP tool discovery now honors `--mcp-config=<path>`, including paths containing `=`. (#512)
+- The repository lock now resolves `qs` to patched 6.16.0 for its published moderate advisories. (#517)
 - The optional `@earendil-works/pi-ai` peer now supports Pi 0.85 alongside 0.84.1, avoiding npm resolution conflicts. Thanks to [@dyld-w](https://github.com/dyld-w) for #507.
 - Session-scoped MCP tool approvals and MCP App iframe consent now persist on and restore from the active Pi session branch. (#492)
 - The `/mcp` panel no longer marks reconnects as cached when cache reload returns no entry, while preserving explicit zero-TTL behavior. Thanks to [@fyq163](https://github.com/fyq163) for #497.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6017,9 +6017,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## Summary
Update only the repository qs lock entry from 6.15.3 to patched 6.16.0 plus a changelog bullet. The new version satisfies the existing body-parser and express ranges; existing dependency entries already meet its requirements.

Closes #517. This addresses GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g in the locked dependency tree. No manifest override, API change, unrelated dependency upgrade, or exploitability claim.

## Validation
- Registry version, integrity, dependencies and advisory patched ranges verified.
- Owned clean npm ci and focused OAuth/form tests passed.
- Fresh dependency review found no issues.
- Rebased onto merged fast-uri fix #516; parent clean production npm ci resolves qs 6.16.0 and fast-uri 3.1.7.
- Combined npm audit --omit=dev reports zero vulnerabilities; diff and worktree are clean.

This updates the repository lock, not existing consumer root locks or SDK-bundled dependency code.