### PR TITLE
fix(ui): navigate sandbox resources with response CSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - name: Verify Chrome browser regression prerequisite
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            google-chrome --version
+          elif command -v google-chrome-stable >/dev/null 2>&1; then
+            google-chrome-stable --version
+          else
+            echo "::error::Chrome is required for the MCP App CSP browser regression on Linux CI"
+            exit 1
+          fi
       - name: Build interactive visualizer example
         run: |
           npm install --prefix examples/interactive-visualizer --no-package-lock --no-audit --no-fund

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Switching a server between transports (HTTP to stdio command or socket) now drops an inherited `bearerTokenStore` flag alongside the other URL-bound credential fields. Thanks to [@zhulinchng](https://github.com/zhulinchng) for PR #552.
 - Per-origin `caFile` trust now routes same-origin requests through the bundled undici fetch so the custom CA dispatcher matches the fetch implementation on newer Node releases (Node 26 ships undici v8 while the dependency pins undici v6); previously every `caFile` connection failed with `UND_ERR_INVALID_ARG`. Thanks to [@zhulinchng](https://github.com/zhulinchng) for PR #550.
+- MCP Apps now load provider-declared asset, connection, and frame domains through a session-bound sandbox resource navigation with response-level CSP enforcement. Thanks to [@tekumara](https://github.com/tekumara) for #548.
 
 ## [2.33.0] - 2026-09-10
 

--- a/__tests__/host-html-template.test.ts
+++ b/__tests__/host-html-template.test.ts
@@ -4,7 +4,6 @@ import { buildHostHtmlTemplate, type HostHtmlTemplateInput } from "../host-html-
 function createMinimalInput(overrides: Partial<HostHtmlTemplateInput> = {}): HostHtmlTemplateInput {
   return {
     sessionToken: "test-token-123",
-    uiResourceToken: "resource-token-456",
     serverName: "test-server",
     toolName: "test-tool",
     toolArgs: { arg1: "value1" },
@@ -68,7 +67,7 @@ describe("buildHostHtmlTemplate", () => {
       expect(html).not.toContain("new PostMessageTransport(iframe.contentWindow, null)");
     });
 
-    it("loads provider HTML only after the proxy ready handshake", () => {
+    it("tells the proxy to navigate only after its ready handshake", () => {
       const html = buildHostHtmlTemplate(createMinimalInput({
         resource: {
           uri: "ui://test/widget",
@@ -80,12 +79,14 @@ describe("buildHostHtmlTemplate", () => {
         },
       }));
 
-      expect(html).toContain("bridge.onsandboxready = async () => {");
-      expect(html).toContain('fetch("/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN)');
+      expect(html).toContain("bridge.onsandboxready = () => {");
       expect(html).toContain("bridge.sendSandboxResourceReady({");
+      expect(html).toContain('html: ""');
       expect(html).toContain("sandbox: INNER_SANDBOX");
       expect(html).toContain('"https://cdn.example.com"');
       expect(html).toContain('"clipboardWrite"');
+      expect(html).not.toContain("<p>provider</p>");
+      expect(html).not.toContain("/ui-app");
     });
 
     it("includes control buttons", () => {
@@ -120,12 +121,10 @@ describe("buildHostHtmlTemplate", () => {
       const html = buildHostHtmlTemplate(
         createMinimalInput({
           sessionToken: "secret-session-token",
-          uiResourceToken: "app-resource-token",
         })
       );
 
       expect(html).toContain('const SESSION_TOKEN = "secret-session-token"');
-      expect(html).toContain('const UI_RESOURCE_TOKEN = "app-resource-token"');
       expect(html).toContain('const SANDBOX_PROXY_URL = "http://localhost:9876/sandbox"');
       expect(html).toContain('iframe.src = SANDBOX_PROXY_URL');
       expect(html).not.toContain('iframe.src = "/ui-app?resource="');

--- a/__tests__/sandbox-proxy-template.test.ts
+++ b/__tests__/sandbox-proxy-template.test.ts
@@ -8,21 +8,31 @@ import {
 
 describe("sandbox proxy template", () => {
   it("uses a safe sandbox policy with a distinct parent origin", () => {
-    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377" });
+    const html = buildSandboxProxyHtml({
+      parentOrigin: "http://localhost:8377",
+      resourcePath: "/resource/resource-nonce",
+    });
 
     expect(html).toContain('<iframe id="mcp-app"');
     expect(html).toContain(`sandbox="${SANDBOX_INNER_SANDBOX}"`);
     expect(html).toContain('const EXPECTED_PARENT_ORIGIN = "http://localhost:8377"');
     expect(html).toContain("event.source === window.parent && event.origin === EXPECTED_PARENT_ORIGIN");
     expect(html).toContain("event.source === innerFrame.contentWindow && event.origin === window.location.origin");
-    expect(html).toContain("document.write(injectCsp(params.html, buildResourceCsp(params.csp)))");
+    expect(html).toContain('const RESOURCE_PATH = "/resource/resource-nonce"');
+    expect(html).toContain('innerFrame.setAttribute("src", RESOURCE_PATH)');
+    expect(html).toContain('innerFrame.addEventListener("load"');
+    expect(html).not.toContain("document.write");
+    expect(html).not.toContain("injectCsp");
     expect(html).not.toContain("allow-popups-to-escape-sandbox");
     expect(html).not.toContain("SESSION_TOKEN");
     expect(html).not.toContain("UI_RESOURCE_TOKEN");
   });
 
   it("relays only validated parent/inner messages and reserves sandbox messages", () => {
-    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377" });
+    const html = buildSandboxProxyHtml({
+      parentOrigin: "http://localhost:8377",
+      resourcePath: "/resource/resource-nonce",
+    });
 
     expect(html).toContain("data.method === SANDBOX_RESOURCE_READY_METHOD");
     expect(html).toContain("data.method === SANDBOX_PROXY_READY_METHOD");
@@ -43,7 +53,10 @@ describe("sandbox proxy template", () => {
   });
 
   it("escapes the injected parent origin as JavaScript data", () => {
-    const html = buildSandboxProxyHtml({ parentOrigin: "http://localhost:8377/<script>\u2028" });
+    const html = buildSandboxProxyHtml({
+      parentOrigin: "http://localhost:8377/<script>\u2028",
+      resourcePath: "/resource/resource-nonce",
+    });
 
     expect(html).not.toContain("<script>\u2028");
     expect(html).toContain("\\u003cscript\\u003e");

--- a/__tests__/ui-server-browser.test.ts
+++ b/__tests__/ui-server-browser.test.ts
@@ -1,0 +1,161 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { describe, expect, it } from "vitest";
+import { startUiServer, type UiServerHandle, type UiServerOptions } from "../ui-server.ts";
+import type { ConsentManager } from "../consent-manager.ts";
+import type { McpServerManager } from "../server-manager.ts";
+
+function resolveChrome(): string | undefined {
+  for (const candidate of ["google-chrome", "google-chrome-stable"]) {
+    const result = spawnSync(candidate, ["--version"], { stdio: "ignore" });
+    if (!result.error && result.status === 0) return candidate;
+  }
+  return undefined;
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function stopChrome(chrome: ChildProcess): Promise<void> {
+  if (chrome.exitCode !== null) return;
+  chrome.kill("SIGKILL");
+  await Promise.race([
+    once(chrome, "exit").then(() => undefined),
+    new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+}
+
+async function waitForRequests(requests: Set<string>, expected: string[], chrome: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    if (expected.every((path) => requests.has(path))) return;
+    if (chrome.exitCode !== null) throw new Error(`Chrome exited before navigation completed (${chrome.exitCode})`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for observer requests: ${[...requests].join(", ")}`);
+}
+
+const chromePath = resolveChrome();
+const chromeRequired = process.platform === "linux" && !!process.env.CI;
+const browserIt = chromePath || chromeRequired ? it : it.skip;
+
+describe("UiServer browser CSP", () => {
+  browserIt("allows declared nested resources and blocks equivalent undeclared origins", async () => {
+    if (!chromePath) {
+      throw new Error("google-chrome or google-chrome-stable is required on Linux CI");
+    }
+
+    const requests = new Set<string>();
+    const observer = http.createServer((req, res) => {
+      const pathname = new URL(req.url ?? "/", "http://observer").pathname;
+      requests.add(pathname);
+      if (pathname.endsWith("script.js")) {
+        res.writeHead(200, { "Content-Type": "application/javascript" });
+        res.end(`fetch(DECLARED + "/declared/fetch"); fetch(UNDECLARED + "/undeclared/fetch").catch(() => {});`);
+        return;
+      }
+      if (pathname.endsWith("style.css")) {
+        res.writeHead(200, { "Content-Type": "text/css" });
+        res.end("body { color: rgb(1, 2, 3); }");
+        return;
+      }
+      if (pathname.endsWith("fetch")) {
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        });
+        res.end("{}");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<!doctype html><title>observed frame</title>");
+    });
+
+    let handle: UiServerHandle | undefined;
+    let chrome: ChildProcess | undefined;
+    let profileDir: string | undefined;
+    try {
+      await new Promise<void>((resolve) => observer.listen(0, "127.0.0.1", resolve));
+      const observerPort = (observer.address() as { port: number }).port;
+      const declaredOrigin = `http://127.0.0.1:${observerPort}`;
+      const undeclaredOrigin = `http://localhost:${observerPort}`;
+      const appHtml = `<!doctype html>
+<html><head>
+<script>const DECLARED = ${JSON.stringify(declaredOrigin)}; const UNDECLARED = ${JSON.stringify(undeclaredOrigin)};</script>
+<link rel="stylesheet" href="${declaredOrigin}/declared/style.css">
+<link rel="stylesheet" href="${undeclaredOrigin}/undeclared/style.css">
+</head><body>
+<script src="${declaredOrigin}/declared/script.js"></script>
+<script src="${undeclaredOrigin}/undeclared/script.js"></script>
+<iframe src="${declaredOrigin}/declared/frame"></iframe>
+<iframe src="${undeclaredOrigin}/undeclared/frame"></iframe>
+</body></html>`;
+
+      const manager = {
+        getConnection: () => undefined,
+        touch: () => undefined,
+        incrementInFlight: () => undefined,
+        decrementInFlight: () => undefined,
+      } as unknown as McpServerManager;
+      const consentManager = {
+        requiresPrompt: () => false,
+        shouldCacheConsent: () => true,
+      } as unknown as ConsentManager;
+      const options: UiServerOptions = {
+        serverName: "browser-csp",
+        toolName: "browser_csp",
+        toolArgs: {},
+        resource: {
+          uri: "ui://test/browser-csp",
+          html: appHtml,
+          mimeType: "text/html",
+          meta: {
+            permissions: [],
+            csp: {
+              resourceDomains: [declaredOrigin],
+              connectDomains: [declaredOrigin],
+              frameDomains: [declaredOrigin],
+            },
+          },
+        },
+        manager,
+        consentManager,
+      };
+      handle = await startUiServer(options);
+      profileDir = await mkdtemp(path.join(tmpdir(), "pi-mcp-chrome-"));
+      chrome = spawn(chromePath, [
+        "--headless=new",
+        "--no-sandbox",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--no-first-run",
+        "--no-default-browser-check",
+        `--user-data-dir=${profileDir}`,
+        handle.url,
+      ], { stdio: "ignore" });
+
+      const declaredPaths = [
+        "/declared/script.js",
+        "/declared/style.css",
+        "/declared/fetch",
+        "/declared/frame",
+      ];
+      await waitForRequests(requests, declaredPaths, chrome);
+      await new Promise((resolve) => setTimeout(resolve, 750));
+
+      expect([...requests].filter((requestPath) => requestPath.startsWith("/undeclared/"))).toEqual([]);
+    } finally {
+      if (chrome) await stopChrome(chrome);
+      if (handle) handle.close("browser-test-cleanup");
+      if (observer.listening) await closeServer(observer);
+      if (profileDir) await rm(profileDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "node:http";
+import net from "node:net";
 import { startUiServer, type UiServerOptions, type UiServerHandle } from "../ui-server.ts";
 import type { McpServerManager } from "../server-manager.ts";
 import type { ConsentManager } from "../consent-manager.ts";
@@ -49,6 +50,18 @@ async function request(
       req.write(JSON.stringify(options.body));
     }
     req.end();
+  });
+}
+
+async function rawHttp10WithoutHost(port: number, path = "/"): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
+      socket.end(`GET ${path} HTTP/1.0\r\n\r\n`);
+    });
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk) => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.on("error", reject);
   });
 }
 
@@ -353,6 +366,18 @@ describe("UiServer", () => {
 
       expect(res.status).toBe(403);
       expect(res.body).toBe("Invalid host");
+    });
+
+    it("rejects raw HTTP/1.0 requests without Host on both listeners", async () => {
+      handle = await startUiServer(createServerOptions());
+
+      const hostResponse = await rawHttp10WithoutHost(handle.port);
+      const proxyResponse = await rawHttp10WithoutHost(handle.proxyPort, "/sandbox");
+
+      expect(hostResponse).toMatch(/^HTTP\/1\.1 400 /);
+      expect(hostResponse).toContain("Missing host");
+      expect(proxyResponse).toMatch(/^HTTP\/1\.1 400 /);
+      expect(proxyResponse).toContain("Missing host");
     });
 
     it("accepts bracketed IPv6 loopback Host headers", async () => {

--- a/__tests__/ui-server.test.ts
+++ b/__tests__/ui-server.test.ts
@@ -163,13 +163,13 @@ function createServerOptions(overrides: Partial<UiServerOptions> = {}): UiServer
   };
 }
 
-async function getUiAppUrl(handle: UiServerHandle): Promise<string> {
-  const host = await request(handle.url);
-  const match = typeof host.body === "string"
-    ? host.body.match(/const UI_RESOURCE_TOKEN = "([^"]+)";/)
+async function getSandboxResourceUrl(handle: UiServerHandle): Promise<string> {
+  const relay = await request(handle.proxyUrl);
+  const match = typeof relay.body === "string"
+    ? relay.body.match(/const RESOURCE_PATH = "([^"]+)";/)
     : null;
-  if (!match?.[1]) throw new Error("UI resource token missing from host page");
-  return `http://localhost:${handle.port}/ui-app?resource=${encodeURIComponent(match[1])}`;
+  if (!match?.[1]) throw new Error("Sandbox resource path missing from relay page");
+  return `${new URL(handle.proxyUrl).origin}${match[1]}`;
 }
 
 describe("UiServer", () => {
@@ -240,6 +240,8 @@ describe("UiServer", () => {
       expect(res.body).toContain("event.source === innerFrame.contentWindow && event.origin === window.location.origin");
       expect(res.body).not.toContain(handle.sessionToken);
       expect(res.body).not.toContain("UI_RESOURCE_TOKEN");
+      expect(res.body).not.toContain("<h1>Test App</h1>");
+      expect(res.body).not.toContain("document.write");
 
       expect((await request(`${handle.proxyUrl}/ui-app`)).status).toBe(404);
       expect((await request(`${handle.proxyUrl}/proxy/ui/heartbeat`, {
@@ -365,27 +367,27 @@ describe("UiServer", () => {
     });
   });
 
-  describe("GET /ui-app", () => {
-    it("does not accept the app resource token on privileged proxy routes", async () => {
+  describe("sandbox resource navigation", () => {
+    it("does not accept the resource nonce on privileged host routes", async () => {
       const manager = createMockManager();
       handle = await startUiServer(createServerOptions({ manager }));
-      const appUrl = new URL(await getUiAppUrl(handle));
-      const resourceToken = appUrl.searchParams.get("resource");
+      const resourceUrl = new URL(await getSandboxResourceUrl(handle));
+      const resourceNonce = resourceUrl.pathname.split("/").at(-1);
 
-      expect(resourceToken).toBeTruthy();
-      expect(resourceToken).not.toBe(handle.sessionToken);
-      expect((await request(`http://localhost:${handle.port}/ui-app?session=${handle.sessionToken}`)).status).toBe(403);
+      expect(resourceNonce).toBeTruthy();
+      expect(resourceNonce).not.toBe(handle.sessionToken);
+      expect((await request(`http://localhost:${handle.port}${resourceUrl.pathname}`)).status).toBe(404);
 
       const res = await request(`http://localhost:${handle.port}/proxy/tools/call`, {
         method: "POST",
-        body: { token: resourceToken, params: { name: "some_tool", arguments: {} } },
+        body: { token: resourceNonce, params: { name: "some_tool", arguments: {} } },
       });
 
       expect(res.status).toBe(403);
       expect(manager.getConnection).not.toHaveBeenCalled();
     });
 
-    it("enforces metadata CSP and response-level sandboxing while preserving app HTML", async () => {
+    it("serves provider HTML under its declared response CSP", async () => {
       const appHtml = `<!-- decoy <head><meta http-equiv="Content-Security-Policy" content="default-src *"></head> -->
 <!doctype html>
 <html>
@@ -405,11 +407,12 @@ describe("UiServer", () => {
             csp: {
               resourceDomains: ["https://esm.sh"],
               connectDomains: ["https://api.excalidraw.com"],
+              frameDomains: ["https://frames.example.com"],
             },
           },
         }),
       }));
-      const url = await getUiAppUrl(handle);
+      const url = await getSandboxResourceUrl(handle);
 
       const res = await request(url);
       const cspHeader = res.headers["content-security-policy"];
@@ -419,11 +422,34 @@ describe("UiServer", () => {
       expect(cspHeader).toContain("default-src 'none'");
       expect(cspHeader).toContain("sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads");
       expect(cspHeader).not.toContain("allow-popups-to-escape-sandbox");
-      expect(cspHeader).not.toContain("allow-same-origin");
+      expect(cspHeader).toContain("allow-same-origin");
+      expect(cspHeader).not.toContain("allow-top-navigation");
       expect(cspHeader).toContain("script-src 'self' 'unsafe-inline' https://esm.sh");
       expect(cspHeader).toContain("style-src 'self' 'unsafe-inline' https://esm.sh");
       expect(cspHeader).toContain("connect-src https://api.excalidraw.com");
+      expect(cspHeader).toContain("frame-src https://frames.example.com");
+      expect(cspHeader).not.toContain("images.example.com");
+      expect(res.headers["cache-control"]).toBe("no-store");
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+      expect(res.headers["referrer-policy"]).toBe("no-referrer");
       expect(res.body).toBe(appHtml);
+    });
+
+    it("rejects invalid method, path, nonce, and Host", async () => {
+      handle = await startUiServer(createServerOptions());
+      const url = await getSandboxResourceUrl(handle);
+      const origin = new URL(url).origin;
+
+      expect((await request(url, { method: "POST" })).status).toBe(404);
+      expect((await request(`${origin}/resource/not-the-session-nonce`)).status).toBe(404);
+      expect((await request(`${url}/extra`)).status).toBe(404);
+      expect((await request(url, { headers: { Host: "attacker.example" } })).status).toBe(403);
+
+      const head = await request(url, { method: "HEAD" });
+      expect(head.status).toBe(200);
+      expect(head.body).toBe("");
+      expect(head.headers["content-security-policy"]).toContain("default-src 'none'");
+      expect(head.headers["cache-control"]).toBe("no-store");
     });
 
     it("rejects malformed CSP metadata before writing the response header", async () => {
@@ -444,7 +470,7 @@ describe("UiServer", () => {
         }),
       }));
 
-      const res = await request(await getUiAppUrl(handle));
+      const res = await request(await getSandboxResourceUrl(handle));
 
       expect(res.status).toBe(200);
       expect(res.headers["content-security-policy"]).toContain("https://safe.example.com");
@@ -462,7 +488,7 @@ describe("UiServer", () => {
         }),
       }));
 
-      const res = await request(await getUiAppUrl(handle));
+      const res = await request(await getSandboxResourceUrl(handle));
 
       expect(res.status).toBe(200);
       expect(res.headers["content-security-policy"]).toContain("default-src 'none'");
@@ -472,7 +498,7 @@ describe("UiServer", () => {
 
     it("emits restrictive default CSP when metadata is undefined", async () => {
       handle = await startUiServer(createServerOptions());
-      const url = await getUiAppUrl(handle);
+      const url = await getSandboxResourceUrl(handle);
 
       const res = await request(url);
 

--- a/host-html-template.ts
+++ b/host-html-template.ts
@@ -8,7 +8,6 @@ const APP_INNER_SANDBOX = APP_PROXY_SANDBOX;
 
 export interface HostHtmlTemplateInput {
   sessionToken: string;
-  uiResourceToken: string;
   serverName: string;
   toolName: string;
   toolArgs: Record<string, unknown>;
@@ -25,7 +24,6 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
   const hostContext = input.hostContext ?? {};
 
   const sessionToken = safeInlineJSON(input.sessionToken);
-  const uiResourceToken = safeInlineJSON(input.uiResourceToken);
   const toolArgs = safeInlineJSON(input.toolArgs);
   const serverName = safeInlineJSON(input.serverName);
   const toolName = safeInlineJSON(input.toolName);
@@ -136,7 +134,6 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     import { AppBridge, PostMessageTransport } from ${moduleUrl};
 
     const SESSION_TOKEN = ${sessionToken};
-    const UI_RESOURCE_TOKEN = ${uiResourceToken};
     const SERVER_NAME = ${serverName};
     const TOOL_NAME = ${toolName};
     const TOOL_ARGS = ${toolArgs};
@@ -231,24 +228,19 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
     );
 
     let sandboxResourceSent = false;
-    bridge.onsandboxready = async () => {
+    bridge.onsandboxready = () => {
       if (sandboxResourceSent) return;
       sandboxResourceSent = true;
-      try {
-        const response = await fetch("/ui-app?resource=" + encodeURIComponent(UI_RESOURCE_TOKEN), {
-          headers: { Accept: "text/html" },
-        });
-        if (!response.ok) throw new Error("UI resource request failed: HTTP " + response.status);
-        const html = await response.text();
-        await bridge.sendSandboxResourceReady({
-          html,
-          sandbox: INNER_SANDBOX,
-          ...(RESOURCE_CSP ? { csp: RESOURCE_CSP } : {}),
-          ...(RESOURCE_PERMISSIONS ? { permissions: RESOURCE_PERMISSIONS } : {}),
-        });
-      } catch (error) {
+      void bridge.sendSandboxResourceReady({
+        // The proxy performs a normal HTTP navigation to its session-bound
+        // resource route. Provider HTML never crosses this trusted document.
+        html: "",
+        sandbox: INNER_SANDBOX,
+        ...(RESOURCE_CSP ? { csp: RESOURCE_CSP } : {}),
+        ...(RESOURCE_PERMISSIONS ? { permissions: RESOURCE_PERMISSIONS } : {}),
+      }).catch((error) => {
         showError("Failed to load MCP App resource: " + String(error));
-      }
+      });
     };
 
     bridge.oncalltool = async (params) => {
@@ -448,6 +440,15 @@ export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
 }
 
 export function buildCspMetaContent(csp: UiResourceCsp | undefined): string {
+  return buildCspContent(csp, APP_SANDBOX);
+}
+
+/** CSP for provider HTML navigated on the isolated proxy origin. */
+export function buildSandboxResourceCsp(csp: UiResourceCsp | undefined): string {
+  return buildCspContent(csp, APP_INNER_SANDBOX);
+}
+
+function buildCspContent(csp: UiResourceCsp | undefined, sandbox: string): string {
   const resourceDomains = sanitizeCspDomains(csp?.resourceDomains);
   const connectDomains = sanitizeCspDomains(csp?.connectDomains);
   const frameDomains = sanitizeCspDomains(csp?.frameDomains);
@@ -455,7 +456,7 @@ export function buildCspMetaContent(csp: UiResourceCsp | undefined): string {
 
   return [
     "default-src 'none'",
-    `sandbox ${APP_SANDBOX}`,
+    `sandbox ${sandbox}`,
     toDirective("script-src", ["'self'", "'unsafe-inline'"], resourceDomains),
     toDirective("style-src", ["'self'", "'unsafe-inline'"], resourceDomains),
     toDirective("font-src", ["'self'"], resourceDomains),

--- a/sandbox-proxy-template.ts
+++ b/sandbox-proxy-template.ts
@@ -16,7 +16,7 @@ export interface SandboxProxyTemplateInput {
 
 /**
  * Build the static document used by the trusted, second-origin sandbox proxy.
- * The only per-session value is the exact origin of the parent host.
+ * The per-session values are the exact parent host origin and opaque resource path.
  */
 export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string {
   const parentOrigin = safeInlineJSON(input.parentOrigin);

--- a/sandbox-proxy-template.ts
+++ b/sandbox-proxy-template.ts
@@ -7,9 +7,11 @@ export const SANDBOX_PROXY_SANDBOX =
   "allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin";
 export const SANDBOX_INNER_SANDBOX = SANDBOX_PROXY_SANDBOX;
 export const SANDBOX_PROXY_PATH = "/sandbox";
+export const SANDBOX_RESOURCE_PATH_PREFIX = "/resource/";
 
 export interface SandboxProxyTemplateInput {
   parentOrigin: string;
+  resourcePath: string;
 }
 
 /**
@@ -18,6 +20,7 @@ export interface SandboxProxyTemplateInput {
  */
 export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string {
   const parentOrigin = safeInlineJSON(input.parentOrigin);
+  const resourcePath = safeInlineJSON(input.resourcePath);
 
   return `<!doctype html>
 <html lang="en">
@@ -34,6 +37,7 @@ export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string 
   <iframe id="mcp-app" title="MCP App" sandbox="${SANDBOX_INNER_SANDBOX}" referrerpolicy="no-referrer"></iframe>
   <script>
     const EXPECTED_PARENT_ORIGIN = ${parentOrigin};
+    const RESOURCE_PATH = ${resourcePath};
     const SANDBOX_PROXY_READY_METHOD = "ui/notifications/sandbox-proxy-ready";
     const SANDBOX_RESOURCE_READY_METHOD = "ui/notifications/sandbox-resource-ready";
     const INNER_SANDBOX = ${safeInlineJSON(SANDBOX_INNER_SANDBOX)};
@@ -41,6 +45,10 @@ export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string 
     const innerFrame = document.getElementById("mcp-app");
     const pendingToInner = [];
     let innerReady = false;
+
+    innerFrame.addEventListener("load", () => {
+      if (innerFrame.getAttribute("src") === RESOURCE_PATH) flushPendingMessages();
+    });
 
     const isObject = (value) => value !== null && typeof value === "object";
     const isMessageFromParent = (event) =>
@@ -68,56 +76,6 @@ export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string 
       }
     };
 
-    const sanitizeDomains = (domains) => {
-      if (!Array.isArray(domains)) return [];
-      return [...new Set(domains.filter((domain) =>
-        typeof domain === "string" &&
-        domain.length > 0 &&
-        /^[\\x21-\\x7E]+$/.test(domain) &&
-        !/[;'\"]/.test(domain),
-      ))];
-    };
-
-    const toDirective = (name, trustedSources, domains) =>
-      name + " " + [...new Set([...trustedSources, ...domains])].join(" ");
-
-    const buildResourceCsp = (csp) => {
-      const resourceDomains = sanitizeDomains(csp?.resourceDomains);
-      const connectDomains = sanitizeDomains(csp?.connectDomains);
-      const frameDomains = sanitizeDomains(csp?.frameDomains);
-      const baseUriDomains = sanitizeDomains(csp?.baseUriDomains);
-      return [
-        "default-src 'none'",
-        "sandbox " + INNER_SANDBOX,
-        toDirective("script-src", ["'self'", "'unsafe-inline'"], resourceDomains),
-        toDirective("style-src", ["'self'", "'unsafe-inline'"], resourceDomains),
-        toDirective("font-src", ["'self'"], resourceDomains),
-        toDirective("img-src", ["'self'", "data:"], resourceDomains),
-        toDirective("media-src", ["'self'", "data:"], resourceDomains),
-        connectDomains.length > 0 ? "connect-src " + connectDomains.join(" ") : "connect-src 'none'",
-        frameDomains.length > 0 ? "frame-src " + frameDomains.join(" ") : "frame-src 'none'",
-        "worker-src 'none'",
-        "object-src 'none'",
-        baseUriDomains.length > 0 ? "base-uri " + baseUriDomains.join(" ") : "base-uri 'self'",
-      ].join("; ");
-    };
-
-    const escapeAttribute = (value) => value
-      .replace(/&/g, "&amp;")
-      .replace(/\"/g, "&quot;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-
-    const injectCsp = (html, csp) => {
-      const meta = '<meta http-equiv="Content-Security-Policy" content="' + escapeAttribute(csp) + '">';
-      const head = html.match(/<head(?:\\s[^>]*)?>/i);
-      if (head && head.index !== undefined) {
-        const end = head.index + head[0].length;
-        return html.slice(0, end) + meta + html.slice(end);
-      }
-      return meta + html;
-    };
-
     const safeSandbox = (requested) => {
       const requestedTokens = typeof requested === "string" ? requested.split(/\\s+/) : [];
       const allowedTokens = new Set(INNER_SANDBOX.split(" "));
@@ -142,17 +100,13 @@ export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string 
     };
 
     const loadResource = (params) => {
-      if (!isObject(params) || typeof params.html !== "string" || !innerFrame.contentDocument) return;
+      if (!isObject(params)) return;
       innerFrame.setAttribute("sandbox", safeSandbox(params.sandbox));
       const allow = buildAllowAttribute(params.permissions);
       if (allow) innerFrame.setAttribute("allow", allow);
       else innerFrame.removeAttribute("allow");
       innerReady = false;
-      const document = innerFrame.contentDocument;
-      document.open();
-      document.write(injectCsp(params.html, buildResourceCsp(params.csp)));
-      document.close();
-      flushPendingMessages();
+      innerFrame.setAttribute("src", RESOURCE_PATH);
     };
 
     window.addEventListener("message", (event) => {
@@ -188,8 +142,8 @@ export function buildSandboxProxyHtml(input: SandboxProxyTemplateInput): string 
 
 /**
  * CSP for the proxy document itself. It contains only the inline relay script
- * and a nested about:blank frame; provider policy is applied separately after
- * the host sends the resource-ready notification.
+ * and a same-origin nested frame. Provider policy is applied on the resource
+ * navigation response, not inherited from this relay document.
  */
 export function buildSandboxProxyCsp(): string {
   return [

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -11,11 +11,12 @@ import { ContentBlockSchema } from "@modelcontextprotocol/core";
 import type { ConsentManager } from "./consent-manager.ts";
 import { ServerError, wrapError } from "./errors.ts";
 import { formatAuthRequiredMessage, normalizeToolArguments } from "./utils.ts";
-import { buildHostHtmlTemplate, buildCspMetaContent } from "./host-html-template.ts";
+import { buildHostHtmlTemplate, buildSandboxResourceCsp } from "./host-html-template.ts";
 import {
   buildSandboxProxyCsp,
   buildSandboxProxyHtml,
   SANDBOX_PROXY_PATH,
+  SANDBOX_RESOURCE_PATH_PREFIX,
 } from "./sandbox-proxy-template.ts";
 import { logger } from "./logger.ts";
 import type { McpServerManager } from "./server-manager.ts";
@@ -85,7 +86,7 @@ export interface UiServerOptions {
 
 export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {
   const sessionToken = options.sessionToken ?? randomUUID();
-  const uiResourceToken = randomUUID();
+  const sandboxResourcePath = `${SANDBOX_RESOURCE_PATH_PREFIX}${randomUUID()}`;
   const log = logger.child({ 
     component: "UiServer",
     server: options.serverName,
@@ -346,7 +347,6 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
         const html = buildHostHtmlTemplate({
           sessionToken,
-          uiResourceToken,
           serverName: options.serverName,
           toolName: options.toolName,
           toolArgs: options.toolArgs,
@@ -388,20 +388,6 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
       if (method === "GET" && url.pathname === "/health") {
         if (!validateTokenQuery(url, sessionToken, res)) return;
         sendJson(res, 200, { ok: true, result: { healthy: true } });
-        return;
-      }
-
-      if (method === "GET" && url.pathname === "/ui-app") {
-        if (!validateTokenQuery(url, uiResourceToken, res, "resource")) return;
-        touchHeartbeat();
-        // Enforce host metadata independently of where app HTML places its document head.
-        const cspContent = buildCspMetaContent(options.resource.meta.csp);
-        res.writeHead(200, {
-          "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "no-store",
-          "Content-Security-Policy": cspContent,
-        });
-        res.end(options.resource.html);
         return;
       }
 
@@ -729,6 +715,8 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               "Content-Type": "text/html; charset=utf-8",
               "Cache-Control": "no-store",
               "Content-Security-Policy": buildSandboxProxyCsp(),
+              "Referrer-Policy": "no-referrer",
+              "X-Content-Type-Options": "nosniff",
             });
             res.end();
             return;
@@ -742,7 +730,19 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
               "Referrer-Policy": "no-referrer",
               "X-Content-Type-Options": "nosniff",
             });
-            res.end(buildSandboxProxyHtml({ parentOrigin }));
+            res.end(buildSandboxProxyHtml({ parentOrigin, resourcePath: sandboxResourcePath }));
+            return;
+          }
+
+          if ((method === "GET" || method === "HEAD") && url.pathname === sandboxResourcePath) {
+            res.writeHead(200, {
+              "Content-Type": "text/html; charset=utf-8",
+              "Cache-Control": "no-store",
+              "Content-Security-Policy": buildSandboxResourceCsp(options.resource.meta.csp),
+              "Referrer-Policy": "no-referrer",
+              "X-Content-Type-Options": "nosniff",
+            });
+            res.end(method === "HEAD" ? undefined : options.resource.html);
             return;
           }
 

--- a/ui-server.ts
+++ b/ui-server.ts
@@ -317,8 +317,12 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     try {
       const method = req.method || "GET";
       const hostHeader = req.headers.host;
-      const url = new URL(req.url || "/", `http://${hostHeader || "127.0.0.1"}`);
-      if (hostHeader !== undefined && !isAllowedHost(url.hostname)) {
+      if (!hostHeader) {
+        sendText(res, 400, "Missing host");
+        return;
+      }
+      const url = new URL(req.url || "/", `http://${hostHeader}`);
+      if (!isAllowedHost(url.hostname)) {
         sendText(res, 403, "Invalid host");
         return;
       }
@@ -704,8 +708,12 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         try {
           const method = req.method || "GET";
           const hostHeader = req.headers.host;
-          const url = new URL(req.url || "/", `http://${hostHeader || "127.0.0.1"}`);
-          if (hostHeader !== undefined && !isAllowedHost(url.hostname)) {
+          if (!hostHeader) {
+            sendText(res, 400, "Missing host");
+            return;
+          }
+          const url = new URL(req.url || "/", `http://${hostHeader}`);
+          if (!isAllowedHost(url.hostname)) {
             sendText(res, 403, "Invalid host");
             return;
           }


### PR DESCRIPTION
Fixes the inherited `about:blank` CSP behavior reported in #548.

Provider HTML now loads through a fresh opaque path on the existing same-origin sandbox proxy. The provider document receives its normalized CSP as an HTTP response header, while the outer relay retains its restrictive CSP and never receives provider domains or the privileged host session capability.

Security and lifecycle behavior covered:
- exact GET/HEAD resource route with loopback Host enforcement
- `no-store`, `nosniff`, and `no-referrer` response headers
- parent/inner source and origin validation
- reserved message rejection and bounded pending queue
- resource navigation load before queued delivery
- declared resource/connect/frame origins allowed; undeclared origins denied

Validation:
- 145 focused tests passed locally
- typecheck and workflow YAML validation passed
- dependency-free Chrome regression runs on Linux CI and fails clearly if Chrome is unavailable
- two security challenges, deslop/simplification, and a fresh final review found no blocker

Closes #548.

Thanks to [@tekumara](https://github.com/tekumara) for the report and detailed reproduction.