### PR TITLE
fix(namespace): correct tool describe guidance

### DIFF
--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -266,7 +266,7 @@ describe("syncNamespaceProxyTools", () => {
     expect(registered.has("mcp__other")).toBe(false);
   });
 
-  it("exposes a `tool` and optional `args` parameter schema for dispatch", async () => {
+  it("exposes dispatch parameters with search-first describe guidance", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered } = makePi();
 
@@ -287,9 +287,13 @@ describe("syncNamespaceProxyTools", () => {
     expect(tool.parameters).toMatchObject({
       properties: {
         tool: expect.anything(),
-        args: expect.anything(),
+        args: {
+          description: expect.stringMatching(/mcp\(\{ search:.*mcp\(\{ describe:/),
+        },
       },
     });
+    expect(JSON.stringify(tool.parameters)).toContain("exact tool name returned by search");
+    expect(JSON.stringify(tool.parameters)).not.toContain("server/tool");
   });
 
   it("skips registration when an existing direct tool already uses mcp__<server>", async () => {

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { executeCall, executeDescribe, executeList, executeSearch, executeStatus } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
+import { buildToolMetadata } from "../tool-metadata.ts";
+import type { ServerEntry } from "../types.ts";
 
 function createState(): McpExtensionState {
   return {
@@ -206,6 +208,45 @@ describe("proxy discovery", () => {
     expect(result.content[0].text).toContain(
       'demo (2 tools (lazy: tools from cache, not connected yet — mcp({ connect: "demo" }) to connect)):',
     );
+  });
+
+  describe.each(["global", "server"] as const)("%s toolPrefix discovery", scope => {
+    it.each([
+      ["server", "demo-mcp_search"],
+      ["short", "demo_search"],
+      ["none", "search"],
+      ["mcp", "mcp__demo-mcp_search"],
+    ] as const)("describes the exact search result with %s prefixes", (prefix, expectedName) => {
+      const state = createState();
+      const server = "demo-mcp";
+      const definition: ServerEntry = { command: "demo" };
+      const globalPrefix = scope === "global" ? prefix : "none";
+      if (scope === "server") definition.toolPrefix = prefix;
+      state.config = {
+        mcpServers: { [server]: definition },
+        settings: { toolPrefix: globalPrefix },
+      };
+      const inputSchema = { type: "object", properties: { query: { type: "string" } }, required: ["query"] };
+      const { metadata } = buildToolMetadata(
+        [{ name: "search", description: "Search demo records", inputSchema }],
+        [],
+        definition,
+        server,
+        globalPrefix,
+      );
+      state.toolMetadata = new Map([[server, metadata]]);
+
+      const search = executeSearch(state, "search", false, server);
+      expect(search.details).toMatchObject({ count: 1, matches: [{ tool: expectedName }] });
+      const matches = search.details.matches as Array<{ tool: string }>;
+      const result = executeDescribe(state, matches[0]!.tool);
+
+      expect(result.details).toMatchObject({
+        mode: "describe",
+        server,
+        tool: { name: expectedName, originalName: "search", inputSchema },
+      });
+    });
   });
 
   it("suggests the matching tool for a prefix-mangled describe name", () => {

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -150,7 +150,7 @@ const parameters = Type.Object({
   tool: Type.String({ description: "Underlying MCP tool name to call on this server." }),
   args: Type.Optional(Type.Object({}, {
     additionalProperties: true,
-    description: "Arguments for the underlying tool. The exact shape depends on the tool being called; use mcp({ describe: 'server/tool' }) to inspect.",
+    description: "Arguments for the underlying tool. Use mcp({ search: '...' }), then mcp({ describe: 'tool_name' }) with the exact tool name returned by search.",
   })),
 });
 


### PR DESCRIPTION
## Why

Namespace proxy argument descriptions currently tell agents to inspect a tool with `mcp({ describe: 'server/tool' })`. The adapter's describe resolver does not interpret slash-qualified names, so following that instruction produces `tool_not_found` (for example, `linear/get_issue` instead of the discovered `linear_get_issue`). This is adapter-level discovery behavior, not a Linear-specific naming requirement.

## What changed

- Replace the unsupported slash example with search-first guidance: pass the exact name returned by `mcp({ search: ... })` to `mcp({ describe: ... })`.
- Extend the namespace registration test to inspect the actual model-facing argument description and reject the old example.
- Verify search-to-describe discovery for all four `toolPrefix` modes, both globally and with per-server overrides.

## AI involvement

- AI assisted diagnosis, implementation, test generation, and diff review.
- The human requested the upstream fix and approved testing both the registered instructions and the discovery flow.

## Validation

- Confirmed the new instruction regression assertion fails against the original description, then passes after the fix.
- `npm test -- --run __tests__/namespace-tools.test.ts __tests__/proxy-modes-discovery.test.ts` — 59 tests passed.
- `npm run typecheck` — passed.
- `git diff --check` — passed.

## Risks / follow-ups

No resolver, configuration, authentication, or dispatch behavior changes. Tests use local metadata and do not connect to live MCP servers. The full test, OAuth, and conformance suites were not run locally.
