### PR TITLE
fix: forward direct tool progress and isolate HTTP cancellation

### DIFF
--- a/__tests__/direct-progress-go-integration.test.ts
+++ b/__tests__/direct-progress-go-integration.test.ts
@@ -1,0 +1,232 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { McpServerManager, type ServerConnection } from "../server-manager.ts";
+
+const hubRoot = process.env.PI_MCP_ADAPTER_A6_HUB_ROOT;
+const integration = hubRoot ? describe : describe.skip;
+const fixtureTimeoutMs = 60_000;
+
+type FixtureReady = {
+  mcpUrl: string;
+  controlUrl: string;
+  identityHeader: string;
+  sources: string[];
+  container: string;
+  maxLifetimeMs: number;
+};
+
+type FixtureState = {
+  sources: Record<string, {
+    opened: number;
+    sourceClosed: boolean;
+    handlerStarted: number;
+    handlerExited: number;
+  }>;
+};
+
+type RunningFixture = {
+  ready: FixtureReady;
+  process: ChildProcess;
+  tempDir: string;
+  managers: McpServerManager[];
+  output: () => string;
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function waitFor<T>(read: () => T | Promise<T>, accept: (value: T) => boolean, message: string, timeoutMs = 3_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let value = await read();
+  while (!accept(value) && Date.now() < deadline) {
+    await sleep(20);
+    value = await read();
+  }
+  if (!accept(value)) throw new Error(`${message}: ${JSON.stringify(value)}`);
+  return value;
+}
+
+async function startFixture(): Promise<RunningFixture> {
+  const apiCwd = path.join(hubRoot!, "api");
+  const tempDir = await mkdtemp(path.join(tmpdir(), "pi-a6-go-fixture-"));
+  const readyPath = path.join(tempDir, "ready.json");
+  const child = spawn("go", [
+    "test", "./internal/mcp", "-run", "^TestA6CrossClientFixture$", "-count=1", "-v",
+    "-args", `-a6-fixture-ready=${readyPath}`, "-a6-fixture-lifetime=60s",
+  ], { cwd: apiCwd, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  child.stdout?.on("data", chunk => { output += chunk; });
+  child.stderr?.on("data", chunk => { output += chunk; });
+
+  try {
+    const ready = await waitFor(async () => {
+      try {
+        return JSON.parse(await readFile(readyPath, "utf8")) as FixtureReady;
+      } catch {
+        if (child.exitCode !== null) throw new Error(`Go fixture exited ${child.exitCode}:\n${output}`);
+        return null;
+      }
+    }, (value): value is FixtureReady => value !== null, "Go fixture did not become ready", 30_000);
+    return { ready, process: child, tempDir, managers: [], output: () => output };
+  } catch (error) {
+    child.kill("SIGKILL");
+    await rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function stopFixture(fixture: RunningFixture): Promise<void> {
+  await fetch(`${fixture.ready.controlUrl}/stop`, { method: "POST" }).catch(() => {});
+  await Promise.all(fixture.managers.map(manager => manager.close().catch(() => {})));
+  const exit = fixture.process.exitCode ?? await Promise.race([
+    new Promise<number | null>(resolve => fixture.process.once("exit", resolve)),
+    sleep(5_000).then(() => null),
+  ]);
+  if (fixture.process.exitCode === null) fixture.process.kill("SIGKILL");
+  await rm(fixture.tempDir, { recursive: true, force: true });
+  if (exit !== 0) throw new Error(`Go fixture exited ${exit}:\n${fixture.output()}`);
+}
+
+async function postControl(fixture: RunningFixture, route: string, body?: string): Promise<void> {
+  const response = await fetch(`${fixture.ready.controlUrl}${route}`, { method: "POST", body });
+  if (!response.ok) throw new Error(`${route}: ${response.status} ${await response.text()}`);
+}
+
+async function getState(fixture: RunningFixture): Promise<FixtureState> {
+  const response = await fetch(`${fixture.ready.controlUrl}/state`);
+  if (!response.ok) throw new Error(`state: ${response.status} ${await response.text()}`);
+  return response.json() as Promise<FixtureState>;
+}
+
+async function createExecutor(fixture: RunningFixture, identity: string) {
+  const manager = new McpServerManager();
+  fixture.managers.push(manager);
+  const definition = {
+    url: fixture.ready.mcpUrl,
+    headers: { [fixture.ready.identityHeader]: identity },
+    auth: false as const,
+    httpTransport: "streamable-http" as const,
+    requestTimeoutMs: fixtureTimeoutMs,
+  };
+  const connection = await manager.connect("hub-fixture", definition);
+  const state = {
+    config: { settings: { toolPrefix: "server" }, mcpServers: { "hub-fixture": definition } },
+    manager,
+    toolMetadata: new Map(),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    completedUiSessions: [],
+  } as any;
+  const execute = createDirectToolExecutor(() => state, () => null, {
+    serverName: "hub-fixture",
+    originalName: "stream_service_logs",
+    prefixedName: "hub-fixture_stream_service_logs",
+    description: "Stream synthetic fixture logs",
+    inputSchema: { type: "object", properties: {} },
+  });
+  return { manager, connection, execute };
+}
+
+function logArgs(pod: string) {
+  return { service: "payments", environment: "development", pod, container: "api" };
+}
+
+function updateText(update: unknown): string {
+  return ((update as { content?: Array<{ type?: string; text?: string }> }).content ?? [])
+    .filter(block => block.type === "text")
+    .map(block => block.text ?? "")
+    .join("\n");
+}
+
+function resultText(result: unknown): string {
+  return updateText(result);
+}
+
+async function withFixture(run: (fixture: RunningFixture) => Promise<void>): Promise<void> {
+  const fixture = await startFixture();
+  try {
+    await run(fixture);
+  } finally {
+    await stopFixture(fixture);
+  }
+}
+
+integration("Pi direct executor against the real Go live-log handler", () => {
+  it("delivers two Go progress chunks through onUpdate before EOF and settlement", async () => {
+    await withFixture(async fixture => {
+      const { execute } = await createExecutor(fixture, "pi-precompletion");
+      const updates: unknown[] = [];
+      let settled = false;
+      const call = execute("pi-go-progress", logArgs("payments-a"), undefined, update => updates.push(update), {} as any)
+        .finally(() => { settled = true; });
+      await waitFor(() => getState(fixture), state => state.sources["payments-a"]?.opened === 1, "source did not open");
+
+      await postControl(fixture, "/sources/payments-a/append", "first synthetic line\n");
+      await waitFor(() => updates.length, count => count >= 1, "first update missing");
+      expect(settled).toBe(false);
+      expect(updateText(updates[0])).toContain("first synthetic line");
+
+      await postControl(fixture, "/sources/payments-a/append", "second synthetic line\n");
+      await waitFor(() => updates.length, count => count >= 2, "second update missing");
+      expect(settled).toBe(false);
+      expect(updateText(updates[1])).toContain("second synthetic line");
+
+      await postControl(fixture, "/sources/payments-a/eof");
+      const result = await call;
+      expect(resultText(result)).toContain('"terminalReason":"eof"');
+      expect(resultText(result)).not.toContain("first synthetic line");
+      expect(resultText(result)).not.toContain("second synthetic line");
+    });
+  }, 70_000);
+
+  it("aborts only A, observes Go cleanup, and keeps B plus the connection usable", async () => {
+    await withFixture(async fixture => {
+      const { manager, connection, execute } = await createExecutor(fixture, "pi-concurrent");
+      const controller = new AbortController();
+      const updatesA: unknown[] = [];
+      const updatesB: unknown[] = [];
+      const callA = execute("pi-go-a", logArgs("payments-a"), controller.signal, update => updatesA.push(update), {} as any);
+      const callB = execute("pi-go-b", logArgs("payments-b"), undefined, update => updatesB.push(update), {} as any);
+      await waitFor(() => getState(fixture), state =>
+        state.sources["payments-a"]?.opened === 1 && state.sources["payments-b"]?.opened === 1,
+      "concurrent sources did not open");
+
+      controller.abort(new Error("Pi cancelled A"));
+      await expect(callA).resolves.toMatchObject({ details: { error: "aborted" } });
+
+      const resetLine = `${"x".repeat(16 * 1024 - 1)}\n`;
+      let closedState: FixtureState | undefined;
+      for (let write = 0; write < 64; write++) {
+        await postControl(fixture, "/sources/payments-a/append", resetLine).catch(() => {});
+        const state = await getState(fixture);
+        if (state.sources["payments-a"]?.sourceClosed && state.sources["payments-a"]?.handlerExited === 1) {
+          closedState = state;
+          break;
+        }
+      }
+      closedState ??= await waitFor(() => getState(fixture), state =>
+        state.sources["payments-a"]?.sourceClosed === true && state.sources["payments-a"]?.handlerExited === 1,
+      "Go did not observe A socket reset", 2_000);
+      expect(closedState.sources["payments-b"]?.sourceClosed).toBe(false);
+      expect(closedState.sources["payments-b"]?.handlerExited).toBe(0);
+      expect(connection.status).toBe("connected");
+
+      await postControl(fixture, "/sources/payments-b/append", "B stayed active\n");
+      await waitFor(() => updatesB.length, count => count >= 1, "B update missing after A abort");
+      expect(updateText(updatesB.at(-1))).toContain("B stayed active");
+
+      await postControl(fixture, "/sources/payments-b/eof");
+      const resultB = await callB;
+      expect(resultText(resultB)).toContain('"terminalReason":"eof"');
+      expect(resultText(resultB)).not.toContain("B stayed active");
+      expect(updatesA).toHaveLength(0);
+
+      const listed = await connection.client.listTools(undefined, manager.getRequestOptions("hub-fixture"));
+      expect(listed.tools.some(tool => tool.name === "stream_service_logs")).toBe(true);
+      expect(connection.status).toBe("connected");
+    });
+  }, 70_000);
+});

--- a/__tests__/direct-progress-http.test.ts
+++ b/__tests__/direct-progress-http.test.ts
@@ -1,0 +1,211 @@
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDirectToolExecutor } from "../direct-tools.ts";
+import { McpServerManager } from "../server-manager.ts";
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  })));
+});
+
+function sendSse(res: http.ServerResponse, message: unknown): void {
+  res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+}
+
+async function createProgressFixture() {
+  const calls: Array<{
+    id: string | number;
+    progressToken: string | number;
+    response: http.ServerResponse;
+    closed: boolean;
+  }> = [];
+  const cancelledRequestIds: Array<string | number> = [];
+
+  const server = http.createServer(async (req, res) => {
+    if (req.method === "GET") {
+      res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+      return;
+    }
+    if (req.method !== "POST") {
+      res.writeHead(405, { Allow: "POST" }).end("Method Not Allowed");
+      return;
+    }
+
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    const message = JSON.parse(body) as {
+      id?: string | number;
+      method?: string;
+      params?: { _meta?: { progressToken?: string | number }; requestId?: string | number };
+    };
+
+    if (message.method === "initialize") {
+      res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "progress-fixture", version: "1.0.0" },
+        },
+      }));
+      return;
+    }
+    if (message.method === "notifications/initialized") {
+      res.writeHead(202).end();
+      return;
+    }
+    if (message.method === "tools/list") {
+      res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: { tools: [{ name: "slow", inputSchema: { type: "object", properties: {} } }] },
+      }));
+      return;
+    }
+    if (message.method === "tools/call") {
+      const progressToken = message.params?._meta?.progressToken;
+      if (message.id === undefined || progressToken === undefined) throw new Error("missing request progress token");
+      const call = { id: message.id, progressToken, response: res, closed: false };
+      calls.push(call);
+      res.on("close", () => { call.closed = true; });
+      res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+      sendSse(res, {
+        jsonrpc: "2.0",
+        method: "notifications/progress",
+        params: { progressToken, progress: 1, total: 2, message: "plain text: not JSON" },
+      });
+      sendSse(res, {
+        jsonrpc: "2.0",
+        method: "notifications/progress",
+        params: { progressToken, progress: 2, total: 2, message: "done streaming" },
+      });
+      return;
+    }
+    if (message.method === "notifications/cancelled") {
+      if (message.params?.requestId !== undefined) cancelledRequestIds.push(message.params.requestId);
+      res.writeHead(202).end();
+      return;
+    }
+    res.writeHead(500).end(`unexpected method: ${message.method}`);
+  });
+  servers.push(server);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("server did not bind");
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    finish(index = 0, text = "final result") {
+      const call = calls[index];
+      if (!call) throw new Error("tool call not active");
+      sendSse(call.response, {
+        jsonrpc: "2.0",
+        id: call.id,
+        result: { content: [{ type: "text", text }] },
+      });
+      call.response.end();
+    },
+    get callRequest() { return calls[0]; },
+    get callResponseClosed() { return calls[0]?.closed ?? false; },
+    calls,
+    cancelledRequestIds,
+  };
+}
+
+async function createExecutor(url: string) {
+  const manager = new McpServerManager();
+  const connection = await manager.connect("fixture", { url, httpTransport: "streamable-http", requestTimeoutMs: 30_000 });
+  const state = {
+    config: { settings: { toolPrefix: "server" }, mcpServers: { fixture: { url, httpTransport: "streamable-http", requestTimeoutMs: 30_000 } } },
+    manager,
+    toolMetadata: new Map(),
+    serverInstructions: new Map(),
+    failureTracker: new Map(),
+    completedUiSessions: [],
+  } as any;
+  const execute = createDirectToolExecutor(() => state, () => null, {
+    serverName: "fixture",
+    originalName: "slow",
+    prefixedName: "fixture_slow",
+    description: "Slow fixture tool",
+    inputSchema: { type: "object", properties: {} },
+  });
+  return { manager, connection, execute };
+}
+
+describe("direct tool HTTP progress", () => {
+  it("forwards two request-correlated MCP progress messages before the final result", async () => {
+    const fixture = await createProgressFixture();
+    const { manager, execute } = await createExecutor(fixture.url);
+    const updates: unknown[] = [];
+    let settled = false;
+
+    try {
+      const resultPromise = execute("pi-call-7", {}, undefined, update => updates.push(update), {} as any)
+        .finally(() => { settled = true; });
+      for (let attempt = 0; attempt < 50 && updates.length < 2; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+
+      expect(settled).toBe(false);
+      expect(fixture.callRequest?.progressToken).toBe(fixture.callRequest?.id);
+      expect(updates).toEqual([
+        {
+          content: [{ type: "text", text: "plain text: not JSON (1/2)" }],
+          details: { progress: true, toolCallId: "pi-call-7", server: "fixture", tool: "slow", current: 1, total: 2 },
+        },
+        {
+          content: [{ type: "text", text: "done streaming (2/2)" }],
+          details: { progress: true, toolCallId: "pi-call-7", server: "fixture", tool: "slow", current: 2, total: 2 },
+        },
+      ]);
+
+      fixture.finish();
+      await expect(resultPromise).resolves.toMatchObject({ content: [{ type: "text", text: "final result" }] });
+    } finally {
+      await manager.close("fixture");
+    }
+  });
+
+  it("closes only the cancelled legacy SSE POST and keeps the connection usable", async () => {
+    const fixture = await createProgressFixture();
+    const { manager, connection, execute } = await createExecutor(fixture.url);
+    const controller = new AbortController();
+
+    try {
+      const cancelledPromise = execute("pi-call-abort", { call: 1 }, controller.signal, vi.fn(), {} as any);
+      const survivingPromise = execute("pi-call-survive", { call: 2 }, undefined, vi.fn(), {} as any);
+      for (let attempt = 0; attempt < 50 && fixture.calls.length < 2; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+
+      controller.abort(new Error("user cancelled"));
+      const cancelledResult = await cancelledPromise;
+      for (let attempt = 0; attempt < 50 && (fixture.cancelledRequestIds.length === 0 || !fixture.calls[0]?.closed); attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+
+      expect(cancelledResult.details).toMatchObject({ error: "aborted" });
+      expect(fixture.cancelledRequestIds).toEqual([fixture.calls[0]?.id]);
+      expect(fixture.calls[0]?.closed).toBe(true);
+      expect(fixture.calls[1]?.closed).toBe(false);
+      expect(connection.status).toBe("connected");
+
+      fixture.finish(1, "survived");
+      await expect(survivingPromise).resolves.toMatchObject({ content: [{ type: "text", text: "survived" }] });
+
+      const subsequentPromise = execute("pi-call-next", { call: 3 }, undefined, vi.fn(), {} as any);
+      for (let attempt = 0; attempt < 50 && fixture.calls.length < 3; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      fixture.finish(2, "subsequent");
+      await expect(subsequentPromise).resolves.toMatchObject({ content: [{ type: "text", text: "subsequent" }] });
+    } finally {
+      await manager.close("fixture");
+    }
+  });
+});

--- a/__tests__/direct-tools-auto-auth.test.ts
+++ b/__tests__/direct-tools-auto-auth.test.ts
@@ -108,7 +108,7 @@ describe("direct tools auto auth", () => {
       name: "namespace.tool",
       arguments: { q: "hello" },
       _meta: undefined,
-    }, { timeout: 4321 });
+    }, { timeout: 4321, onprogress: expect.any(Function) });
     expect(result.content[0].text).toContain("ok");
   });
 

