### PR TITLE
fix(namespace): correct tool describe guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 
 ### Fixed
+- Namespace proxy argument guidance now uses exact search-result tool names for schema inspection. Thanks to [@r1ckyIn](https://github.com/r1ckyIn) for PR #519.
 - Early MCP tool discovery now honors `--mcp-config=<path>`, including paths containing `=`. (#512)
 - The repository lock now resolves `qs` to patched 6.16.0 for its published moderate advisories. (#517)
 - The optional `@earendil-works/pi-ai` peer now supports Pi 0.85 alongside 0.84.1, avoiding npm resolution conflicts. Thanks to [@dyld-w](https://github.com/dyld-w) for #507.

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -293,6 +293,8 @@ describe("syncNamespaceProxyTools", () => {
       },
     });
     expect(JSON.stringify(tool.parameters)).toContain("exact tool name returned by search");
+    expect(JSON.stringify(tool.parameters)).toContain("When mcp is available");
+    expect(JSON.stringify(tool.parameters)).toContain("to inspect schemas; for unique names use");
     expect(JSON.stringify(tool.parameters)).not.toContain("server/tool");
   });
 

--- a/__tests__/namespace-tools.test.ts
+++ b/__tests__/namespace-tools.test.ts
@@ -266,7 +266,7 @@ describe("syncNamespaceProxyTools", () => {
     expect(registered.has("mcp__other")).toBe(false);
   });
 
-  it("exposes a `tool` and optional `args` parameter schema for dispatch", async () => {
+  it("exposes dispatch parameters with search-first describe guidance", async () => {
     const { syncNamespaceProxyTools } = await importSync();
     const { pi, registered } = makePi();
 
@@ -287,9 +287,13 @@ describe("syncNamespaceProxyTools", () => {
     expect(tool.parameters).toMatchObject({
       properties: {
         tool: expect.anything(),
-        args: expect.anything(),
+        args: {
+          description: expect.stringMatching(/mcp\(\{ search:.*mcp\(\{ describe:/),
+        },
       },
     });
+    expect(JSON.stringify(tool.parameters)).toContain("exact tool name returned by search");
+    expect(JSON.stringify(tool.parameters)).not.toContain("server/tool");
   });
 
   it("skips registration when an existing direct tool already uses mcp__<server>", async () => {

--- a/__tests__/proxy-modes-discovery.test.ts
+++ b/__tests__/proxy-modes-discovery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { executeCall, executeDescribe, executeList, executeSearch, executeStatus } from "../proxy-modes.ts";
 import type { McpExtensionState } from "../state.ts";
+import { buildToolMetadata } from "../tool-metadata.ts";
+import type { ServerEntry } from "../types.ts";
 
 function createState(): McpExtensionState {
   return {
@@ -206,6 +208,45 @@ describe("proxy discovery", () => {
     expect(result.content[0].text).toContain(
       'demo (2 tools (lazy: tools from cache, not connected yet — mcp({ connect: "demo" }) to connect)):',
     );
+  });
+
+  describe.each(["global", "server"] as const)("%s toolPrefix discovery", scope => {
+    it.each([
+      ["server", "demo-mcp_search"],
+      ["short", "demo_search"],
+      ["none", "search"],
+      ["mcp", "mcp__demo-mcp_search"],
+    ] as const)("describes the exact search result with %s prefixes", (prefix, expectedName) => {
+      const state = createState();
+      const server = "demo-mcp";
+      const definition: ServerEntry = { command: "demo" };
+      const globalPrefix = scope === "global" ? prefix : "none";
+      if (scope === "server") definition.toolPrefix = prefix;
+      state.config = {
+        mcpServers: { [server]: definition },
+        settings: { toolPrefix: globalPrefix },
+      };
+      const inputSchema = { type: "object", properties: { query: { type: "string" } }, required: ["query"] };
+      const { metadata } = buildToolMetadata(
+        [{ name: "search", description: "Search demo records", inputSchema }],
+        [],
+        definition,
+        server,
+        globalPrefix,
+      );
+      state.toolMetadata = new Map([[server, metadata]]);
+
+      const search = executeSearch(state, "search", false, server);
+      expect(search.details).toMatchObject({ count: 1, matches: [{ tool: expectedName }] });
+      const matches = search.details.matches as Array<{ tool: string }>;
+      const result = executeDescribe(state, matches[0]!.tool);
+
+      expect(result.details).toMatchObject({
+        mode: "describe",
+        server,
+        tool: { name: expectedName, originalName: "search", inputSchema },
+      });
+    });
   });
 
   it("suggests the matching tool for a prefix-mangled describe name", () => {

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -150,7 +150,7 @@ const parameters = Type.Object({
   tool: Type.String({ description: "Underlying MCP tool name to call on this server." }),
   args: Type.Optional(Type.Object({}, {
     additionalProperties: true,
-    description: "Arguments for the underlying tool. Use mcp({ search: '...' }), then mcp({ describe: 'tool_name' }) with the exact tool name returned by search.",
+    description: "Arguments for the underlying tool. When mcp is available, use mcp({ search: '...' }) to inspect schemas; for unique names use mcp({ describe: 'tool_name' }) with the exact tool name returned by search.",
   })),
 });
 

--- a/namespace-tools.ts
+++ b/namespace-tools.ts
@@ -150,7 +150,7 @@ const parameters = Type.Object({
   tool: Type.String({ description: "Underlying MCP tool name to call on this server." }),
   args: Type.Optional(Type.Object({}, {
     additionalProperties: true,
-    description: "Arguments for the underlying tool. The exact shape depends on the tool being called; use mcp({ describe: 'server/tool' }) to inspect.",
+    description: "Arguments for the underlying tool. Use mcp({ search: '...' }), then mcp({ describe: 'tool_name' }) with the exact tool name returned by search.",
   })),
 });
 


### PR DESCRIPTION
## Summary

Carries [@r1ckyIn](https://github.com/r1ckyIn)'s original fix and tests from #519, with Unreleased changelog credit and a small guidance clarification. The original contributor commit is preserved; this maintainer branch leaves the contributor's fork untouched.

- Replace unsupported `server/tool` describe syntax with exact search-result names.
- Use schema-bearing search results directly; recommend describe only for unique names and discovery only when `mcp` is available.
- Retain the contributor's global/per-server prefix coverage. Extend the existing registered-description assertions for the two qualifications.

## Validation

- Focused namespace and proxy-discovery tests: 59 passed, including after the final wording change.
- Typecheck and diff hygiene: passed.
- Fresh exact contributor-head review completed; subsequent maintainer changes are the credit line and a bounded wording/test correction. No resolver, registration, dispatch, or configuration behavior changed.

This addresses the ambiguity finding through accurate instructions, not a new discovery API or changes to `disableProxyTool`.

Supersedes #519 after this PR lands. Thanks to [@r1ckyIn](https://github.com/r1ckyIn) for the fix and tests.
