### PR TITLE
fix: consult approval brokers before session grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime MCP status snapshots now include each server's `directToolCount`, the number of direct tools currently registered with Pi, including resource tools. Thanks to [@FischLu](https://github.com/FischLu) for #482.
 
 ### Changed
+- Approval brokers now observe and can gate cached MCP calls; session grants apply only on abstention or no claim. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #534.
 - MCP setup and server panels now use Pi's active theme and TUI components while preserving their existing workflows. (#488)
 - MCP sampling requests now route through Pi's `ModelRegistry.complete`, leaving provider authentication, environment, and base URL handling to the host.
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ pi.events.on(MCP_TOOL_APPROVAL_REQUEST_EVENT, (request: McpToolApprovalRequest) 
 });
 ```
 
-The request includes `serverName`, `originalToolName`, `prefixedToolName`, `args`, `origin`, and optional `signal`. The first synchronous claim wins. `allow_for_session` updates the same session-scoped approval cache and persistence path as the built-in dialog; `deny` blocks the MCP call; `abstain` or no claim preserves the fallback behavior above. Brokered approval runs for every uncached MCP call regardless of `approveTools` configuration, across proxy, direct, `mcpScript`, resource, and iframe origins.
+The request includes `serverName`, `originalToolName`, `prefixedToolName`, `args`, `origin`, and optional `signal`. The first synchronous claim wins. Brokered approval runs for every resolved MCP call reaching the approval gate, including calls matching session grants restored from the active branch, regardless of `approveTools` configuration, across proxy, direct, `mcpScript`, resource, and iframe origins. `allow_once` permits only the current call; `allow_for_session` updates the same session-scoped approval cache and persistence path as the built-in dialog; `deny` blocks the current MCP call even if cached, without revoking its grant. Only `abstain` or no claim consults the cache, then the configured approval/UI fallback above if no matching grant exists. With no broker listener, fallback behavior is unchanged.
 
 ### Output Guard
 

--- a/__tests__/approval-broker-real-path.test.ts
+++ b/__tests__/approval-broker-real-path.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { MCP_TOOL_APPROVAL_REQUEST_EVENT, type McpToolApprovalRequest } from "../types.ts";
+
+// Real host event bus, registered tools, session, and stdio MCP transport.
+// The receipt log distinguishes broker denial from a call dispatched to the server.
+describe("approval broker through Pi registered script calls", () => {
+  it.each(["deny", "abstain", "no claim"] as const)(
+    "consults the broker before a cached grant: %s",
+    async (secondDecision) => {
+      const root = await mkdtemp(join(tmpdir(), "pi-mcp-approval-broker-"));
+      const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+      const originalArgv = [...process.argv];
+      let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+      try {
+        const agentDir = join(root, "agent");
+        const cwd = join(root, "project");
+        await Promise.all([mkdir(agentDir), mkdir(cwd)]);
+        process.env.PI_CODING_AGENT_DIR = agentDir;
+        const receipts = join(root, "receipts.jsonl");
+        await writeFile(receipts, "");
+        const configPath = join(agentDir, "mcp.json");
+        await writeFile(configPath, JSON.stringify({
+          mcpServers: {
+            fixture: {
+              command: process.execPath,
+              args: [resolve("__tests__/fixtures/approval-broker-server.mjs")],
+              env: { MCP_APPROVAL_RECEIPTS: receipts },
+              lifecycle: "eager",
+            },
+          },
+          settings: { approveTools: true, sampling: false, elicitation: false },
+        }));
+        process.argv.push("--mcp-config", configPath);
+        const requests: McpToolApprovalRequest[] = [];
+        const errors: string[] = [];
+        const settingsManager = SettingsManager.inMemory();
+        const loader = new DefaultResourceLoader({
+          cwd,
+          agentDir,
+          settingsManager,
+          additionalExtensionPaths: [resolve("index.ts")],
+          extensionFactories: [(pi) => {
+            pi.events.on(MCP_TOOL_APPROVAL_REQUEST_EVENT, (request: McpToolApprovalRequest) => {
+              requests.push(request);
+              const decision = requests.length === 1 ? "allow_for_session"
+                : requests.length === 2 ? secondDecision : "abstain";
+              if (decision !== "no claim") expect(request.claim(() => decision)).toBe(true);
+            });
+          }],
+        });
+        await loader.reload();
+        ({ session } = await createAgentSession({
+          cwd, agentDir, resourceLoader: loader,
+          sessionManager: SessionManager.inMemory(cwd), settingsManager, noTools: "all",
+        }));
+        await session.bindExtensions({ mode: "print", onError: error => errors.push(error.error) });
+        await session.extensionRunner.emit({ type: "agent_start" });
+        const script = session.extensionRunner.getAllRegisteredTools()
+          .find(tool => tool.definition.name === "mcpScript")?.definition;
+        expect(script).toBeDefined();
+        const result = await script!.execute("approval-script", {
+          code: `
+            const first = await tools.call("fixture_echo", { value: "same" });
+            const second = await tools.call("fixture_echo", { value: "same" });
+            const third = await tools.call("fixture_echo", { value: "same" });
+            const uncached = await tools.call("fixture_echo", { value: "new" });
+            return [first, second, third, uncached];
+          `,
+        }, undefined, undefined, session.extensionRunner.createContext());
+        const text = result.content.filter(block => block.type === "text").at(-1);
+        expect(text?.type).toBe("text");
+        const results = JSON.parse((text as { text: string }).text);
+        expect(results[0]).toMatchObject({ ok: true });
+        expect(results[1]).toMatchObject(secondDecision === "deny"
+          ? { ok: false, error: { code: "approval_denied" } } : { ok: true });
+        // A denial is not revocation: the next abstention still uses the grant.
+        expect(results[2]).toMatchObject({ ok: true });
+        expect(results[3]).toMatchObject({ ok: false, error: { code: "approval_required" } });
+        expect(requests).toHaveLength(4);
+        expect(new Set(requests.map(request => request.requestId)).size).toBe(4);
+        requests.forEach((request, index) => expect(request).toMatchObject({
+          origin: "script", serverName: "fixture", originalToolName: "echo",
+          prefixedToolName: "fixture_echo", args: { value: index === 3 ? "new" : "same" },
+        }));
+        const received = (await readFile(receipts, "utf8")).trim().split("\n").map(line => JSON.parse(line));
+        expect(received).toHaveLength(secondDecision === "deny" ? 2 : 3);
+        received.forEach(receipt => expect(receipt).toMatchObject({ name: "echo", arguments: { value: "same" } }));
+        expect(errors).toEqual([]);
+      } finally {
+        try {
+          await session?.extensionRunner.emit({ type: "session_shutdown", reason: "test" });
+        } finally {
+          session?.dispose();
+          process.argv.splice(0, process.argv.length, ...originalArgv);
+          if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+          else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+          await rm(root, { recursive: true, force: true });
+        }
+      }
+    },
+    20_000,
+  );
+});

--- a/__tests__/fixtures/approval-broker-server.mjs
+++ b/__tests__/fixtures/approval-broker-server.mjs
@@ -1,0 +1,21 @@
+import { appendFile } from "node:fs/promises";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "approval-broker-server", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [{
+    name: "echo",
+    description: "Echo a value and record receipt",
+    inputSchema: { type: "object", properties: { value: { type: "string" } }, required: ["value"] },
+  }],
+}));
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  await appendFile(process.env.MCP_APPROVAL_RECEIPTS, `${JSON.stringify(request.params)}\n`);
+  return { content: [{ type: "text", text: request.params.arguments.value }] };
+});
+await server.connect(new StdioServerTransport());

--- a/__tests__/tool-approval.test.ts
+++ b/__tests__/tool-approval.test.ts
@@ -358,7 +358,7 @@ describe("tool approval", () => {
     await ensureToolCallApproved(state, "demo", tool, {}, undefined);
     await ensureToolCallApproved(state, "demo", tool, { query: "other" }, undefined);
 
-    expect(broker).toHaveBeenCalledTimes(2);
+    expect(broker).toHaveBeenCalledTimes(3);
     expect(state.approvedToolCalls.size).toBe(2);
     expect(persist).toHaveBeenCalledTimes(2);
   });

--- a/tool-approval.ts
+++ b/tool-approval.ts
@@ -137,12 +137,6 @@ export async function ensureToolCallApproved(
   origin: McpToolApprovalOrigin = toolMeta.resourceUri ? "resource" : "proxy",
   approvalMetadata?: ReadonlyMap<string, readonly ToolMetadata[]>,
 ): Promise<ToolCallApprovalResult> {
-  const { cacheKey } = getToolApprovalIdentity(serverName, toolMeta, args);
-  const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
-  if (approvedToolCalls.has(cacheKey)) {
-    return { ok: true };
-  }
-
   const brokerDecision = await requestBrokerApproval(state, serverName, toolMeta, args, origin, signal);
   if (brokerDecision === "allow_once") return { ok: true };
   if (brokerDecision === "allow_for_session") {
@@ -150,6 +144,12 @@ export async function ensureToolCallApproved(
     return { ok: true };
   }
   if (brokerDecision === "deny") return { ok: false, reason: "denied" };
+
+  const { cacheKey } = getToolApprovalIdentity(serverName, toolMeta, args);
+  const approvedToolCalls = state.approvedToolCalls ??= new Map<string, true>();
+  if (approvedToolCalls.has(cacheKey)) {
+    return { ok: true };
+  }
 
   if (!isToolCallApprovalRequired(state.config, serverName, toolMeta, approvalMetadata ?? state.toolMetadata)) {
     return { ok: true };


### PR DESCRIPTION
## Summary

- consult the host approval broker before session/restored approval grants
- honor cached grants only when the broker abstains or no listener claims the request
- let a broker deny a cached call without revoking its stored grant
- document the intentional precedence change and add real Pi/script/stdio regression coverage

Fixes #534.

Thanks to [@yanqianglu](https://github.com/yanqianglu) for identifying the cache bypass.

## Validation

- 4 focused approval/session/script files: 60 tests passed
- all three new public-contract cases fail under the previous cache-first order and pass with this change
- `npm run typecheck`
- `git diff --check`
- fresh exact-head review before mechanical rebase: no findings; promoted tree verified equal to the clean merge-tree composition with current main