--- a/__tests__/server-manager-auth-cache-recovery-integration.test.ts
+++ b/__tests__/server-manager-auth-cache-recovery-integration.test.ts
@@ -33,7 +33,7 @@ vi.mock("@modelcontextprotocol/client", async importOriginal => ({
     return client;
   }),
   StreamableHTTPClientTransport: vi.fn().mockImplementation((_url: URL, options: TransportOptions) => {
-    const transport = { options, close: vi.fn(async () => undefined) };
+    const transport = { options, hasPerRequestStream: true, close: vi.fn(async () => undefined) };
     mocks.transports.push(transport);
     return transport;
   }),

--- a/__tests__/server-manager-auth-cache-recovery.test.ts
+++ b/__tests__/server-manager-auth-cache-recovery.test.ts
@@ -27,7 +27,7 @@ vi.mock("@modelcontextprotocol/client", async importOriginal => ({
     listPrompts: vi.fn(async () => { const error = mocks.listPromptsErrors.shift(); if (error) throw error; return { prompts: [] }; }),
     getServerCapabilities: vi.fn(() => mocks.capabilities), getInstructions: vi.fn(() => undefined), close: vi.fn(async () => undefined),
   })),
-  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => ({ url, options, close: vi.fn(async () => undefined) })),
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => ({ url, options, hasPerRequestStream: true, close: vi.fn(async () => undefined) })),
   SSEClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => ({ url, options, close: vi.fn(async () => undefined) })),
 }));
 vi.mock("@modelcontextprotocol/client/stdio", () => ({ StdioClientTransport: vi.fn() }));

