### PR TITLE
fix(http): bridge Request inputs for CA fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Switching a server between transports (HTTP to stdio command or socket) now drops an inherited `bearerTokenStore` flag alongside the other URL-bound credential fields. Thanks to [@zhulinchng](https://github.com/zhulinchng) for PR #552.
+- Per-origin `caFile` trust now routes same-origin requests through the bundled undici fetch so the custom CA dispatcher matches the fetch implementation on newer Node releases (Node 26 ships undici v8 while the dependency pins undici v6); previously every `caFile` connection failed with `UND_ERR_INVALID_ARG`.
 
 ## [2.33.0] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Switching a server between transports (HTTP to stdio command or socket) now drops an inherited `bearerTokenStore` flag alongside the other URL-bound credential fields. Thanks to [@zhulinchng](https://github.com/zhulinchng) for PR #552.
-- Per-origin `caFile` trust now routes same-origin requests through the bundled undici fetch so the custom CA dispatcher matches the fetch implementation on newer Node releases (Node 26 ships undici v8 while the dependency pins undici v6); previously every `caFile` connection failed with `UND_ERR_INVALID_ARG`.
+- Per-origin `caFile` trust now routes same-origin requests through the bundled undici fetch so the custom CA dispatcher matches the fetch implementation on newer Node releases (Node 26 ships undici v8 while the dependency pins undici v6); previously every `caFile` connection failed with `UND_ERR_INVALID_ARG`. Thanks to [@zhulinchng](https://github.com/zhulinchng) for PR #550.
 
 ## [2.33.0] - 2026-09-10
 

--- a/__tests__/http-ca.test.ts
+++ b/__tests__/http-ca.test.ts
@@ -88,6 +88,18 @@ describe("per-origin custom CA", () => {
     ]);
   });
 
