### PR TITLE
fix: diagnose macOS local-network connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp({ connect })` now reports the direct tools it discovers on the tool result via `addedToolNames`, Pi's result-scoped tool activation surface, so they load from that transcript point instead of through an active-tool list rewrite. (#490) Thanks to [@chiptoe-svg](https://github.com/chiptoe-svg) for PR #494.
 
 ### Fixed
+- macOS HTTP connection failures to literal private/link-local IPs now retain network details and suggest Local Network Privacy checks without assuming a privacy denial. Thanks to [@tdhooghe](https://github.com/tdhooghe) for #543.
 - MCP runtime cancellation now works on Node 20.0.0 when `AbortSignal.any` is unavailable. (#537)
 - OAuth now forwards configured service headers to same-origin discovery, registration, token exchange, and refresh requests, enabling authentication behind service-token gateways without leaking credentials to other origins. Thanks to [@ethanbrown3](https://github.com/ethanbrown3) for PR #533 and [@Davasny](https://github.com/Davasny) for reporting #530.
 - Script `mcp({ action: "auth-start" })` now opens the authorization URL and watches the loopback callback to complete OAuth automatically, while retaining pasted `auth-complete` as a fallback. Thanks to [@exoulster](https://github.com/exoulster) for PR #532.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ In the configuration examples below, `30000` is illustrative only. If `requestTi
 
 `caFile` works with Streamable HTTP, SSE, and per-request header commands. Requests using this trust reject all redirects; configure the final HTTPS endpoint directly. Other origins and servers retain default trust. Layered configuration drops inherited trust when replacing the URL or switching away from HTTP. This option covers the MCP origin, including connection-owned OAuth requests to that exact origin, but not the separate interactive OAuth flow or private-CA authorization servers on other origins. Thanks to [@desmonna](https://github.com/desmonna) for #527.
 
+#### macOS local-network access
+
+On macOS 15+, Local Network Privacy may deny access to a LAN MCP server depending on the app responsible for hosting Pi. For HTTP URLs with literal private/link-local IPv4 or IPv6 addresses, the adapter adds a hint to `EHOSTUNREACH`, `ENETUNREACH`, or `EACCES` connection errors while retaining the original cause. These codes can also mean routing or firewall trouble; the hint is not proof of a privacy denial. Hostnames are not resolved for this diagnostic.
+
+Check **System Settings > Privacy & Security > Local Network** for the hosting app, enable access if listed, then restart that app and Pi. If it is absent or access still fails, try launching Pi directly from Apple Terminal.app or over SSH (contexts Apple documents as exempt). Permission is attributed to responsible code, not necessarily Node or Pi; signing an unsigned CLI alone does not guarantee a permission prompt or fix host attribution. See [Apple TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy).
+
 #### Protocol version negotiation
 
 The adapter defaults to `protocolVersion: "legacy"`. Omitting the field uses the classic MCP initialize sequence without `server/discover` or 2026 headers, preserving compatibility with deployed 2025-era servers.

--- a/__tests__/server-manager-local-network.test.ts
+++ b/__tests__/server-manager-local-network.test.ts
@@ -8,8 +8,10 @@ afterEach(() => {
 
 async function connectFailure(host: string, code = "EHOSTUNREACH", platform = "darwin") {
   vi.spyOn(process, "platform", "get").mockReturnValue(platform as NodeJS.Platform);
-  const detail = Object.assign(new Error(`connect ${code}: network detail`), { code });
-  const original = new TypeError("fetch failed", { cause: new AggregateError([detail], "connect attempts failed") });
+  const detail = Object.assign(new Error("connect https://user:secret@192.168.10.7/mcp?token=secret"), { code });
+  const duplicate = Object.assign(new Error("Authorization: Bearer secret"), { code });
+  const original = new TypeError("fetch failed", { cause: new AggregateError([detail, duplicate], "connect attempts failed") });
+  detail.cause = original;
   const fetch = vi.fn().mockRejectedValue(original);
   vi.stubGlobal("fetch", fetch);
   const manager = new McpServerManager();
@@ -31,10 +33,13 @@ describe("macOS LAN connection diagnostics", () => {
     ["169.254.1.2", "EHOSTUNREACH"], ["[fd00::1]", "EHOSTUNREACH"],
     ["[fc00::1]", "EHOSTUNREACH"], ["[fe80::1]", "EHOSTUNREACH"],
     ["[febf::1]", "EHOSTUNREACH"], ["[::ffff:192.168.10.7]", "EHOSTUNREACH"],
+    ["user:secret@192.168.10.7", "EHOSTUNREACH"],
   ])("adds a tentative diagnostic for %s / %s without probing", async (host, code) => {
     const { error, original, fetch } = await connectFailure(host, code);
     expect(error.message).toContain("fetch failed");
-    expect(error.message).toContain(`connect ${code}: network detail`);
+    expect(error.message.split(code)).toHaveLength(2);
+    expect(error.message).not.toContain("secret");
+    expect(error.message).not.toContain("https://");
     expect(error.message).toContain("macOS Local Network Privacy may be blocking access");
     expect(error.message).toContain("System Settings > Privacy & Security > Local Network");
     expect(error.message).toContain("Terminal.app or SSH");

--- a/__tests__/server-manager-local-network.test.ts
+++ b/__tests__/server-manager-local-network.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpServerManager } from "../server-manager.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function connectFailure(host: string, code = "EHOSTUNREACH", platform = "darwin") {
+  vi.spyOn(process, "platform", "get").mockReturnValue(platform as NodeJS.Platform);
+  const detail = Object.assign(new Error(`connect ${code}: network detail`), { code });
+  const original = new TypeError("fetch failed", { cause: new AggregateError([detail], "connect attempts failed") });
+  const fetch = vi.fn().mockRejectedValue(original);
+  vi.stubGlobal("fetch", fetch);
+  const manager = new McpServerManager();
+  try {
+    await manager.connect("lan", { url: `https://${host}/mcp`, oauth: false });
+    throw new Error("connection unexpectedly succeeded");
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    return { error: error as Error, original, fetch };
+  } finally {
+    await manager.closeAll();
+  }
+}
+
+describe("macOS LAN connection diagnostics", () => {
+  it.each([
+    ["192.168.10.7", "EHOSTUNREACH"], ["10.0.0.2", "ENETUNREACH"],
+    ["172.16.0.1", "EACCES"], ["172.31.255.254", "EHOSTUNREACH"],
+    ["169.254.1.2", "EHOSTUNREACH"], ["[fd00::1]", "EHOSTUNREACH"],
+    ["[fc00::1]", "EHOSTUNREACH"], ["[fe80::1]", "EHOSTUNREACH"],
+    ["[febf::1]", "EHOSTUNREACH"], ["[::ffff:192.168.10.7]", "EHOSTUNREACH"],
+  ])("adds a tentative diagnostic for %s / %s without probing", async (host, code) => {
+    const { error, original, fetch } = await connectFailure(host, code);
+    expect(error.message).toContain("fetch failed");
+    expect(error.message).toContain(`connect ${code}: network detail`);
+    expect(error.message).toContain("macOS Local Network Privacy may be blocking access");
+    expect(error.message).toContain("System Settings > Privacy & Security > Local Network");
+    expect(error.message).toContain("Terminal.app or SSH");
+    expect(error.cause).toBe(original);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["192.168.10.7", "EHOSTUNREACH", "linux"],
+    ["192.168.10.7", "EHOSTUNREACH", "win32"],
+    ["192.168.10.7", "ECONNREFUSED", "darwin"],
+    ["192.168.10.7", "ETIMEDOUT", "darwin"],
+    ["192.168.10.7", "CERT_HAS_EXPIRED", "darwin"],
+    ...["8.8.8.8", "127.0.0.1", "172.15.255.255", "172.32.0.1", "[::1]",
+      "[2001:4860::8888]", "[fec0::1]", "[::ffff:127.0.0.1]", "localhost", "mcp.local", "example.com"]
+      .map(host => [host, "EHOSTUNREACH", "darwin"]),
+  ])("does not suggest privacy for %s / %s / %s", async (host, code, platform) => {
+    const { error } = await connectFailure(host, code, platform);
+    expect(error.message).not.toContain("Local Network Privacy");
+    expect(error.message).toContain("fetch failed");
+  });
+});

--- a/__tests__/server-manager-local-network.test.ts
+++ b/__tests__/server-manager-local-network.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SseError } from "@modelcontextprotocol/client";
 import { McpServerManager } from "../server-manager.ts";
 
 afterEach(() => {
@@ -27,6 +28,51 @@ async function connectFailure(host: string, code = "EHOSTUNREACH", platform = "d
 }
 
 describe("macOS LAN connection diagnostics", () => {
+  it.each([
+    ["darwin", "192.168.10.7", "EHOSTUNREACH", true],
+    ["darwin", "192.168.10.7", "ENETUNREACH", true],
+    ["darwin", "192.168.10.7", "EACCES", true],
+    ["darwin", "192.168.10.7", "ECONNREFUSED", false],
+    ["darwin", "8.8.8.8", "EHOSTUNREACH", false],
+    ["darwin", "127.0.0.1", "EHOSTUNREACH", false],
+    ["linux", "192.168.10.7", "EHOSTUNREACH", false],
+  ] as const)("enriches only qualifying SSE failures: %s / %s / %s", async (platform, host, code, qualifies) => {
+    vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+    const original = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("network detail"), { code }),
+    });
+    const fetch = vi.fn().mockRejectedValue(original);
+    vi.stubGlobal("fetch", fetch);
+    const manager = new McpServerManager();
+    try {
+      await manager.connect("lan", {
+        url: `https://${host}/mcp`, oauth: false, httpTransport: "sse",
+      });
+      expect.fail("connection unexpectedly succeeded");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      if (!(error instanceof Error)) throw error;
+      if (!qualifies) {
+        expect(error).toBeInstanceOf(SseError);
+        expect(error.message).toBe("SSE error: TypeError: fetch failed: network detail");
+        expect(error.cause).toBeUndefined();
+        expect(fetch).toHaveBeenCalledTimes(2);
+        return;
+      }
+      expect(error.message).toContain("macOS Local Network Privacy may be blocking access");
+      expect(error.message).toContain(code);
+      expect(error.cause).toBeInstanceOf(AggregateError);
+      if (!(error.cause instanceof AggregateError)) throw error;
+      const [sdkError, fetchError] = error.cause.errors;
+      expect(sdkError).toBeInstanceOf(SseError);
+      expect(error.message.startsWith(`${sdkError.message} — `)).toBe(true);
+      expect(fetchError).toBe(original);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      await manager.closeAll();
+    }
+  });
+
   it.each([
     ["192.168.10.7", "EHOSTUNREACH"], ["10.0.0.2", "ENETUNREACH"],
     ["172.16.0.1", "EACCES"], ["172.31.255.254", "EHOSTUNREACH"],

--- a/__tests__/server-manager-stderr-capture.test.ts
+++ b/__tests__/server-manager-stderr-capture.test.ts
@@ -197,6 +197,20 @@ describe("McpServerManager stderr capture", () => {
     );
   });
 
+  it("leaves macOS stdio network failures unchanged without HTTP requests", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { McpServerManager } = await import("../server-manager.ts");
+    const manager = new McpServerManager();
+    const original = new Error("connection failed", {
+      cause: Object.assign(new Error("connect 192.168.10.7"), { code: "EHOSTUNREACH" }),
+    });
+    mocks.connectImpl = async () => { throw original; };
+    await expect(manager.connect("stdio", { command: "node" })).rejects.toBe(original);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("bounds captured stderr and keeps only its final three lines", async () => {
     const { McpServerManager } = await import("../server-manager.ts");
     const manager = new McpServerManager();

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -6,9 +6,11 @@ import {
   SdkError,
   SdkErrorCode,
   SdkHttpError,
+  SseError,
   SSEClientTransport,
   StreamableHTTPClientTransport,
   UnauthorizedError,
+  type FetchLike,
   type GetPromptResult,
   type ListToolsResult,
   type ReadResourceResult,
@@ -1325,9 +1327,21 @@ export class McpServerManager {
       | { status: "failed"; client: Client; transport: Transport; error: unknown }
     > => {
       const authProvider = "provider" in authState ? authState.provider : undefined;
+      let sseFetchFailure: unknown;
+      const transportFetch: FetchLike | undefined = kind === "sse" && process.platform === "darwin" && isLiteralLocalAddress(serverUrl)
+        ? async (input, init) => {
+          try {
+            return await (requestFetch ?? globalThis.fetch)(input, init);
+          } catch (error) {
+            // EventSource discards the fetch cause before the SDK creates SseError.
+            if (localNetworkFailureCodes(error).length > 0) sseFetchFailure = error;
+            throw error;
+          }
+        }
+        : requestFetch;
       const transportOptions = {
         ...(requestInit !== undefined ? { requestInit } : {}),
-        ...(requestFetch !== undefined ? { fetch: requestFetch } : {}),
+        ...(transportFetch !== undefined ? { fetch: transportFetch } : {}),
         ...(authProvider !== undefined ? { authProvider } : {}),
         ...(authProvider !== undefined
           && definition.oauth !== false
@@ -1347,6 +1361,9 @@ export class McpServerManager {
         await this.connectClientWithAbort(client, transport, requestOptions, signal);
         return { status: "connected", client, transport };
       } catch (error) {
+        if (error instanceof SseError && sseFetchFailure !== undefined) {
+          error = new AggregateError([error, sseFetchFailure], error.message);
+        }
         const abortCleanupFailed = error instanceof AggregateError
           && error.message === "MCP connection abort cleanup failed";
         if (!abortCleanupFailed) {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -96,19 +96,19 @@ function isLiteralLocalAddress(url: string): boolean {
   return local.check(hostname, family === 6 ? "ipv6" : "ipv4");
 }
 
-function localNetworkFailureDetails(error: unknown, seen = new Set<object>()): string[] {
+function localNetworkFailureCodes(error: unknown, seen = new Set<object>()): string[] {
   if (typeof error !== "object" || error === null || seen.has(error)) return [];
   seen.add(error);
-  const details: string[] = [];
+  const codes: string[] = [];
   if ("code" in error && typeof error.code === "string"
     && ["EHOSTUNREACH", "ENETUNREACH", "EACCES"].includes(error.code)) {
-    details.push(error instanceof Error ? `${error.code}: ${error.message}` : error.code);
+    codes.push(error.code);
   }
-  if ("cause" in error) details.push(...localNetworkFailureDetails(error.cause, seen));
+  if ("cause" in error) codes.push(...localNetworkFailureCodes(error.cause, seen));
   if (error instanceof AggregateError) {
-    for (const nested of error.errors) details.push(...localNetworkFailureDetails(nested, seen));
+    for (const nested of error.errors) codes.push(...localNetworkFailureCodes(nested, seen));
   }
-  return details;
+  return [...new Set(codes)];
 }
 
 function isUnauthorizedHttpError(error: unknown): boolean {
@@ -1016,9 +1016,9 @@ export class McpServerManager {
   private async enrichHttpConnectionError(definition: ServerDefinition, error: unknown): Promise<Error> {
     const originalMessage = error instanceof Error ? error.message : String(error);
     if (process.platform === "darwin") {
-      const details = localNetworkFailureDetails(error);
-      if (details.length > 0 && isLiteralLocalAddress(resolveServerUrl(definition)!)) {
-        return new Error(`${originalMessage} — ${details.join("; ")} — macOS Local Network Privacy may be blocking access. Check System Settings > Privacy & Security > Local Network for the app hosting Pi; enable access if listed and restart it. Try launching Pi from Terminal.app or SSH. Routing or firewall problems can also cause this error.`, { cause: error });
+      const codes = localNetworkFailureCodes(error);
+      if (codes.length > 0 && isLiteralLocalAddress(resolveServerUrl(definition)!)) {
+        return new Error(`${originalMessage} — ${codes.join(", ")} — macOS Local Network Privacy may be blocking access. Check System Settings > Privacy & Security > Local Network for the app hosting Pi; enable access if listed and restart it. Try launching Pi from Terminal.app or SSH. Routing or firewall problems can also cause this error.`, { cause: error });
       }
     }
     if (isTransientHttpConnectError(error)) {

--- a/server-manager.ts
+++ b/server-manager.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, statSync } from "node:fs";
+import { BlockList, isIP } from "node:net";
 import { isDeepStrictEqual } from "node:util";
 import {
   Client,
@@ -80,6 +81,35 @@ type HttpAuthProviderState =
   | { status: "implicit-stored"; provider: McpOAuthProvider }
   | { status: "explicit"; provider: McpOAuthProvider }
   | { status: "implicit-challenged"; provider: McpOAuthProvider };
+
+function isLiteralLocalAddress(url: string): boolean {
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "");
+  const family = isIP(hostname);
+  if (!family) return false;
+  const local = new BlockList();
+  local.addSubnet("10.0.0.0", 8);
+  local.addSubnet("172.16.0.0", 12);
+  local.addSubnet("192.168.0.0", 16);
+  local.addSubnet("169.254.0.0", 16);
+  local.addSubnet("fc00::", 7, "ipv6");
+  local.addSubnet("fe80::", 10, "ipv6");
+  return local.check(hostname, family === 6 ? "ipv6" : "ipv4");
+}
+
+function localNetworkFailureDetails(error: unknown, seen = new Set<object>()): string[] {
+  if (typeof error !== "object" || error === null || seen.has(error)) return [];
+  seen.add(error);
+  const details: string[] = [];
+  if ("code" in error && typeof error.code === "string"
+    && ["EHOSTUNREACH", "ENETUNREACH", "EACCES"].includes(error.code)) {
+    details.push(error instanceof Error ? `${error.code}: ${error.message}` : error.code);
+  }
+  if ("cause" in error) details.push(...localNetworkFailureDetails(error.cause, seen));
+  if (error instanceof AggregateError) {
+    for (const nested of error.errors) details.push(...localNetworkFailureDetails(nested, seen));
+  }
+  return details;
+}
 
 function isUnauthorizedHttpError(error: unknown): boolean {
   return error instanceof UnauthorizedError || (error instanceof SdkHttpError && error.status === 401);
@@ -985,6 +1015,12 @@ export class McpServerManager {
 
   private async enrichHttpConnectionError(definition: ServerDefinition, error: unknown): Promise<Error> {
     const originalMessage = error instanceof Error ? error.message : String(error);
+    if (process.platform === "darwin") {
+      const details = localNetworkFailureDetails(error);
+      if (details.length > 0 && isLiteralLocalAddress(resolveServerUrl(definition)!)) {
+        return new Error(`${originalMessage} — ${details.join("; ")} — macOS Local Network Privacy may be blocking access. Check System Settings > Privacy & Security > Local Network for the app hosting Pi; enable access if listed and restart it. Try launching Pi from Terminal.app or SSH. Routing or firewall problems can also cause this error.`, { cause: error });
+      }
+    }
     if (isTransientHttpConnectError(error)) {
       return new Error(`${originalMessage} — endpoint is temporarily unavailable (HTTP 503)`, { cause: error });
     }


### PR DESCRIPTION
## Summary

- add a tentative macOS Local Network Privacy diagnostic for HTTP MCP failures to literal private or link-local addresses
- preserve structured failures across both Streamable HTTP and SSE without extra diagnostic requests
- document responsible-app remediation and diagnostic limits

## Validation

- focused manager/startup/lazy/proxy suite: 261 tests passed
- TypeScript typecheck passed
- public package export checks passed
- package dry-run passed

Fixes #543.

Thanks to @tdhooghe for the detailed report and reproduction evidence.