--- a/__tests__/server-manager-http-auth.test.ts
+++ b/__tests__/server-manager-http-auth.test.ts
@@ -61,7 +61,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     return client;
   }),
   StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
-    const transport = { url, options, close: vi.fn(async () => undefined) };
+    const transport = { url, options, hasPerRequestStream: true, close: vi.fn(async () => undefined) };
     mocks.httpTransports.push(transport);
     return transport;
   }),
@@ -486,6 +486,6 @@ describe("McpServerManager HTTP bearer auth", () => {
 
     expect(mocks.clients).toHaveLength(1);
     expect(mocks.httpTransports).toHaveLength(1);
-    expect(mocks.clients[0].connect).toHaveBeenCalledWith(mocks.httpTransports[0], { timeout: 5000 });
+    expect(mocks.clients[0].connect).toHaveBeenCalledWith(expect.anything(), { timeout: 5000 });
   });
 });

--- a/__tests__/server-manager-reconnect.test.ts
+++ b/__tests__/server-manager-reconnect.test.ts
@@ -33,7 +33,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     return client;
   }),
   StreamableHTTPClientTransport: vi.fn().mockImplementation((url: URL, options: TransportOptions) => {
-    const transport = { url, options, close: vi.fn(async () => undefined) };
+    const transport = { url, options, hasPerRequestStream: true, close: vi.fn(async () => undefined) };
     mocks.httpTransports.push(transport);
     return transport;
   }),

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -22,6 +22,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
     this.close = vi.fn(async () => undefined);
   }),
   StreamableHTTPClientTransport: vi.fn().mockImplementation(function (this: any) {
+    this.hasPerRequestStream = true;
     this.close = vi.fn(async () => undefined);
     mocks.transports.push(this);
   }),

