### PR TITLE
feat: install and authenticate MCP servers from one URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - HTTPS MCP servers can configure an origin-scoped `caFile` PEM trust bundle without disabling certificate verification, for Streamable HTTP and SSE. Thanks to [@desmonna](https://github.com/desmonna) for #527.
 - `directTools: "search"` registers a server's tools as real direct tools but inactive; `mcp({ search })` activates the matches additively, reported as `addedToolNames`. Activation is per process and search is its only trigger. Search-mode tools do not count toward the 75-tool advisory. Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #525.
+- The script MCP gateway can now install, validate, connect, and authenticate a durable server configuration from one endpoint URL with `mcp({ action: "install", url: "..." })`.
 - Script `tools.describe()` now exposes server-advertised output schemas for `data.structuredContent`, preserved through metadata caching and refresh. (#522)
 - Stdio MCP servers can opt out of arbitrary adapter environment inheritance with `inheritEnv: false`; SDK platform defaults and explicit `env` overlays remain. Thanks to [@zenolam](https://github.com/zenolam) for #509.
 - Local Claude plugin bundles can now be loaded from trusted configured directories, including bundled MCP servers and skills. Thanks to [@gugu91](https://github.com/gugu91) for PR #493.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - HTTPS MCP servers can configure an origin-scoped `caFile` PEM trust bundle without disabling certificate verification, for Streamable HTTP and SSE. Thanks to [@desmonna](https://github.com/desmonna) for #527.
 - `directTools: "search"` registers a server's tools as real direct tools but inactive; `mcp({ search })` activates the matches additively, reported as `addedToolNames`. Activation is per process and search is its only trigger. Search-mode tools do not count toward the 75-tool advisory. Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #525.
-- The script MCP gateway can now install, validate, connect, and authenticate a durable server configuration from one endpoint URL with `mcp({ action: "install", url: "..." })`. Thanks to [@exoulster](https://github.com/exoulster) for PR #532.
+- Install MCP servers from a URL with `mcp({ action: "install", url: "..." })`. Thanks to [@exoulster](https://github.com/exoulster) for PR #532.
 - Script `tools.describe()` now exposes server-advertised output schemas for `data.structuredContent`, preserved through metadata caching and refresh. (#522)
 - Stdio MCP servers can opt out of arbitrary adapter environment inheritance with `inheritEnv: false`; SDK platform defaults and explicit `env` overlays remain. Thanks to [@zenolam](https://github.com/zenolam) for #509.
 - Local Claude plugin bundles can now be loaded from trusted configured directories, including bundled MCP servers and skills. Thanks to [@gugu91](https://github.com/gugu91) for PR #493.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - HTTPS MCP servers can configure an origin-scoped `caFile` PEM trust bundle without disabling certificate verification, for Streamable HTTP and SSE. Thanks to [@desmonna](https://github.com/desmonna) for #527.
 - `directTools: "search"` registers a server's tools as real direct tools but inactive; `mcp({ search })` activates the matches additively, reported as `addedToolNames`. Activation is per process and search is its only trigger. Search-mode tools do not count toward the 75-tool advisory. Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #525.
-- The script MCP gateway can now install, validate, connect, and authenticate a durable server configuration from one endpoint URL with `mcp({ action: "install", url: "..." })`.
+- The script MCP gateway can now install, validate, connect, and authenticate a durable server configuration from one endpoint URL with `mcp({ action: "install", url: "..." })`. Thanks to [@exoulster](https://github.com/exoulster) for PR #532.
 - Script `tools.describe()` now exposes server-advertised output schemas for `data.structuredContent`, preserved through metadata caching and refresh. (#522)
 - Stdio MCP servers can opt out of arbitrary adapter environment inheritance with `inheritEnv: false`; SDK platform defaults and explicit `env` overlays remain. Thanks to [@zenolam](https://github.com/zenolam) for #509.
 - Local Claude plugin bundles can now be loaded from trusted configured directories, including bundled MCP servers and skills. Thanks to [@gugu91](https://github.com/gugu91) for PR #493.
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - MCP runtime cancellation now works on Node 20.0.0 when `AbortSignal.any` is unavailable. (#537)
 - OAuth now forwards configured service headers to same-origin discovery, registration, token exchange, and refresh requests, enabling authentication behind service-token gateways without leaking credentials to other origins. Thanks to [@ethanbrown3](https://github.com/ethanbrown3) for PR #533 and [@Davasny](https://github.com/Davasny) for reporting #530.
-- Script `mcp({ action: "auth-start" })` now opens the authorization URL and watches the loopback callback to complete OAuth automatically, while retaining pasted `auth-complete` as a fallback.
+- Script `mcp({ action: "auth-start" })` now opens the authorization URL and watches the loopback callback to complete OAuth automatically, while retaining pasted `auth-complete` as a fallback. Thanks to [@exoulster](https://github.com/exoulster) for PR #532.
 - Script calls now preserve full intermediate data for filtering within a fixed 16 MiB cumulative transfer budget, returning `intermediate_result_too_large` when exhausted while retaining final-output guards. (#520)
 - Namespace proxy argument guidance now uses exact search-result tool names for schema inspection. Thanks to [@r1ckyIn](https://github.com/r1ckyIn) for PR #519.
 - Script `tools.describe()` now retains documented input field guidance alongside compact parameter shapes, including formats and units. (#521)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - MCP runtime cancellation now works on Node 20.0.0 when `AbortSignal.any` is unavailable. (#537)
 - OAuth now forwards configured service headers to same-origin discovery, registration, token exchange, and refresh requests, enabling authentication behind service-token gateways without leaking credentials to other origins. Thanks to [@ethanbrown3](https://github.com/ethanbrown3) for PR #533 and [@Davasny](https://github.com/Davasny) for reporting #530.
+- Script `mcp({ action: "auth-start" })` now opens the authorization URL and watches the loopback callback to complete OAuth automatically, while retaining pasted `auth-complete` as a fallback.
 - Script calls now preserve full intermediate data for filtering within a fixed 16 MiB cumulative transfer budget, returning `intermediate_result_too_large` when exhausted while retaining final-output guards. (#520)
 - Namespace proxy argument guidance now uses exact search-result tool names for schema inspection. Thanks to [@r1ckyIn](https://github.com/r1ckyIn) for PR #519.
 - Script `tools.describe()` now retains documented input field guidance alongside compact parameter shapes, including formats and units. (#521)

--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ The adapter owns only its client socket and closes that connection when the Pi r
 
 ### Install from one URL
 
-When a user supplies an MCP endpoint URL, the agent can complete setup through the gateway without editing configuration by hand:
+Install an MCP endpoint without editing configuration:
 
 ```js
 mcp({ action: "install", url: "https://example.com/mcp" })
 ```
 
-The install action validates the endpoint, reuses a server already configured at the same URL or derives a stable name from the hostname, connects it in the current runtime, and persists it to Pi's global MCP config. Pass `server` to choose a name or `target: "project"` to write `.mcp.json` in the current project instead. Unsafe URLs, name collisions, and endpoints that fail MCP connection validation are not persisted.
+Install validates and connects the endpoint. New entries use a name derived from the hostname and are saved to Pi's global MCP config; existing URL entries are reused without rewriting. Pass `server` to choose a name or `target: "project"` to save to the project's `.mcp.json`. Unsafe URLs, name collisions, and failed connections are not persisted.
 
 In exclusive config mode, a project target must be the active config path; otherwise use the global target. URL install cannot promote runtime-registered servers: save their complete definitions manually so required headers and transport/auth settings are retained.
 
@@ -880,7 +880,7 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 
 If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls automatically run OAuth when needed and retry once.
 
-In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. The proxy tool's `auth-start` action opens and watches reachable loopback flows automatically. In remote/headless sessions, or for pre-registered HTTPS callbacks that the adapter cannot observe, use `auth-complete` to paste the full redirect URL back into Pi. `/mcp-auth` without a server only opens a picker in the interactive UI.
+In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. `/mcp-auth` without a server only opens a picker in the interactive UI. For gateway authorization and manual callback completion, see [Remote/headless OAuth](#remoteheadless-oauth).
 
 ### MCP output schemas
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ mcp({ action: "install", url: "https://example.com/mcp" })
 
 The install action validates the endpoint, reuses a server already configured at the same URL or derives a stable name from the hostname, connects it in the current runtime, and persists it to Pi's global MCP config. Pass `server` to choose a name or `target: "project"` to write `.mcp.json` in the current project instead. Unsafe URLs, name collisions, and endpoints that fail MCP connection validation are not persisted.
 
+In exclusive config mode, a project target must be the active config path; otherwise use the global target. URL install cannot promote runtime-registered servers: save their complete definitions manually so required headers and transport/auth settings are retained.
+
 Public servers are ready immediately. For OAuth servers, the same action opens the authorization page and watches a reachable loopback callback. After the user grants consent, an `mcp-oauth-status` message returns the agent to connect the server and verify its discovered tools. Remote/headless callbacks retain the manual completion fallback below.
 
 ### Remote/headless OAuth

--- a/README.md
+++ b/README.md
@@ -383,6 +383,18 @@ To share one stdio MCP server across Pi sessions, run it under [`rmcp-mux`](http
 
 The adapter owns only its client socket and closes that connection when the Pi runtime stops. `rmcp-mux` owns the upstream process, request routing, initialization cache, restart policy, client limits, and socket permissions. Start and configure the mux separately; the adapter never discovers, starts, adopts, or stops its daemon. A socket is an explicit trusted local endpoint, so do not point unrelated projects or users at a mux service unless its tools, state, credentials, and filesystem access are intended to be shared.
 
+### Install from one URL
+
+When a user supplies an MCP endpoint URL, the agent can complete setup through the gateway without editing configuration by hand:
+
+```js
+mcp({ action: "install", url: "https://example.com/mcp" })
+```
+
+The install action validates the endpoint, reuses a server already configured at the same URL or derives a stable name from the hostname, connects it in the current runtime, and persists it to Pi's global MCP config. Pass `server` to choose a name or `target: "project"` to write `.mcp.json` in the current project instead. Unsafe URLs, name collisions, and endpoints that fail MCP connection validation are not persisted.
+
+Public servers are ready immediately. For OAuth servers, the same action opens the authorization page and watches a reachable loopback callback. After the user grants consent, an `mcp-oauth-status` message returns the agent to connect the server and verify its discovered tools. Remote/headless callbacks retain the manual completion fallback below.
+
 ### Remote/headless OAuth
 
 If Pi is running on a remote server, `/mcp-auth <server>` shows a clickable authorization URL first. Open it in your local browser and approve access, then select **Yes** in Pi to open the callback input. The browser may fail to load the localhost callback page because localhost refers to your workstation; copy the full URL from its address bar and paste it into Pi. The authorization screen closes automatically instead when the browser can reach Pi's callback directly.

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ On Linux, if credential access fails because Pi inherited a revoked session keyr
 mcp({ action: "auth-start", server: "linear-server" })
 ```
 
-Open the returned authorization URL in your local browser. After approval, your browser redirects to a localhost URL. On a remote server that local page may fail to load; copy the full URL from the browser address bar anyway and complete the flow in the same Pi session:
+For a loopback redirect, the adapter attempts to open the returned authorization URL, watches the callback, completes token exchange, and sends an `mcp-oauth-status` event when authentication finishes. If Pi is remote or cannot open a browser, open the returned URL locally. If the browser cannot reach Pi's callback, copy the full localhost URL from the address bar and complete the flow in the same Pi session:
 
 ```js
 mcp({
@@ -866,7 +866,7 @@ Servers that provide usage guidance via the MCP `instructions` field surface it 
 
 If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls automatically run OAuth when needed and retry once.
 
-In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. In remote/headless sessions, use the proxy tool's `auth-start` and `auth-complete` actions to copy the authorization URL locally and paste the redirect URL back into Pi. `/mcp-auth` without a server only opens a picker in the interactive UI.
+In interactive sessions, you can also authenticate from `/mcp` with `ctrl+a` or Enter on a server that needs auth. The proxy tool's `auth-start` action opens and watches reachable loopback flows automatically. In remote/headless sessions, or for pre-registered HTTPS callbacks that the adapter cannot observe, use `auth-complete` to paste the full redirect URL back into Pi. `/mcp-auth` without a server only opens a picker in the interactive UI.
 
 ### MCP output schemas
 

--- a/__tests__/exclusive-config.test.ts
+++ b/__tests__/exclusive-config.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,6 +8,7 @@ import {
   findAvailableImportConfigs,
   getMcpDiscoverySummary,
   loadMcpConfig,
+  writeSharedServerEntry,
 } from "../config.ts";
 
 const roots: string[] = [];
@@ -17,6 +19,22 @@ afterEach(async () => {
 });
 
 describe("exclusive MCP config", () => {
+  it.each(["exclusive", "merge"])("reloads queued URL writes at the active project path in %s mode", async (mode) => {
+    const root = await mkdtemp(join(tmpdir(), "pi-mcp-install-reload-"));
+    roots.push(root);
+    const destination = join(root, ".mcp.json");
+    vi.stubEnv("PI_CODING_AGENT_DIR", join(root, "agent"));
+    vi.stubEnv("PI_MCP_CONFIG_MODE", mode);
+    const prior = { url: "https://prior.example/mcp", headers: { "X-Service": "retained" } };
+    await writeConfig(destination, { custom: { retained: true }, mcpServers: { prior } });
+    const installed = { first: { url: "https://first.example/mcp" }, second: { url: "https://second.example/mcp" } };
+    await Promise.all(Object.entries(installed).map(([name, entry]) =>
+      withFileMutationQueue(destination, async () => { writeSharedServerEntry(destination, name, entry); }),
+    ));
+    expect(loadMcpConfig(destination, root).mcpServers).toMatchObject({ prior, ...installed });
+    expect(JSON.parse(await readFile(destination, "utf8"))).toEqual({ custom: { retained: true }, mcpServers: { prior, ...installed } });
+  });
+
   it("loads the private agent config by default and honors an explicit override", async () => {
     const root = await mkdtemp(join(tmpdir(), "pi-mcp-exclusive-"));
     roots.push(root);

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1032,12 +1032,13 @@ describe("mcpAdapter session lifecycle", () => {
     expect(state.manager.close).not.toHaveBeenCalled();
   });
 
-  it.each(["pre-aborted", "connect-throws", "aborted-after-connect"])("rolls back cancellation and exceptional exits: %s", async (scenario) => {
+  it.each(["pre-aborted", "registration-throws", "connect-throws", "aborted-after-connect"])("rolls back cancellation and exceptional exits: %s", async (scenario) => {
     const state = createState();
     mocks.initializeMcp.mockResolvedValue(state);
     const controller = new AbortController();
     const error = new Error("cancelled");
     if (scenario === "pre-aborted") controller.abort(error);
+    if (scenario === "registration-throws") state.lifecycle.registerServer.mockImplementation(() => { throw error; });
     mocks.executeConnect.mockImplementation(async () => {
       state.toolMetadata.set("demo", []);
       if (scenario === "connect-throws") throw error;

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { MCP_APPROVAL_CUSTOM_TYPE, getToolApprovalIdentity, makeToolApprovalKey 
 
 const mocks = vi.hoisted(() => ({
   initializeMcp: vi.fn(),
+  clearFailure: vi.fn(),
   updateStatusBar: vi.fn(),
   flushMetadataCache: vi.fn(),
   notifyToolMetadataUpdated: vi.fn(),
@@ -32,6 +33,9 @@ const mocks = vi.hoisted(() => ({
   openMcpAuthPanel: vi.fn(),
   openMcpPanel: vi.fn(),
   openMcpSetup: vi.fn(),
+  getPiGlobalConfigPath: vi.fn(() => "/tmp/agent/mcp.json"),
+  getProjectConfigPath: vi.fn(() => "/tmp/project/.mcp.json"),
+  writeSharedServerEntry: vi.fn((path: string) => path),
   writeProjectServerDisabledOverride: vi.fn(() => ({ path: "/tmp/project/.pi/mcp.json", changed: true })),
   executeAuthComplete: vi.fn(),
   executeAuthStart: vi.fn(),
@@ -51,6 +55,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../init.ts", () => ({
   initializeMcp: mocks.initializeMcp,
+  clearFailure: mocks.clearFailure,
   updateStatusBar: mocks.updateStatusBar,
   flushMetadataCache: mocks.flushMetadataCache,
   notifyToolMetadataUpdated: mocks.notifyToolMetadataUpdated,
@@ -67,6 +72,9 @@ vi.mock("../config.ts", () => ({
   cloneMcpConfig: mocks.cloneMcpConfig,
   discoverConfiguredClaudePluginSkills: mocks.discoverConfiguredClaudePluginSkills,
   resolveConfiguredClaudePluginMcp: mocks.resolveConfiguredClaudePluginMcp,
+  getPiGlobalConfigPath: mocks.getPiGlobalConfigPath,
+  getProjectConfigPath: mocks.getProjectConfigPath,
+  writeSharedServerEntry: mocks.writeSharedServerEntry,
   writeProjectServerDisabledOverride: mocks.writeProjectServerDisabledOverride,
 }));
 
@@ -133,10 +141,12 @@ function createDeferred<T>() {
 
 function createState() {
   return {
-    manager: { getAllConnections: () => new Map(), getConnection: vi.fn(() => undefined) },
+    manager: { close: vi.fn().mockResolvedValue(undefined), getAllConnections: () => new Map(), getConnection: vi.fn(() => undefined) },
     lifecycle: {
       gracefulShutdown: vi.fn().mockResolvedValue(undefined),
       ensureConverged: vi.fn().mockResolvedValue(undefined),
+      registerServer: vi.fn(),
+      unregisterServer: vi.fn(),
     },
     toolMetadata: new Map(),
     directToolCounts: new Map(),
@@ -278,6 +288,9 @@ describe("mcpAdapter session lifecycle", () => {
     });
     mocks.getMissingConfiguredDirectToolServers.mockReturnValue([]);
     mocks.resolveDirectTools.mockReturnValue([]);
+    mocks.getPiGlobalConfigPath.mockReturnValue("/tmp/agent/mcp.json");
+    mocks.getProjectConfigPath.mockReturnValue("/tmp/project/.mcp.json");
+    mocks.writeSharedServerEntry.mockImplementation((path: string) => path);
     mocks.getConfigPathFromArgv.mockReturnValue(undefined);
     mocks.normalizeDirectToolInputSchema.mockImplementation((schema: unknown) => schema && typeof schema === "object" && !Array.isArray(schema)
       ? Object.fromEntries(Object.entries(schema).filter(([key]) => key !== "$schema" && key !== "additionalProperties"))
@@ -873,6 +886,128 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.executeConnect).toHaveBeenCalledWith(state, "demo", undefined);
     expect(mocks.reconnectServers).toHaveBeenCalledWith(state, expect.any(Object), "demo");
     expect(mocks.resolveDirectTools).toHaveBeenCalledTimes(callsAfterInitialSync);
+  });
+
+  it("installs and connects a validated MCP URL without reloading", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeConnect.mockResolvedValue({
+      content: [{ type: "text", text: "demo (1 tool)" }],
+      details: { mode: "connect", server: "demo" },
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+
+    const result = await proxyTool.execute(
+      "call-install",
+      { action: "install", url: "https://demo.example.com/mcp", server: "demo" },
+      undefined,
+      undefined,
+      { cwd: "/tmp/project" },
+    );
+
+    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "demo");
+    expect(state.config.mcpServers.demo).toEqual({ url: "https://demo.example.com/mcp", directTools: false });
+    expect(state.lifecycle.registerServer).toHaveBeenCalledWith("demo", state.config.mcpServers.demo, undefined);
+    expect(mocks.writeSharedServerEntry).toHaveBeenCalledWith(
+      "/tmp/agent/mcp.json",
+      "demo",
+      { url: "https://demo.example.com/mcp" },
+    );
+    expect(result.details).toMatchObject({ mode: "install", status: "connected", server: "demo" });
+  });
+
+  it("persists an OAuth MCP URL and starts watched authorization", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeConnect.mockResolvedValue({
+      content: [{ type: "text", text: "authentication required" }],
+      details: { mode: "connect", error: "auth_required", server: "forex" },
+    });
+    mocks.executeAuthStart.mockResolvedValue({
+      content: [{ type: "text", text: "opening authorization URL" }],
+      details: { mode: "auth-start", server: "forex", authorizationUrl: "https://identity.example.com/authorize" },
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+
+    const result = await proxyTool.execute(
+      "call-install",
+      { action: "install", url: "https://forex-dev.1above.io/mcp", server: "forex", target: "project" },
+      undefined,
+      undefined,
+      { cwd: "/tmp/project" },
+    );
+
+    expect(mocks.writeSharedServerEntry).toHaveBeenCalledWith(
+      "/tmp/project/.mcp.json",
+      "forex",
+      { url: "https://forex-dev.1above.io/mcp" },
+    );
+    expect(mocks.executeAuthStart).toHaveBeenCalledWith(state, "forex");
+    expect(result.details).toMatchObject({ mode: "install", status: "awaiting_auth", server: "forex" });
+  });
+
+  it("reuses the configured name for an already installed URL", async () => {
+    const config = { mcpServers: { forex: { url: "https://forex-dev.1above.io/mcp", oauth: { scope: "forex:read" } } } };
+    const state = createState();
+    state.config = config;
+    mocks.loadMcpConfig.mockReturnValue(config);
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeConnect.mockResolvedValue({ content: [{ type: "text", text: "connected" }], details: { mode: "connect" } });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    const result = await proxyTool.execute(
+      "call-install",
+      { action: "install", url: "https://forex-dev.1above.io/mcp" },
+      undefined,
+      undefined,
+      { cwd: "/tmp/project" },
+    );
+
+    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "forex");
+    expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({ mode: "install", status: "connected", server: "forex" });
+  });
+
+  it("rolls back provisional runtime state when endpoint validation fails", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    mocks.executeConnect.mockResolvedValue({
+      content: [{ type: "text", text: "connection failed" }],
+      details: { mode: "connect", error: "connect_failed" },
+    });
+
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    const result = await proxyTool.execute(
+      "call-install",
+      { action: "install", url: "https://invalid.example.com/mcp", server: "invalid" },
+      undefined,
+      undefined,
+      { cwd: "/tmp/project" },
+    );
+
+    expect(state.config.mcpServers.invalid).toBeUndefined();
+    expect(state.lifecycle.unregisterServer).toHaveBeenCalledWith("invalid");
+    expect(state.manager.close).toHaveBeenCalledWith("invalid");
+    expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({ mode: "install", error: "validation_failed" });
   });
 
   it("reports direct tools discovered by proxy connect as addedToolNames without rewriting active tools", async () => {

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolve } from "node:path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { MCP_STATUS_EVENT } from "../types.ts";
 import { ConsentManager } from "../consent-manager.ts";
 import { MCP_APPROVAL_CUSTOM_TYPE, getToolApprovalIdentity, makeToolApprovalKey } from "../session-approvals.ts";
@@ -9,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   clearFailure: vi.fn(),
   updateStatusBar: vi.fn(),
   flushMetadataCache: vi.fn(),
+  updateMetadataCache: vi.fn(),
   notifyToolMetadataUpdated: vi.fn(),
   initializeOAuth: vi.fn().mockResolvedValue(undefined),
   createOAuthRuntime: vi.fn((signal: AbortSignal) => ({ signal })),
@@ -58,6 +61,7 @@ vi.mock("../init.ts", () => ({
   clearFailure: mocks.clearFailure,
   updateStatusBar: mocks.updateStatusBar,
   flushMetadataCache: mocks.flushMetadataCache,
+  updateMetadataCache: mocks.updateMetadataCache,
   notifyToolMetadataUpdated: mocks.notifyToolMetadataUpdated,
 }));
 
@@ -149,6 +153,10 @@ function createState() {
       unregisterServer: vi.fn(),
     },
     toolMetadata: new Map(),
+    promptMetadata: new Map(),
+    promptMetadataLive: new Set(),
+    serverInstructions: new Map(),
+    resourceCounts: new Map(),
     directToolCounts: new Map(),
     config: { mcpServers: {} },
     oauthRuntime: { signal: new AbortController().signal },
@@ -910,7 +918,7 @@ describe("mcpAdapter session lifecycle", () => {
       { cwd: "/tmp/project" },
     );
 
-    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "demo");
+    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "demo", undefined);
     expect(state.config.mcpServers.demo).toEqual({ url: "https://demo.example.com/mcp", directTools: false });
     expect(state.lifecycle.registerServer).toHaveBeenCalledWith("demo", state.config.mcpServers.demo, undefined);
     expect(mocks.writeSharedServerEntry).toHaveBeenCalledWith(
@@ -977,9 +985,128 @@ describe("mcpAdapter session lifecycle", () => {
       { cwd: "/tmp/project" },
     );
 
-    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "forex");
+    expect(mocks.executeConnect).toHaveBeenCalledWith(state, "forex", undefined);
     expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({ mode: "install", status: "connected", server: "forex" });
+  });
+
+  it("rejects an inactive project target before provisional registration or connection", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const gateway = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    vi.stubEnv("PI_MCP_CONFIG_MODE", "exclusive");
+    try {
+      const result = await gateway.execute("install", { action: "install", target: "project", url: "https://demo.example/mcp" }, undefined, undefined, { cwd: "/tmp/project" });
+      expect(result.details.error).toBe("inactive_target");
+      expect(state.config.mcpServers).toEqual({});
+      expect(state.lifecycle.registerServer).not.toHaveBeenCalled();
+      expect(mocks.executeConnect).not.toHaveBeenCalled();
+      expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("rejects runtime promotion without discarding the required service header", async () => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const { default: mcpAdapter, registerMcpServer } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    registerMcpServer({ pi: api, name: "demo", definition: { url: "https://demo.example/mcp", headers: { "X-Service-Token": "required" } } });
+    const before = structuredClone(state.config.mcpServers.demo);
+    const gateway = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    const result = await gateway.execute("install", { action: "install", url: "https://demo.example/mcp" }, undefined, undefined, { cwd: "/tmp/project" });
+    expect(result.details.error).toBe("runtime_promotion_unsupported");
+    expect(state.config.mcpServers.demo).toEqual(before);
+    expect(mocks.executeConnect).not.toHaveBeenCalled();
+    expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
+    expect(state.manager.close).not.toHaveBeenCalled();
+  });
+
+  it.each(["pre-aborted", "connect-throws", "aborted-after-connect"])("rolls back cancellation and exceptional exits: %s", async (scenario) => {
+    const state = createState();
+    mocks.initializeMcp.mockResolvedValue(state);
+    const controller = new AbortController();
+    const error = new Error("cancelled");
+    if (scenario === "pre-aborted") controller.abort(error);
+    mocks.executeConnect.mockImplementation(async () => {
+      state.toolMetadata.set("demo", []);
+      if (scenario === "connect-throws") throw error;
+      controller.abort(error);
+      return { content: [], details: {} };
+    });
+    const { default: mcpAdapter } = await import("../index.ts");
+    const { api, handlers } = createPi();
+    mcpAdapter(api);
+    await handlers.get("session_start")?.({}, {});
+    const gateway = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+    await expect(gateway.execute("install", { action: "install", server: "demo", url: "https://demo.example/mcp" }, controller.signal, undefined, { cwd: "/tmp/project" })).rejects.toBe(error);
+    expect(state.config.mcpServers).toEqual({});
+    expect(state.toolMetadata.has("demo")).toBe(false);
+    expect(state.provisionalInstalls?.size ?? 0).toBe(0);
+    expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
+    if (scenario === "pre-aborted") {
+      expect(state.lifecycle.registerServer).not.toHaveBeenCalled();
+      expect(mocks.executeConnect).not.toHaveBeenCalled();
+    } else {
+      expect(state.lifecycle.unregisterServer).toHaveBeenCalledWith("demo");
+      expect(state.manager.close).toHaveBeenCalledWith("demo");
+    }
+  });
+
+  it("removes failed-install discovery from public search and prompts without changing prior cache bytes", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "mcp-install-rollback-"));
+    vi.stubEnv("PI_CODING_AGENT_DIR", dir);
+    try {
+      const cache = await vi.importActual<typeof import("../metadata-cache.ts")>("../metadata-cache.ts");
+      const init = await vi.importActual<typeof import("../init.ts")>("../init.ts");
+      const proxy = await vi.importActual<typeof import("../proxy-modes.ts")>("../proxy-modes.ts");
+      const oldEntry = { configHash: "prior", tools: [], resources: [], cachedAt: 1, instructions: "prior" };
+      cache.saveMetadataCache({ version: 1, servers: { prior: oldEntry, demo: oldEntry } });
+      const before = readFileSync(cache.getMetadataCachePath(), "utf8");
+      const state = createState();
+      state.serverInstructions.set("prior", "prior");
+      mocks.initializeMcp.mockResolvedValue(state);
+      mocks.executeSearch.mockImplementation(proxy.executeSearch);
+      mocks.executeConnect.mockImplementation(async () => {
+        state.toolMetadata.set("demo", [{ name: "demo_probe", originalName: "probe", description: "provisional" }]);
+        state.promptMetadata.set("demo", [{ serverName: "demo", originalName: "prompt", commandName: "demo-prompt", description: "provisional" }]);
+        state.promptMetadataLive.add("demo");
+        state.serverInstructions.set("demo", "provisional");
+        state.resourceCounts.set("demo", 1);
+        state.manager.getConnection.mockReturnValue({ status: "connected", tools: [], resources: [], instructions: "provisional" });
+        init.updateMetadataCache(state, "demo");
+        await state.onToolMetadataUpdated?.("demo", "proxy-connect");
+        return { content: [{ type: "text", text: "connected" }], details: {} };
+      });
+      mocks.writeSharedServerEntry.mockImplementation(() => { throw new Error("read-only"); });
+      const { default: mcpAdapter } = await import("../index.ts");
+      const { api, handlers } = createPi();
+      mcpAdapter(api);
+      await handlers.get("session_start")?.({}, {});
+      const gateway = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
+      const searchBefore = await gateway.execute("before", { search: "provisional", regex: true });
+      const result = await gateway.execute("install", { action: "install", server: "demo", url: "https://demo.example/mcp" }, undefined, undefined, { cwd: "/tmp/project" });
+      expect(result.details.error).toBe("persistence_failed");
+      expect(await gateway.execute("after", { search: "provisional", regex: true })).toEqual(searchBefore);
+      for (const map of [state.toolMetadata, state.promptMetadata, state.serverInstructions, state.resourceCounts, state.directToolCounts]) expect(map.has("demo")).toBe(false);
+      expect(state.promptMetadataLive.has("demo")).toBe(false);
+      expect(state.serverInstructions.get("prior")).toBe("prior");
+      expect(state.config.mcpServers.demo).toBeUndefined();
+      expect(state.lifecycle.unregisterServer).toHaveBeenCalledWith("demo");
+      expect(state.manager.close).toHaveBeenCalledWith("demo");
+      expect(api.registerCommand.mock.calls.some(([name]: [string]) => name === "demo-prompt")).toBe(false);
+      expect(readFileSync(cache.getMetadataCachePath(), "utf8")).toBe(before);
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("rolls back provisional runtime state when endpoint validation fails", async () => {
@@ -1010,10 +1137,10 @@ describe("mcpAdapter session lifecycle", () => {
     expect(result.details).toMatchObject({ mode: "install", error: "validation_failed" });
   });
 
-  it("reports direct tools discovered by proxy connect as addedToolNames without rewriting active tools", async () => {
+  it.each(["connect", "install"])("reports direct tools discovered by proxy %s as addedToolNames without rewriting active tools", async (action) => {
     const config = {
       mcpServers: {
-        demo: { command: "demo", directTools: true },
+        demo: { url: "https://demo.example.com/mcp", directTools: true },
       },
     };
     const state = createState();
@@ -1044,9 +1171,11 @@ describe("mcpAdapter session lifecycle", () => {
     const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
     const activeBeforeConnect = activeTools();
 
-    const result = await proxyTool.execute("call-1", { connect: "demo" });
+    const result = await proxyTool.execute("call-1", action === "connect" ? { connect: "demo" }
+      : { action: "install", url: config.mcpServers.demo.url }, undefined, undefined, { cwd: "/tmp/project" });
 
-    expect(result).toMatchObject({ content: connectResult.content, details: connectResult.details });
+    if (action === "connect") expect(result).toMatchObject({ content: connectResult.content, details: connectResult.details });
+    else expect(result.details).toMatchObject({ mode: "install", status: "connected" });
     expect(result.addedToolNames).toEqual(["demo_search", "demo_read"]);
     expect(activeTools()).toEqual([...activeBeforeConnect, "demo_search", "demo_read"]);
     expect(api.setActiveTools).not.toHaveBeenCalled();
@@ -2719,8 +2848,8 @@ describe("directTools: \"search\" — registered inactive, activated by search",
     expect(activeTools()).toEqual(["bash", "mcp"]); // search is the only load point
   });
 
-  it("connect does not report held-inactive search-mode tools as loaded", async () => {
-    const config = { settings: { scriptMode: false }, mcpServers: { demo: { command: "demo", directTools: "search" } } };
+  it.each(["connect", "install"])("%s does not report held-inactive search-mode tools as loaded", async (action) => {
+    const config = { settings: { scriptMode: false }, mcpServers: { demo: { url: "https://demo.example/mcp", directTools: "search" } } };
     const state = createState();
     state.config = config;
     mocks.loadMcpConfig.mockReturnValue(config);
@@ -2742,7 +2871,8 @@ describe("directTools: \"search\" — registered inactive, activated by search",
     await Promise.resolve();
     await Promise.resolve();
     const proxyTool = api.registerTool.mock.calls.find((call: any[]) => call[0].name === "mcp")?.[0];
-    const result = await proxyTool.execute("call-1", { connect: "demo" });
+    const result = await proxyTool.execute("call-1", action === "connect" ? { connect: "demo" }
+      : { action: "install", url: config.mcpServers.demo.url }, undefined, undefined, { cwd: "/tmp/project" });
     expect(result.addedToolNames).toBeUndefined(); // nothing loaded yet — search is the load point
     expect(activeTools()).toEqual(["bash", "mcp"]); // registered, held inactive
   });

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -961,7 +961,7 @@ describe("mcpAdapter session lifecycle", () => {
       "forex",
       { url: "https://forex-dev.1above.io/mcp" },
     );
-    expect(mocks.executeAuthStart).toHaveBeenCalledWith(state, "forex");
+    expect(mocks.executeAuthStart).toHaveBeenCalledWith(state, "forex", undefined);
     expect(result.details).toMatchObject({ mode: "install", status: "awaiting_auth", server: "forex" });
     expect(result.details.path).toBe("/tmp/project/.mcp.json");
   });

--- a/__tests__/index-lifecycle.test.ts
+++ b/__tests__/index-lifecycle.test.ts
@@ -927,6 +927,7 @@ describe("mcpAdapter session lifecycle", () => {
       { url: "https://demo.example.com/mcp" },
     );
     expect(result.details).toMatchObject({ mode: "install", status: "connected", server: "demo" });
+    expect(result.details.path).toBe("/tmp/agent/mcp.json");
   });
 
   it("persists an OAuth MCP URL and starts watched authorization", async () => {
@@ -962,6 +963,7 @@ describe("mcpAdapter session lifecycle", () => {
     );
     expect(mocks.executeAuthStart).toHaveBeenCalledWith(state, "forex");
     expect(result.details).toMatchObject({ mode: "install", status: "awaiting_auth", server: "forex" });
+    expect(result.details.path).toBe("/tmp/project/.mcp.json");
   });
 
   it("reuses the configured name for an already installed URL", async () => {
@@ -988,6 +990,7 @@ describe("mcpAdapter session lifecycle", () => {
     expect(mocks.executeConnect).toHaveBeenCalledWith(state, "forex", undefined);
     expect(mocks.writeSharedServerEntry).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({ mode: "install", status: "connected", server: "forex" });
+    expect(result.details).not.toHaveProperty("path");
   });
 
   it("rejects an inactive project target before provisional registration or connection", async () => {

--- a/__tests__/mcp-install.test.ts
+++ b/__tests__/mcp-install.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { canonicalMcpServerUrl, normalizeMcpInstallRequest } from "../mcp-install.ts";
+
+describe("single-URL MCP installation", () => {
+  it("normalizes HTTPS endpoints and derives a stable server name", () => {
+    expect(normalizeMcpInstallRequest({ url: " https://forex-dev.1above.io/mcp " })).toEqual({
+      url: "https://forex-dev.1above.io/mcp",
+      serverName: "forex-dev",
+    });
+  });
+
+  it("accepts an explicit safe server name", () => {
+    expect(normalizeMcpInstallRequest({
+      url: "https://forex-dev.1above.io/mcp",
+      serverName: "forex",
+    }).serverName).toBe("forex");
+  });
+
+  it("allows loopback HTTP without allowing remote plaintext HTTP", () => {
+    expect(normalizeMcpInstallRequest({ url: "http://127.0.0.1:3000/mcp" }).serverName).toBe("local-mcp");
+    expect(() => normalizeMcpInstallRequest({ url: "http://example.com/mcp" })).toThrow("must use HTTPS");
+  });
+
+  it.each([
+    "https://user:secret@example.com/mcp",
+    "https://example.com/mcp#token",
+    "file:///tmp/mcp.sock",
+  ])("rejects unsafe endpoint %s", (url) => {
+    expect(() => normalizeMcpInstallRequest({ url })).toThrow();
+  });
+
+  it("rejects unsafe explicit names", () => {
+    expect(() => normalizeMcpInstallRequest({
+      url: "https://example.com/mcp",
+      serverName: "../../server",
+    })).toThrow("server name");
+  });
+
+  it("canonicalizes comparable existing URLs", () => {
+    expect(canonicalMcpServerUrl("https://example.com")).toBe("https://example.com/");
+    expect(canonicalMcpServerUrl("not a URL")).toBeUndefined();
+  });
+});

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -120,6 +120,40 @@ describe("manual OAuth proxy actions", () => {
     );
   });
 
+  it.each(["before-close", "during-close"])("does not publish background completion after owner cancellation %s", async (boundary) => {
+    const controller = new AbortController();
+    let finishAuth!: (status: string) => void;
+    mocks.authenticate.mockImplementationOnce(() => new Promise<string>((resolve) => { finishAuth = resolve; }));
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+    const state = createState({ owner: { signal: controller.signal } });
+    if (boundary === "during-close") state.manager.close.mockImplementation(async () => { controller.abort(); });
+
+    await executeAuthStart(state, "demo");
+    if (boundary === "before-close") controller.abort();
+    finishAuth("authenticated");
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    if (boundary === "before-close") expect(state.manager.close).not.toHaveBeenCalled();
+    expect(mocks.clearFailure).not.toHaveBeenCalled();
+    expect(mocks.updateStatusBar).not.toHaveBeenCalled();
+    expect(state.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not publish failure when the owner stops during the credential recheck", async () => {
+    const controller = new AbortController();
+    mocks.authenticate.mockRejectedValueOnce(new Error("authentication failed"));
+    mocks.getAuthStatus.mockImplementationOnce(async () => {
+      controller.abort();
+      return "not_authenticated";
+    });
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+    const state = createState({ owner: { signal: controller.signal } });
+    await executeAuthStart(state, "demo");
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mocks.getAuthStatus).toHaveBeenCalled();
+    expect(state.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("deduplicates repeated background callback watchers", async () => {
     const { executeAuthStart } = await import("../proxy-modes.ts");
     const state = createState();

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
   completeAuthFromInput: vi.fn(),
+  getAuthStatus: vi.fn(),
   startAuth: vi.fn(),
   supportsOAuth: vi.fn(),
   lazyConnect: vi.fn(),
@@ -14,8 +16,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../mcp-auth-flow.ts", () => ({
-  authenticate: vi.fn(),
+  authenticate: mocks.authenticate,
   completeAuthFromInput: mocks.completeAuthFromInput,
+  getAuthStatus: mocks.getAuthStatus,
   startAuth: mocks.startAuth,
   supportsOAuth: mocks.supportsOAuth,
 }));
@@ -31,6 +34,7 @@ vi.mock("../init.ts", () => ({
 }));
 
 function createState(overrides: Record<string, unknown> = {}) {
+  const ownerController = new AbortController();
   return {
     config: {
       settings: {},
@@ -40,7 +44,11 @@ function createState(overrides: Record<string, unknown> = {}) {
       },
     },
     manager: { close: vi.fn(async () => {}) },
+    owner: { signal: ownerController.signal, isActive: () => true },
     oauthRuntime: { signal: new AbortController().signal },
+    authStorageOptions: {},
+    openBrowser: vi.fn(async () => {}),
+    sendMessage: vi.fn(),
     toolMetadata: new Map(),
     failureTracker: new Map([["demo", Date.now()]]),
     failureMessages: new Map([["demo", "stale failure"]]),
@@ -51,7 +59,9 @@ function createState(overrides: Record<string, unknown> = {}) {
 describe("manual OAuth proxy actions", () => {
   beforeEach(() => {
     vi.resetModules();
+    mocks.authenticate.mockReset().mockImplementation(() => new Promise(() => {}));
     mocks.completeAuthFromInput.mockReset().mockResolvedValue("authenticated");
+    mocks.getAuthStatus.mockReset().mockResolvedValue("not_authenticated");
     mocks.startAuth.mockReset().mockResolvedValue({
       authorizationUrl: "https://auth.example.com/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A19876%2Fcallback",
     });
@@ -73,9 +83,16 @@ describe("manual OAuth proxy actions", () => {
       "demo",
       "https://api.example.com/mcp",
       state.config.mcpServers.demo,
-      { runtime: state.oauthRuntime },
+      { authStorageOptions: state.authStorageOptions, signal: state.owner.signal, runtime: state.oauthRuntime },
     );
-    expect(result.content[0].text).toContain("Open this URL in your local browser");
+    expect(mocks.authenticate).toHaveBeenCalledWith(
+      "demo",
+      "https://api.example.com/mcp",
+      state.config.mcpServers.demo,
+      { authStorageOptions: state.authStorageOptions, runtime: state.oauthRuntime, openAuthorizationUrl: state.openBrowser },
+    );
+    expect(result.content[0].text).toContain("attempting to open this authorization URL");
+    expect(result.content[0].text).toContain("watching for its callback");
     expect(result.content[0].text).toContain("https://auth.example.com/authorize");
     expect(result.content[0].text).toContain("auth-complete");
     expect(result.content[0].text).toContain('args: { redirectUrl: "PASTE_REDIRECT_URL_HERE" }');
@@ -84,14 +101,47 @@ describe("manual OAuth proxy actions", () => {
     expect(result.details).toMatchObject({ mode: "auth-start", server: "demo" });
   });
 
+  it("reports background callback completion and resets connection state", async () => {
+    mocks.authenticate.mockResolvedValueOnce("authenticated");
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+    const state = createState();
+
+    await executeAuthStart(state, "demo");
+
+    await vi.waitFor(() => expect(state.manager.close).toHaveBeenCalledWith("demo"));
+    expect(state.failureTracker.has("demo")).toBe(false);
+    expect(mocks.updateStatusBar).toHaveBeenCalledWith(state);
+    expect(state.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "mcp-oauth-status",
+        details: { server: "demo", status: "authenticated" },
+      }),
+      { triggerTurn: true },
+    );
+  });
+
+  it("deduplicates repeated background callback watchers", async () => {
+    const { executeAuthStart } = await import("../proxy-modes.ts");
+    const state = createState();
+
+    await executeAuthStart(state, "demo");
+    await executeAuthStart(state, "demo");
+
+    expect(mocks.startAuth).toHaveBeenCalledTimes(2);
+    expect(mocks.authenticate).toHaveBeenCalledTimes(1);
+  });
+
   it("explains manual completion for pre-registered HTTPS callbacks", async () => {
     mocks.startAuth.mockResolvedValueOnce({
       authorizationUrl: "https://auth.example.com/authorize?redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback",
     });
     const { executeAuthStart } = await import("../proxy-modes.ts");
 
-    const result = await executeAuthStart(createState(), "demo");
+    const state = createState();
+    const result = await executeAuthStart(state, "demo");
 
+    expect(mocks.authenticate).not.toHaveBeenCalled();
+    expect(state.openBrowser).toHaveBeenCalledWith(expect.stringContaining("https://auth.example.com/authorize"));
     expect(result.content[0].text).toContain("pre-registered HTTPS callback");
     expect(result.content[0].text).toContain("even if the destination page reports an error");
     expect(result.content[0].text).toContain("Remote HTTPS callbacks must include the full callback URL");
@@ -118,7 +168,7 @@ describe("manual OAuth proxy actions", () => {
     expect(mocks.completeAuthFromInput).toHaveBeenCalledWith(
       "demo",
       "http://localhost:19876/callback?code=abc&state=state",
-      { runtime: state.oauthRuntime },
+      { authStorageOptions: state.authStorageOptions, signal: state.owner.signal, runtime: state.oauthRuntime },
     );
     expect(state.manager.close).toHaveBeenCalledWith("demo");
     expect(state.failureTracker.has("demo")).toBe(false);

--- a/__tests__/proxy-modes-manual-auth.test.ts
+++ b/__tests__/proxy-modes-manual-auth.test.ts
@@ -114,7 +114,7 @@ describe("manual OAuth proxy actions", () => {
     expect(state.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         customType: "mcp-oauth-status",
-        details: { server: "demo", status: "authenticated" },
+        details: expect.objectContaining({ server: "demo", status: "authenticated" }),
       }),
       { triggerTurn: true },
     );

--- a/__tests__/server-manager-oauth-service-headers.test.ts
+++ b/__tests__/server-manager-oauth-service-headers.test.ts
@@ -180,6 +180,9 @@ it("signs connection-owned cross-origin token and MCP requests, but not provider
       requestHeadersCommand: { command: process.execPath, args: [script] },
     });
     expect(connection.status).toBe("connected");
+    // The SDK opens its GET stream asynchronously. Let its signer reach fetch
+    // before teardown can cancel it between logging and request observation.
+    await expect.poll(() => seen.some(request => request.url === `${origin}/mcp` && request.method === "GET")).toBe(true);
     await manager.closeAll();
     const metadata = seen.filter(request => request.url === metadataUrl);
     expect(metadata.length).toBeGreaterThan(0);

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -309,7 +309,7 @@ export function resolveDirectTools(
  * `mcp({ instructions })`.
  */
 export function buildProxyDescription(config: McpConfig): string {
-  let desc = `MCP gateway — server status, tool search/describe, auth, and single MCP tool calls. When one request needs several MCP calls with logic between them, use mcpScript. Non-MCP Pi tools should be called directly, not through mcp.\n`;
+  let desc = `MCP gateway — URL installation, server status, tool search/describe, auth, and single MCP tool calls. When a user supplies an MCP endpoint URL, install it with the install action. When one request needs several MCP calls with logic between them, use mcpScript. Non-MCP Pi tools should be called directly, not through mcp.\n`;
 
   const serverNames = Object.keys(config.mcpServers)
     .filter((serverName) => !isServerDisabled(config.mcpServers[serverName]));
@@ -336,6 +336,7 @@ export function buildProxyDescription(config: McpConfig): string {
   }
 
   desc += `\nUsage:\n`;
+  desc += `  mcp({ action: "install", url: "https://example.com/mcp" }) → Install, connect, and authenticate an MCP URL\n`;
   desc += `  mcp({ })                              → Show server status and tool counts\n`;
   desc += `  mcp({ server: "name" })               → List tools from server\n`;
   desc += `  mcp({ search: "query" })              → Search MCP tools by name/description\n`;
@@ -344,7 +345,7 @@ export function buildProxyDescription(config: McpConfig): string {
   desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`;
   desc += `  mcp({ tool: "name", args: { key: "value" } })         → Call a tool (object args; JSON string also accepted)\n`;
   desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`;
-  desc += `  mcp({ action: "auth-start", server: "name" })      → Start manual OAuth and get a browser URL\n`;
+  desc += `  mcp({ action: "auth-start", server: "name" })      → Open OAuth and watch for completion\n`;
   desc += `  mcp({ action: "auth-complete", server: "name", args: { redirectUrl: "..." } }) → Complete manual OAuth\n`;
   desc += `\nMode: action > tool (call) > connect > describe > instructions > search > server (list) > nothing (status)`;
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { AgentToolUpdateCallback, ExtensionAPI, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue, type AgentToolUpdateCallback, type ExtensionAPI, type ExtensionContext, type ToolInfo } from "@earendil-works/pi-coding-agent";
 import { resolve } from "node:path";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpAdapterOptions, McpConfig, PromptMetadata, ServerEntry } from "./types.ts";
@@ -6,9 +6,9 @@ import type { McpOAuthRuntime } from "./mcp-auth-flow.ts";
 import { Type } from "typebox";
 import type { TSchema } from "typebox";
 import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, authenticateServer, logoutServer, manageBearerToken, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
-import { cloneMcpConfig, discoverConfiguredClaudePluginSkills, loadMcpConfig, resolveConfiguredClaudePluginMcp, writeProjectServerDisabledOverride } from "./config.ts";
+import { cloneMcpConfig, discoverConfiguredClaudePluginSkills, getPiGlobalConfigPath, getProjectConfigPath, loadMcpConfig, resolveConfiguredClaudePluginMcp, writeProjectServerDisabledOverride, writeSharedServerEntry } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, prepareDirectToolArguments, resolveDirectTools } from "./direct-tools.ts";
-import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
+import { clearFailure, flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
@@ -24,6 +24,7 @@ import { runMcpScript } from "./mcp-code.ts";
 import { cleanupMaterializedBinaryResources } from "./tool-registrar.ts";
 import { syncNamespaceProxyTools } from "./namespace-tools.ts";
 import { restoreSessionApprovalState } from "./session-approvals.ts";
+import { canonicalMcpServerUrl, normalizeMcpInstallRequest } from "./mcp-install.ts";
 
 export type { McpAdapterOptions } from "./types.ts";
 export type { ServerEntry } from "./types.ts";
@@ -1166,12 +1167,147 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     });
   }
 
+  async function executeInstall(
+    targetState: McpExtensionState,
+    rawUrl: string | undefined,
+    requestedName: string | undefined,
+    target: string | undefined,
+    cwd: string,
+    signal?: AbortSignal,
+  ) {
+    if (programmaticConfig) {
+      return {
+        content: [{ type: "text" as const, text: "MCP install is unavailable when the adapter uses programmatic configuration." }],
+        details: { mode: "install", error: "programmatic_config" },
+      };
+    }
+    if (target !== undefined && target !== "global" && target !== "project") {
+      return {
+        content: [{ type: "text" as const, text: "MCP install target must be 'global' or 'project'." }],
+        details: { mode: "install", error: "invalid_target" },
+      };
+    }
+
+    let normalized: ReturnType<typeof normalizeMcpInstallRequest>;
+    try {
+      normalized = normalizeMcpInstallRequest({
+        url: rawUrl ?? "",
+        ...(requestedName !== undefined ? { serverName: requestedName } : {}),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text" as const, text: `Failed to install MCP server: ${message}` }],
+        details: { mode: "install", error: "invalid_request", message },
+      };
+    }
+
+    const matchingUrl = Object.entries(targetState.config.mcpServers).find(([, definition]) =>
+      definition.url !== undefined && canonicalMcpServerUrl(definition.url) === normalized.url,
+    );
+    const serverName = requestedName?.trim() || matchingUrl?.[0] || normalized.serverName;
+    const existing = targetState.config.mcpServers[serverName];
+    if (existing && canonicalMcpServerUrl(existing.url ?? "") !== normalized.url) {
+      return {
+        content: [{ type: "text" as const, text: `MCP server name "${serverName}" is already configured with a different endpoint.` }],
+        details: { mode: "install", error: "name_conflict", server: serverName, url: normalized.url },
+      };
+    }
+
+    const persistedEntry: ServerEntry = { url: normalized.url };
+    const runtimeEntry: ServerEntry = existing ?? { ...persistedEntry, directTools: false };
+    const provisional = existing === undefined;
+    const persistenceRequired = provisional || runtimeServers.has(serverName);
+    if (provisional) {
+      targetState.config.mcpServers[serverName] = runtimeEntry;
+      attachRuntimeServerLifecycle(targetState, serverName, runtimeEntry);
+      syncToolSurface();
+      updateStatusBar(targetState);
+    }
+
+    const rollback = async (): Promise<void> => {
+      if (!provisional || targetState.config.mcpServers[serverName] !== runtimeEntry) return;
+      delete targetState.config.mcpServers[serverName];
+      targetState.lifecycle.unregisterServer(serverName);
+      await targetState.manager.close(serverName);
+      clearFailure(targetState, serverName, "install-rollback");
+      syncToolSurface();
+      updateStatusBar(targetState);
+    };
+
+    const connectResult = signal
+      ? await executeConnect(targetState, serverName, signal)
+      : await executeConnect(targetState, serverName);
+    const connectDetails = connectResult.details as { error?: string } | undefined;
+    const connectText = connectResult.content.find((content) => content.type === "text")?.text;
+    if (connectDetails?.error && connectDetails.error !== "auth_required") {
+      await rollback();
+      return {
+        content: [{ type: "text" as const, text: `MCP installation validation failed for "${serverName}". ${connectText ?? "Connection failed."}` }],
+        details: { mode: "install", error: "validation_failed", server: serverName, url: normalized.url },
+      };
+    }
+
+    let persistedPath: string | undefined;
+    if (persistenceRequired) {
+      persistedPath = target === "project" ? getProjectConfigPath(cwd) : getPiGlobalConfigPath(earlyConfigPath);
+      try {
+        await withFileMutationQueue(persistedPath, async () => {
+          writeSharedServerEntry(persistedPath!, serverName, persistedEntry);
+        });
+      } catch (error) {
+        await rollback();
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `MCP server validation succeeded, but configuration could not be saved: ${message}` }],
+          details: { mode: "install", error: "persistence_failed", server: serverName, url: normalized.url, message },
+        };
+      }
+    }
+
+    if (connectDetails?.error === "auth_required") {
+      const authResult = signal
+        ? await executeAuthStart(targetState, serverName, signal)
+        : await executeAuthStart(targetState, serverName);
+      const authDetails = authResult.details as { error?: string } | undefined;
+      const authText = authResult.content.find((content) => content.type === "text")?.text;
+      return {
+        content: [{
+          type: "text" as const,
+          text: `${persistenceRequired ? "Installed" : "Found"} MCP server "${serverName}" at ${normalized.url}.\n\n${authText ?? "OAuth authorization is required."}`,
+        }],
+        details: {
+          mode: "install",
+          status: authDetails?.error ? "auth_start_failed" : "awaiting_auth",
+          server: serverName,
+          url: normalized.url,
+          ...(persistedPath ? { path: persistedPath } : {}),
+          ...(authDetails?.error ? { error: authDetails.error } : {}),
+        },
+      };
+    }
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: `${persistenceRequired ? "Installed and connected" : "Already installed; connected"} MCP server "${serverName}" at ${normalized.url}.\n\n${connectText ?? ""}`.trim(),
+      }],
+      details: {
+        mode: "install",
+        status: "connected",
+        server: serverName,
+        url: normalized.url,
+        ...(persistedPath ? { path: persistedPath } : {}),
+      },
+    };
+  }
+
   function registerProxyTool(description: string): void {
     (pi.registerTool as (tool: unknown) => unknown)({
       name: "mcp",
       label: "MCP",
       description,
-      promptSnippet: "MCP gateway — status, search, describe, auth, and single MCP tool calls",
+      promptSnippet: "MCP gateway — install by URL, status, search, describe, auth, and single MCP tool calls",
       renderShell: toolRenderShell,
       renderCall: createMcpProxyToolCallRenderer(toolRenderOptions),
       parameters: Type.Object({
@@ -1191,8 +1327,10 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         includeSchemas: Type.Optional(Type.Boolean({ description: "Include parameter schemas in search results (default: true)" })),
         limit: optionalNumber({ minimum: 1, description: "Maximum search results to return (default: 12)" }),
         offset: optionalNumber({ minimum: 0, description: "Search result offset (default: 0)" }),
-        server: Type.Optional(Type.String({ description: "Filter to specific server (also disambiguates tool calls)" })),
-        action: Type.Optional(Type.String({ description: "Action: 'ui-messages', 'auth-start', or 'auth-complete'" })),
+        server: Type.Optional(Type.String({ description: "Server name (filters/disambiguates calls and optionally names an install)" })),
+        action: Type.Optional(Type.String({ description: "Action: 'install', 'ui-messages', 'auth-start', or 'auth-complete'" })),
+        url: Type.Optional(Type.String({ description: "MCP endpoint URL for action: 'install'" })),
+        target: Type.Optional(Type.String({ description: "Install target: 'global' (default) or 'project'" })),
       }),
       renderResult: renderMcpToolResult,
       async execute(_toolCallId: string, params: {
@@ -1208,6 +1346,8 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         offset?: number;
         server?: string;
         action?: string;
+        url?: string;
+        target?: string;
       }, signal: AbortSignal | undefined, _onUpdate: AgentToolUpdateCallback<Record<string, unknown>> | undefined, _ctx: ExtensionContext) {
         let executeOwner = currentOwner;
         const parseArgs = (value: string | Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
@@ -1240,7 +1380,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           || value.instructions !== undefined
           || value.search !== undefined
           || value.server !== undefined
-          || value.action !== undefined;
+          || value.action !== undefined
+          || value.url !== undefined
+          || value.target !== undefined;
         if (!hasGatewayMode(params) && params.args !== undefined) {
           throw new Error("Gateway params were nested inside `args`; pass them top-level (for example, mcp({ search: \"...\" }) or mcp({ tool: \"...\", args: {} })).");
         }
@@ -1280,6 +1422,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         }
         executeOwner?.throwIfInactive();
 
+        if (params.action === "install") {
+          return executeInstall(state, params.url, params.server, params.target, _ctx.cwd, signal);
+        }
         if (params.action === "ui-messages") {
           return executeUiMessages(state);
         }

--- a/index.ts
+++ b/index.ts
@@ -1262,7 +1262,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     const persistedEntry: ServerEntry = { url: normalized.url };
     const runtimeEntry: ServerEntry = existing ?? { ...persistedEntry, directTools: false };
     const provisional = existing === undefined;
-    const persistenceRequired = provisional;
     const restoreMetadata = [targetState.toolMetadata, targetState.promptMetadata, targetState.serverInstructions,
       targetState.resourceCounts, targetState.directToolCounts].map((map) => {
       const previous = map.get(serverName);
@@ -1316,14 +1315,12 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       };
     }
 
-    let persistedPath: string | undefined;
-    if (persistenceRequired) {
-      persistedPath = destination;
+    if (provisional) {
       try {
-        await withFileMutationQueue(persistedPath, async () => {
+        await withFileMutationQueue(destination, async () => {
           signal?.throwIfAborted();
           installOwner?.throwIfInactive();
-          writeSharedServerEntry(persistedPath!, serverName, persistedEntry);
+          writeSharedServerEntry(destination, serverName, persistedEntry);
         });
       } catch (error) {
         await rollback();
@@ -1333,10 +1330,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           details: { mode: "install", error: "persistence_failed", server: serverName, url: normalized.url, message },
         };
       }
-    }
-
-    targetState.provisionalInstalls?.delete(serverName);
-    if (provisional) {
+      targetState.provisionalInstalls?.delete(serverName);
       try {
         updateMetadataCache(targetState, serverName);
       } catch (error) {
@@ -1355,14 +1349,14 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         ...connectResult,
         content: [{
           type: "text" as const,
-          text: `${persistenceRequired ? "Installed" : "Found"} MCP server "${serverName}" at ${normalized.url}.\n\n${authText ?? "OAuth authorization is required."}`,
+          text: `${provisional ? "Installed" : "Found"} MCP server "${serverName}" at ${normalized.url}.\n\n${authText ?? "OAuth authorization is required."}`,
         }],
         details: {
           mode: "install",
           status: authDetails?.error ? "auth_start_failed" : "awaiting_auth",
           server: serverName,
           url: normalized.url,
-          ...(persistedPath ? { path: persistedPath } : {}),
+          ...(provisional ? { path: destination } : {}),
           ...(authDetails?.error ? { error: authDetails.error } : {}),
         },
       };
@@ -1372,14 +1366,14 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       ...connectResult,
       content: [{
         type: "text" as const,
-        text: `${persistenceRequired ? "Installed and connected" : "Already installed; connected"} MCP server "${serverName}" at ${normalized.url}.\n\n${connectText ?? ""}`.trim(),
+        text: `${provisional ? "Installed and connected" : "Already installed; connected"} MCP server "${serverName}" at ${normalized.url}.\n\n${connectText ?? ""}`.trim(),
       }],
       details: {
         mode: "install",
         status: "connected",
         server: serverName,
         url: normalized.url,
-        ...(persistedPath ? { path: persistedPath } : {}),
+        ...(provisional ? { path: destination } : {}),
       },
     };
   }

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import type { TSchema } from "typebox";
 import { showStatus, showTools, showPrompts, reconnectServer, reconnectServers, authenticateServer, logoutServer, manageBearerToken, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { cloneMcpConfig, discoverConfiguredClaudePluginSkills, getPiGlobalConfigPath, getProjectConfigPath, loadMcpConfig, resolveConfiguredClaudePluginMcp, writeProjectServerDisabledOverride, writeSharedServerEntry } from "./config.ts";
 import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, prepareDirectToolArguments, resolveDirectTools } from "./direct-tools.ts";
-import { clearFailure, flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
+import { clearFailure, flushMetadataCache, initializeMcp, updateMetadataCache, updateStatusBar } from "./init.ts";
 import { isServerInActiveFailureBackoff } from "./failure-backoff.ts";
 import { loadMetadataCache, parseDirectToolSelectors, type MetadataCache } from "./metadata-cache.ts";
 import { createPromptCommand, resolveCachedPrompts } from "./prompts.ts";
@@ -555,7 +555,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
   }
 
   function syncPromptCommands(): void {
-    registerPromptCommands([...(state?.promptMetadata?.values() ?? [])].flat());
+    registerPromptCommands([...(state?.promptMetadata?.entries() ?? [])]
+      .filter(([name]) => !state?.provisionalInstalls?.has(name))
+      .flatMap(([, prompts]) => prompts));
   }
 
   registerPromptCommands(resolveCachedPrompts(earlyConfig));
@@ -1167,6 +1169,24 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     });
   }
 
+  async function connectAndReport(targetState: McpExtensionState, serverName: string, signal?: AbortSignal, ctx?: ExtensionContext): Promise<Awaited<ReturnType<typeof executeConnect>> & { addedToolNames?: string[] }> {
+    const directToolsBefore = new Map([...registeredDirectTools.keys()].map((name) => [name, registeredDirectToolVersions.get(name) ?? 0]));
+    const result = await executeConnect(targetState, serverName, signal);
+    if (!directToolsFrozen) syncToolSurface(ctx);
+    const reportedNames = reportedDirectToolNamesByServer.get(serverName) ?? new Set<string>();
+    // Attribute only this server's new definitions; search-mode tools load on search, not connect.
+    const addedToolNames = [...registeredDirectTools.keys()].filter(
+      (name) => (!directToolsBefore.has(name) || (registeredDirectToolVersions.get(name) ?? 0) !== directToolsBefore.get(name))
+        && registeredDirectToolServers.get(name) === serverName
+        && !reportedNames.has(name)
+        && !lazyDirectTools.has(name),
+    );
+    if (addedToolNames.length === 0) return result;
+    for (const name of addedToolNames) reportedNames.add(name);
+    reportedDirectToolNamesByServer.set(serverName, reportedNames);
+    return { ...result, addedToolNames };
+  }
+
   async function executeInstall(
     targetState: McpExtensionState,
     rawUrl: string | undefined,
@@ -1175,6 +1195,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     cwd: string,
     signal?: AbortSignal,
   ) {
+    const installOwner = currentOwner;
+    signal?.throwIfAborted();
+    installOwner?.throwIfInactive();
     if (programmaticConfig) {
       return {
         content: [{ type: "text" as const, text: "MCP install is unavailable when the adapter uses programmatic configuration." }],
@@ -1185,6 +1208,15 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       return {
         content: [{ type: "text" as const, text: "MCP install target must be 'global' or 'project'." }],
         details: { mode: "install", error: "invalid_target" },
+      };
+    }
+
+    const destination = target === "project" ? getProjectConfigPath(cwd) : getPiGlobalConfigPath(earlyConfigPath);
+    if (target === "project" && process.env.PI_MCP_CONFIG_MODE?.trim().toLowerCase() === "exclusive"
+      && resolve(destination) !== resolve(getPiGlobalConfigPath(earlyConfigPath))) {
+      return {
+        content: [{ type: "text" as const, text: "Project installation is unavailable in exclusive config mode; use the global target." }],
+        details: { mode: "install", error: "inactive_target" },
       };
     }
 
@@ -1214,11 +1246,34 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       };
     }
 
+    if (targetState.provisionalInstalls?.has(serverName)) {
+      return {
+        content: [{ type: "text" as const, text: `MCP server "${serverName}" is still being installed. Retry after that installation finishes.` }],
+        details: { mode: "install", error: "install_in_progress", server: serverName },
+      };
+    }
+    if (runtimeServers.has(serverName)) {
+      return {
+        content: [{ type: "text" as const, text: `Runtime MCP server "${serverName}" cannot be promoted by URL install. Save its full definition manually.` }],
+        details: { mode: "install", error: "runtime_promotion_unsupported", server: serverName },
+      };
+    }
+
     const persistedEntry: ServerEntry = { url: normalized.url };
     const runtimeEntry: ServerEntry = existing ?? { ...persistedEntry, directTools: false };
     const provisional = existing === undefined;
-    const persistenceRequired = provisional || runtimeServers.has(serverName);
+    const persistenceRequired = provisional;
+    const restoreMetadata = [targetState.toolMetadata, targetState.promptMetadata, targetState.serverInstructions,
+      targetState.resourceCounts, targetState.directToolCounts].map((map) => {
+      const previous = map.get(serverName);
+      return () => {
+        if (previous === undefined) map.delete(serverName);
+        else (map as Map<string, unknown>).set(serverName, previous);
+      };
+    });
+    const hadLivePrompts = targetState.promptMetadataLive.has(serverName);
     if (provisional) {
+      (targetState.provisionalInstalls ??= new Set()).add(serverName);
       targetState.config.mcpServers[serverName] = runtimeEntry;
       attachRuntimeServerLifecycle(targetState, serverName, runtimeEntry);
       syncToolSurface();
@@ -1229,20 +1284,33 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       if (!provisional || targetState.config.mcpServers[serverName] !== runtimeEntry) return;
       delete targetState.config.mcpServers[serverName];
       targetState.lifecycle.unregisterServer(serverName);
-      await targetState.manager.close(serverName);
-      clearFailure(targetState, serverName, "install-rollback");
-      syncToolSurface();
-      updateStatusBar(targetState);
+      try {
+        await targetState.manager.close(serverName);
+      } finally {
+        targetState.provisionalInstalls?.delete(serverName);
+        for (const restore of restoreMetadata) restore();
+        if (!hadLivePrompts) targetState.promptMetadataLive.delete(serverName);
+        clearFailure(targetState, serverName, "install-rollback");
+        syncToolSurface();
+        updateStatusBar(targetState);
+      }
     };
 
-    const connectResult = signal
-      ? await executeConnect(targetState, serverName, signal)
-      : await executeConnect(targetState, serverName);
+    let connectResult: Awaited<ReturnType<typeof connectAndReport>>;
+    try {
+      connectResult = await connectAndReport(targetState, serverName, signal);
+      signal?.throwIfAborted();
+      installOwner?.throwIfInactive();
+    } catch (error) {
+      await rollback();
+      throw error;
+    }
     const connectDetails = connectResult.details as { error?: string } | undefined;
     const connectText = connectResult.content.find((content) => content.type === "text")?.text;
     if (connectDetails?.error && connectDetails.error !== "auth_required") {
       await rollback();
       return {
+        ...connectResult,
         content: [{ type: "text" as const, text: `MCP installation validation failed for "${serverName}". ${connectText ?? "Connection failed."}` }],
         details: { mode: "install", error: "validation_failed", server: serverName, url: normalized.url },
       };
@@ -1250,9 +1318,11 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
     let persistedPath: string | undefined;
     if (persistenceRequired) {
-      persistedPath = target === "project" ? getProjectConfigPath(cwd) : getPiGlobalConfigPath(earlyConfigPath);
+      persistedPath = destination;
       try {
         await withFileMutationQueue(persistedPath, async () => {
+          signal?.throwIfAborted();
+          installOwner?.throwIfInactive();
           writeSharedServerEntry(persistedPath!, serverName, persistedEntry);
         });
       } catch (error) {
@@ -1265,6 +1335,16 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       }
     }
 
+    targetState.provisionalInstalls?.delete(serverName);
+    if (provisional) {
+      try {
+        updateMetadataCache(targetState, serverName);
+      } catch (error) {
+        logger.warn(`MCP: installed "${serverName}" but could not cache metadata: ${error}`);
+      }
+      syncPromptCommands();
+    }
+
     if (connectDetails?.error === "auth_required") {
       const authResult = signal
         ? await executeAuthStart(targetState, serverName, signal)
@@ -1272,6 +1352,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       const authDetails = authResult.details as { error?: string } | undefined;
       const authText = authResult.content.find((content) => content.type === "text")?.text;
       return {
+        ...connectResult,
         content: [{
           type: "text" as const,
           text: `${persistenceRequired ? "Installed" : "Found"} MCP server "${serverName}" at ${normalized.url}.\n\n${authText ?? "OAuth authorization is required."}`,
@@ -1288,6 +1369,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
     }
 
     return {
+      ...connectResult,
       content: [{
         type: "text" as const,
         text: `${persistenceRequired ? "Installed and connected" : "Already installed; connected"} MCP server "${serverName}" at ${normalized.url}.\n\n${connectText ?? ""}`.trim(),
@@ -1461,30 +1543,7 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
           return executeCall(state, params.tool, parsedArgs, params.server, getPiTools, signal);
         }
         if (params.connect) {
-          // Direct tools discovered by this connect are registered by the
-          // metadata-update hook inside executeConnect or by the sync below.
-          // Report them on the result so Pi treats this transcript point as
-          // their load point instead of relying on an active-tool rewrite.
-          // Only this server's tools are attributed: another server's refresh
-          // or a concurrent connect can register tools while this one awaits.
-          const directToolsBefore = new Set(registeredDirectTools.keys());
-          const directToolVersionsBefore = new Map([...registeredDirectTools.keys()].map((name) => [name, registeredDirectToolVersions.get(name) ?? 0]));
-          const result = await executeConnect(state, params.connect, signal);
-          if (!directToolsFrozen) syncToolSurface(_ctx as ExtensionContext);
-          const reportedNames = reportedDirectToolNamesByServer.get(params.connect) ?? new Set<string>();
-          // A search-mode tool is registered but held inactive; it is not
-          // loaded at this point, so it must not be reported as such — a
-          // search that matches it is its load point.
-          const addedToolNames = [...registeredDirectTools.keys()].filter(
-            (name) => (!directToolsBefore.has(name) || (registeredDirectToolVersions.get(name) ?? 0) !== (directToolVersionsBefore.get(name) ?? 0))
-              && registeredDirectToolServers.get(name) === params.connect
-              && !reportedNames.has(name)
-              && !lazyDirectTools.has(name),
-          );
-          if (addedToolNames.length === 0) return result;
-          for (const name of addedToolNames) reportedNames.add(name);
-          reportedDirectToolNamesByServer.set(params.connect, reportedNames);
-          return { ...result, addedToolNames };
+          return connectAndReport(state, params.connect, signal, _ctx as ExtensionContext);
         }
         if (params.describe) {
           return executeDescribe(state, params.describe);

--- a/index.ts
+++ b/index.ts
@@ -1303,9 +1303,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       await rollback();
       throw error;
     }
-    const connectDetails = connectResult.details as { error?: string } | undefined;
+    const connectError = connectResult.details?.error;
     const connectText = connectResult.content.find((content) => content.type === "text")?.text;
-    if (connectDetails?.error && connectDetails.error !== "auth_required") {
+    if (connectError && connectError !== "auth_required") {
       await rollback();
       return {
         ...connectResult,
@@ -1338,11 +1338,9 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       syncPromptCommands();
     }
 
-    if (connectDetails?.error === "auth_required") {
-      const authResult = signal
-        ? await executeAuthStart(targetState, serverName, signal)
-        : await executeAuthStart(targetState, serverName);
-      const authDetails = authResult.details as { error?: string } | undefined;
+    if (connectError === "auth_required") {
+      const authResult = await executeAuthStart(targetState, serverName, signal);
+      const authError = authResult.details?.error;
       const authText = authResult.content.find((content) => content.type === "text")?.text;
       return {
         ...connectResult,
@@ -1352,11 +1350,11 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
         }],
         details: {
           mode: "install",
-          status: authDetails?.error ? "auth_start_failed" : "awaiting_auth",
+          status: authError ? "auth_start_failed" : "awaiting_auth",
           server: serverName,
           url: normalized.url,
           ...(provisional ? { path: destination } : {}),
-          ...(authDetails?.error ? { error: authDetails.error } : {}),
+          ...(authError ? { error: authError } : {}),
         },
       };
     }

--- a/index.ts
+++ b/index.ts
@@ -1271,14 +1271,6 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
       };
     });
     const hadLivePrompts = targetState.promptMetadataLive.has(serverName);
-    if (provisional) {
-      (targetState.provisionalInstalls ??= new Set()).add(serverName);
-      targetState.config.mcpServers[serverName] = runtimeEntry;
-      attachRuntimeServerLifecycle(targetState, serverName, runtimeEntry);
-      syncToolSurface();
-      updateStatusBar(targetState);
-    }
-
     const rollback = async (): Promise<void> => {
       if (!provisional || targetState.config.mcpServers[serverName] !== runtimeEntry) return;
       delete targetState.config.mcpServers[serverName];
@@ -1297,6 +1289,13 @@ function installMcpAdapter(pi: ExtensionAPI, options: McpAdapterOptions) {
 
     let connectResult: Awaited<ReturnType<typeof connectAndReport>>;
     try {
+      if (provisional) {
+        (targetState.provisionalInstalls ??= new Set()).add(serverName);
+        targetState.config.mcpServers[serverName] = runtimeEntry;
+        attachRuntimeServerLifecycle(targetState, serverName, runtimeEntry);
+        syncToolSurface();
+        updateStatusBar(targetState);
+      }
       connectResult = await connectAndReport(targetState, serverName, signal);
       signal?.throwIfAborted();
       installOwner?.throwIfInactive();

--- a/init.ts
+++ b/init.ts
@@ -568,6 +568,7 @@ export function updateMetadataCache(
   serverName: string,
   options: { preserveEmptyResources?: boolean } = {},
 ): void {
+  if (state.provisionalInstalls?.has(serverName)) return;
   const connection = state.manager.getConnection(serverName);
   if (!connection || connection.status !== "connected") return;
 

--- a/mcp-auth-flow.ts
+++ b/mcp-auth-flow.ts
@@ -54,6 +54,7 @@ export interface McpOAuthRuntime {
 
 export interface AuthenticateOptions {
   onAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
+  openAuthorizationUrl?: (authorizationUrl: string) => void | Promise<void>
   onAuthorizationInput?: (
     authorizationUrl: string,
     signal: AbortSignal,
@@ -961,7 +962,11 @@ export async function authenticate(
         console.log(`MCP Auth: Open this URL to authenticate ${serverName}:\n${authorizationUrl}`)
       }
       try {
-        await abortable(open(authorizationUrl), signal)
+        await abortable(Promise.resolve(
+          options.openAuthorizationUrl
+            ? options.openAuthorizationUrl(authorizationUrl)
+            : open(authorizationUrl),
+        ), signal)
       } catch (error) {
         if (isAbortError(error, signal)) throw error
         console.warn(`MCP Auth: Failed to open browser for ${serverName}; waiting for manual callback`, { error })

--- a/mcp-install.ts
+++ b/mcp-install.ts
@@ -1,0 +1,60 @@
+const SERVER_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+export interface McpInstallRequest {
+  url: string;
+  serverName?: string;
+}
+
+export interface NormalizedMcpInstallRequest {
+  url: string;
+  serverName: string;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+function deriveServerName(url: URL): string {
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const firstLabel = isLoopbackHostname(url.hostname) ? "local-mcp" : hostname.split(".")[0];
+  const normalized = (firstLabel || "mcp")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return normalized || "mcp";
+}
+
+export function normalizeMcpInstallRequest(request: McpInstallRequest): NormalizedMcpInstallRequest {
+  if (typeof request.url !== "string" || request.url.trim() === "") {
+    throw new Error("MCP install requires a non-empty URL");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(request.url.trim());
+  } catch (error) {
+    throw new Error("MCP install URL must be an absolute URL", { cause: error });
+  }
+
+  if (parsed.username || parsed.password) throw new Error("MCP install URL must not contain credentials");
+  if (parsed.hash) throw new Error("MCP install URL must not contain a fragment");
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopbackHostname(parsed.hostname))) {
+    throw new Error("MCP install URL must use HTTPS, except for loopback HTTP servers");
+  }
+
+  const serverName = request.serverName?.trim() || deriveServerName(parsed);
+  if (!SERVER_NAME_PATTERN.test(serverName)) {
+    throw new Error("MCP server name must be 1-64 letters, numbers, underscores, or hyphens and start with a letter or number");
+  }
+
+  return { url: parsed.toString(), serverName };
+}
+
+export function canonicalMcpServerUrl(value: string): string | undefined {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/mcp-local-oauth-flow.test.ts
+++ b/mcp-local-oauth-flow.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http"
 import { after, before, describe, it } from "node:test"
 
 import {
+  authenticate,
   completeAuth,
   initializeOAuth,
   shutdownOAuth,
@@ -193,6 +194,36 @@ describe("local OAuth authorization-code flow", () => {
     assert.ok(secureStorePayload.includes("example-refresh-token"))
     assert.ok(!secureStorePayload.includes(codeVerifier))
     assert.ok(!secureStorePayload.includes(state))
+  })
+
+  it("opens the authorization URL and completes from the watched loopback callback", async () => {
+    const watchedServerName = `${serverName}-watched`
+    let openedAuthorizationUrl: string | undefined
+
+    try {
+      const status = await authenticate(watchedServerName, serverUrl, {
+        url: serverUrl,
+        auth: "oauth",
+        oauth: { redirectUri: "http://127.0.0.1:{port}/callback", scope: "mcp:read" },
+      }, {
+        openAuthorizationUrl: async (authorizationUrl) => {
+          openedAuthorizationUrl = authorizationUrl
+          const authorizationRequest = new URL(authorizationUrl)
+          const callbackUrl = new URL(authorizationRequest.searchParams.get("redirect_uri")!)
+          callbackUrl.searchParams.set("code", "watched-authorization-code")
+          callbackUrl.searchParams.set("state", authorizationRequest.searchParams.get("state")!)
+          callbackUrl.searchParams.set("iss", origin)
+          const response = await fetch(callbackUrl)
+          assert.strictEqual(response.status, 200)
+        },
+      })
+
+      assert.strictEqual(status, "authenticated")
+      assert.ok(openedAuthorizationUrl)
+      assert.strictEqual(tokenRequest?.get("code"), "watched-authorization-code")
+    } finally {
+      clearAllCredentials(watchedServerName)
+    }
   })
 
   it("re-registers a stale dynamic client after a refresh invalid_grant", async () => {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "mcp-code.ts",
     "mcp-script-worker.mjs",
     "mcp-probe.ts",
+    "mcp-install.ts",
     "agent-plugin-loader.ts",
     "resource-tools.ts",
     "lifecycle.ts",

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -3,7 +3,7 @@ import { UrlElicitationRequiredError, type Client, type Progress, type RequestOp
 import { createRequire } from "node:module";
 import type { McpExtensionState } from "./state.ts";
 import type { ToolMetadata, McpContent } from "./types.ts";
-import { getServerPrefix, isServerDisabled, parseUiPromptHandoff } from "./types.ts";
+import { getServerPrefix, isServerDisabled, parseUiPromptHandoff, type ServerEntry } from "./types.ts";
 import { lazyConnect, markKeepAliveAfterConnect, notifyToolMetadataUpdated, updateServerMetadata, updateMetadataCache, getFailureAgeSeconds, updateStatusBar, clearFailure, recordFailure } from "./init.ts";
 import { abortable, throwIfAborted } from "./abort.ts";
 import { combineAbortSignals, isAbortError } from "./runtime-owner.ts";
@@ -14,7 +14,7 @@ import { resolveMcpResultContent, transformMcpContent, transformMcpResourceConte
 import { guardMcpOutput, guardedMcpDetails, resolveMcpOutputGuardOptions } from "./mcp-output-guard.ts";
 import { maybeStartUiSession, summarizeUiSessionResult, type UiSessionRuntime } from "./ui-session.ts";
 import { formatAuthRequiredMessage, formatMcpStatus, normalizeToolArguments, resolveServerUrl, truncateAtWord } from "./utils.ts";
-import { authenticate, completeAuthFromInput, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
+import { authenticate, completeAuthFromInput, getAuthStatus, startAuth, supportsOAuth } from "./mcp-auth-flow.ts";
 import { SessionRecoveryAuthRequiredError, withSessionRecovery } from "./session-recovery.ts";
 import { paginate, rankSuggestions, rankToolMatches, resolveSearchKeywords } from "./search-ranking.ts";
 import { ensureToolCallApproved, isToolCallApprovalRequired } from "./tool-approval.ts";
@@ -33,6 +33,8 @@ const REGEX_SAFETY_CHECK_PARAMS = {
   incubationTimeout: 50,
   timeout: 250,
 } as const;
+
+const backgroundAuthWatchers = new WeakMap<McpExtensionState, Map<string, Promise<void>>>();
 
 type AutoAuthResult =
   | { status: "skipped" }
@@ -128,6 +130,69 @@ function disabledResult(mode: string, serverName: string): ProxyToolResult {
   };
 }
 
+function emitAuthStatus(state: McpExtensionState, serverName: string, status: "authenticated" | "failed", message: string): void {
+  state.ui?.notify(message, status === "authenticated" ? "info" : "error");
+  state.sendMessage?.(
+    {
+      customType: "mcp-oauth-status",
+      content: [{ type: "text", text: message }],
+      display: message,
+      details: { server: serverName, status },
+    },
+    { triggerTurn: true },
+  );
+}
+
+function ensureBackgroundAuthWatcher(
+  state: McpExtensionState,
+  serverName: string,
+  serverUrl: string,
+  definition: ServerEntry,
+): void {
+  let watchers = backgroundAuthWatchers.get(state);
+  if (!watchers) {
+    watchers = new Map();
+    backgroundAuthWatchers.set(state, watchers);
+  }
+  if (watchers.has(serverName)) return;
+
+  const authOptions = {
+    authStorageOptions: state.authStorageOptions,
+    runtime: state.oauthRuntime,
+    openAuthorizationUrl: state.openBrowser,
+  };
+  const watcher = authenticate(serverName, serverUrl, definition, authOptions).then(async (status) => {
+    if (status !== "authenticated") throw new Error(`OAuth authentication ended with status: ${status}`);
+    await state.manager.close(serverName);
+    clearFailure(state, serverName, "auth-background-complete");
+    updateStatusBar(state);
+    emitAuthStatus(
+      state,
+      serverName,
+      "authenticated",
+      `OAuth authentication completed for MCP server "${serverName}".`,
+    );
+  });
+  watchers.set(serverName, watcher);
+
+  void watcher.catch(async (error) => {
+    if (isAbortError(error, state.owner.signal)) return;
+    try {
+      if (await getAuthStatus(serverName, authOptions) === "authenticated") return;
+    } catch (statusError) {
+      if (isAbortError(statusError, state.owner.signal)) return;
+    }
+    emitAuthStatus(
+      state,
+      serverName,
+      "failed",
+      `OAuth authentication failed for MCP server "${serverName}". Start authorization again or inspect trusted logs.`,
+    );
+  }).finally(() => {
+    if (watchers?.get(serverName) === watcher) watchers.delete(serverName);
+  });
+}
+
 function getAuthRequiredMessage(
   state: McpExtensionState,
   serverName: string,
@@ -165,18 +230,20 @@ function formatManualAuthInstructions(serverName: string, authorizationUrl: stri
   const redirect = getRedirectDetails(authorizationUrl);
   const redirectNote = redirect.remote
     ? "The provider uses a pre-registered HTTPS callback. Copy its full URL from the browser address bar, even if the destination page reports an error."
-    : redirect.port
-      ? `The redirect URL will use local port ${redirect.port}. On a remote server it is expected for that localhost page to fail locally; copy the address bar URL anyway.`
-      : "";
+    : `The adapter is watching${redirect.port ? ` local port ${redirect.port}` : " the local callback"} and will report when authentication completes.`;
 
   return [
     `MCP OAuth required for "${serverName}".`,
     "",
-    "Open this URL in your local browser:",
+    redirect.remote
+      ? "The adapter is attempting to open this authorization URL in your local browser:"
+      : "The adapter is attempting to open this authorization URL and watching for its callback:",
     "",
     authorizationUrl,
     "",
-    "After approving, copy the full callback URL from your browser address bar and send it back with:",
+    redirect.remote
+      ? "After approving, copy the full callback URL from your browser address bar and send it back with:"
+      : "If the browser does not open or the callback is not detected, open the URL above and complete manually with:",
     `mcp({ action: "auth-complete", server: "${serverName}", args: { redirectUrl: "PASTE_REDIRECT_URL_HERE" } })`,
     "",
     redirect.remote
@@ -464,6 +531,16 @@ export async function executeAuthStart(state: McpExtensionState, serverName: str
         content: [{ type: "text" as const, text: `OAuth authentication successful for "${serverName}".` }],
         details: { mode: "auth-start", server: serverName, authenticated: true },
       };
+    }
+
+    if (getRedirectDetails(authorizationUrl).remote) {
+      try {
+        await state.openBrowser(authorizationUrl);
+      } catch (error) {
+        if (isAbortError(error, ownedSignal)) throw error;
+      }
+    } else {
+      ensureBackgroundAuthWatcher(state, serverName, serverUrl, definition);
     }
 
     return {

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -137,7 +137,11 @@ function emitAuthStatus(state: McpExtensionState, serverName: string, status: "a
       customType: "mcp-oauth-status",
       content: [{ type: "text", text: message }],
       display: message,
-      details: { server: serverName, status },
+      details: {
+        server: serverName,
+        status,
+        ...(status === "authenticated" ? { nextAction: { connect: serverName } } : {}),
+      },
     },
     { triggerTurn: true },
   );
@@ -170,7 +174,7 @@ function ensureBackgroundAuthWatcher(
       state,
       serverName,
       "authenticated",
-      `OAuth authentication completed for MCP server "${serverName}".`,
+      `OAuth authentication completed for MCP server "${serverName}". Connect it now to load and verify its tools.`,
     );
   });
   watchers.set(serverName, watcher);

--- a/proxy-modes.ts
+++ b/proxy-modes.ts
@@ -166,8 +166,10 @@ function ensureBackgroundAuthWatcher(
     openAuthorizationUrl: state.openBrowser,
   };
   const watcher = authenticate(serverName, serverUrl, definition, authOptions).then(async (status) => {
+    throwIfAborted(state.owner.signal);
     if (status !== "authenticated") throw new Error(`OAuth authentication ended with status: ${status}`);
     await state.manager.close(serverName);
+    throwIfAborted(state.owner.signal);
     clearFailure(state, serverName, "auth-background-complete");
     updateStatusBar(state);
     emitAuthStatus(
@@ -186,6 +188,7 @@ function ensureBackgroundAuthWatcher(
     } catch (statusError) {
       if (isAbortError(statusError, state.owner.signal)) return;
     }
+    if (state.owner.signal.aborted) return;
     emitAuthStatus(
       state,
       serverName,

--- a/state.ts
+++ b/state.ts
@@ -43,6 +43,8 @@ export interface McpExtensionState {
   serverInstructions: Map<string, string>;
   config: McpConfig;
   programmaticConfig?: boolean;
+  /** Install validations must not publish durable cache entries before config persistence. */
+  provisionalInstalls?: Set<string>;
   oauthRuntime: McpOAuthRuntime;
   authStorageOptions: AuthStorageOptions;
   failureTracker: Map<string, number>;


### PR DESCRIPTION
## Summary

- add `mcp({ action: "install", url: "https://example.com/mcp" })` for durable URL-only MCP setup
- validate and provisionally connect endpoints before atomic persistence; roll back invalid endpoints and reject unsafe URLs or name collisions
- reuse existing servers by canonical URL, support explicit names and project/global targets, and avoid a reload for the active proxy surface
- open OAuth authorization through Pi's browser launcher, watch loopback callbacks, complete PKCE token exchange automatically, and emit a turn-triggering completion event
- preserve `auth-complete` for remote/headless and pre-registered HTTPS callback fallbacks

## Intended UX

A user can tell the agent: `Install https://example.com/mcp`. The agent calls the install action. Public servers connect immediately. OAuth servers open consent automatically; after consent the callback watcher returns the agent to connect and verify discovered tools. No manual JSON editing, client ID, callback copy, or second auth command is needed for a reachable local loopback flow.

Registration and authentication remain separate from user authorization: the user still grants consent in the authorization server.

## Verification

- `npm run typecheck`
- `npm run test:oauth` (152 passed)
- `npm test` (1,495 passed)
- `npm run test:public-exports` (2 passed)
- package dry run includes `mcp-install.ts`
- host compatibility checked for `withFileMutationQueue` on Pi 0.84.1 and 0.84.4