+  it.each(["GET", "HEAD"])("does not lock a Request body rejected by a %s override", async method => {
+    const url = "https://localhost";
+    const control = new Request(url, { method: "POST", body: "request-body" });
+    await expect(globalThis.fetch(control, { method })).rejects.toThrow(/GET|HEAD/);
+    const expectedState = { bodyUsed: control.bodyUsed, locked: control.body!.locked };
+    expect(expectedState).toEqual({ bodyUsed: false, locked: false });
+
+    const input = new Request(url, { method: "POST", body: "request-body" });
+    await expect(own(url).fetch(input, { method })).rejects.toThrow(/GET|HEAD/);
+    expect({ bodyUsed: input.bodyUsed, locked: input.body!.locked }).toEqual(expectedState);
+  });
+
   it("preserves hostname verification", async () => {
     const url = await listen((_req, res) => res.end("ok"), "hostname");
     await expect(own(url, fixture("hostname")).fetch(url)).rejects.toMatchObject({ cause: { code: "ERR_TLS_CERT_ALTNAME_INVALID" } });

--- a/__tests__/http-ca.test.ts
+++ b/__tests__/http-ca.test.ts
@@ -100,6 +100,44 @@ describe("per-origin custom CA", () => {
     expect({ bodyUsed: input.bodyUsed, locked: input.body!.locked }).toEqual(expectedState);
   });
 
+  it("does not lock a Request body before rejecting an invalid init method", async () => {
+    const url = "https://localhost";
+    const control = new Request(url, { method: "POST", body: "request-body" });
+    const controlResult = globalThis.fetch(control, { method: " GET " });
+    expect(controlResult).toBeInstanceOf(Promise);
+    await expect(controlResult).rejects.toThrow(TypeError);
+    const expectedState = { bodyUsed: control.bodyUsed, locked: control.body!.locked };
+    expect(expectedState).toEqual({ bodyUsed: false, locked: false });
+
+    const input = new Request(url, { method: "POST", body: "request-body" });
+    const result = own(url).fetch(input, { method: " GET " });
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow(TypeError);
+    expect({ bodyUsed: input.bodyUsed, locked: input.body!.locked }).toEqual(expectedState);
+  });
+
+  it.each(["consumed", "locked"] as const)("rejects a %s Request body asynchronously", async state => {
+    const url = "https://localhost";
+    const control = new Request(url, { method: "POST", body: "request-body" });
+    const controlReader = state === "locked" ? control.body!.getReader() : undefined;
+    if (state === "consumed") await control.text();
+    const controlResult = globalThis.fetch(control);
+    expect(controlResult).toBeInstanceOf(Promise);
+    await expect(controlResult).rejects.toThrow(TypeError);
+    const expectedState = { bodyUsed: control.bodyUsed, locked: control.body!.locked };
+
+    const input = new Request(url, { method: "POST", body: "request-body" });
+    const inputReader = state === "locked" ? input.body!.getReader() : undefined;
+    if (state === "consumed") await input.text();
+    let result: Promise<Response> | undefined;
+    expect(() => { result = own(url).fetch(input); }).not.toThrow();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result!).rejects.toThrow(TypeError);
+    expect({ bodyUsed: input.bodyUsed, locked: input.body!.locked }).toEqual(expectedState);
+    controlReader?.releaseLock();
+    inputReader?.releaseLock();
+  });
+
   it("preserves hostname verification", async () => {
     const url = await listen((_req, res) => res.end("ok"), "hostname");
     await expect(own(url, fixture("hostname")).fetch(url)).rejects.toMatchObject({ cause: { code: "ERR_TLS_CERT_ALTNAME_INVALID" } });

--- a/__tests__/http-ca.test.ts
+++ b/__tests__/http-ca.test.ts
@@ -61,6 +61,33 @@ describe("per-origin custom CA", () => {
     expect(hits).toBe(0);
   });
 
+  it("bridges same-origin global Request inputs without losing request or init semantics", async () => {
+    const seen: Array<{ method: string; header: string | undefined; body: string }> = [];
+    const url = await listen(async (req, res) => {
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      seen.push({ method: req.method!, header: req.headers["x-source"] as string | undefined, body });
+      res.end("ok");
+    });
+    const trusted = own(url);
+    const inherited = new Request(`${url}/inherited`, {
+      method: "POST", headers: { "x-source": "request" }, body: "request-body",
+    });
+    expect(await (await trusted.fetch(inherited)).text()).toBe("ok");
+
+    const overridden = new Request(`${url}/overridden`, {
+      method: "POST", headers: { "x-source": "request" }, body: "request-body",
+    });
+    expect(await (await trusted.fetch(overridden, {
+      method: "PUT", headers: { "x-source": "init" }, body: "init-body",
+    })).text()).toBe("ok");
+    expect(overridden.bodyUsed).toBe(false);
+    expect(seen).toEqual([
+      { method: "POST", header: "request", body: "request-body" },
+      { method: "PUT", header: "init", body: "init-body" },
+    ]);
+  });
+
   it("preserves hostname verification", async () => {
     const url = await listen((_req, res) => res.end("ok"), "hostname");
     await expect(own(url, fixture("hostname")).fetch(url)).rejects.toMatchObject({ cause: { code: "ERR_TLS_CERT_ALTNAME_INVALID" } });

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -66,7 +66,7 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
             referrer: input.referrer,
             referrerPolicy: input.referrerPolicy,
             signal: input.signal,
-          })
+          } as unknown as UndiciRequestInit)
           : input;
         const options = {
           ...init,

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { X509Certificate } from "node:crypto";
-import { Agent, fetch as undiciFetch } from "undici";
+import { Agent, Request as UndiciRequest, fetch as undiciFetch } from "undici";
+import type { RequestInit as UndiciRequestInit } from "undici";
 import type { ServerEntry } from "./types.ts";
 import { getMissingEnvVars, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 
@@ -46,8 +47,30 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
       // Agent share an implementation. Never follow a redirect with this
       // dispatcher, even to the same origin (no trust-bearing redirect hops).
       // Attach after header-command Request reconstruction.
-      const options: RequestInit & { dispatcher: Agent } = { ...init, dispatcher, redirect: "error" };
-      return (undiciFetch as unknown as typeof globalThis.fetch)(input, options);
+      const bundledInput = input instanceof Request
+        ? new UndiciRequest(input.url, {
+          method: input.method,
+          headers: [...input.headers],
+          // An overriding body must not consume the Request's original body.
+          ...(init?.body == null && input.body ? { body: input.body.values(), duplex: "half" as const } : {}),
+          cache: input.cache,
+          credentials: input.credentials,
+          integrity: input.integrity,
+          keepalive: input.keepalive,
+          mode: input.mode,
+          redirect: input.redirect,
+          referrer: input.referrer,
+          referrerPolicy: input.referrerPolicy,
+          signal: input.signal,
+        })
+        : input;
+      const options = {
+        ...init,
+        ...(init?.headers !== undefined ? { headers: [...new Headers(init.headers)] } : {}),
+        dispatcher,
+        redirect: "error" as const,
+      } as unknown as UndiciRequestInit;
+      return undiciFetch(bundledInput, options) as unknown as Promise<Response>;
     },
     close: () => closed ??= dispatcher.destroy(),
   };

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -47,34 +47,37 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
       // Agent share an implementation. Never follow a redirect with this
       // dispatcher, even to the same origin (no trust-bearing redirect hops).
       // Attach after header-command Request reconstruction.
-      if (input instanceof Request && input.body && init?.body == null
-        && /^(GET|HEAD)$/i.test(init?.method ?? input.method)) {
-        return Promise.reject(new TypeError("Request with GET/HEAD method cannot have body."));
+      try {
+        const bundledInput = input instanceof Request
+          ? new UndiciRequest(input.url, {
+            method: input.method,
+            headers: [...input.headers],
+            // Defer acquiring the source stream until bundled Request validation
+            // succeeds. An overriding body never consumes the original body.
+            ...(init?.body == null && input.body ? { body: (async function* () {
+              yield* input.body!;
+            })(), duplex: "half" as const } : {}),
+            cache: input.cache,
+            credentials: input.credentials,
+            integrity: input.integrity,
+            keepalive: input.keepalive,
+            mode: input.mode,
+            redirect: input.redirect,
+            referrer: input.referrer,
+            referrerPolicy: input.referrerPolicy,
+            signal: input.signal,
+          })
+          : input;
+        const options = {
+          ...init,
+          ...(init?.headers !== undefined ? { headers: [...new Headers(init.headers)] } : {}),
+          dispatcher,
+          redirect: "error" as const,
+        } as unknown as UndiciRequestInit;
+        return undiciFetch(bundledInput, options) as unknown as Promise<Response>;
+      } catch (error) {
+        return Promise.reject(error);
       }
-      const bundledInput = input instanceof Request
-        ? new UndiciRequest(input.url, {
-          method: input.method,
-          headers: [...input.headers],
-          // An overriding body must not consume the Request's original body.
-          ...(init?.body == null && input.body ? { body: input.body.values(), duplex: "half" as const } : {}),
-          cache: input.cache,
-          credentials: input.credentials,
-          integrity: input.integrity,
-          keepalive: input.keepalive,
-          mode: input.mode,
-          redirect: input.redirect,
-          referrer: input.referrer,
-          referrerPolicy: input.referrerPolicy,
-          signal: input.signal,
-        })
-        : input;
-      const options = {
-        ...init,
-        ...(init?.headers !== undefined ? { headers: [...new Headers(init.headers)] } : {}),
-        dispatcher,
-        redirect: "error" as const,
-      } as unknown as UndiciRequestInit;
-      return undiciFetch(bundledInput, options) as unknown as Promise<Response>;
     },
     close: () => closed ??= dispatcher.destroy(),
   };

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { X509Certificate } from "node:crypto";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 import type { ServerEntry } from "./types.ts";
 import { getMissingEnvVars, resolveConfigPath, resolveServerUrl } from "./utils.ts";
 