--- a/__tests__/streamable-http-request-abort.test.ts
+++ b/__tests__/streamable-http-request-abort.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
+import { StreamableHttpRequestAbortTransport } from "../streamable-http-request-abort.ts";
+
+type SendOptions = Parameters<Transport["send"]>[1];
+
+function request(id: number): JSONRPCMessage {
+  return { jsonrpc: "2.0", id, method: "tools/call", params: { name: "slow", arguments: {} } };
+}
+
+function cancelled(id: number): JSONRPCMessage {
+  return { jsonrpc: "2.0", method: "notifications/cancelled", params: { requestId: id, reason: "cancelled" } };
+}
+
+function createBase(send = vi.fn(async (_message: JSONRPCMessage, _options?: SendOptions) => {})): Transport & { send: typeof send } {
+  return {
+    send,
+    start: vi.fn(async () => {}),
+    hasPerRequestStream: true,
+    close: vi.fn(async () => {}),
+    sessionId: "session-1",
+    setProtocolVersion: vi.fn(),
+    setSupportedProtocolVersions: vi.fn(),
+  };
+}
+
+describe("StreamableHttpRequestAbortTransport", () => {
+  it.each([undefined, false])("rejects a base transport with hasPerRequestStream=%s", hasPerRequestStream => {
+    const base = createBase();
+    base.hasPerRequestStream = hasPerRequestStream;
+
+    expect(() => new StreamableHttpRequestAbortTransport(base)).toThrow(
+      "StreamableHttpRequestAbortTransport requires a per-request stream transport",
+    );
+  });
+
+  it("forwards a supplied modern request signal unchanged", async () => {
+    const base = createBase();
+    const transport = new StreamableHttpRequestAbortTransport(base);
+    const signal = new AbortController().signal;
+
+    await transport.send(request(1), { requestSignal: signal });
+
+    expect(base.send).toHaveBeenCalledWith(request(1), { requestSignal: signal });
+    expect(base.send.mock.calls[0]?.[1]?.requestSignal).toBe(signal);
+  });
+
+  it("aborts only the matching legacy request and still forwards cancellation", async () => {
+    const base = createBase();
+    const transport = new StreamableHttpRequestAbortTransport(base);
+
+    await transport.send(request(1));
+    await transport.send(request(2));
+    const firstSignal = base.send.mock.calls[0]?.[1]?.requestSignal;
+    const secondSignal = base.send.mock.calls[1]?.[1]?.requestSignal;
+    await transport.send(cancelled(1));
+
+    expect(firstSignal?.aborted).toBe(true);
+    expect(secondSignal?.aborted).toBe(false);
+    expect(base.send).toHaveBeenLastCalledWith(cancelled(1), undefined);
+  });
+
+  it("cleans active signals on response, stream end, send rejection, base close, and close", async () => {
+    const rejectSend = vi.fn(async (message: JSONRPCMessage, _options?: SendOptions) => {
+      if ("id" in message && message.id === 3) throw new Error("send failed");
+    });
+    const base = createBase(rejectSend);
+    const transport = new StreamableHttpRequestAbortTransport(base);
+    const onclose = vi.fn();
+    transport.onclose = onclose;
+
+    await transport.send(request(1));
+    const responseSignal = rejectSend.mock.calls[0]?.[1]?.requestSignal;
+    base.onmessage?.({ jsonrpc: "2.0", id: 1, result: {} });
+    await transport.send(cancelled(1));
+    expect(responseSignal?.aborted).toBe(false);
+
+    await transport.send(request(2));
+    const streamSignal = rejectSend.mock.calls[2]?.[1]?.requestSignal;
+    rejectSend.mock.calls[2]?.[1]?.onRequestStreamEnd?.();
+    await transport.send(cancelled(2));
+    expect(streamSignal?.aborted).toBe(false);
+
+    await expect(transport.send(request(3))).rejects.toThrow("send failed");
+    const rejectedSignal = rejectSend.mock.calls[4]?.[1]?.requestSignal;
+    await transport.send(cancelled(3));
+    expect(rejectedSignal?.aborted).toBe(false);
+
+    await transport.send(request(4));
+    const baseCloseSignal = rejectSend.mock.calls[6]?.[1]?.requestSignal;
+    base.onclose?.();
+    expect(baseCloseSignal?.aborted).toBe(true);
+    expect(onclose).toHaveBeenCalledOnce();
+
+    await transport.send(request(5));
+    const closeSignal = rejectSend.mock.calls[7]?.[1]?.requestSignal;
+    await transport.close();
+    expect(closeSignal?.aborted).toBe(true);
+    expect(base.close).toHaveBeenCalledOnce();
+    expect(transport.sessionId).toBe("session-1");
+  });
+});

