### PR TITLE
Fix caFile connections on Node 26 via bundled undici fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Per-origin `caFile` trust now routes same-origin requests through the bundled undici fetch so the custom CA dispatcher matches the fetch implementation on newer Node releases (Node 26 ships undici v8 while the dependency pins undici v6); previously every `caFile` connection failed with `UND_ERR_INVALID_ARG`.
+
 ## [2.33.0] - 2026-09-10
 
 ### Highlights

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { X509Certificate } from "node:crypto";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 import type { ServerEntry } from "./types.ts";
 import { getMissingEnvVars, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 
@@ -39,10 +39,15 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
     fetch: (input, init) => {
       const url = new URL(input instanceof Request ? input.url : input.toString());
       if (url.origin !== origin) return globalThis.fetch(input, init);
-      // Attach after header-command Request reconstruction. Never follow a redirect
-      // with this dispatcher, even to the same origin (no trust-bearing redirect hops).
+      // The Agent comes from the bundled undici copy, whose internals do not
+      // match the global fetch dispatcher contract on newer Node releases
+      // (Node 26 ships undici v8; the dependency pins undici v6). Route
+      // same-origin requests through the bundled fetch so dispatcher and
+      // Agent share an implementation. Never follow a redirect with this
+      // dispatcher, even to the same origin (no trust-bearing redirect hops).
+      // Attach after header-command Request reconstruction.
       const options: RequestInit & { dispatcher: Agent } = { ...init, dispatcher, redirect: "error" };
-      return globalThis.fetch(input, options);
+      return (undiciFetch as unknown as typeof globalThis.fetch)(input, options);
     },
     close: () => closed ??= dispatcher.destroy(),
   };


### PR DESCRIPTION
Fixes #549.

## Problem

`createCaFetch` built its `Agent` from the pinned `undici@6` dependency but passed it as `init.dispatcher` to the global `fetch`, whose internals track the runtime Node (undici v8 on Node 26). The cross-version dispatcher handoff fails validation (`UND_ERR_INVALID_ARG: invalid onError method`) before TLS starts, so every `caFile` connection — Streamable HTTP, SSE, fallback, and connection-owned OAuth metadata — fails on Node 26. Works on Node 22 only because both sides happen to be undici v6.

## Fix

Same-origin requests now go through `fetch` imported from the same bundled `undici` copy that provides the `Agent`, keeping both sides on one implementation regardless of the Node version (a dep bump alone would just relocate the breakage across Node lines — see the version matrix in #549). Off-origin requests still use the global fetch; redirect rejection, origin scoping, and dispatcher cleanup are unchanged.

## Verification

- Without the fix on Node v26.8.2: 9 of 15 tests in `__tests__/http-ca.test.ts` fail with `UND_ERR_INVALID_ARG`.
- With the fix: 15/15 pass, `npm run typecheck` clean, full vitest suite 1602/1602, `test:oauth` 186/186, `test:public-exports` 2/2, `bash conformance/run.sh` all PASS.