### PR TITLE
fix(runtime): support abort signal composition on Node 20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 
 ### Fixed
+- MCP runtime cancellation now works on Node 20.0.0 when `AbortSignal.any` is unavailable. (#537)
 - OAuth now forwards configured service headers to same-origin discovery, registration, token exchange, and refresh requests, enabling authentication behind service-token gateways without leaking credentials to other origins. Thanks to [@ethanbrown3](https://github.com/ethanbrown3) for PR #533 and [@Davasny](https://github.com/Davasny) for reporting #530.
 - Script calls now preserve full intermediate data for filtering within a fixed 16 MiB cumulative transfer budget, returning `intermediate_result_too_large` when exhausted while retaining final-output guards. (#520)
 - Namespace proxy argument guidance now uses exact search-result tool names for schema inspection. Thanks to [@r1ckyIn](https://github.com/r1ckyIn) for PR #519.

--- a/__tests__/combine-abort-signals.test.ts
+++ b/__tests__/combine-abort-signals.test.ts
@@ -1,0 +1,70 @@
+import { getEventListeners } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { combineAbortSignals } from "../runtime-owner.ts";
+
+const nativeAny = AbortSignal.any;
+afterEach(() => vi.unstubAllGlobals());
+
+function withoutNativeAny() {
+  class LegacyAbortSignal extends AbortSignal {}
+  Object.defineProperty(LegacyAbortSignal, "any", { value: undefined });
+  vi.stubGlobal("AbortSignal", LegacyAbortSignal);
+}
+
+for (const fallback of [false, true]) {
+  describe(fallback ? "fallback signal combination" : "runtime signal combination", () => {
+    it("preserves empty and single-signal fast paths", () => {
+      if (fallback) withoutNativeAny();
+      const signal = new AbortController().signal;
+      expect(combineAbortSignals()).toBeUndefined();
+      expect(combineAbortSignals(undefined, undefined)).toBeUndefined();
+      expect(combineAbortSignals(undefined, signal, undefined)).toBe(signal);
+    });
+
+    it("uses input order for already-aborted reasons without adding listeners", () => {
+      if (fallback) withoutNativeAny();
+      const live = new AbortController();
+      const first = new AbortController();
+      const second = new AbortController();
+      second.abort(new Error("second"));
+      first.abort(new Error("first"));
+      const signal = combineAbortSignals(live.signal, first.signal, second.signal)!;
+      expect(signal.aborted).toBe(true);
+      expect(signal.reason).toBe(first.signal.reason);
+      for (const input of [live, first, second]) {
+        expect(getEventListeners(input.signal, "abort")).toHaveLength(0);
+      }
+    });
+
+    it("settles once with the first observed reason and removes all listeners", () => {
+      if (fallback) withoutNativeAny();
+      const first = new AbortController();
+      const second = new AbortController();
+      const signal = combineAbortSignals(first.signal, undefined, second.signal, first.signal)!;
+      const aborted = vi.fn();
+      signal.addEventListener("abort", aborted);
+      expect(signal.aborted).toBe(false);
+      const reason = { message: "second aborted first" };
+      second.abort(reason);
+      expect(signal.aborted).toBe(true);
+      expect(signal.reason).toBe(reason);
+      expect(getEventListeners(first.signal, "abort")).toHaveLength(0);
+      expect(getEventListeners(second.signal, "abort")).toHaveLength(0);
+      first.abort(new Error("later"));
+      expect(signal.reason).toBe(reason);
+      expect(aborted).toHaveBeenCalledTimes(1);
+    });
+  });
+}
+
+it.skipIf(typeof nativeAny !== "function")("delegates multiple signals to native AbortSignal.any", () => {
+  const result = new AbortController().signal;
+  const any = vi.fn(() => result);
+  class NativeAbortSignal extends AbortSignal {}
+  Object.defineProperty(NativeAbortSignal, "any", { value: any });
+  vi.stubGlobal("AbortSignal", NativeAbortSignal);
+  const first = new AbortController().signal;
+  const second = new AbortController().signal;
+  expect(combineAbortSignals(first, undefined, second)).toBe(result);
+  expect(any).toHaveBeenCalledExactlyOnceWith([first, second]);
+});

--- a/runtime-owner.ts
+++ b/runtime-owner.ts
@@ -52,7 +52,22 @@ export function combineAbortSignals(...signals: Array<AbortSignal | undefined>):
   const active = signals.filter((signal): signal is AbortSignal => signal !== undefined);
   if (active.length === 0) return undefined;
   if (active.length === 1) return active[0];
-  return AbortSignal.any(active);
+  if (typeof AbortSignal.any === "function") return AbortSignal.any(active);
+
+  // AbortSignal.any was added after Node 20.0.0, our minimum supported version.
+  const controller = new AbortController();
+  const alreadyAborted = active.find(signal => signal.aborted);
+  if (alreadyAborted) {
+    controller.abort(alreadyAborted.reason);
+    return controller.signal;
+  }
+
+  const onAbort = (event: Event) => {
+    for (const signal of active) signal.removeEventListener("abort", onAbort);
+    controller.abort((event.target as AbortSignal).reason);
+  };
+  for (const signal of active) signal.addEventListener("abort", onAbort, { once: true });
+  return controller.signal;
 }
 
 /** Fence session-bound UI calls after the owning extension runtime stops. */


### PR DESCRIPTION
## Summary

- use native `AbortSignal.any` when available
- fall back to a small first-abort signal combiner on Node 20.0.0
- preserve zero/one-signal fast paths, abort reasons, one-shot behavior, and listener cleanup

Fixes #537.

## Validation

- Node 20.0.0 negative control before the fix: 4 focused failures with `AbortSignal.any is not a function`
- Node 20.0.0 after the fix: 18 focused tests passed; native-only test skipped
- current Node: 19 focused tests passed
- `npm run typecheck`
- fresh exact-head review: no findings
- mechanical rebase onto current main verified equal to the clean merge-tree composition