--- a/direct-tools.ts
+++ b/direct-tools.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { UrlElicitationRequiredError, type Client } from "@modelcontextprotocol/client";
+import { UrlElicitationRequiredError, type Client, type Progress, type RequestOptions } from "@modelcontextprotocol/client";
 import type { McpExtensionState } from "./state.ts";
 import type { DirectToolSpec, McpConfig, McpContent, ToolPrefix } from "./types.ts";
 import type { MetadataCache } from "./metadata-cache.ts";
@@ -27,6 +27,7 @@ type ClientReadResourceResult = Awaited<ReturnType<Client["readResource"]>>;
 
 const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"]);
 export const DIRECT_TOOLS_ADVISORY_THRESHOLD = 75;
+const MAX_DIRECT_PROGRESS_TEXT_LENGTH = 8 * 1024;
 
 type DirectAutoAuthResult =
   | { status: "skipped" }
@@ -339,12 +340,39 @@ type DirectToolExecute = (
   ctx: ExtensionContext,
 ) => Promise<AgentToolResult<Record<string, unknown>>>;
 
+function withDirectToolProgress(
+  options: RequestOptions | undefined,
+  onUpdate: AgentToolUpdateCallback<Record<string, unknown>> | undefined,
+  toolCallId: string,
+  spec: DirectToolSpec,
+): RequestOptions | undefined {
+  if (!onUpdate) return options;
+  return {
+    ...options,
+    onprogress: (progress: Progress) => {
+      const ratio = `${progress.progress}${progress.total === undefined ? "" : `/${progress.total}`}`;
+      const text = (progress.message ? `${progress.message} (${ratio})` : ratio).slice(0, MAX_DIRECT_PROGRESS_TEXT_LENGTH);
+      onUpdate({
+        content: [{ type: "text", text }],
+        details: {
+          progress: true,
+          toolCallId,
+          server: spec.serverName,
+          tool: spec.originalName,
+          current: progress.progress,
+          ...(progress.total !== undefined ? { total: progress.total } : {}),
+        },
+      });
+    },
+  };
+}
+
 export function createDirectToolExecutor(
   getState: () => McpExtensionState | null,
   getInitPromise: () => Promise<McpExtensionState> | null,
   spec: DirectToolSpec
 ): DirectToolExecute {
-  return async function execute(_toolCallId, params, signal) {
+  return async function execute(toolCallId, params, signal, onUpdate) {
     throwIfAborted(signal);
     let state = getState();
     const initPromise = getInitPromise();
@@ -447,7 +475,12 @@ export function createDirectToolExecutor(
     }
 
     let uiSession: UiSessionRuntime | null = null;
-    const requestOptions = state.manager.getRequestOptions?.(spec.serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined);
+    const requestOptions = withDirectToolProgress(
+      state.manager.getRequestOptions?.(spec.serverName, ownedSignal) ?? (ownedSignal ? { signal: ownedSignal } : undefined),
+      onUpdate,
+      toolCallId,
+      spec,
+    );
 
     const outputGuardOptions = resolveMcpOutputGuardOptions(state.config.settings);
     const recoverAuthConnection = async () => {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "server-manager.ts",
     "request-headers-command.ts",
     "unix-socket-transport.ts",
+    "streamable-http-request-abort.ts",
     "json-schema-validator.ts",
     "session-recovery.ts",
     "sampling-handler.ts",

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -20,6 +20,7 @@ import {
 } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { UnixSocketClientTransport } from "./unix-socket-transport.ts";
+import { StreamableHttpRequestAbortTransport } from "./streamable-http-request-abort.ts";
 import { probeMcpEndpoint } from "./mcp-probe.ts";
 import {
   isServerDisabled,
@@ -1275,7 +1276,7 @@ export class McpServerManager {
           : {}),
       };
       const baseTransport: Transport = kind === "streamable-http"
-        ? new StreamableHTTPClientTransport(url, transportOptions)
+        ? new StreamableHttpRequestAbortTransport(new StreamableHTTPClientTransport(url, transportOptions))
         : new SSEClientTransport(url, transportOptions);
       const transport = traceObserver
         ? wrapTransportWithMcpTrace(baseTransport, serverName, kind, traceObserver)

--- a/streamable-http-request-abort.ts
+++ b/streamable-http-request-abort.ts
@@ -1,0 +1,106 @@
+import type { JSONRPCMessage, Transport } from "@modelcontextprotocol/client";
+
+type SendOptions = Parameters<Transport["send"]>[1];
+type RequestId = string | number;
+
+function requestId(message: JSONRPCMessage): RequestId | undefined {
+  return "method" in message && "id" in message ? message.id : undefined;
+}
+
+function responseId(message: JSONRPCMessage): RequestId | undefined {
+  return !("method" in message) && "id" in message ? message.id : undefined;
+}
+
+function cancelledRequestId(message: JSONRPCMessage): RequestId | undefined {
+  if (!("method" in message) || message.method !== "notifications/cancelled") return undefined;
+  const params = message.params as { requestId?: unknown } | undefined;
+  return typeof params?.requestId === "string" || typeof params?.requestId === "number"
+    ? params.requestId
+    : undefined;
+}
+
+/** Adds legacy per-request cancellation without changing modern SDK signals. */
+export class StreamableHttpRequestAbortTransport implements Transport {
+  readonly hasPerRequestStream = true;
+  private readonly activeRequests = new Map<RequestId, AbortController>();
+  private messageHandler: Transport["onmessage"];
+  private errorHandler: Transport["onerror"];
+  private closeHandler: Transport["onclose"];
+
+  constructor(private readonly base: Transport) {
+    if (base.hasPerRequestStream !== true) {
+      throw new TypeError("StreamableHttpRequestAbortTransport requires a per-request stream transport");
+    }
+    base.onmessage = (message, extra) => {
+      const id = responseId(message);
+      if (id !== undefined) this.activeRequests.delete(id);
+      this.onmessage?.(message, extra);
+    };
+    base.onerror = error => this.onerror?.(error);
+    base.onclose = () => {
+      this.abortActiveRequests();
+      this.onclose?.();
+    };
+  }
+
+  get onmessage(): Transport["onmessage"] { return this.messageHandler; }
+  set onmessage(handler: Transport["onmessage"]) { this.messageHandler = handler; }
+  get onerror(): Transport["onerror"] { return this.errorHandler; }
+  set onerror(handler: Transport["onerror"]) { this.errorHandler = handler; }
+  get onclose(): Transport["onclose"] { return this.closeHandler; }
+  set onclose(handler: Transport["onclose"]) { this.closeHandler = handler; }
+  get sessionId(): string | undefined { return this.base.sessionId; }
+
+  start(): Promise<void> {
+    return this.base.start();
+  }
+
+  async send(message: JSONRPCMessage, options?: SendOptions): Promise<void> {
+    const cancelledId = cancelledRequestId(message);
+    if (cancelledId !== undefined) {
+      this.activeRequests.get(cancelledId)?.abort();
+      this.activeRequests.delete(cancelledId);
+    }
+
+    const id = options?.requestSignal ? undefined : requestId(message);
+    if (id === undefined) {
+      await this.base.send(message, options);
+      return;
+    }
+
+    const controller = new AbortController();
+    this.activeRequests.set(id, controller);
+    const onRequestStreamEnd = options?.onRequestStreamEnd;
+    try {
+      await this.base.send(message, {
+        ...options,
+        requestSignal: controller.signal,
+        onRequestStreamEnd: () => {
+          this.activeRequests.delete(id);
+          onRequestStreamEnd?.();
+        },
+      });
+    } catch (error) {
+      this.activeRequests.delete(id);
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.abortActiveRequests();
+    await this.base.close();
+  }
+
+  setProtocolVersion(version: string): void {
+    this.base.setProtocolVersion?.(version);
+  }
+
+  setSupportedProtocolVersions(versions: string[]): void {
+    this.base.setSupportedProtocolVersions?.(versions);
+  }
+
+  private abortActiveRequests(): void {
+    for (const controller of this.activeRequests.values()) controller.abort();
+    this.activeRequests.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- Forward MCP progress to Pi direct-tool onUpdate results, with independently bounded text and no cumulative buffer.
- Use the public Streamable HTTP transport requestSignal hook to abort only the canceled legacy request while still forwarding notifications/cancelled. Preserve native modern signals and reject unsupported transports.
- Add synthetic HTTP regressions for pre-completion updates, concurrent cancellation isolation, cleanup, and connection reuse. Include an opt-in integration test against a separately supplied Go Hub checkout.

## Validation
- Typecheck and public export tests passed.
- 64 focused wrapper/HTTP tests passed.
- Parent reran direct progress/cancellation tests and both opt-in Pi-to-Go integration tests successfully.
- Independent source review passed after adding the transport capability guard.
- Full suite: 1484 passed, 1 skipped, 1 failed due to missing generated examples/interactive-visualizer/dist/app.html. Example build could not resolve chart.js/auto because example dependencies were not installed.

## Limits
- No installed Pi package or production service was changed.
- HTTP disconnect detection on the Go fixture requires subsequent socket I/O; integration tests drive bounded writes and verify actual source/handler cleanup before manager close.
- Opt-in integration requires PI_MCP_ADAPTER_A6_HUB_ROOT pointing to the companion Hub checkout with the fixture. Ordinary tests skip it.