@@ -39,10 +39,15 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
     fetch: (input, init) => {
       const url = new URL(input instanceof Request ? input.url : input.toString());
       if (url.origin !== origin) return globalThis.fetch(input, init);
-      // Attach after header-command Request reconstruction. Never follow a redirect
-      // with this dispatcher, even to the same origin (no trust-bearing redirect hops).
+      // The Agent comes from the bundled undici copy, whose internals do not
+      // match the global fetch dispatcher contract on newer Node releases
+      // (Node 26 ships undici v8; the dependency pins undici v6). Route
+      // same-origin requests through the bundled fetch so dispatcher and
+      // Agent share an implementation. Never follow a redirect with this
+      // dispatcher, even to the same origin (no trust-bearing redirect hops).
+      // Attach after header-command Request reconstruction.
       const options: RequestInit & { dispatcher: Agent } = { ...init, dispatcher, redirect: "error" };
-      return globalThis.fetch(input, options);
+      return (undiciFetch as unknown as typeof globalThis.fetch)(input, options);
     },
     close: () => closed ??= dispatcher.destroy(),
   };

--- a/http-ca.ts
+++ b/http-ca.ts
@@ -47,6 +47,10 @@ export function createCaFetch(definition: ServerEntry): { fetch: (input: URL | R
       // Agent share an implementation. Never follow a redirect with this
       // dispatcher, even to the same origin (no trust-bearing redirect hops).
       // Attach after header-command Request reconstruction.
+      if (input instanceof Request && input.body && init?.body == null
+        && /^(GET|HEAD)$/i.test(init?.method ?? input.method)) {
+        return Promise.reject(new TypeError("Request with GET/HEAD method cannot have body."));
+      }
       const bundledInput = input instanceof Request
         ? new UndiciRequest(input.url, {
           method: input.method,


### PR DESCRIPTION
Supersedes #550 with a maintainer-owned promotion after fixing the review findings and rebasing onto current `main`.

Preserves Zhu Lin’s bundled-undici fix and original commit authorship. The final bridge:
- pairs the bundled undici `Agent`, `Request`, and `fetch` for same-origin `caFile` traffic on Node 26
- leaves off-origin requests on the global fetch path
- rejects redirects before trust-bearing cross-origin hops
- preserves global `Request` plus `RequestInit` semantics
- defers inherited body acquisition until bundled validation succeeds
- returns rejected Promises instead of synchronously throwing for consumed or locked bodies

Validation:
- focused CA suite: 21/21 passed
- typecheck passed
- diff hygiene passed

Closes #549.

Thanks to [@zhulinchng](https://github.com/zhulinchng) for #550.